### PR TITLE
fix(chain-tracker): filter providers by ApiInterface + refresh example configs

### DIFF
--- a/config/smartrouter_examples/smartrouter_eth.yml
+++ b/config/smartrouter_examples/smartrouter_eth.yml
@@ -60,6 +60,43 @@ direct-rpc:
     node-urls:
       - url: "wss://ethereum-rpc.publicnode.com"
 
+  # Additional JSON-RPC test nodes (kept duplicated intentionally)
+  - name: "Google1"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://json-rpc.8zfcse2amst1lajmh299uq4jn.blockchainnodeengine.com?key=AIzaSyDyUtm6b-e-xKDQgVWzlroHdVTytiXEDik"
+        skip-verifications:
+          - chain-id
+          - pruning
+
+  - name: "Google2"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://json-rpc.8zfcse2amst1lajmh299uq4jn.blockchainnodeengine.com?key=AIzaSyDyUtm6b-e-xKDQgVWzlroHdVTytiXEDik"
+        skip-verifications:
+          - chain-id
+          - pruning
+
+  - name: "QuickNode1"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://wispy-distinguished-glitter.quiknode.pro/c6f9247c83ef5fd069dbef2c228ee1229b55e406/"
+        skip-verifications:
+          - chain-id
+          - pruning
+
+  - name: "QuickNode2"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://wispy-distinguished-glitter.quiknode.pro/c6f9247c83ef5fd069dbef2c228ee1229b55e406/"
+        skip-verifications:
+          - chain-id
+          - pruning
+
 backup-direct-rpc:
   # Backup HTTP Endpoint (used only when all primary direct-rpc peers are exhausted)
   - name: "eth-rpc-backup"

--- a/config/smartrouter_examples/smartrouter_eth.yml
+++ b/config/smartrouter_examples/smartrouter_eth.yml
@@ -9,7 +9,7 @@ endpoints:
     network-address: "0.0.0.0:3360"
 
 direct-rpc:
-  # HTTP Endpoint 1
+  # HTTP+WS Endpoint 1
   - name: "eth-rpc-1"
     chain-id: "ETH1"
     api-interface: "jsonrpc"
@@ -18,8 +18,9 @@ direct-rpc:
         skip-verifications:
           - chain-id
           - pruning
+      - url: "wss://eth.llamarpc.com"
 
-  # HTTP Endpoint 2
+  # HTTP+WS Endpoint 2
   - name: "eth-rpc-2"
     chain-id: "ETH1"
     api-interface: "jsonrpc"
@@ -28,8 +29,9 @@ direct-rpc:
         skip-verifications:
           - chain-id
           - pruning
+      - url: "wss://json-rpc.8zfcse2amst1lajmh299uq4jn.blockchainnodeengine.com/?key=AIzaSyDyUtm6b-e-xKDQgVWzlroHdVTytiXEDik"
 
-  # HTTP Endpoint 3
+  # HTTP+WS Endpoint 3
   - name: "eth-rpc-3"
     chain-id: "ETH1"
     api-interface: "jsonrpc"
@@ -38,6 +40,7 @@ direct-rpc:
         skip-verifications:
           - chain-id
           - pruning
+      - url: "wss://ethereum-rpc.publicnode.com"
 
   # WebSocket Endpoint 1 (Phase 5 - Subscriptions)
   - name: "eth-ws-1"
@@ -69,6 +72,7 @@ direct-rpc:
         skip-verifications:
           - chain-id
           - pruning
+      - url: "wss://json-rpc.8zfcse2amst1lajmh299uq4jn.blockchainnodeengine.com?key=AIzaSyDyUtm6b-e-xKDQgVWzlroHdVTytiXEDik"
 
   - name: "Google2"
     chain-id: "ETH1"
@@ -78,6 +82,7 @@ direct-rpc:
         skip-verifications:
           - chain-id
           - pruning
+      - url: "wss://json-rpc.8zfcse2amst1lajmh299uq4jn.blockchainnodeengine.com?key=AIzaSyDyUtm6b-e-xKDQgVWzlroHdVTytiXEDik"
 
   - name: "QuickNode1"
     chain-id: "ETH1"
@@ -87,6 +92,7 @@ direct-rpc:
         skip-verifications:
           - chain-id
           - pruning
+      - url: "wss://wispy-distinguished-glitter.quiknode.pro/c6f9247c83ef5fd069dbef2c228ee1229b55e406/"
 
   - name: "QuickNode2"
     chain-id: "ETH1"
@@ -96,9 +102,10 @@ direct-rpc:
         skip-verifications:
           - chain-id
           - pruning
+      - url: "wss://wispy-distinguished-glitter.quiknode.pro/c6f9247c83ef5fd069dbef2c228ee1229b55e406/"
 
 backup-direct-rpc:
-  # Backup HTTP Endpoint (used only when all primary direct-rpc peers are exhausted)
+  # Backup HTTP+WS Endpoint (used only when all primary direct-rpc peers are exhausted)
   - name: "eth-rpc-backup"
     chain-id: "ETH1"
     api-interface: "jsonrpc"
@@ -107,3 +114,4 @@ backup-direct-rpc:
         skip-verifications:
           - chain-id
           - pruning
+      - url: "wss://rpc.ankr.com/eth/ws"

--- a/config/smartrouter_examples/smartrouter_lava.yml
+++ b/config/smartrouter_examples/smartrouter_lava.yml
@@ -16,6 +16,10 @@ endpoints:
     chain-id: "LAVA"
     api-interface: "tendermintrpc"
 
+  - network-address: "0.0.0.0:3363"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+
 direct-rpc:
   # 3 upstream REST endpoints (PublicNode TLS)
   - name: "lava-publicnode-rest-1"
@@ -122,3 +126,46 @@ direct-rpc:
       - url: "wss://lava-rpc.publicnode.com:443/websocket"
         skip-verifications:
           - pruning
+
+  # 3 upstream Ethereum JSON-RPC endpoints.
+  # Each provider must include a wss:// URL alongside the https:// URL so the
+  # router can serve eth_subscribe (websocket is a required addon for ETH1).
+  - name: "eth-rpc-1"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://eth.llamarpc.com"
+        skip-verifications:
+          - chain-id
+          - pruning
+      - url: "wss://ethereum-rpc.publicnode.com"
+        skip-verifications:
+          - chain-id
+          - pruning
+
+  - name: "eth-rpc-2"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://ethereum-rpc.publicnode.com"
+        skip-verifications:
+          - chain-id
+          - pruning
+      - url: "wss://ethereum-rpc.publicnode.com"
+        skip-verifications:
+          - chain-id
+          - pruning
+
+  - name: "eth-rpc-3"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://rpc.ankr.com/eth"
+        skip-verifications:
+          - chain-id
+          - pruning
+      - url: "wss://ethereum-rpc.publicnode.com"
+        skip-verifications:
+          - chain-id
+          - pruning
+

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -462,18 +462,26 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 		return err
 	}
 
-	// Filter the relevant static providers
+	// Filter the relevant static providers.
+	// IMPORTANT: filter on both ChainID *and* ApiInterface. A single chain (e.g. LAVA)
+	// can expose several api-interfaces (rest, grpc, tendermintrpc); selecting only by
+	// ChainID would let, say, the grpc endpoint pick a rest provider as its chain
+	// tracker source. The chain tracker would then craft a grpc-shaped GET_BLOCKNUM
+	// message (from the grpc chainParser) but dispatch it through the rest proxy,
+	// which fails with "invalid message type in rest" and aborts startup.
 	relevantStaticProviderList := []*lavasession.RPCStaticProviderEndpoint{}
 	for _, staticProvider := range options.staticProvidersList {
-		if staticProvider.ChainID == rpcEndpoint.ChainID {
+		if staticProvider.ChainID == rpcEndpoint.ChainID &&
+			staticProvider.ApiInterface == rpcEndpoint.ApiInterface {
 			relevantStaticProviderList = append(relevantStaticProviderList, staticProvider)
 		}
 	}
 
-	// Filter backup providers for this chain (needed for policy derivation)
+	// Filter backup providers for this chain+interface (needed for policy derivation)
 	relevantBackupProviderList := []*lavasession.RPCStaticProviderEndpoint{}
 	for _, backupProvider := range options.backupProvidersList {
-		if backupProvider.ChainID == rpcEndpoint.ChainID {
+		if backupProvider.ChainID == rpcEndpoint.ChainID &&
+			backupProvider.ApiInterface == rpcEndpoint.ApiInterface {
 			relevantBackupProviderList = append(relevantBackupProviderList, backupProvider)
 		}
 	}


### PR DESCRIPTION
Closes #MAG-1611

### Code change — chain-tracker provider filter
Filters `relevantStaticProviderList` and `relevantBackupProviderList` by both `ChainID` *and* `ApiInterface`. Without this, chains exposing multiple api-interfaces (e.g. LAVA: rest/grpc/tendermintrpc) crashed at startup with `invalid message type in rest`, because the chain tracker for one endpoint could pick a provider belonging to a different api-interface and dispatch a parser-shaped message through the wrong proxy.

### Config-example refresh
- `smartrouter_lava.yml`: add ETH wss upstreams.
- `smartrouter_eth.yml`: add additional JSON-RPC test nodes for chain tracker.
- `smartrouter_eth.yml`: update RPC endpoints to support WebSocket connections (adds wss URLs alongside existing https).

These keep the bundled examples usable for local chain-tracker testing.

## Test plan
- [x] `make test` passes (full suite, all packages ok)
- [x] `make lint` clean
- [ ] Local run with the eth example config still loads and the chain tracker initialises cleanly:
  `smartrouter config/smartrouter_examples/smartrouter_eth.yml --geolocation 1 --use-static-spec specs/`
- [ ] Local run with the lava example config initialises chain trackers for all three api-interfaces (rest, grpc, tendermintrpc) without `invalid message type in rest`.

