### PR TITLE
fix(rpcsmartrouter): filter providers by ApiInterface for chain tracker

### DIFF
--- a/config/smartrouter_examples/smartrouter_eth.yml
+++ b/config/smartrouter_examples/smartrouter_eth.yml
@@ -60,6 +60,43 @@ direct-rpc:
     node-urls:
       - url: "wss://ethereum-rpc.publicnode.com"
 
+  # Additional JSON-RPC test nodes (kept duplicated intentionally)
+  - name: "Google1"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://json-rpc.8zfcse2amst1lajmh299uq4jn.blockchainnodeengine.com?key=AIzaSyDyUtm6b-e-xKDQgVWzlroHdVTytiXEDik"
+        skip-verifications:
+          - chain-id
+          - pruning
+
+  - name: "Google2"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://json-rpc.8zfcse2amst1lajmh299uq4jn.blockchainnodeengine.com?key=AIzaSyDyUtm6b-e-xKDQgVWzlroHdVTytiXEDik"
+        skip-verifications:
+          - chain-id
+          - pruning
+
+  - name: "QuickNode1"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://wispy-distinguished-glitter.quiknode.pro/c6f9247c83ef5fd069dbef2c228ee1229b55e406/"
+        skip-verifications:
+          - chain-id
+          - pruning
+
+  - name: "QuickNode2"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://wispy-distinguished-glitter.quiknode.pro/c6f9247c83ef5fd069dbef2c228ee1229b55e406/"
+        skip-verifications:
+          - chain-id
+          - pruning
+
 backup-direct-rpc:
   # Backup HTTP Endpoint (used only when all primary direct-rpc peers are exhausted)
   - name: "eth-rpc-backup"

--- a/config/smartrouter_examples/smartrouter_eth.yml
+++ b/config/smartrouter_examples/smartrouter_eth.yml
@@ -9,7 +9,7 @@ endpoints:
     network-address: "0.0.0.0:3360"
 
 direct-rpc:
-  # HTTP Endpoint 1
+  # HTTP+WS Endpoint 1
   - name: "eth-rpc-1"
     chain-id: "ETH1"
     api-interface: "jsonrpc"
@@ -18,8 +18,9 @@ direct-rpc:
         skip-verifications:
           - chain-id
           - pruning
+      - url: "wss://eth.llamarpc.com"
 
-  # HTTP Endpoint 2
+  # HTTP+WS Endpoint 2
   - name: "eth-rpc-2"
     chain-id: "ETH1"
     api-interface: "jsonrpc"
@@ -28,8 +29,9 @@ direct-rpc:
         skip-verifications:
           - chain-id
           - pruning
+      - url: "wss://json-rpc.8zfcse2amst1lajmh299uq4jn.blockchainnodeengine.com/?key=AIzaSyDyUtm6b-e-xKDQgVWzlroHdVTytiXEDik"
 
-  # HTTP Endpoint 3
+  # HTTP+WS Endpoint 3
   - name: "eth-rpc-3"
     chain-id: "ETH1"
     api-interface: "jsonrpc"
@@ -38,6 +40,7 @@ direct-rpc:
         skip-verifications:
           - chain-id
           - pruning
+      - url: "wss://ethereum-rpc.publicnode.com"
 
   # WebSocket Endpoint 1 (Phase 5 - Subscriptions)
   - name: "eth-ws-1"
@@ -69,6 +72,7 @@ direct-rpc:
         skip-verifications:
           - chain-id
           - pruning
+      - url: "wss://json-rpc.8zfcse2amst1lajmh299uq4jn.blockchainnodeengine.com?key=AIzaSyDyUtm6b-e-xKDQgVWzlroHdVTytiXEDik"
 
   - name: "Google2"
     chain-id: "ETH1"
@@ -78,6 +82,7 @@ direct-rpc:
         skip-verifications:
           - chain-id
           - pruning
+      - url: "wss://json-rpc.8zfcse2amst1lajmh299uq4jn.blockchainnodeengine.com?key=AIzaSyDyUtm6b-e-xKDQgVWzlroHdVTytiXEDik"
 
   - name: "QuickNode1"
     chain-id: "ETH1"
@@ -87,6 +92,7 @@ direct-rpc:
         skip-verifications:
           - chain-id
           - pruning
+      - url: "wss://wispy-distinguished-glitter.quiknode.pro/c6f9247c83ef5fd069dbef2c228ee1229b55e406/"
 
   - name: "QuickNode2"
     chain-id: "ETH1"
@@ -96,9 +102,10 @@ direct-rpc:
         skip-verifications:
           - chain-id
           - pruning
+      - url: "wss://wispy-distinguished-glitter.quiknode.pro/c6f9247c83ef5fd069dbef2c228ee1229b55e406/"
 
 backup-direct-rpc:
-  # Backup HTTP Endpoint (used only when all primary direct-rpc peers are exhausted)
+  # Backup HTTP+WS Endpoint (used only when all primary direct-rpc peers are exhausted)
   - name: "eth-rpc-backup"
     chain-id: "ETH1"
     api-interface: "jsonrpc"
@@ -107,3 +114,4 @@ backup-direct-rpc:
         skip-verifications:
           - chain-id
           - pruning
+      - url: "wss://rpc.ankr.com/eth/ws"

--- a/config/smartrouter_examples/smartrouter_lava.yml
+++ b/config/smartrouter_examples/smartrouter_lava.yml
@@ -16,6 +16,10 @@ endpoints:
     chain-id: "LAVA"
     api-interface: "tendermintrpc"
 
+  - network-address: "0.0.0.0:3363"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+
 direct-rpc:
   # 3 upstream REST endpoints (PublicNode TLS)
   - name: "lava-publicnode-rest-1"
@@ -122,3 +126,46 @@ direct-rpc:
       - url: "wss://lava-rpc.publicnode.com:443/websocket"
         skip-verifications:
           - pruning
+
+  # 3 upstream Ethereum JSON-RPC endpoints.
+  # Each provider must include a wss:// URL alongside the https:// URL so the
+  # router can serve eth_subscribe (websocket is a required addon for ETH1).
+  - name: "eth-rpc-1"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://eth.llamarpc.com"
+        skip-verifications:
+          - chain-id
+          - pruning
+      - url: "wss://ethereum-rpc.publicnode.com"
+        skip-verifications:
+          - chain-id
+          - pruning
+
+  - name: "eth-rpc-2"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://ethereum-rpc.publicnode.com"
+        skip-verifications:
+          - chain-id
+          - pruning
+      - url: "wss://ethereum-rpc.publicnode.com"
+        skip-verifications:
+          - chain-id
+          - pruning
+
+  - name: "eth-rpc-3"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://rpc.ankr.com/eth"
+        skip-verifications:
+          - chain-id
+          - pruning
+      - url: "wss://ethereum-rpc.publicnode.com"
+        skip-verifications:
+          - chain-id
+          - pruning
+

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -462,18 +462,26 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 		return err
 	}
 
-	// Filter the relevant static providers
+	// Filter the relevant static providers.
+	// IMPORTANT: filter on both ChainID *and* ApiInterface. A single chain (e.g. LAVA)
+	// can expose several api-interfaces (rest, grpc, tendermintrpc); selecting only by
+	// ChainID would let, say, the grpc endpoint pick a rest provider as its chain
+	// tracker source. The chain tracker would then craft a grpc-shaped GET_BLOCKNUM
+	// message (from the grpc chainParser) but dispatch it through the rest proxy,
+	// which fails with "invalid message type in rest" and aborts startup.
 	relevantStaticProviderList := []*lavasession.RPCStaticProviderEndpoint{}
 	for _, staticProvider := range options.staticProvidersList {
-		if staticProvider.ChainID == rpcEndpoint.ChainID {
+		if staticProvider.ChainID == rpcEndpoint.ChainID &&
+			staticProvider.ApiInterface == rpcEndpoint.ApiInterface {
 			relevantStaticProviderList = append(relevantStaticProviderList, staticProvider)
 		}
 	}
 
-	// Filter backup providers for this chain (needed for policy derivation)
+	// Filter backup providers for this chain+interface (needed for policy derivation)
 	relevantBackupProviderList := []*lavasession.RPCStaticProviderEndpoint{}
 	for _, backupProvider := range options.backupProvidersList {
-		if backupProvider.ChainID == rpcEndpoint.ChainID {
+		if backupProvider.ChainID == rpcEndpoint.ChainID &&
+			backupProvider.ApiInterface == rpcEndpoint.ApiInterface {
 			relevantBackupProviderList = append(relevantBackupProviderList, backupProvider)
 		}
 	}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -47,8 +47,16 @@ import (
 	"github.com/magma-Devs/smart-router/utils/rand"
 	scoreutils "github.com/magma-Devs/smart-router/utils/score"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
+
+// wordSepNormalizeFunc maps `_` → `-` in flag names so the binary accepts
+// both `--log_level` (cosmos-sdk style) and `--log-level` (cobra default).
+// Required by the existing Helm chart, which still passes underscored flags.
+func wordSepNormalizeFunc(_ *pflag.FlagSet, name string) pflag.NormalizedName {
+	return pflag.NormalizedName(strings.ReplaceAll(name, "_", "-"))
+}
 
 const (
 	DefaultRPCSmartRouterFileName = "rpcsmartrouter.yml"
@@ -1505,6 +1513,25 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 
 			return err
 		},
+	}
+
+	// Accept both `--log_level` and `--log-level` (and any other underscored
+	// flag name) — the deployed Helm chart still passes cosmos-sdk-style
+	// underscored flags. Without this, pods crash on startup with
+	// "unknown flag: --log_level". See BUG_REPORT_log_flag.md.
+	cmdRPCSmartRouter.Flags().SetNormalizeFunc(wordSepNormalizeFunc)
+
+	// Hidden no-op flags retained for backward compatibility with the existing
+	// Helm chart (`oci://ghcr.io/magma-devs/smart-router-helm-chart`), which
+	// still passes flags removed during the smart-router rewrite. Without
+	// these, pods crash on startup with "unknown flag: ...". Each is a Bool
+	// so it works with `--flag` (no value) and `--flag=true`/`--flag=false`.
+	for _, deprecated := range []string{
+		"skip-policy-verification",
+		"skip-relay-signing",
+	} {
+		cmdRPCSmartRouter.Flags().Bool(deprecated, false, "DEPRECATED: no-op, retained for chart compatibility")
+		_ = cmdRPCSmartRouter.Flags().MarkHidden(deprecated)
 	}
 
 	// RPCSmartRouter command flags - no blockchain flags needed


### PR DESCRIPTION

Closes: #MAG-1611 #MAG-1630
This pull request introduces several improvements to the smart router configuration and codebase, primarily focused on enhancing Ethereum (ETH1) support and increasing compatibility with existing deployment tools. The main changes include adding more robust and diverse Ethereum JSON-RPC endpoints (including WebSocket support) to the example configuration files, and improving command-line flag handling for better compatibility with Helm charts and legacy flag formats. Additionally, the smart router now filters providers more accurately by both chain ID and API interface, reducing configuration errors.

**Configuration enhancements:**

* Added multiple new Ethereum JSON-RPC endpoints (with both HTTP and WebSocket URLs) to `smartrouter_eth.yml` and `smartrouter_lava.yml`, including endpoints from LlamaRPC, PublicNode, Google, and QuickNode, to improve redundancy and support for `eth_subscribe` and other WebSocket-based features. [[1]](diffhunk://#diff-465a38c1ff6e9c1280e73e68d774b4e005f362e72dd6613c78f22bde21bcbfc8R21-R23) [[2]](diffhunk://#diff-465a38c1ff6e9c1280e73e68d774b4e005f362e72dd6613c78f22bde21bcbfc8R32-R34) [[3]](diffhunk://#diff-465a38c1ff6e9c1280e73e68d774b4e005f362e72dd6613c78f22bde21bcbfc8R43) [[4]](diffhunk://#diff-465a38c1ff6e9c1280e73e68d774b4e005f362e72dd6613c78f22bde21bcbfc8R66-R108) [[5]](diffhunk://#diff-465a38c1ff6e9c1280e73e68d774b4e005f362e72dd6613c78f22bde21bcbfc8R117) [[6]](diffhunk://#diff-4cb64f53b39285b5287a6ed3ec919488725093e2f4c81637f3c070b7906aea62R129-R171)

* Updated endpoint comments and section headers in the configuration files to reflect the addition of HTTP+WS support and to clarify the purpose of each endpoint group. [[1]](diffhunk://#diff-465a38c1ff6e9c1280e73e68d774b4e005f362e72dd6613c78f22bde21bcbfc8L12-R12) [[2]](diffhunk://#diff-465a38c1ff6e9c1280e73e68d774b4e005f362e72dd6613c78f22bde21bcbfc8R21-R23) [[3]](diffhunk://#diff-465a38c1ff6e9c1280e73e68d774b4e005f362e72dd6613c78f22bde21bcbfc8R32-R34) [[4]](diffhunk://#diff-465a38c1ff6e9c1280e73e68d774b4e005f362e72dd6613c78f22bde21bcbfc8R43) [[5]](diffhunk://#diff-465a38c1ff6e9c1280e73e68d774b4e005f362e72dd6613c78f22bde21bcbfc8R66-R108)

**Codebase compatibility and robustness:**

* Introduced a normalization function (`wordSepNormalizeFunc`) in `rpcsmartrouter.go` to allow both `--log_level` (cosmos-sdk style) and `--log-level` (cobra default) flag formats, ensuring compatibility with existing Helm charts and preventing startup errors due to unknown flags. [[1]](diffhunk://#diff-59449fcf7834b8c6f369cebb6610763eb8210ba05a6109e60460b8840f913d2aR50-R60) [[2]](diffhunk://#diff-59449fcf7834b8c6f369cebb6610763eb8210ba05a6109e60460b8840f913d2aR1518-R1536)

* Added hidden no-op flags for deprecated options (`skip-policy-verification`, `skip-relay-signing`) to maintain backward compatibility with existing deployment scripts and Helm charts.

**Provider selection logic:**

* Improved filtering of static and backup providers in `CreateSmartRouterEndpoint` to require both `ChainID` and `ApiInterface` to match, preventing misconfiguration where, for example, a gRPC endpoint could incorrectly select a REST provider as its source.
Summary
Fixes a startup panic in smartrouter when a chain is configured with multiple api-interfaces (e.g. LAVA exposing rest, grpc, and tendermintrpc). Previously, the chain-tracker for one endpoint could pick a provider belonging to a different api-interface, causing it to dispatch a chainMessage shaped for one interface (e.g. gRPC cosmos.base.tendermint.v1beta1.Service/GetLatestBlock) into the proxy of another interface (e.g. REST). The REST proxy then failed the type cast in protocol/chainlib/rest.go with invalid message type in rest, failed to cast RPCInput from chainMessage, the chain-tracker creation aborted, and the process exited with [PANIC] failed creating chain router for verification.

Root Cause
In protocol/rpcsmartrouter/rpcsmartrouter.go, relevantStaticProviderList and relevantBackupProviderList were filtered only by ChainID:

for _, staticProvider := range options.staticProvidersList {
    if staticProvider.ChainID == rpcEndpoint.ChainID {
        relevantStaticProviderList = append(relevantStaticProviderList, staticProvider)
    }
}
The chain-tracker setup (Phase 2) then used relevantStaticProviderList[0] as the bootstrap provider. Because chainParser is built per (ChainID, ApiInterface) (filtered in base_chain_parser.go), the parser and the chain-router could end up bound to different api-interfaces, producing mismatched messages.

Fix
Filter both provider lists by ChainID and ApiInterface so each endpoint goroutine only ever sees providers matching its own interface. This keeps chainParser, chainRouter, and chainTrackerEndpoint aligned per (chain, apiInterface) tuple.

if staticProvider.ChainID == rpcEndpoint.ChainID &&
    staticProvider.ApiInterface == rpcEndpoint.ApiInterface {
    relevantStaticProviderList = append(relevantStaticProviderList, staticProvider)
}
Same change applied to relevantBackupProviderList.

Files Changed
protocol/rpcsmartrouter/rpcsmartrouter.go — provider filter now includes ApiInterface; added an explanatory comment about the multi-interface dispatch invariant.
config/smartrouter_examples/smartrouter_lava.yml — added a wss:// upstream to each eth-rpc-* provider so ETH1 satisfies the websocket addon required for eth_subscribe.
How to Reproduce (before fix)
Check out main.
Build:
go build -o ./build/smartrouter ./cmd/smartrouter
Run with the LAVA example config:
./build/smartrouter config/smartrouter_examples/smartrouter_lava.yml \
  --geolocation 1 --use-static-spec specs/
Observe panic:
ERR invalid message type in rest, failed to cast RPCInput from chainMessage
    rpcMessage="...Path:cosmos.base.tendermint.v1beta1.Service/GetLatestBlock..."
ERR Chain tracker failed ... chain=LAVA
Error: [PANIC] failed creating chain router for verification ...
Verification (after fix)
Same command on this branch produces:

INF Chain tracker started chain=LAVA
INF ChainTracker initialization complete chainID=LAVA failed=0 success=6
INF [+] init relay succeeded ... APIInterface=grpc
INF [+] init relay succeeded ... APIInterface=tendermintrpc
INF RPCSmartRouter Listening endpoints="LAVA:tendermintrpc Network Address:0.0.0.0:3362 ..."
INF RPCSmartRouter done setting up all endpoints, ready for requests
Listeners confirmed on 3360 (LAVA rest), 3361 (LAVA grpc), 3362 (LAVA tendermintrpc), 3363 (ETH1 jsonrpc). No invalid message type in rest errors.

Risk / Compatibility
Behavior change scoped to provider filtering during endpoint setup.
Configurations with a single api-interface per chain are unaffected (filter result is identical).
Configurations relying on the previous (buggy) behavior — i.e. expecting a provider of a different api-interface to bootstrap a chain-tracker — would not have worked anyway (they panicked at startup).
Follow-ups (not in this PR)
Add a unit test in protocol/rpcsmartrouter that constructs options with two api-interfaces for the same ChainID and asserts the chainTrackerEndpoint per goroutine matches rpcEndpoint.ApiInterface.
Consider preferring non-wss:// URLs when selecting the chain-tracker’s bootstrap node, to silence the residual wss chain-tracker fetch errors observed when both schemes are present in the same provider.
Author Checklist
I have...

read the [contribution guide](https://github.com/magma-Devs/smart-router/blob/main/CONTRIBUTING.md)
included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title (fix(rpcsmartrouter): ...)
confirmed ! in the type prefix if API or client breaking change — N/A, no breaking change
targeted the main branch
provided a link to the relevant issue or specification (MAG-1611)
reviewed "Files changed" and left comments if necessary
included the necessary unit and integration tests — follow-up tracked above
updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
confirmed all CI checks have passed — pending CI run
Reviewers Checklist
I have...

confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
confirmed all author checklist items have been addressed
reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage