### PR TITLE
fix: if a provider is failing to set up, do not panic, add to retry list

### DIFF
--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -1792,11 +1792,16 @@ func (rpsr *RPCSmartRouter) updateEpoch(epoch uint64) {
 			rpsr.backupProviderSessions[chainKey] = freshBackupSessions
 		}
 		server := rpsr.rpcServers[chainKey]
+
+		// UpdateAllProviders stays under rpsr.mu so the (rpsr.providerSessions write
+		// → csm push) pair is atomic with retryFailedStaticProviders' matching pair.
+		// Otherwise the two callers can push snapshots to csm in the opposite order
+		// they wrote rpsr.providerSessions, silently dropping providers until the
+		// next epoch. The synchronous body of UpdateAllProviders is a bounded map
+		// rebuild; probing is dispatched to a goroutine.
+		err := sessionManager.UpdateAllProviders(epoch, freshProviderSessions, freshBackupSessions)
 		rpsr.mu.Unlock()
 
-		// Heavy calls stay outside the lock (UpdateAllProviders triggers async probing,
-		// cleanupStaleTrackers does tracker removal)
-		err := sessionManager.UpdateAllProviders(epoch, freshProviderSessions, freshBackupSessions)
 		if err != nil {
 			utils.LavaFormatError("Failed to update providers on epoch change", err,
 				utils.LogAttr("epoch", epoch),
@@ -1804,8 +1809,9 @@ func (rpsr *RPCSmartRouter) updateEpoch(epoch uint64) {
 			)
 		}
 
-		// Cleanup stale ChainTrackers for endpoints no longer in the provider sessions
-		// This must happen AFTER UpdateAllProviders so connections are closed first
+		// cleanupStaleTrackers is the genuinely heavy work (tracker teardown +
+		// connection close) and stays outside the lock. Must run AFTER
+		// UpdateAllProviders so connections are closed first.
 		if server != nil {
 			rpsr.cleanupStaleTrackers(chainKey, server, freshProviderSessions, freshBackupSessions)
 		}
@@ -1954,10 +1960,16 @@ func (rpsr *RPCSmartRouter) retryFailedStaticProviders(
 
 			sessionManager := rpsr.sessionManagers[sessionManagerKey]
 			backupSessions := rpsr.backupProviderSessions[sessionManagerKey]
+
+			// UpdateAllProviders stays under rpsr.mu so this (rpsr.providerSessions
+			// write → csm push) pair is atomic with updateEpoch's matching pair.
+			// Otherwise a concurrent epoch tick can push to csm in the opposite
+			// order it wrote rpsr.providerSessions, silently dropping recovered
+			// providers until the next epoch.
+			err := sessionManager.UpdateAllProviders(currentEpoch, mergedSessions, backupSessions)
 			rpsr.mu.Unlock()
 
-			// Re-register all providers with session manager
-			if err := sessionManager.UpdateAllProviders(currentEpoch, mergedSessions, backupSessions); err != nil {
+			if err != nil {
 				utils.LavaFormatWarning("retry: failed to re-register recovered providers", err,
 					utils.LogAttr("chain", rpcEndpoint.ChainID),
 				)

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -148,10 +148,15 @@ type AnalyticsServerAddresses struct {
 type RPCSmartRouter struct {
 	// Smart router doesn't need blockchain state tracking
 	epochTimer             *common.EpochTimer
-	mu                     sync.Mutex                                                      // protects the four maps below during parallel endpoint setup
+	mu                     sync.Mutex                                                      // protects the maps below during parallel endpoint setup and retry
 	sessionManagers        map[string]*lavasession.ConsumerSessionManager                  // key: chainID-apiInterface
 	providerSessions       map[string]map[uint64]*lavasession.ConsumerSessionsWithProvider // key: chainID-apiInterface
 	backupProviderSessions map[string]map[uint64]*lavasession.ConsumerSessionsWithProvider // key: chainID-apiInterface
+
+	// failedStaticProviders holds providers that failed verification at startup,
+	// keyed by sessionManagerKey (chainID-apiInterface). The retry loop reads this
+	// to periodically re-validate and re-register recovered providers.
+	failedStaticProviders map[string][]*lavasession.RPCStaticProviderEndpoint
 
 	// Server references for per-endpoint ChainTracker cleanup on epoch updates
 	rpcServers map[string]*RPCSmartRouterServer // key: chainID-apiInterface
@@ -186,6 +191,7 @@ func (rpsr *RPCSmartRouter) Start(ctx context.Context, options *rpcSmartRouterSt
 	rpsr.sessionManagers = make(map[string]*lavasession.ConsumerSessionManager)
 	rpsr.providerSessions = make(map[string]map[uint64]*lavasession.ConsumerSessionsWithProvider)
 	rpsr.backupProviderSessions = make(map[string]map[uint64]*lavasession.ConsumerSessionsWithProvider)
+	rpsr.failedStaticProviders = make(map[string][]*lavasession.RPCStaticProviderEndpoint)
 	rpsr.rpcServers = make(map[string]*RPCSmartRouterServer)
 
 	// RPCSmartRouter always runs in standalone mode with time-based epochs
@@ -708,13 +714,285 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 		return sessions
 	}
 
-	// Convert static providers to ConsumerSessionsWithProvider format
-	providerSessions := convertProvidersToSessions(relevantStaticProviderList)
+	// ============================================================================
+	// PHASE 1: Static Provider Validation
+	// ============================================================================
+	// Validate static providers BEFORE converting to sessions or registering.
+	// Only validates providers matching this endpoint's api-interface.
+	// See: the provider's validation approach for reference.
+	var failedStaticNames map[string]struct{}
+	var failedStaticEndpoints []*lavasession.RPCStaticProviderEndpoint
 
-	// Convert backup providers to sessions (already filtered above during policy derivation)
-	var backupProviderSessions map[uint64]*lavasession.ConsumerSessionsWithProvider
+	if len(relevantStaticProviderList) > 0 {
+		utils.LavaFormatInfo("Validating static providers",
+			utils.LogAttr("chain", rpcEndpoint.ChainID),
+			utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
+			utils.LogAttr("providerCount", len(relevantStaticProviderList)),
+		)
+
+		totalAttemptedCount := 0
+		failedStaticNames = make(map[string]struct{})
+
+		for _, staticProvider := range relevantStaticProviderList {
+			// Skip providers with different api-interface (validated by their own endpoint)
+			if staticProvider.ApiInterface != rpcEndpoint.ApiInterface {
+				utils.LavaFormatDebug("Skipping provider - different api-interface",
+					utils.LogAttr("provider", staticProvider.Name),
+					utils.LogAttr("providerInterface", staticProvider.ApiInterface),
+					utils.LogAttr("endpointInterface", rpcEndpoint.ApiInterface),
+				)
+				continue
+			}
+			totalAttemptedCount++
+
+			// Prepare ALL URLs for validation together (matches provider behavior).
+			// ChainRouter requires both with-addon and without-addon routes for addon URLs
+			// (see chain_router.go:258 which appends "" to addons list).
+			verificationNodeUrls := []common.NodeUrl{}
+			for _, nodeUrl := range staticProvider.NodeUrls {
+				verificationNodeUrls = append(verificationNodeUrls, nodeUrl)
+				// For addon URLs, also add a non-addon copy for routing flexibility
+				if len(nodeUrl.Addons) > 0 {
+					noAddonUrl := nodeUrl
+					noAddonUrl.Addons = []string{}
+					verificationNodeUrls = append(verificationNodeUrls, noAddonUrl)
+				}
+			}
+
+			verificationEndpoint := &lavasession.RPCProviderEndpoint{
+				NetworkAddress: staticProvider.NetworkAddress,
+				ChainID:        staticProvider.ChainID,
+				ApiInterface:   staticProvider.ApiInterface,
+				Geolocation:    staticProvider.Geolocation,
+				NodeUrls:       verificationNodeUrls,
+			}
+
+			// Scoped context for this verification attempt. GetChainRouter creates
+			// connector goroutines tied to ctx that only exit on cancellation.
+			// Without this, temporary routers leak goroutines for the app lifetime.
+			// Timeout bounds a hung provider (e.g. blackholed TCP) so it can't stall
+			// validation of the remaining providers.
+			verifyCtx, verifyCancel := context.WithTimeout(ctx, 30*time.Second)
+
+			// Create chain router with all URLs for complete supportedMap (HTTP + WebSocket)
+			parallelConnections := uint(lavasession.DefaultMaximumStreamsOverASingleConnection)
+			verificationRouter, err := chainlib.GetChainRouter(verifyCtx, parallelConnections, verificationEndpoint, chainParser)
+			if err != nil {
+				verifyCancel()
+				failedStaticNames[staticProvider.Name] = struct{}{}
+				failedStaticEndpoints = append(failedStaticEndpoints, staticProvider)
+				utils.LavaFormatWarning("static provider: failed creating chain router — excluding from provider list", err,
+					utils.LogAttr("chain", rpcEndpoint.ChainID),
+					utils.LogAttr("provider", staticProvider.Name),
+				)
+				continue
+			}
+
+			// Create full ChainFetcher for verification (respects severity, skip-verifications)
+			verificationFetcher := chainlib.NewChainFetcher(verifyCtx, &chainlib.ChainFetcherOptions{
+				ChainRouter: verificationRouter,
+				ChainParser: chainParser,
+				Endpoint:    verificationEndpoint,
+				Cache:       nil,
+			})
+
+			utils.LavaFormatInfo("Validating static provider",
+				utils.LogAttr("name", staticProvider.Name),
+				utils.LogAttr("chain", rpcEndpoint.ChainID),
+				utils.LogAttr("urlCount", len(staticProvider.NodeUrls)),
+			)
+
+			err = verificationFetcher.Validate(verifyCtx)
+			verifyCancel() // cleanup temporary router resources regardless of outcome
+			if err != nil {
+				failedStaticNames[staticProvider.Name] = struct{}{}
+				failedStaticEndpoints = append(failedStaticEndpoints, staticProvider)
+				utils.LavaFormatWarning("static provider validation failed — excluding from provider list", err,
+					utils.LogAttr("chain", rpcEndpoint.ChainID),
+					utils.LogAttr("provider", staticProvider.Name),
+				)
+				continue
+			}
+
+			utils.LavaFormatInfo("Static provider validated successfully",
+				utils.LogAttr("chain", rpcEndpoint.ChainID),
+				utils.LogAttr("provider", staticProvider.Name),
+			)
+		}
+
+		healthyCount := totalAttemptedCount - len(failedStaticNames)
+
+		// If ALL static providers failed verification, this endpoint cannot serve traffic
+		if totalAttemptedCount > 0 && healthyCount == 0 {
+			err := utils.LavaFormatError("all static providers failed verification — cannot serve endpoint", nil,
+				utils.LogAttr("chain", rpcEndpoint.ChainID),
+				utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
+				utils.LogAttr("failedCount", len(failedStaticNames)),
+			)
+			errCh <- err
+			return err
+		}
+
+		if len(failedStaticNames) > 0 {
+			utils.LavaFormatWarning("ATTENTION: some static providers failed verification and were excluded — they will be retried in the background",
+				nil,
+				utils.LogAttr("chain", rpcEndpoint.ChainID),
+				utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
+				utils.LogAttr("failed", len(failedStaticNames)),
+				utils.LogAttr("healthy", healthyCount),
+			)
+		} else {
+			utils.LavaFormatInfo("All providers validated for api-interface",
+				utils.LogAttr("chain", rpcEndpoint.ChainID),
+				utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
+				utils.LogAttr("validated", healthyCount),
+				utils.LogAttr("total", len(relevantStaticProviderList)),
+			)
+		}
+	}
+
+	// ============================================================================
+	// PHASE 1B: Backup Provider Validation (non-fatal)
+	// ============================================================================
+	// Validate backup providers using the same logic as PHASE 1, but treat all
+	// failures as non-fatal warnings. A broken backup should never block startup —
+	// static providers must still serve. Operators are clearly notified at startup
+	// so they can fix backup endpoints before they are actually needed in an emergency.
+	// Providers that fail validation are excluded from the registered backup list.
+	var failedBackupNames map[string]struct{}
+
 	if len(relevantBackupProviderList) > 0 {
-		backupProviderSessions = convertProvidersToSessions(relevantBackupProviderList)
+		utils.LavaFormatInfo("Validating backup providers (non-fatal)",
+			utils.LogAttr("chain", rpcEndpoint.ChainID),
+			utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
+			utils.LogAttr("backupCount", len(relevantBackupProviderList)),
+		)
+
+		failedBackupNames = make(map[string]struct{})
+		validatedBackups := 0
+		for _, backupProvider := range relevantBackupProviderList {
+			if backupProvider.ApiInterface != rpcEndpoint.ApiInterface {
+				utils.LavaFormatDebug("Skipping backup provider - different api-interface",
+					utils.LogAttr("provider", backupProvider.Name),
+					utils.LogAttr("providerInterface", backupProvider.ApiInterface),
+					utils.LogAttr("endpointInterface", rpcEndpoint.ApiInterface),
+				)
+				continue
+			}
+			validatedBackups++
+
+			// Build verificationNodeUrls with addon expansion (identical to PHASE 1)
+			verificationNodeUrls := []common.NodeUrl{}
+			for _, nodeUrl := range backupProvider.NodeUrls {
+				verificationNodeUrls = append(verificationNodeUrls, nodeUrl)
+				if len(nodeUrl.Addons) > 0 {
+					noAddonUrl := nodeUrl
+					noAddonUrl.Addons = []string{}
+					verificationNodeUrls = append(verificationNodeUrls, noAddonUrl)
+				}
+			}
+
+			verificationEndpoint := &lavasession.RPCProviderEndpoint{
+				NetworkAddress: backupProvider.NetworkAddress,
+				ChainID:        backupProvider.ChainID,
+				ApiInterface:   backupProvider.ApiInterface,
+				Geolocation:    backupProvider.Geolocation,
+				NodeUrls:       verificationNodeUrls,
+			}
+
+			verifyCtx, verifyCancel := context.WithCancel(ctx)
+
+			parallelConnections := uint(lavasession.DefaultMaximumStreamsOverASingleConnection)
+			verificationRouter, err := chainlib.GetChainRouter(verifyCtx, parallelConnections, verificationEndpoint, chainParser)
+			if err != nil {
+				verifyCancel()
+				failedBackupNames[backupProvider.Name] = struct{}{}
+				utils.LavaFormatWarning("backup provider: failed creating chain router — excluding from backup list", err,
+					utils.LogAttr("chain", rpcEndpoint.ChainID),
+					utils.LogAttr("provider", backupProvider.Name),
+				)
+				continue
+			}
+
+			verificationFetcher := chainlib.NewChainFetcher(verifyCtx, &chainlib.ChainFetcherOptions{
+				ChainRouter: verificationRouter,
+				ChainParser: chainParser,
+				Endpoint:    verificationEndpoint,
+				Cache:       nil,
+			})
+
+			utils.LavaFormatInfo("Validating backup provider",
+				utils.LogAttr("name", backupProvider.Name),
+				utils.LogAttr("chain", rpcEndpoint.ChainID),
+				utils.LogAttr("urlCount", len(backupProvider.NodeUrls)),
+			)
+
+			err = verificationFetcher.Validate(verifyCtx)
+			verifyCancel()
+			if err != nil {
+				failedBackupNames[backupProvider.Name] = struct{}{}
+				utils.LavaFormatWarning("backup provider validation failed — excluding from backup list", err,
+					utils.LogAttr("chain", rpcEndpoint.ChainID),
+					utils.LogAttr("provider", backupProvider.Name),
+				)
+				continue
+			}
+
+			utils.LavaFormatInfo("Backup provider validated successfully",
+				utils.LogAttr("chain", rpcEndpoint.ChainID),
+				utils.LogAttr("provider", backupProvider.Name),
+			)
+		}
+
+		if len(failedBackupNames) > 0 {
+			utils.LavaFormatWarning("ATTENTION: some backup providers failed validation and were excluded — they will not be used during emergency failover",
+				nil,
+				utils.LogAttr("chain", rpcEndpoint.ChainID),
+				utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
+				utils.LogAttr("failed", len(failedBackupNames)),
+				utils.LogAttr("validated", validatedBackups),
+			)
+		} else {
+			utils.LavaFormatInfo("All backup providers validated",
+				utils.LogAttr("chain", rpcEndpoint.ChainID),
+				utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
+				utils.LogAttr("validated", validatedBackups),
+			)
+		}
+	}
+
+	// ============================================================================
+	// Session Registration (after validation — only healthy providers)
+	// ============================================================================
+	// Filter to only healthy providers before converting to sessions.
+	// This ensures the session manager and rpsr.providerSessions never contain
+	// failed providers, so updateEpoch won't recreate sessions for dead nodes.
+	healthyStaticProviders := relevantStaticProviderList
+	if len(failedStaticNames) > 0 {
+		healthyStaticProviders = make([]*lavasession.RPCStaticProviderEndpoint, 0, len(relevantStaticProviderList)-len(failedStaticNames))
+		for _, p := range relevantStaticProviderList {
+			if _, failed := failedStaticNames[p.Name]; !failed {
+				healthyStaticProviders = append(healthyStaticProviders, p)
+			}
+		}
+	}
+
+	healthyBackupProviders := relevantBackupProviderList
+	if len(failedBackupNames) > 0 {
+		healthyBackupProviders = make([]*lavasession.RPCStaticProviderEndpoint, 0, len(relevantBackupProviderList)-len(failedBackupNames))
+		for _, p := range relevantBackupProviderList {
+			if _, failed := failedBackupNames[p.Name]; !failed {
+				healthyBackupProviders = append(healthyBackupProviders, p)
+			}
+		}
+	}
+
+	// Convert only healthy providers to ConsumerSessionsWithProvider format
+	providerSessions := convertProvidersToSessions(healthyStaticProviders)
+
+	var backupProviderSessions map[uint64]*lavasession.ConsumerSessionsWithProvider
+	if len(healthyBackupProviders) > 0 {
+		backupProviderSessions = convertProvidersToSessions(healthyBackupProviders)
 		utils.LavaFormatInfo("Configured backup providers for endpoint",
 			utils.Attribute{Key: "chainID", Value: chainID},
 			utils.Attribute{Key: "apiInterface", Value: rpcEndpoint.ApiInterface},
@@ -736,20 +1014,39 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 		backupSession.Lock.Unlock()
 	}
 
-	// Update the session manager with static providers and backup providers
+	// Register with session manager — one call, correct from the start
 	err = sessionManager.UpdateAllProviders(currentEpoch, providerSessions, backupProviderSessions)
 	if err != nil {
 		errCh <- err
 		return utils.LavaFormatError("failed updating static providers", err)
 	}
 
-	// Store provider sessions for epoch updates
+	// Store provider sessions and failed providers for epoch updates and background retry
 	rpsr.mu.Lock()
 	rpsr.providerSessions[sessionManagerKey] = providerSessions
 	if len(backupProviderSessions) > 0 {
 		rpsr.backupProviderSessions[sessionManagerKey] = backupProviderSessions
 	}
+	if len(failedStaticEndpoints) > 0 {
+		rpsr.failedStaticProviders[sessionManagerKey] = failedStaticEndpoints
+	}
 	rpsr.mu.Unlock()
+
+	// Launch background retry for failed static providers (if any)
+	if len(failedStaticEndpoints) > 0 {
+		failedNames := make([]string, len(failedStaticEndpoints))
+		for i, p := range failedStaticEndpoints {
+			failedNames[i] = p.Name
+		}
+		utils.LavaFormatInfo("Launching background retry goroutine for failed static providers",
+			utils.LogAttr("chain", rpcEndpoint.ChainID),
+			utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
+			utils.LogAttr("failedCount", len(failedStaticEndpoints)),
+			utils.LogAttr("failedProviders", failedNames),
+			utils.LogAttr("retryInterval", "3m"),
+		)
+		go rpsr.retryFailedStaticProviders(ctx, sessionManagerKey, chainParser, rpcEndpoint, convertProvidersToSessions)
+	}
 
 	var relaysMonitor *metrics.RelaysMonitor
 	if options.cmdFlags.RelaysHealthEnableFlag {
@@ -767,7 +1064,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	// Collect ALL WebSocket-capable endpoints from static providers for direct subscriptions
 	// WebSocket URLs are identified by ws:// or wss:// prefix
 	var wsEndpoints []*common.NodeUrl
-	for _, provider := range relevantStaticProviderList {
+	for _, provider := range healthyStaticProviders {
 		for i := range provider.NodeUrls {
 			url := strings.ToLower(provider.NodeUrls[i].Url)
 			if strings.HasPrefix(url, "ws://") || strings.HasPrefix(url, "wss://") {
@@ -803,7 +1100,6 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 			utils.LogAttr("optimizerEnabled", optimizer != nil),
 		)
 	} else {
-		// No WebSocket endpoints configured - use NoOp manager that returns clear errors
 		// No WebSocket endpoints configured — use NoOp manager that returns clear errors
 		wsSubscriptionManager = NewNoOpWSSubscriptionManager(rpcEndpoint.ChainID, rpcEndpoint.ApiInterface)
 		utils.LavaFormatInfo("No WebSocket endpoints configured for direct subscriptions",
@@ -818,7 +1114,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	var grpcEndpoints []*common.NodeUrl
 	if rpcEndpoint.ApiInterface == spectypes.APIInterfaceGrpc {
 		// Collect gRPC endpoints from static providers
-		for _, provider := range relevantStaticProviderList {
+		for _, provider := range healthyStaticProviders {
 			if provider.ApiInterface == spectypes.APIInterfaceGrpc {
 				for i := range provider.NodeUrls {
 					grpcEndpoints = append(grpcEndpoints, &provider.NodeUrls[i])
@@ -854,235 +1150,14 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	}
 
 	// ============================================================================
-	// PHASE 1: Static Provider Validation
-	// ============================================================================
-	// Validate ALL static providers BEFORE creating chain tracker (matches provider behavior).
-	// Only validates providers matching this endpoint's api-interface.
-	// See: the provider's validation approach for reference.
-	if len(relevantStaticProviderList) > 0 {
-		utils.LavaFormatInfo("Validating static providers",
-			utils.LogAttr("chain", rpcEndpoint.ChainID),
-			utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
-			utils.LogAttr("providerCount", len(relevantStaticProviderList)),
-		)
-
-		validatedCount := 0
-		for _, staticProvider := range relevantStaticProviderList {
-			// Skip providers with different api-interface (validated by their own endpoint)
-			if staticProvider.ApiInterface != rpcEndpoint.ApiInterface {
-				utils.LavaFormatDebug("Skipping provider - different api-interface",
-					utils.LogAttr("provider", staticProvider.Name),
-					utils.LogAttr("providerInterface", staticProvider.ApiInterface),
-					utils.LogAttr("endpointInterface", rpcEndpoint.ApiInterface),
-				)
-				continue
-			}
-			validatedCount++
-
-			// Prepare ALL URLs for validation together (matches provider behavior).
-			// ChainRouter requires both with-addon and without-addon routes for addon URLs
-			// (see chain_router.go:258 which appends "" to addons list).
-			verificationNodeUrls := []common.NodeUrl{}
-			for _, nodeUrl := range staticProvider.NodeUrls {
-				verificationNodeUrls = append(verificationNodeUrls, nodeUrl)
-				// For addon URLs, also add a non-addon copy for routing flexibility
-				if len(nodeUrl.Addons) > 0 {
-					noAddonUrl := nodeUrl
-					noAddonUrl.Addons = []string{}
-					verificationNodeUrls = append(verificationNodeUrls, noAddonUrl)
-				}
-			}
-
-			verificationEndpoint := &lavasession.RPCProviderEndpoint{
-				NetworkAddress: staticProvider.NetworkAddress,
-				ChainID:        staticProvider.ChainID,
-				ApiInterface:   staticProvider.ApiInterface,
-				Geolocation:    staticProvider.Geolocation,
-				NodeUrls:       verificationNodeUrls,
-			}
-
-			// Create chain router with all URLs for complete supportedMap (HTTP + WebSocket)
-			parallelConnections := uint(lavasession.DefaultMaximumStreamsOverASingleConnection)
-			verificationRouter, err := chainlib.GetChainRouter(ctx, parallelConnections, verificationEndpoint, chainParser)
-			if err != nil {
-				err = utils.LavaFormatError("[PANIC] failed creating chain router for verification", err,
-					utils.LogAttr("chain", rpcEndpoint.ChainID),
-					utils.LogAttr("provider", staticProvider.Name),
-				)
-				errCh <- err
-				return err
-			}
-
-			// Create full ChainFetcher for verification (respects severity, skip-verifications)
-			verificationFetcher := chainlib.NewChainFetcher(ctx, &chainlib.ChainFetcherOptions{
-				ChainRouter: verificationRouter,
-				ChainParser: chainParser,
-				Endpoint:    verificationEndpoint,
-				Cache:       nil,
-			})
-
-			utils.LavaFormatInfo("Validating static provider",
-				utils.LogAttr("name", staticProvider.Name),
-				utils.LogAttr("chain", rpcEndpoint.ChainID),
-				utils.LogAttr("urlCount", len(staticProvider.NodeUrls)),
-			)
-
-			err = verificationFetcher.Validate(ctx)
-			if err != nil {
-				err = utils.LavaFormatError("[PANIC] static provider validation failed", err,
-					utils.LogAttr("chain", rpcEndpoint.ChainID),
-					utils.LogAttr("provider", staticProvider.Name),
-				)
-				errCh <- err
-				return err
-			}
-
-			utils.LavaFormatInfo("Static provider validated successfully",
-				utils.LogAttr("chain", rpcEndpoint.ChainID),
-				utils.LogAttr("provider", staticProvider.Name),
-			)
-		}
-
-		utils.LavaFormatInfo("All providers validated for api-interface",
-			utils.LogAttr("chain", rpcEndpoint.ChainID),
-			utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
-			utils.LogAttr("validated", validatedCount),
-			utils.LogAttr("total", len(relevantStaticProviderList)),
-		)
-	}
-
-	// ============================================================================
-	// PHASE 1B: Backup Provider Validation (non-fatal)
-	// ============================================================================
-	// Validate backup providers using the same logic as PHASE 1, but treat all
-	// failures as non-fatal warnings. A broken backup should never block startup —
-	// static providers must still serve. Operators are clearly notified at startup
-	// so they can fix backup endpoints before they are actually needed in an emergency.
-	// Providers that fail validation are excluded from the registered backup list.
-	if len(relevantBackupProviderList) > 0 {
-		utils.LavaFormatInfo("Validating backup providers (non-fatal)",
-			utils.LogAttr("chain", rpcEndpoint.ChainID),
-			utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
-			utils.LogAttr("backupCount", len(relevantBackupProviderList)),
-		)
-
-		failedBackupNames := make(map[string]struct{})
-		validatedBackups := 0
-		for _, backupProvider := range relevantBackupProviderList {
-			if backupProvider.ApiInterface != rpcEndpoint.ApiInterface {
-				utils.LavaFormatDebug("Skipping backup provider - different api-interface",
-					utils.LogAttr("provider", backupProvider.Name),
-					utils.LogAttr("providerInterface", backupProvider.ApiInterface),
-					utils.LogAttr("endpointInterface", rpcEndpoint.ApiInterface),
-				)
-				continue
-			}
-			validatedBackups++
-
-			// Build verificationNodeUrls with addon expansion (identical to PHASE 1)
-			verificationNodeUrls := []common.NodeUrl{}
-			for _, nodeUrl := range backupProvider.NodeUrls {
-				verificationNodeUrls = append(verificationNodeUrls, nodeUrl)
-				if len(nodeUrl.Addons) > 0 {
-					noAddonUrl := nodeUrl
-					noAddonUrl.Addons = []string{}
-					verificationNodeUrls = append(verificationNodeUrls, noAddonUrl)
-				}
-			}
-
-			verificationEndpoint := &lavasession.RPCProviderEndpoint{
-				NetworkAddress: backupProvider.NetworkAddress,
-				ChainID:        backupProvider.ChainID,
-				ApiInterface:   backupProvider.ApiInterface,
-				Geolocation:    backupProvider.Geolocation,
-				NodeUrls:       verificationNodeUrls,
-			}
-
-			parallelConnections := uint(lavasession.DefaultMaximumStreamsOverASingleConnection)
-			verificationRouter, err := chainlib.GetChainRouter(ctx, parallelConnections, verificationEndpoint, chainParser)
-			if err != nil {
-				failedBackupNames[backupProvider.Name] = struct{}{}
-				utils.LavaFormatWarning("backup provider: failed creating chain router — excluding from backup list", err,
-					utils.LogAttr("chain", rpcEndpoint.ChainID),
-					utils.LogAttr("provider", backupProvider.Name),
-				)
-				continue
-			}
-
-			verificationFetcher := chainlib.NewChainFetcher(ctx, &chainlib.ChainFetcherOptions{
-				ChainRouter: verificationRouter,
-				ChainParser: chainParser,
-				Endpoint:    verificationEndpoint,
-				Cache:       nil,
-			})
-
-			utils.LavaFormatInfo("Validating backup provider",
-				utils.LogAttr("name", backupProvider.Name),
-				utils.LogAttr("chain", rpcEndpoint.ChainID),
-				utils.LogAttr("urlCount", len(backupProvider.NodeUrls)),
-			)
-
-			if err = verificationFetcher.Validate(ctx); err != nil {
-				failedBackupNames[backupProvider.Name] = struct{}{}
-				utils.LavaFormatWarning("backup provider validation failed — excluding from backup list", err,
-					utils.LogAttr("chain", rpcEndpoint.ChainID),
-					utils.LogAttr("provider", backupProvider.Name),
-				)
-				continue
-			}
-
-			utils.LavaFormatInfo("Backup provider validated successfully",
-				utils.LogAttr("chain", rpcEndpoint.ChainID),
-				utils.LogAttr("provider", backupProvider.Name),
-			)
-		}
-
-		if len(failedBackupNames) > 0 {
-			utils.LavaFormatWarning("ATTENTION: some backup providers failed validation and were excluded — they will not be used during emergency failover",
-				nil,
-				utils.LogAttr("chain", rpcEndpoint.ChainID),
-				utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
-				utils.LogAttr("failed", len(failedBackupNames)),
-				utils.LogAttr("validated", validatedBackups),
-			)
-
-			// Rebuild backup sessions excluding failed providers, then re-register so the
-			// session manager never holds references to endpoints that cannot be reached.
-			// PublicLavaAddress in ConsumerSessionsWithProvider is set from provider.Name
-			// (see NewConsumerSessionWithProvider in convertProvidersToSessions above).
-			filteredBackupSessions := make(map[uint64]*lavasession.ConsumerSessionsWithProvider)
-			for idx, session := range backupProviderSessions {
-				if _, failed := failedBackupNames[session.PublicLavaAddress]; !failed {
-					filteredBackupSessions[idx] = session
-				}
-			}
-
-			if err = sessionManager.UpdateAllProviders(currentEpoch, providerSessions, filteredBackupSessions); err != nil {
-				utils.LavaFormatWarning("failed to re-register filtered backup providers", err,
-					utils.LogAttr("chain", rpcEndpoint.ChainID),
-				)
-			} else {
-				rpsr.mu.Lock()
-				rpsr.backupProviderSessions[sessionManagerKey] = filteredBackupSessions
-				rpsr.mu.Unlock()
-			}
-		} else {
-			utils.LavaFormatInfo("All backup providers validated",
-				utils.LogAttr("chain", rpcEndpoint.ChainID),
-				utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
-				utils.LogAttr("validated", validatedBackups),
-			)
-		}
-	}
-
-	// ============================================================================
 	// PHASE 2: Chain Tracker Setup
 	// ============================================================================
-	// Create ChainTracker for latest block tracking using first provider.
+	// Create ChainTracker for latest block tracking using first healthy provider.
 	// ChainTracker polls for latest block and maintains block history for sync verification.
+	// Uses healthyStaticProviders (not the unfiltered list) to avoid polling a dead node.
 	var chainTracker chaintracker.IChainTracker
-	if len(relevantStaticProviderList) > 0 {
-		firstProvider := relevantStaticProviderList[0]
+	if len(healthyStaticProviders) > 0 {
+		firstProvider := healthyStaticProviders[0]
 
 		// Minimal endpoint for ChainTracker (no addons needed, only polls latest block)
 		chainTrackerEndpoint := &lavasession.RPCProviderEndpoint{
@@ -1607,12 +1682,17 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 }
 
 func (rpsr *RPCSmartRouter) updateEpoch(epoch uint64) {
-	// Update all session managers for this epoch
-	for chainKey, sm := range rpsr.sessionManagers {
-		sessionManager := sm
+	// Copy session manager keys under lock to avoid iterating the map
+	// concurrently with retryFailedStaticProviders which writes to rpsr maps under rpsr.mu.
+	rpsr.mu.Lock()
+	chainKeys := make([]string, 0, len(rpsr.sessionManagers))
+	for k := range rpsr.sessionManagers {
+		chainKeys = append(chainKeys, k)
+	}
+	rpsr.mu.Unlock()
+
+	for _, chainKey := range chainKeys {
 		chainKeyLog := chainKey
-		oldProviderSessions := rpsr.providerSessions[chainKey]
-		oldBackupSessions := rpsr.backupProviderSessions[chainKey]
 
 		utils.LavaFormatInfo("ConsumerSessionManager: Epoch update triggered",
 			utils.LogAttr("epoch", epoch),
@@ -1637,6 +1717,14 @@ func (rpsr *RPCSmartRouter) updateEpoch(epoch uint64) {
 			epochChainID = server.listenEndpoint.ChainID
 			epochApiInterface = server.listenEndpoint.ApiInterface
 		}
+		// Lock for the read → create-fresh → write-back section.
+		// This prevents races with retryFailedStaticProviders, which merges
+		// recovered providers into rpsr.providerSessions under the same lock.
+		// The locked section is pure CPU work (map lookups + object creation).
+		rpsr.mu.Lock()
+		sessionManager := rpsr.sessionManagers[chainKey]
+		oldProviderSessions := rpsr.providerSessions[chainKey]
+		oldBackupSessions := rpsr.backupProviderSessions[chainKey]
 
 		// Create FRESH ConsumerSessionsWithProvider objects to avoid session accumulation
 		// This is critical: reusing the same objects causes sessions to accumulate in the Sessions map
@@ -1703,9 +1791,11 @@ func (rpsr *RPCSmartRouter) updateEpoch(epoch uint64) {
 		if len(freshBackupSessions) > 0 {
 			rpsr.backupProviderSessions[chainKey] = freshBackupSessions
 		}
+		server := rpsr.rpcServers[chainKey]
+		rpsr.mu.Unlock()
 
-		// Update session manager with fresh provider sessions
-		// This triggers cleanup and provider unblocking while preventing session accumulation
+		// Heavy calls stay outside the lock (UpdateAllProviders triggers async probing,
+		// cleanupStaleTrackers does tracker removal)
 		err := sessionManager.UpdateAllProviders(epoch, freshProviderSessions, freshBackupSessions)
 		if err != nil {
 			utils.LavaFormatError("Failed to update providers on epoch change", err,
@@ -1716,8 +1806,173 @@ func (rpsr *RPCSmartRouter) updateEpoch(epoch uint64) {
 
 		// Cleanup stale ChainTrackers for endpoints no longer in the provider sessions
 		// This must happen AFTER UpdateAllProviders so connections are closed first
-		if server, exists := rpsr.rpcServers[chainKey]; exists && server != nil {
+		if server != nil {
 			rpsr.cleanupStaleTrackers(chainKey, server, freshProviderSessions, freshBackupSessions)
+		}
+	}
+}
+
+// retryFailedStaticProviders periodically re-validates failed static providers
+// and re-registers them with the session manager when they recover.
+// It runs as a background goroutine, one per endpoint that had failures.
+func (rpsr *RPCSmartRouter) retryFailedStaticProviders(
+	ctx context.Context,
+	sessionManagerKey string,
+	chainParser chainlib.ChainParser,
+	rpcEndpoint *lavasession.RPCEndpoint,
+	convertProvidersToSessions func([]*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider,
+) {
+	retryInterval := 3 * time.Minute // same as SpecValidator's disabled-chain interval
+	ticker := time.NewTicker(retryInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		rpsr.mu.Lock()
+		failedProviders := rpsr.failedStaticProviders[sessionManagerKey]
+		rpsr.mu.Unlock()
+
+		if len(failedProviders) == 0 {
+			utils.LavaFormatInfo("All failed static providers recovered — stopping retry loop",
+				utils.LogAttr("chain", rpcEndpoint.ChainID),
+				utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
+			)
+			return
+		}
+
+		utils.LavaFormatInfo("Retrying failed static providers",
+			utils.LogAttr("chain", rpcEndpoint.ChainID),
+			utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
+			utils.LogAttr("failedCount", len(failedProviders)),
+		)
+
+		var stillFailed []*lavasession.RPCStaticProviderEndpoint
+		var recovered []*lavasession.RPCStaticProviderEndpoint
+
+		for _, provider := range failedProviders {
+			// Build verification endpoint (same logic as Phase 1)
+			verificationNodeUrls := []common.NodeUrl{}
+			for _, nodeUrl := range provider.NodeUrls {
+				verificationNodeUrls = append(verificationNodeUrls, nodeUrl)
+				if len(nodeUrl.Addons) > 0 {
+					noAddonUrl := nodeUrl
+					noAddonUrl.Addons = []string{}
+					verificationNodeUrls = append(verificationNodeUrls, noAddonUrl)
+				}
+			}
+
+			verificationEndpoint := &lavasession.RPCProviderEndpoint{
+				NetworkAddress: provider.NetworkAddress,
+				ChainID:        provider.ChainID,
+				ApiInterface:   provider.ApiInterface,
+				Geolocation:    provider.Geolocation,
+				NodeUrls:       verificationNodeUrls,
+			}
+
+			// Scoped context for this verification attempt. GetChainRouter creates
+			// connector goroutines tied to ctx that only exit on cancellation.
+			// Without this, each retry iteration leaks goroutines and connections
+			// for permanently failing providers.
+			// Timeout bounds a hung provider so it can't stall retries of the
+			// remaining providers in this cycle.
+			attemptCtx, attemptCancel := context.WithTimeout(ctx, 30*time.Second)
+
+			parallelConnections := uint(lavasession.DefaultMaximumStreamsOverASingleConnection)
+			verificationRouter, err := chainlib.GetChainRouter(attemptCtx, parallelConnections, verificationEndpoint, chainParser)
+			if err != nil {
+				attemptCancel()
+				stillFailed = append(stillFailed, provider)
+				utils.LavaFormatWarning("retry: static provider chain router creation still failing", err,
+					utils.LogAttr("chain", rpcEndpoint.ChainID),
+					utils.LogAttr("provider", provider.Name),
+				)
+				continue
+			}
+
+			verificationFetcher := chainlib.NewChainFetcher(attemptCtx, &chainlib.ChainFetcherOptions{
+				ChainRouter: verificationRouter,
+				ChainParser: chainParser,
+				Endpoint:    verificationEndpoint,
+				Cache:       nil,
+			})
+
+			err = verificationFetcher.Validate(attemptCtx)
+			attemptCancel() // cleanup temporary router resources regardless of outcome
+			if err != nil {
+				stillFailed = append(stillFailed, provider)
+				utils.LavaFormatWarning("retry: static provider verification still failing", err,
+					utils.LogAttr("chain", rpcEndpoint.ChainID),
+					utils.LogAttr("provider", provider.Name),
+				)
+				continue
+			}
+
+			recovered = append(recovered, provider)
+			utils.LavaFormatInfo("[+] static provider recovered and passed verification",
+				utils.LogAttr("chain", rpcEndpoint.ChainID),
+				utils.LogAttr("provider", provider.Name),
+			)
+		}
+
+		// Update state: move recovered providers into active sessions
+		if len(recovered) > 0 {
+			recoveredSessions := convertProvidersToSessions(recovered)
+
+			rpsr.mu.Lock()
+			currentEpoch := rpsr.epochTimer.GetCurrentEpoch()
+
+			// Copy-on-write: create a new map merging old + recovered sessions.
+			// The old map may still be referenced by goroutines (probeProviders,
+			// cleanupStaleTrackers) that iterate it without the lock.
+			oldSessions := rpsr.providerSessions[sessionManagerKey]
+			mergedSessions := make(map[uint64]*lavasession.ConsumerSessionsWithProvider, len(oldSessions)+len(recoveredSessions))
+			for k, v := range oldSessions {
+				mergedSessions[k] = v
+			}
+			maxIdx := uint64(0)
+			for idx := range mergedSessions {
+				if idx >= maxIdx {
+					maxIdx = idx + 1
+				}
+			}
+			for _, session := range recoveredSessions {
+				session.Lock.Lock()
+				session.PairingEpoch = currentEpoch
+				session.Lock.Unlock()
+				mergedSessions[maxIdx] = session
+				maxIdx++
+			}
+			rpsr.providerSessions[sessionManagerKey] = mergedSessions
+
+			// Update failed list
+			rpsr.failedStaticProviders[sessionManagerKey] = stillFailed
+
+			sessionManager := rpsr.sessionManagers[sessionManagerKey]
+			backupSessions := rpsr.backupProviderSessions[sessionManagerKey]
+			rpsr.mu.Unlock()
+
+			// Re-register all providers with session manager
+			if err := sessionManager.UpdateAllProviders(currentEpoch, mergedSessions, backupSessions); err != nil {
+				utils.LavaFormatWarning("retry: failed to re-register recovered providers", err,
+					utils.LogAttr("chain", rpcEndpoint.ChainID),
+				)
+			} else {
+				for _, p := range recovered {
+					utils.LavaFormatInfo("[+] static provider re-registered successfully",
+						utils.LogAttr("chain", rpcEndpoint.ChainID),
+						utils.LogAttr("provider", p.Name),
+					)
+				}
+			}
+		} else {
+			rpsr.mu.Lock()
+			rpsr.failedStaticProviders[sessionManagerKey] = stillFailed
+			rpsr.mu.Unlock()
 		}
 	}
 }

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -720,7 +720,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	// Validate static providers BEFORE converting to sessions or registering.
 	// Only validates providers matching this endpoint's api-interface.
 	// See: the provider's validation approach for reference.
-	var failedStaticNames map[string]struct{}
+	var failedStaticSet map[*lavasession.RPCStaticProviderEndpoint]struct{}
 	var failedStaticEndpoints []*lavasession.RPCStaticProviderEndpoint
 
 	if len(relevantStaticProviderList) > 0 {
@@ -731,7 +731,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 		)
 
 		totalAttemptedCount := 0
-		failedStaticNames = make(map[string]struct{})
+		failedStaticSet = make(map[*lavasession.RPCStaticProviderEndpoint]struct{})
 
 		for _, staticProvider := range relevantStaticProviderList {
 			// Skip providers with different api-interface (validated by their own endpoint)
@@ -779,7 +779,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 			verificationRouter, err := chainlib.GetChainRouter(verifyCtx, parallelConnections, verificationEndpoint, chainParser)
 			if err != nil {
 				verifyCancel()
-				failedStaticNames[staticProvider.Name] = struct{}{}
+				failedStaticSet[staticProvider] = struct{}{}
 				failedStaticEndpoints = append(failedStaticEndpoints, staticProvider)
 				utils.LavaFormatWarning("static provider: failed creating chain router — excluding from provider list", err,
 					utils.LogAttr("chain", rpcEndpoint.ChainID),
@@ -805,7 +805,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 			err = verificationFetcher.Validate(verifyCtx)
 			verifyCancel() // cleanup temporary router resources regardless of outcome
 			if err != nil {
-				failedStaticNames[staticProvider.Name] = struct{}{}
+				failedStaticSet[staticProvider] = struct{}{}
 				failedStaticEndpoints = append(failedStaticEndpoints, staticProvider)
 				utils.LavaFormatWarning("static provider validation failed — excluding from provider list", err,
 					utils.LogAttr("chain", rpcEndpoint.ChainID),
@@ -820,25 +820,25 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 			)
 		}
 
-		healthyCount := totalAttemptedCount - len(failedStaticNames)
+		healthyCount := totalAttemptedCount - len(failedStaticSet)
 
 		// If ALL static providers failed verification, this endpoint cannot serve traffic
 		if totalAttemptedCount > 0 && healthyCount == 0 {
 			err := utils.LavaFormatError("all static providers failed verification — cannot serve endpoint", nil,
 				utils.LogAttr("chain", rpcEndpoint.ChainID),
 				utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
-				utils.LogAttr("failedCount", len(failedStaticNames)),
+				utils.LogAttr("failedCount", len(failedStaticSet)),
 			)
 			errCh <- err
 			return err
 		}
 
-		if len(failedStaticNames) > 0 {
+		if len(failedStaticSet) > 0 {
 			utils.LavaFormatWarning("ATTENTION: some static providers failed verification and were excluded — they will be retried in the background",
 				nil,
 				utils.LogAttr("chain", rpcEndpoint.ChainID),
 				utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
-				utils.LogAttr("failed", len(failedStaticNames)),
+				utils.LogAttr("failed", len(failedStaticSet)),
 				utils.LogAttr("healthy", healthyCount),
 			)
 		} else {
@@ -859,7 +859,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	// static providers must still serve. Operators are clearly notified at startup
 	// so they can fix backup endpoints before they are actually needed in an emergency.
 	// Providers that fail validation are excluded from the registered backup list.
-	var failedBackupNames map[string]struct{}
+	var failedBackupSet map[*lavasession.RPCStaticProviderEndpoint]struct{}
 
 	if len(relevantBackupProviderList) > 0 {
 		utils.LavaFormatInfo("Validating backup providers (non-fatal)",
@@ -868,7 +868,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 			utils.LogAttr("backupCount", len(relevantBackupProviderList)),
 		)
 
-		failedBackupNames = make(map[string]struct{})
+		failedBackupSet = make(map[*lavasession.RPCStaticProviderEndpoint]struct{})
 		validatedBackups := 0
 		for _, backupProvider := range relevantBackupProviderList {
 			if backupProvider.ApiInterface != rpcEndpoint.ApiInterface {
@@ -906,7 +906,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 			verificationRouter, err := chainlib.GetChainRouter(verifyCtx, parallelConnections, verificationEndpoint, chainParser)
 			if err != nil {
 				verifyCancel()
-				failedBackupNames[backupProvider.Name] = struct{}{}
+				failedBackupSet[backupProvider] = struct{}{}
 				utils.LavaFormatWarning("backup provider: failed creating chain router — excluding from backup list", err,
 					utils.LogAttr("chain", rpcEndpoint.ChainID),
 					utils.LogAttr("provider", backupProvider.Name),
@@ -930,7 +930,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 			err = verificationFetcher.Validate(verifyCtx)
 			verifyCancel()
 			if err != nil {
-				failedBackupNames[backupProvider.Name] = struct{}{}
+				failedBackupSet[backupProvider] = struct{}{}
 				utils.LavaFormatWarning("backup provider validation failed — excluding from backup list", err,
 					utils.LogAttr("chain", rpcEndpoint.ChainID),
 					utils.LogAttr("provider", backupProvider.Name),
@@ -944,12 +944,12 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 			)
 		}
 
-		if len(failedBackupNames) > 0 {
+		if len(failedBackupSet) > 0 {
 			utils.LavaFormatWarning("ATTENTION: some backup providers failed validation and were excluded — they will not be used during emergency failover",
 				nil,
 				utils.LogAttr("chain", rpcEndpoint.ChainID),
 				utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
-				utils.LogAttr("failed", len(failedBackupNames)),
+				utils.LogAttr("failed", len(failedBackupSet)),
 				utils.LogAttr("validated", validatedBackups),
 			)
 		} else {
@@ -968,20 +968,20 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	// This ensures the session manager and rpsr.providerSessions never contain
 	// failed providers, so updateEpoch won't recreate sessions for dead nodes.
 	healthyStaticProviders := relevantStaticProviderList
-	if len(failedStaticNames) > 0 {
-		healthyStaticProviders = make([]*lavasession.RPCStaticProviderEndpoint, 0, len(relevantStaticProviderList)-len(failedStaticNames))
+	if len(failedStaticSet) > 0 {
+		healthyStaticProviders = make([]*lavasession.RPCStaticProviderEndpoint, 0, len(relevantStaticProviderList)-len(failedStaticSet))
 		for _, p := range relevantStaticProviderList {
-			if _, failed := failedStaticNames[p.Name]; !failed {
+			if _, failed := failedStaticSet[p]; !failed {
 				healthyStaticProviders = append(healthyStaticProviders, p)
 			}
 		}
 	}
 
 	healthyBackupProviders := relevantBackupProviderList
-	if len(failedBackupNames) > 0 {
-		healthyBackupProviders = make([]*lavasession.RPCStaticProviderEndpoint, 0, len(relevantBackupProviderList)-len(failedBackupNames))
+	if len(failedBackupSet) > 0 {
+		healthyBackupProviders = make([]*lavasession.RPCStaticProviderEndpoint, 0, len(relevantBackupProviderList)-len(failedBackupSet))
 		for _, p := range relevantBackupProviderList {
-			if _, failed := failedBackupNames[p.Name]; !failed {
+			if _, failed := failedBackupSet[p]; !failed {
 				healthyBackupProviders = append(healthyBackupProviders, p)
 			}
 		}

--- a/protocol/rpcsmartrouter/rpcsmartrouter_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_test.go
@@ -1,9 +1,12 @@
 package rpcsmartrouter
 
 import (
+	"context"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
 	"github.com/magma-Devs/smart-router/protocol/metrics"
 	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
@@ -34,6 +37,53 @@ func gatherHealthGauge(t *testing.T, spec, apiInterface, endpointID string) (flo
 		}
 	}
 	return 0, false
+}
+
+// createTestRPCSmartRouter creates an RPCSmartRouter with all maps initialized and an epoch timer.
+func createTestRPCSmartRouter() *RPCSmartRouter {
+	return &RPCSmartRouter{
+		epochTimer:             common.NewEpochTimer(15 * time.Minute),
+		sessionManagers:        make(map[string]*lavasession.ConsumerSessionManager),
+		providerSessions:       make(map[string]map[uint64]*lavasession.ConsumerSessionsWithProvider),
+		backupProviderSessions: make(map[string]map[uint64]*lavasession.ConsumerSessionsWithProvider),
+		failedStaticProviders:  make(map[string][]*lavasession.RPCStaticProviderEndpoint),
+		rpcServers:             make(map[string]*RPCSmartRouterServer),
+	}
+}
+
+// createTestSessionManager creates a ConsumerSessionManager for a given chain key.
+func createTestSessionManager(chainID, apiInterface string) (*lavasession.ConsumerSessionManager, *lavasession.RPCEndpoint) {
+	rpcEndpoint := &lavasession.RPCEndpoint{
+		ChainID:        chainID,
+		ApiInterface:   apiInterface,
+		NetworkAddress: "127.0.0.1:3333",
+	}
+	optimizer := provideroptimizer.NewProviderOptimizer(provideroptimizer.StrategyBalanced, time.Second, uint(1), nil, chainID)
+	sm := lavasession.NewConsumerSessionManager(rpcEndpoint, optimizer, nil, nil, "test-router", lavasession.NewActiveSubscriptionProvidersStorage())
+	return sm, rpcEndpoint
+}
+
+// createTestProviderSession creates a ConsumerSessionsWithProvider for testing.
+func createTestProviderSession(name string, epoch uint64) *lavasession.ConsumerSessionsWithProvider {
+	session := lavasession.NewConsumerSessionWithProvider(
+		name,
+		[]*lavasession.Endpoint{{NetworkAddress: "http://" + name + ":8080", Enabled: true}},
+		100,
+		epoch,
+		int64(1),
+	)
+	session.StaticProvider = true
+	return session
+}
+
+// createTestStaticProviderEndpoint creates an RPCStaticProviderEndpoint for testing.
+func createTestStaticProviderEndpoint(name, chainID, apiInterface string) *lavasession.RPCStaticProviderEndpoint {
+	return &lavasession.RPCStaticProviderEndpoint{
+		Name:         name,
+		ChainID:      chainID,
+		ApiInterface: apiInterface,
+		NodeUrls:     []common.NodeUrl{{Url: "http://" + name + ":8080"}},
+	}
 }
 
 func TestUpdateEpoch_FreshSessions(t *testing.T) {
@@ -323,4 +373,401 @@ func TestUpdateEpoch_NilListenEndpointDoesNotPanic(t *testing.T) {
 	// Even without the metric reset, the in-memory struct reset (from commit 1559d6b29) must still run.
 	require.True(t, disabledEndpoint.Enabled,
 		"endpoint.ResetHealth() must still fire even when listenEndpoint is nil — the metric reset is optional but the struct reset is load-bearing")
+}
+
+// ============================================================================= */
+// Graceful Verification Failure Tests
+// =============================================================================
+
+// Scenario 1: All providers healthy — no failures, no retry, baseline behavior.
+func TestGracefulFailure_AllProvidersHealthy_NoRetryLaunched(t *testing.T) {
+	rand.InitRandomSeed()
+	rpsr := createTestRPCSmartRouter()
+
+	chainKey := "LAV1-tendermintrpc"
+	sm, _ := createTestSessionManager("LAV1", "tendermintrpc")
+	rpsr.sessionManagers[chainKey] = sm
+
+	// Two healthy providers, no failures
+	rpsr.providerSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: createTestProviderSession("providerA", 1),
+		1: createTestProviderSession("providerB", 1),
+	}
+	// No failed providers
+	// rpsr.failedStaticProviders[chainKey] is not set (empty map)
+
+	// Verify: no failed providers stored
+	require.Empty(t, rpsr.failedStaticProviders[chainKey])
+
+	// Verify: both providers in sessions
+	require.Len(t, rpsr.providerSessions[chainKey], 2)
+
+	// Verify: epoch update works and preserves both providers
+	rpsr.updateEpoch(2)
+	require.Len(t, rpsr.providerSessions[chainKey], 2)
+	require.Equal(t, "providerA", rpsr.providerSessions[chainKey][0].PublicLavaAddress)
+	require.Equal(t, "providerB", rpsr.providerSessions[chainKey][1].PublicLavaAddress)
+}
+
+// Scenario 3: One provider fails, others healthy — epoch doesn't resurrect the failed one.
+func TestGracefulFailure_EpochDoesNotResurrectFailedProviders(t *testing.T) {
+	rand.InitRandomSeed()
+	rpsr := createTestRPCSmartRouter()
+
+	chainKey := "LAV1-tendermintrpc"
+	sm, _ := createTestSessionManager("LAV1", "tendermintrpc")
+	rpsr.sessionManagers[chainKey] = sm
+
+	// Only healthy providers in sessions (B was excluded at startup)
+	rpsr.providerSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: createTestProviderSession("providerA", 1),
+		1: createTestProviderSession("providerC", 1),
+	}
+
+	// B is in the failed list (excluded at startup, awaiting retry)
+	rpsr.failedStaticProviders[chainKey] = []*lavasession.RPCStaticProviderEndpoint{
+		createTestStaticProviderEndpoint("providerB", "LAV1", "tendermintrpc"),
+	}
+
+	// Trigger epoch update
+	rpsr.updateEpoch(2)
+
+	// Verify: only A and C in sessions — B was NOT resurrected
+	sessions := rpsr.providerSessions[chainKey]
+	require.Len(t, sessions, 2)
+	addresses := map[string]bool{}
+	for _, s := range sessions {
+		addresses[s.PublicLavaAddress] = true
+	}
+	require.True(t, addresses["providerA"], "providerA should be in sessions")
+	require.True(t, addresses["providerC"], "providerC should be in sessions")
+	require.False(t, addresses["providerB"], "providerB should NOT be resurrected by epoch")
+
+	// Verify: failed providers list is unchanged
+	require.Len(t, rpsr.failedStaticProviders[chainKey], 1)
+	require.Equal(t, "providerB", rpsr.failedStaticProviders[chainKey][0].Name)
+}
+
+// Scenario 3 (continued): Filtering logic — failedStaticNames correctly filters provider lists.
+func TestGracefulFailure_FilteringLogic(t *testing.T) {
+	// Simulate the filtering that happens in CreateSmartRouterEndpoint after Phase 1
+	relevantStaticProviderList := []*lavasession.RPCStaticProviderEndpoint{
+		createTestStaticProviderEndpoint("providerA", "LAV1", "tendermintrpc"),
+		createTestStaticProviderEndpoint("providerB", "LAV1", "tendermintrpc"),
+		createTestStaticProviderEndpoint("providerC", "LAV1", "tendermintrpc"),
+	}
+
+	// B failed validation
+	failedStaticNames := map[string]struct{}{
+		"providerB": {},
+	}
+
+	// Apply the same filtering logic as the production code (line 828-834)
+	healthyStaticProviders := make([]*lavasession.RPCStaticProviderEndpoint, 0, len(relevantStaticProviderList)-len(failedStaticNames))
+	for _, p := range relevantStaticProviderList {
+		if _, failed := failedStaticNames[p.Name]; !failed {
+			healthyStaticProviders = append(healthyStaticProviders, p)
+		}
+	}
+
+	require.Len(t, healthyStaticProviders, 2)
+	require.Equal(t, "providerA", healthyStaticProviders[0].Name)
+	require.Equal(t, "providerC", healthyStaticProviders[1].Name)
+}
+
+// Scenario 4: All static providers fail — filtering produces empty list.
+func TestGracefulFailure_AllFailedFiltering(t *testing.T) {
+	relevantStaticProviderList := []*lavasession.RPCStaticProviderEndpoint{
+		createTestStaticProviderEndpoint("providerA", "LAV1", "tendermintrpc"),
+		createTestStaticProviderEndpoint("providerB", "LAV1", "tendermintrpc"),
+	}
+
+	// Both failed
+	failedStaticNames := map[string]struct{}{
+		"providerA": {},
+		"providerB": {},
+	}
+
+	// Simulate the all-fail check
+	totalAttemptedCount := 2
+	healthyCount := totalAttemptedCount - len(failedStaticNames)
+	require.Equal(t, 0, healthyCount, "Should detect all providers failed")
+
+	// Filtering produces empty list
+	healthyStaticProviders := make([]*lavasession.RPCStaticProviderEndpoint, 0)
+	for _, p := range relevantStaticProviderList {
+		if _, failed := failedStaticNames[p.Name]; !failed {
+			healthyStaticProviders = append(healthyStaticProviders, p)
+		}
+	}
+	require.Empty(t, healthyStaticProviders)
+}
+
+// Scenario 2: No providers configured — nil failedStaticNames is safe.
+func TestGracefulFailure_NilFailedStaticNames(t *testing.T) {
+	// When there are no static providers, failedStaticNames is nil (var declaration, no make)
+	var failedStaticNames map[string]struct{}
+
+	// This must not panic — len() on nil map returns 0
+	require.Equal(t, 0, len(failedStaticNames))
+
+	// The filtering condition is safe on nil
+	if len(failedStaticNames) > 0 {
+		t.Fatal("should not enter this block with nil map")
+	}
+
+	// Direct lookup on nil map returns zero value (no panic)
+	_, exists := failedStaticNames["anything"]
+	require.False(t, exists)
+}
+
+// Scenario 5: Only one provider, and it fails — boundary of the all-fail check.
+func TestGracefulFailure_SingleProviderFails(t *testing.T) {
+	failedStaticNames := map[string]struct{}{
+		"providerA": {},
+	}
+	totalAttemptedCount := 1
+	healthyCount := totalAttemptedCount - len(failedStaticNames)
+
+	// healthyCount == 0 triggers the all-fail branch
+	require.Equal(t, 0, healthyCount)
+}
+
+// Scenario 9: Mixed static + backup failures — both filtered independently.
+func TestGracefulFailure_MixedStaticAndBackupFiltering(t *testing.T) {
+	staticProviders := []*lavasession.RPCStaticProviderEndpoint{
+		createTestStaticProviderEndpoint("staticA", "LAV1", "tendermintrpc"),
+		createTestStaticProviderEndpoint("staticB", "LAV1", "tendermintrpc"),
+		createTestStaticProviderEndpoint("staticC", "LAV1", "tendermintrpc"),
+	}
+	backupProviders := []*lavasession.RPCStaticProviderEndpoint{
+		createTestStaticProviderEndpoint("backupX", "LAV1", "tendermintrpc"),
+		createTestStaticProviderEndpoint("backupY", "LAV1", "tendermintrpc"),
+	}
+
+	failedStaticNames := map[string]struct{}{"staticB": {}}
+	failedBackupNames := map[string]struct{}{"backupX": {}}
+
+	// Filter statics
+	healthyStatics := make([]*lavasession.RPCStaticProviderEndpoint, 0)
+	for _, p := range staticProviders {
+		if _, failed := failedStaticNames[p.Name]; !failed {
+			healthyStatics = append(healthyStatics, p)
+		}
+	}
+
+	// Filter backups
+	healthyBackups := make([]*lavasession.RPCStaticProviderEndpoint, 0)
+	for _, p := range backupProviders {
+		if _, failed := failedBackupNames[p.Name]; !failed {
+			healthyBackups = append(healthyBackups, p)
+		}
+	}
+
+	require.Len(t, healthyStatics, 2)
+	require.Equal(t, "staticA", healthyStatics[0].Name)
+	require.Equal(t, "staticC", healthyStatics[1].Name)
+
+	require.Len(t, healthyBackups, 1)
+	require.Equal(t, "backupY", healthyBackups[0].Name)
+}
+
+// Scenario 20: Duplicate provider names — healthy one gets excluded as collateral.
+func TestGracefulFailure_DuplicateNameCollision(t *testing.T) {
+	providers := []*lavasession.RPCStaticProviderEndpoint{
+		{
+			Name: "my-node", ChainID: "LAV1", ApiInterface: "tendermintrpc",
+			NodeUrls: []common.NodeUrl{{Url: "http://healthy:8080"}},
+		},
+		{
+			Name: "my-node", ChainID: "LAV1", ApiInterface: "tendermintrpc",
+			NodeUrls: []common.NodeUrl{{Url: "http://dead:8080"}},
+		},
+	}
+
+	// The dead one fails, name "my-node" is added to failedStaticNames
+	failedStaticNames := map[string]struct{}{"my-node": {}}
+
+	// Filter — both get excluded because they share the name
+	healthy := make([]*lavasession.RPCStaticProviderEndpoint, 0)
+	for _, p := range providers {
+		if _, failed := failedStaticNames[p.Name]; !failed {
+			healthy = append(healthy, p)
+		}
+	}
+
+	require.Empty(t, healthy, "Both providers excluded because they share the same name")
+}
+
+// Scenario 13/14/15: Retry goroutine self-terminates when failedStaticProviders is empty.
+func TestGracefulFailure_RetryGoroutineSelfTerminates(t *testing.T) {
+	rand.InitRandomSeed()
+	rpsr := createTestRPCSmartRouter()
+
+	chainKey := "LAV1-tendermintrpc"
+	sm, rpcEndpoint := createTestSessionManager("LAV1", "tendermintrpc")
+	rpsr.sessionManagers[chainKey] = sm
+
+	rpsr.providerSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: createTestProviderSession("providerA", 1),
+	}
+
+	// Start with NO failed providers — retry should exit immediately on first tick
+	// (simulates the case where all providers recovered before the tick)
+	rpsr.failedStaticProviders[chainKey] = []*lavasession.RPCStaticProviderEndpoint{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Use a short-lived mock convertProvidersToSessions that should never be called
+	convertFn := func(providers []*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+		t.Fatal("convertProvidersToSessions should not be called when failedProviders is empty")
+		return nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		rpsr.retryFailedStaticProviders(ctx, chainKey, nil, rpcEndpoint, convertFn)
+		close(done)
+	}()
+
+	// The goroutine should exit within one ticker interval (3 minutes).
+	// We can't wait 3 minutes in a test, so cancel context to force exit if it doesn't self-terminate.
+	select {
+	case <-done:
+		// Goroutine self-terminated — test passes
+	case <-time.After(5 * time.Second):
+		// In the real code, the ticker is 3 minutes. The goroutine won't self-terminate
+		// in 5 seconds because it waits for the ticker. Cancel context to verify clean exit.
+		cancel()
+		<-done
+		// This is expected — the goroutine waits for the ticker before checking.
+		// The important thing is it exited cleanly after context cancellation.
+	}
+}
+
+// Scenario 17: Concurrent updateEpoch + retry goroutine — no race on rpsr.providerSessions.
+// Run with: go test -race -run TestGracefulFailure_ConcurrentEpochAndRetry
+func TestGracefulFailure_ConcurrentEpochAndRetry(t *testing.T) {
+	rand.InitRandomSeed()
+	rpsr := createTestRPCSmartRouter()
+
+	chainKey := "LAV1-tendermintrpc"
+	sm, _ := createTestSessionManager("LAV1", "tendermintrpc")
+	rpsr.sessionManagers[chainKey] = sm
+
+	rpsr.providerSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: createTestProviderSession("providerA", 1),
+	}
+
+	// Simulate: retry goroutine merges a recovered provider concurrently with epoch update
+	var wg sync.WaitGroup
+
+	// Goroutine 1: simulate retry merging a recovered provider (copy-on-write)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			rpsr.mu.Lock()
+			oldSessions := rpsr.providerSessions[chainKey]
+			newSessions := make(map[uint64]*lavasession.ConsumerSessionsWithProvider, len(oldSessions)+1)
+			for k, v := range oldSessions {
+				newSessions[k] = v
+			}
+			newSessions[uint64(100+i)] = createTestProviderSession("recovered", uint64(i))
+			rpsr.providerSessions[chainKey] = newSessions
+			rpsr.mu.Unlock()
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	// Goroutine 2: simulate epoch updates
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			rpsr.updateEpoch(uint64(10 + i))
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	wg.Wait()
+
+	// If we reach here without a race detector complaint, the test passes.
+	// Verify sessions are still accessible
+	rpsr.mu.Lock()
+	sessions := rpsr.providerSessions[chainKey]
+	rpsr.mu.Unlock()
+	require.NotNil(t, sessions)
+}
+
+// Scenario 18: Copy-on-write correctness — old map is not mutated when merging recovered providers.
+func TestGracefulFailure_CopyOnWriteDoesNotMutateOldMap(t *testing.T) {
+	// Create the "old" sessions map (currently active)
+	oldSessions := map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: createTestProviderSession("providerA", 1),
+		1: createTestProviderSession("providerC", 1),
+	}
+
+	// Snapshot the original length
+	originalLen := len(oldSessions)
+
+	// Simulate the copy-on-write merge from retryFailedStaticProviders (lines 1719-1737)
+	recoveredSession := createTestProviderSession("providerB", 1)
+
+	mergedSessions := make(map[uint64]*lavasession.ConsumerSessionsWithProvider, len(oldSessions)+1)
+	for k, v := range oldSessions {
+		mergedSessions[k] = v
+	}
+	maxIdx := uint64(0)
+	for idx := range mergedSessions {
+		if idx >= maxIdx {
+			maxIdx = idx + 1
+		}
+	}
+	mergedSessions[maxIdx] = recoveredSession
+
+	// Verify: old map is NOT mutated
+	require.Len(t, oldSessions, originalLen, "Old map must not be mutated by copy-on-write")
+
+	// Verify: new map has the merged result
+	require.Len(t, mergedSessions, originalLen+1)
+	require.Equal(t, "providerB", mergedSessions[maxIdx].PublicLavaAddress)
+
+	// Verify: old entries are shared (same pointers)
+	require.Equal(t, oldSessions[0], mergedSessions[0])
+	require.Equal(t, oldSessions[1], mergedSessions[1])
+}
+
+// Scenario 22: Short epoch fires before retry — epoch only sees healthy providers.
+func TestGracefulFailure_EpochBeforeRetry_OnlyHealthyProviders(t *testing.T) {
+	rand.InitRandomSeed()
+	rpsr := createTestRPCSmartRouter()
+
+	chainKey := "LAV1-tendermintrpc"
+	sm, _ := createTestSessionManager("LAV1", "tendermintrpc")
+	rpsr.sessionManagers[chainKey] = sm
+
+	// Startup result: only A is healthy, B failed
+	rpsr.providerSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: createTestProviderSession("providerA", 1),
+	}
+	rpsr.failedStaticProviders[chainKey] = []*lavasession.RPCStaticProviderEndpoint{
+		createTestStaticProviderEndpoint("providerB", "LAV1", "tendermintrpc"),
+	}
+
+	// Epoch fires multiple times before retry runs
+	rpsr.updateEpoch(2)
+	rpsr.updateEpoch(3)
+	rpsr.updateEpoch(4)
+
+	// Verify: still only A in sessions after 3 epochs — B never resurrected
+	sessions := rpsr.providerSessions[chainKey]
+	require.Len(t, sessions, 1)
+	require.Equal(t, "providerA", sessions[0].PublicLavaAddress)
+	require.Equal(t, uint64(4), sessions[0].PairingEpoch)
+
+	// Verify: failed list unchanged
+	require.Len(t, rpsr.failedStaticProviders[chainKey], 1)
+	require.Equal(t, "providerB", rpsr.failedStaticProviders[chainKey][0].Name)
 }

--- a/protocol/rpcsmartrouter/rpcsmartrouter_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_test.go
@@ -572,7 +572,9 @@ func TestGracefulFailure_MixedStaticAndBackupFiltering(t *testing.T) {
 	require.Equal(t, "backupY", healthyBackups[0].Name)
 }
 
-// Scenario 20: Duplicate provider names — healthy one gets excluded as collateral.
+// Scenario 20: Duplicate provider names are tolerated — only the actually-failing
+// instance is excluded. Pointer-keyed failed-set means name collisions don't cause
+// collateral exclusion of the healthy duplicate.
 func TestGracefulFailure_DuplicateNameCollision(t *testing.T) {
 	providers := []*lavasession.RPCStaticProviderEndpoint{
 		{
@@ -585,18 +587,20 @@ func TestGracefulFailure_DuplicateNameCollision(t *testing.T) {
 		},
 	}
 
-	// The dead one fails, name "my-node" is added to failedStaticNames
-	failedStaticNames := map[string]struct{}{"my-node": {}}
+	// Only the dead one fails — keyed by pointer identity, not by Name
+	failedStaticSet := map[*lavasession.RPCStaticProviderEndpoint]struct{}{
+		providers[1]: {},
+	}
 
-	// Filter — both get excluded because they share the name
 	healthy := make([]*lavasession.RPCStaticProviderEndpoint, 0)
 	for _, p := range providers {
-		if _, failed := failedStaticNames[p.Name]; !failed {
+		if _, failed := failedStaticSet[p]; !failed {
 			healthy = append(healthy, p)
 		}
 	}
 
-	require.Empty(t, healthy, "Both providers excluded because they share the same name")
+	require.Len(t, healthy, 1, "Only the failing duplicate is excluded; the healthy one survives")
+	require.Equal(t, "http://healthy:8080", healthy[0].NodeUrls[0].Url)
 }
 
 // Scenario 13/14/15: Retry goroutine self-terminates when failedStaticProviders is empty.


### PR DESCRIPTION
What the branch fixes                                                                                                                     
   
  The branch hardens protocol/rpcsmartrouter/rpcsmartrouter.go against three startup/runtime failure modes that previously caused panics,   
  silent data loss, or unnecessary outages:
                                                                                                                                            
  1. A single broken static provider crashes the whole smart router — startup validation called LavaFormatError("[PANIC] …") on the first   
  failure, taking the process down even when other providers were healthy.
  2. Two providers sharing the same Name could mass-exclude each other — the failed-set was keyed by provider.Name, so deduplication by name
   caused collateral exclusions.                                                                                                            
  3. Race between updateEpoch and the new retry goroutine — both write to rpsr.providerSessions and push to the consumer session manager
  (CSM); without coordination they could push snapshots in the opposite order they wrote the map, silently dropping providers until the next
   epoch.                 
                                                                                                                                            
  How it fixes them — by commit

  2ffb84f — don't panic on setup failure; retry in background                                                                               
   
  - Replaces [PANIC] errors in Phase 1 static-provider validation with LavaFormatWarning and adds the failed provider to a per-endpoint     
  failedStaticSet / failedStaticEndpoints list. Validation continues for the remaining providers instead of aborting.
  - Only fails the endpoint hard (errCh <- err) when all static providers for that api-interface fail (healthyCount == 0).                  
  - Restructures the flow so session registration happens after validation using only healthyStaticProviders / healthyBackupProviders.      
  Previously the unfiltered list was registered first and then re-registered after backup validation — the new path is "one call, correct   
  from the start" (rpcsmartrouter.go:462).                                                                                                  
  - Adds a new field failedStaticProviders map[string][]*lavasession.RPCStaticProviderEndpoint on RPCSmartRouter (rpcsmartrouter.go:155) and
   a new background goroutine retryFailedStaticProviders (rpcsmartrouter.go:~1820) that:                                                    
    - Wakes every 3 minutes (matches SpecValidator's disabled-chain interval).
    - Re-runs GetChainRouter + ChainFetcher.Validate against each failed endpoint inside a scoped 30s context.WithTimeout, with defer       
  cancel() — fixes goroutine/connection leaks from connector goroutines that only exit on ctx cancellation.                                 
    - On recovery, copy-on-write merges recovered sessions into rpsr.providerSessions (the old map may still be iterated by probeProviders /
   cleanupStaleTrackers without the lock) and calls sessionManager.UpdateAllProviders.                                                      
    - Exits when the failed list drains.
  - Also wraps the Phase 1 verification calls in a scoped context.WithTimeout(ctx, 30s) so a hung/blackholed provider can't stall validation
   of the others, and so temporary chain routers don't leak goroutines for the app's lifetime (rpcsmartrouter.go:~770,                      
  rpcsmartrouter.go:~800).                                                                                                                  
  - ChainTracker now uses healthyStaticProviders[0] instead of relevantStaticProviderList[0] so it doesn't poll a known-dead node.          
  - Adds 451 lines of tests in rpcsmartrouter_test.go.                                                                                      
                                                                                                                                            
  6763481 — duplicate provider names cause collateral exclusion                                                                             
                                                                                                                                            
  - Re-keys the failed sets from map[string]struct{} (keyed by provider.Name) to map[*lavasession.RPCStaticProviderEndpoint]struct{} (keyed 
  by pointer identity). Same fix applied to the backup-provider path (failedBackupNames → failedBackupSet).
  - Two providers configured with the same Name are now treated as distinct entities; only the actually-failing one is excluded.            
                                                                                                                                            
  9473684 — mutex around UpdateAllProviders to fix epoch-update race                                                                        
                                                                                                                                            
  - Pulls the existing rpsr.mu lock around the read → build-fresh-sessions → write-back → sessionManager.UpdateAllProviders block in        
  updateEpoch (rpcsmartrouter.go:~1690–1750), and the matching block in retryFailedStaticProviders.
  - The invariant being protected: the pair (write to rpsr.providerSessions, push snapshot to CSM) must be atomic. Without the lock,        
  updateEpoch and the retry goroutine can interleave so that CSM ends up with the older of the two snapshots while rpsr.providerSessions    
  holds the newer one — silently dropping providers until the next epoch tick repairs it.
  - The locked region is bounded CPU work (map rebuild + UpdateAllProviders's synchronous body, which dispatches probing to a goroutine).   
  The genuinely heavy cleanupStaleTrackers call stays outside the lock.                                                                     
  - Also changes updateEpoch to snapshot the session-manager keys under the lock first, then iterate, so map iteration isn't concurrent with
   the retry goroutine's writes.                                                                                                            
                          
  Net effect                                                                                                                                
                          
  A misconfigured or temporarily-down static provider no longer takes the smart router down at boot; it is excluded, logged loudly, and     
  re-validated every 3 minutes until it recovers — at which point it gets re-registered without an epoch boundary. Concurrent epoch ticks
  and recovery merges can no longer corrupt the CSM view of the provider set.  