### PR TITLE
fix(CV consistency): fix in CV in the case of consistency mismatch in  chosen providers

### DIFF
--- a/protocol/lavasession/used_providers.go
+++ b/protocol/lavasession/used_providers.go
@@ -193,6 +193,45 @@ func (up *UsedProviders) AddUnwantedAddresses(address string, routerKey RouterKe
 	uniqueUsedProviders.unwantedProviders[address] = struct{}{}
 }
 
+// ReleaseFromLatestBatch removes a provider from the current batch as if it
+// had never dispatched. Use when a session is dropped AFTER AddUsed but BEFORE
+// any response was sent to the RelayProcessor (e.g. by a pre-dispatch filter
+// such as filterEndpointsByConsistency in the smart router).
+//
+// Decrements sessionsLatestBatch so RelayProcessor.checkEndProcessing's
+// "all workers reported back" exit (responsesCount >= sessionsLatestBatch)
+// matches the number of goroutines actually launched. Also removes the
+// provider from the in-flight set, marks it unwanted so subsequent retries
+// skip it, and records it as errored for debugging.
+//
+// Idempotent: a second call for the same provider is a no-op (the providers
+// map check guards against double-decrement).
+//
+// MUST NOT be called from the response path. The response path goes through
+// SingleConsumerSession.Free → RemoveUsed, which intentionally leaves
+// sessionsLatestBatch alone — the RelayProcessor counts via responsesCount.
+func (up *UsedProviders) ReleaseFromLatestBatch(provider string, routerKey RouterKey, err error) {
+	if up == nil {
+		return
+	}
+	up.lock.Lock()
+	defer up.lock.Unlock()
+	uniqueUsedProviders := up.createOrUseUniqueUsedProvidersForKey(routerKey)
+
+	if _, inBatch := uniqueUsedProviders.providers[provider]; !inBatch {
+		return
+	}
+
+	delete(uniqueUsedProviders.providers, provider)
+	up.setUnwanted(uniqueUsedProviders, provider)
+	if err != nil {
+		uniqueUsedProviders.erroredProviders[provider] = struct{}{}
+	}
+	if up.sessionsLatestBatch > 0 {
+		up.sessionsLatestBatch--
+	}
+}
+
 func (up *UsedProviders) RemoveUsed(provider string, routerKey RouterKey, err error) {
 	if up == nil {
 		return

--- a/protocol/lavasession/used_providers_test.go
+++ b/protocol/lavasession/used_providers_test.go
@@ -58,6 +58,61 @@ func TestUsedProviders(t *testing.T) {
 	})
 }
 
+func TestReleaseFromLatestBatch(t *testing.T) {
+	t.Run("decrements batch counter and is idempotent", func(t *testing.T) {
+		usedProviders := NewUsedProviders(nil)
+		consumerSessionsMap := ConsumerSessionsMap{
+			"p1": &SessionInfo{},
+			"p2": &SessionInfo{},
+			"p3": &SessionInfo{},
+		}
+		usedProviders.AddUsed(consumerSessionsMap, nil)
+		require.Equal(t, 3, usedProviders.SessionsLatestBatch())
+		require.Equal(t, 3, usedProviders.CurrentlyUsed())
+
+		// Release p1: counter drops, currentlyUsed drops, p1 marked unwanted.
+		usedProviders.ReleaseFromLatestBatch("p1", NewRouterKey(nil), fmt.Errorf("filtered"))
+		require.Equal(t, 2, usedProviders.SessionsLatestBatch())
+		require.Equal(t, 2, usedProviders.CurrentlyUsed())
+		unwanted := usedProviders.GetUnwantedProvidersToSend(NewRouterKey(nil))
+		require.Contains(t, unwanted, "p1")
+
+		// Idempotent: second call for p1 must not double-decrement.
+		usedProviders.ReleaseFromLatestBatch("p1", NewRouterKey(nil), fmt.Errorf("filtered"))
+		require.Equal(t, 2, usedProviders.SessionsLatestBatch())
+		require.Equal(t, 2, usedProviders.CurrentlyUsed())
+
+		// Release the rest: counter floors at 0, no underflow.
+		usedProviders.ReleaseFromLatestBatch("p2", NewRouterKey(nil), nil)
+		usedProviders.ReleaseFromLatestBatch("p3", NewRouterKey(nil), nil)
+		require.Zero(t, usedProviders.SessionsLatestBatch())
+		require.Zero(t, usedProviders.CurrentlyUsed())
+
+		// Releasing an unknown provider is a no-op (no panic, no underflow).
+		usedProviders.ReleaseFromLatestBatch("never-added", NewRouterKey(nil), nil)
+		require.Zero(t, usedProviders.SessionsLatestBatch())
+	})
+
+	t.Run("response-path RemoveUsed leaves counter alone, ReleaseFromLatestBatch decrements", func(t *testing.T) {
+		usedProviders := NewUsedProviders(nil)
+		consumerSessionsMap := ConsumerSessionsMap{
+			"p1": &SessionInfo{},
+			"p2": &SessionInfo{},
+		}
+		usedProviders.AddUsed(consumerSessionsMap, nil)
+		require.Equal(t, 2, usedProviders.SessionsLatestBatch())
+
+		// Simulate a normal response cycle for p1: RemoveUsed must NOT decrement
+		// the batch counter (responsesCount on the RelayProcessor side handles it).
+		usedProviders.RemoveUsed("p1", NewRouterKey(nil), nil)
+		require.Equal(t, 2, usedProviders.SessionsLatestBatch())
+
+		// Simulate a pre-dispatch filter dropping p2: counter must drop.
+		usedProviders.ReleaseFromLatestBatch("p2", NewRouterKey(nil), fmt.Errorf("filtered"))
+		require.Equal(t, 1, usedProviders.SessionsLatestBatch())
+	})
+}
+
 func TestUsedProvidersAsync(t *testing.T) {
 	t.Run("concurrency", func(t *testing.T) {
 		usedProviders := NewUsedProviders(nil)

--- a/protocol/relaycore/interfaces.go
+++ b/protocol/relaycore/interfaces.go
@@ -132,7 +132,7 @@ type DecisionInput struct {
 // RelayPolicyInf is the interface that the policy engine must implement.
 type RelayPolicyInf interface {
 	Decide(input DecisionInput) DecisionOutput
-	OnSendRelayResult(err error, isPairingListEmpty bool) SendResult
+	OnSendRelayResult(err error, isPairingListEmpty bool, selection Selection) SendResult
 	GetConsecutiveBatchErrors() int
 }
 

--- a/protocol/relaycore/unified_relay_state_machine.go
+++ b/protocol/relaycore/unified_relay_state_machine.go
@@ -300,7 +300,7 @@ func (sm *UnifiedRelayStateMachine) GetRelayTaskChannel() (chan RelayStateSendIn
 			select {
 			case err := <-sm.batchUpdate:
 				isPairingListEmpty := err != nil && errors.Is(err, lavasession.PairingListEmptyError)
-				result := sm.policy.OnSendRelayResult(err, isPairingListEmpty)
+				result := sm.policy.OnSendRelayResult(err, isPairingListEmpty, sm.selection)
 
 				switch result {
 				case SendSuccess:

--- a/protocol/relaypolicy/policy.go
+++ b/protocol/relaypolicy/policy.go
@@ -104,11 +104,22 @@ func (p *Policy) decideMutation(input DecisionInput) MutationOutput {
 
 // OnSendRelayResult handles pre-relay send decisions. Called from the state machine's
 // batchUpdate case. Merges DP#11 (circuit breaker) and DP#12 (batch send retry).
-func (p *Policy) OnSendRelayResult(err error, isPairingListEmpty bool) SendResult {
+func (p *Policy) OnSendRelayResult(err error, isPairingListEmpty bool, selection relaycore.Selection) relaycore.SendResult {
 	if err == nil {
 		p.consecutiveBatchErrors = 0
 		p.consecutivePairingErrors = 0
 		return SendSuccess
+	}
+
+	// CrossValidation cannot meaningfully retry at the batch level — the
+	// SendRetry path forces NumOfProviders=1, which silently violates the
+	// user's quorum requirement and lets a generic "failed relay,
+	// insufficient results" error mask the precise cause (e.g. consistency-
+	// filter shortfall). Stop immediately so the original err is what the
+	// state machine surfaces, mirroring the CrossValidation short-circuit
+	// at the top of Decide.
+	if selection == relaycore.CrossValidation {
+		return SendStop
 	}
 
 	p.consecutiveBatchErrors++

--- a/protocol/relaypolicy/policy_test.go
+++ b/protocol/relaypolicy/policy_test.go
@@ -142,31 +142,43 @@ func TestDecide_HashError(t *testing.T) {
 func TestOnSendRelayResult(t *testing.T) {
 	t.Run("success resets counters", func(t *testing.T) {
 		policy := NewPolicy(PolicyConfig{SendRelayAttempts: 3, EnableCircuitBreaker: true, CircuitBreakerThreshold: 2})
-		policy.OnSendRelayResult(fmt.Errorf("err"), false)
-		result := policy.OnSendRelayResult(nil, false)
+		policy.OnSendRelayResult(fmt.Errorf("err"), false, relaycore.Stateless)
+		result := policy.OnSendRelayResult(nil, false, relaycore.Stateless)
 		require.Equal(t, SendSuccess, result)
 		require.Equal(t, 0, policy.GetConsecutiveBatchErrors())
 	})
 
 	t.Run("batch errors stop after threshold", func(t *testing.T) {
 		policy := NewPolicy(PolicyConfig{SendRelayAttempts: 2})
-		require.Equal(t, SendRetry, policy.OnSendRelayResult(fmt.Errorf("err1"), false))
-		require.Equal(t, SendRetry, policy.OnSendRelayResult(fmt.Errorf("err2"), false))
-		require.Equal(t, SendStop, policy.OnSendRelayResult(fmt.Errorf("err3"), false))
+		require.Equal(t, SendRetry, policy.OnSendRelayResult(fmt.Errorf("err1"), false, relaycore.Stateless))
+		require.Equal(t, SendRetry, policy.OnSendRelayResult(fmt.Errorf("err2"), false, relaycore.Stateless))
+		require.Equal(t, SendStop, policy.OnSendRelayResult(fmt.Errorf("err3"), false, relaycore.Stateless))
 	})
 
 	t.Run("circuit breaker trips on pairing errors", func(t *testing.T) {
 		policy := NewPolicy(PolicyConfig{SendRelayAttempts: 10, EnableCircuitBreaker: true, CircuitBreakerThreshold: 2})
-		require.Equal(t, SendRetry, policy.OnSendRelayResult(fmt.Errorf("pairing"), true))
-		require.Equal(t, SendStop, policy.OnSendRelayResult(fmt.Errorf("pairing"), true))
+		require.Equal(t, SendRetry, policy.OnSendRelayResult(fmt.Errorf("pairing"), true, relaycore.Stateless))
+		require.Equal(t, SendStop, policy.OnSendRelayResult(fmt.Errorf("pairing"), true, relaycore.Stateless))
 	})
 
 	t.Run("non-pairing error resets pairing counter", func(t *testing.T) {
 		policy := NewPolicy(PolicyConfig{SendRelayAttempts: 10, EnableCircuitBreaker: true, CircuitBreakerThreshold: 2})
-		policy.OnSendRelayResult(fmt.Errorf("pairing"), true)
-		policy.OnSendRelayResult(fmt.Errorf("other"), false) // resets pairing counter
-		result := policy.OnSendRelayResult(fmt.Errorf("pairing"), true)
+		policy.OnSendRelayResult(fmt.Errorf("pairing"), true, relaycore.Stateless)
+		policy.OnSendRelayResult(fmt.Errorf("other"), false, relaycore.Stateless) // resets pairing counter
+		result := policy.OnSendRelayResult(fmt.Errorf("pairing"), true, relaycore.Stateless)
 		require.Equal(t, SendRetry, result) // only 1 consecutive, threshold is 2
+	})
+
+	t.Run("CrossValidation stops immediately on any error", func(t *testing.T) {
+		policy := NewPolicy(PolicyConfig{SendRelayAttempts: 10, EnableCircuitBreaker: true, CircuitBreakerThreshold: 5})
+		// Even on the first error, CV must stop — the SendRetry path forces
+		// NumOfProviders=1, which would silently violate the user's quorum
+		// requirement and mask the precise error with a generic
+		// "failed relay, insufficient results" later.
+		require.Equal(t, SendStop, policy.OnSendRelayResult(fmt.Errorf("pairing"), true, relaycore.CrossValidation))
+		require.Equal(t, SendStop, policy.OnSendRelayResult(fmt.Errorf("other"), false, relaycore.CrossValidation))
+		// And success still resets and returns SendSuccess for CV.
+		require.Equal(t, SendSuccess, policy.OnSendRelayResult(nil, false, relaycore.CrossValidation))
 	})
 }
 
@@ -304,25 +316,25 @@ func TestConsumerStateMachineBatchErrorCounterResetsOnSuccess(t *testing.T) {
 	})
 
 	// Send 2 batch errors (below threshold of 3)
-	result := policy.OnSendRelayResult(fmt.Errorf("send failed"), false)
+	result := policy.OnSendRelayResult(fmt.Errorf("send failed"), false, relaycore.Stateless)
 	require.Equal(t, relaycore.SendRetry, result, "First error should retry")
 	require.Equal(t, 1, policy.GetConsecutiveBatchErrors())
 
-	result = policy.OnSendRelayResult(fmt.Errorf("send failed"), false)
+	result = policy.OnSendRelayResult(fmt.Errorf("send failed"), false, relaycore.Stateless)
 	require.Equal(t, relaycore.SendRetry, result, "Second error should retry")
 	require.Equal(t, 2, policy.GetConsecutiveBatchErrors())
 
 	// Success resets the counter
-	result = policy.OnSendRelayResult(nil, false)
+	result = policy.OnSendRelayResult(nil, false, relaycore.Stateless)
 	require.Equal(t, relaycore.SendSuccess, result)
 	require.Equal(t, 0, policy.GetConsecutiveBatchErrors(), "Counter should reset on success")
 
 	// Now 3 more errors should be needed to trigger stop (not 1)
-	policy.OnSendRelayResult(fmt.Errorf("err"), false)
-	policy.OnSendRelayResult(fmt.Errorf("err"), false)
-	result = policy.OnSendRelayResult(fmt.Errorf("err"), false)
+	policy.OnSendRelayResult(fmt.Errorf("err"), false, relaycore.Stateless)
+	policy.OnSendRelayResult(fmt.Errorf("err"), false, relaycore.Stateless)
+	result = policy.OnSendRelayResult(fmt.Errorf("err"), false, relaycore.Stateless)
 	require.Equal(t, relaycore.SendRetry, result, "Third error should still retry (counter was reset)")
 
-	result = policy.OnSendRelayResult(fmt.Errorf("err"), false)
+	result = policy.OnSendRelayResult(fmt.Errorf("err"), false, relaycore.Stateless)
 	require.Equal(t, relaycore.SendStop, result, "Fourth error (>3) should stop")
 }

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -752,10 +752,15 @@ func (rpcss *RPCSmartRouterServer) sendRelayToDirectEndpoints(
 	// Pre-request consistency validation: filter out endpoints that are too far behind
 	validSessions, failedSessions, filterErr := rpcss.filterEndpointsByConsistency(ctx, sessions, protocolMessage)
 
-	// Release failed sessions via OnSessionFailure:
-	// - Provides QoS punishment (AppendRelayFailure)
-	// - Properly unlocks the session
-	// - Adds provider to unwantedProviders for retry exclusion
+	// Release failed sessions:
+	// - ReleaseFromLatestBatch decrements UsedProviders.sessionsLatestBatch so
+	//   RelayProcessor.checkEndProcessing matches the goroutines we will
+	//   actually launch. Without this the CV path can wait the full
+	//   processingTimeout (~30s) for responses that never arrive.
+	// - OnSessionFailure provides QoS punishment, unlocks the session, and
+	//   marks the provider unwanted for retry exclusion.
+	usedProviders := relayProcessor.GetUsedProviders()
+	releaseRouterKey := lavasession.NewRouterKeyFromExtensions(protocolMessage.GetExtensions())
 	for endpointAddress, sessionInfo := range failedSessions {
 		if sessionInfo != nil && sessionInfo.Session != nil {
 			utils.LavaFormatDebug("releasing stale session via OnSessionFailure",
@@ -763,6 +768,7 @@ func (rpcss *RPCSmartRouterServer) sendRelayToDirectEndpoints(
 				utils.LogAttr("error", lavasession.ConsistencyPreValidationError),
 				utils.LogAttr("GUID", ctx),
 			)
+			usedProviders.ReleaseFromLatestBatch(endpointAddress, releaseRouterKey, lavasession.ConsistencyPreValidationError)
 			rpcss.sessionManager.OnSessionFailure(sessionInfo.Session, lavasession.ConsistencyPreValidationError)
 		}
 	}
@@ -770,6 +776,25 @@ func (rpcss *RPCSmartRouterServer) sendRelayToDirectEndpoints(
 	// If ALL sessions failed consistency validation, return error to trigger retry with different providers
 	if filterErr != nil {
 		return filterErr
+	}
+
+	// Post-filter CV guard: even with the counter fixed, fail fast (and with
+	// a precise error message) when the filter dropped the surviving session
+	// count below the agreement threshold. Returning PairingListEmptyError
+	// lets the state machine retry with a fresh batch; the consistency-failed
+	// providers are already in unwantedProviders.
+	selection := relayProcessor.GetSelection()
+	crossValidationParams := relayProcessor.GetCrossValidationParams()
+	if selection == relaycore.CrossValidation && crossValidationParams != nil &&
+		len(validSessions) < crossValidationParams.AgreementThreshold {
+		return utils.LavaFormatError("insufficient sessions for cross-validation consensus after consistency filter",
+			lavasession.PairingListEmptyError,
+			utils.LogAttr("agreementThreshold", crossValidationParams.AgreementThreshold),
+			utils.LogAttr("sessionsAcquired", len(sessions)),
+			utils.LogAttr("sessionsAfterFilter", len(validSessions)),
+			utils.LogAttr("sessionsFiltered", len(failedSessions)),
+			utils.LogAttr("GUID", ctx),
+		)
 	}
 
 	sessions = validSessions

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -787,6 +787,18 @@ func (rpcss *RPCSmartRouterServer) sendRelayToDirectEndpoints(
 	crossValidationParams := relayProcessor.GetCrossValidationParams()
 	if selection == relaycore.CrossValidation && crossValidationParams != nil &&
 		len(validSessions) < crossValidationParams.AgreementThreshold {
+		// Release the surviving valid sessions before returning. No goroutines
+		// will be launched for them, so without this they stay in
+		// UsedProviders.providers (CurrentlyUsed > 0). The state machine's
+		// validateReturnCondition only delivers the err to returnCondition when
+		// CurrentlyUsed == 0, so the request would otherwise stall for the
+		// full processingTimeout (~30s) instead of failing fast.
+		for endpointAddress, sessionInfo := range validSessions {
+			if sessionInfo != nil && sessionInfo.Session != nil {
+				usedProviders.ReleaseFromLatestBatch(endpointAddress, releaseRouterKey, nil)
+				sessionInfo.Session.Free(nil)
+			}
+		}
 		return utils.LavaFormatError("insufficient sessions for cross-validation consensus after consistency filter",
 			lavasession.PairingListEmptyError,
 			utils.LogAttr("agreementThreshold", crossValidationParams.AgreementThreshold),

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -778,11 +778,12 @@ func (rpcss *RPCSmartRouterServer) sendRelayToDirectEndpoints(
 		return filterErr
 	}
 
-	// Post-filter CV guard: even with the counter fixed, fail fast (and with
-	// a precise error message) when the filter dropped the surviving session
-	// count below the agreement threshold. Returning PairingListEmptyError
-	// lets the state machine retry with a fresh batch; the consistency-failed
-	// providers are already in unwantedProviders.
+	// Post-filter CV guard: fail fast with a precise error message when the
+	// filter dropped the surviving session count below the agreement threshold.
+	// Returning PairingListEmptyError surfaces the precise cause; the CV
+	// short-circuit in Policy.OnSendRelayResult ensures the state machine
+	// stops immediately rather than retrying with NumOfProviders=1 (which
+	// would silently violate quorum and mask this error).
 	selection := relayProcessor.GetSelection()
 	crossValidationParams := relayProcessor.GetCrossValidationParams()
 	if selection == relaycore.CrossValidation && crossValidationParams != nil &&

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -14,7 +15,10 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcclient"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/extensionslib"
 	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavaprotocol"
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
+	"github.com/magma-Devs/smart-router/protocol/qos"
 	"github.com/magma-Devs/smart-router/protocol/relaycore"
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
 	spectypes "github.com/magma-Devs/smart-router/types/spec"
@@ -1977,4 +1981,160 @@ func TestConsistencyPreValidationError_NotRetryable(t *testing.T) {
 	// SessionOutOfSyncError IS a session sync loss (for comparison)
 	require.True(t, lavasession.IsSessionSyncLoss(lavasession.SessionOutOfSyncError),
 		"SessionOutOfSyncError should be treated as session sync loss")
+}
+
+// ============================================================================
+// Tests for the post-filter CrossValidation guard fast-fail behavior
+// (commits a78426a + 97266e4)
+// ============================================================================
+
+// cvGuardStateMachine implements relaycore.RelayStateMachine for the CV-guard
+// integration test. It only needs to expose the UsedProviders, the selection,
+// and the cross-validation params; the early-exit path under test does not
+// touch the other methods.
+type cvGuardStateMachine struct {
+	usedProviders *lavasession.UsedProviders
+	cvParams      *common.CrossValidationParams
+}
+
+func (m *cvGuardStateMachine) GetProtocolMessage() chainlib.ProtocolMessage { return nil }
+func (m *cvGuardStateMachine) GetDebugState() bool                          { return false }
+func (m *cvGuardStateMachine) GetRelayTaskChannel() (chan relaycore.RelayStateSendInstructions, error) {
+	return make(chan relaycore.RelayStateSendInstructions), nil
+}
+func (m *cvGuardStateMachine) UpdateBatch(err error)                                       {}
+func (m *cvGuardStateMachine) GetSelection() relaycore.Selection                           { return relaycore.CrossValidation }
+func (m *cvGuardStateMachine) GetCrossValidationParams() *common.CrossValidationParams     { return m.cvParams }
+func (m *cvGuardStateMachine) GetUsedProviders() *lavasession.UsedProviders                { return m.usedProviders }
+func (m *cvGuardStateMachine) SetResultsChecker(rc relaycore.ResultsCheckerInf)            {}
+func (m *cvGuardStateMachine) SetRelayRetriesManager(rm *lavaprotocol.RelayRetriesManager) {}
+
+// cvGuardMetrics is a no-op MetricsInterface + ChainIdAndApiInterfaceGetter
+// for the CV-guard test. The early-exit path does not hit metrics callbacks.
+type cvGuardMetrics struct{}
+
+func (cvGuardMetrics) SetRelayNodeErrorMetric(chainId, apiInterface, providerAddress, method string) {
+}
+func (cvGuardMetrics) GetChainIdAndApiInterface() (string, string) { return "LAVA", "rest" }
+
+// TestSendRelayToDirectEndpoints_CrossValidationGuardReleasesAllSessions is the
+// regression catch for commit 97266e4. When filterEndpointsByConsistency drops
+// the surviving session count below AgreementThreshold for a CrossValidation
+// request, the post-filter guard must release the SURVIVING valid sessions
+// before returning, not just the failed ones. Without this, the state machine's
+// validateReturnCondition waits for CurrentlyUsed() == 0 to deliver the err,
+// so the request stalls the full processingTimeout (~30s) instead of failing fast.
+//
+// Setup: 3 sessions (1 synced, 2 stale), AgreementThreshold=2.
+// Filter drops the 2 stale; the surviving 1 is < AT, so the CV guard fires.
+//
+// Asserts:
+//   - returns in well under processingTimeout (the regression was a 30s stall)
+//   - error wraps lavasession.PairingListEmptyError (CV state machine short-circuits on this)
+//   - usedProviders.CurrentlyUsed() == 0 (catches surviving-session leak — 97266e4 regression)
+//   - usedProviders.SessionsLatestBatch() == 0 (catches counter leak — a78426a regression)
+func TestSendRelayToDirectEndpoints_CrossValidationGuardReleasesAllSessions(t *testing.T) {
+	ctx := context.Background()
+
+	// Real chainParser so sendRelayToDirectEndpoints' early ChainBlockStats() call works.
+	noopHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	chainParser, _, _, closeServer, _, err := chainlib.CreateChainLibMocks(
+		ctx, "LAVA", spectypes.APIInterfaceRest, noopHandler, nil, "../../", nil)
+	if closeServer != nil {
+		defer closeServer()
+	}
+	require.NoError(t, err)
+
+	// seenBlock=200, EndpointLagThreshold=10 (default). Endpoints below 190 are dropped.
+	consistency := newMockConsistency()
+	userData := common.UserData{DappId: "test", ConsumerIp: "1.2.3.4"}
+	consistency.SetSeenBlock(200, userData)
+
+	syncedEp := &lavasession.Endpoint{NetworkAddress: "http://synced:8545"}
+	syncedEp.LatestBlock.Store(195)
+	staleEp1 := &lavasession.Endpoint{NetworkAddress: "http://stale1:8545"}
+	staleEp1.LatestBlock.Store(50)
+	staleEp2 := &lavasession.Endpoint{NetworkAddress: "http://stale2:8545"}
+	staleEp2.LatestBlock.Store(50)
+
+	mkSession := func(addr string, ep *lavasession.Endpoint) *lavasession.SingleConsumerSession {
+		return &lavasession.SingleConsumerSession{
+			// Parent.Endpoints[0] is read by the QoS metrics path inside
+			// OnSessionFailure (consumer_session_manager.go:1807); leaving the
+			// slice empty panics. The endpoint identity doesn't matter here —
+			// only the indexing has to succeed.
+			Parent:     &lavasession.ConsumerSessionsWithProvider{PublicLavaAddress: addr, Endpoints: []*lavasession.Endpoint{ep}},
+			Connection: &lavasession.DirectRPCSessionConnection{Endpoint: ep},
+			QoSManager: qos.NewQoSManager(),
+		}
+	}
+	sess1 := mkSession("lava@provider1", syncedEp)
+	sess2 := mkSession("lava@provider2", staleEp1)
+	sess3 := mkSession("lava@provider3", staleEp2)
+	for _, s := range []*lavasession.SingleConsumerSession{sess1, sess2, sess3} {
+		_, ok := s.TryUseSession()
+		require.True(t, ok, "test setup: failed to lock session")
+	}
+
+	// Mimic GetSessions: AddUsed registers all 3 in UsedProviders; SetUsageForSession
+	// wires each session back to UsedProviders so Free(nil) calls RemoveUsed correctly.
+	usedProviders := lavasession.NewUsedProviders(nil)
+	sessionsMap := lavasession.ConsumerSessionsMap{
+		"lava@provider1": &lavasession.SessionInfo{Session: sess1},
+		"lava@provider2": &lavasession.SessionInfo{Session: sess2},
+		"lava@provider3": &lavasession.SessionInfo{Session: sess3},
+	}
+	usedProviders.AddUsed(sessionsMap, nil)
+	routerKey := lavasession.NewRouterKey(nil)
+	require.NoError(t, sess1.SetUsageForSession(0, nil, usedProviders, routerKey))
+	require.NoError(t, sess2.SetUsageForSession(0, nil, usedProviders, routerKey))
+	require.NoError(t, sess3.SetUsageForSession(0, nil, usedProviders, routerKey))
+	require.Equal(t, 3, usedProviders.CurrentlyUsed(), "test setup: expected 3 in CurrentlyUsed")
+	require.Equal(t, 3, usedProviders.SessionsLatestBatch(), "test setup: expected 3 in SessionsLatestBatch")
+
+	// CrossValidation, AgreementThreshold=2. Filter drops 2 of 3 → guard fires (1 < 2).
+	cvParams := &common.CrossValidationParams{MaxParticipants: 3, AgreementThreshold: 2}
+	sm := &cvGuardStateMachine{usedProviders: usedProviders, cvParams: cvParams}
+	metricsStub := cvGuardMetrics{}
+	relayProcessor := relaycore.NewRelayProcessor(
+		ctx, cvParams, consistency, metricsStub, metricsStub,
+		lavaprotocol.NewRelayRetriesManager(), sm)
+
+	// Real session manager — OnSessionFailure runs against it for the 2 dropped sessions.
+	rpcEndpoint := &lavasession.RPCEndpoint{ChainID: "LAVA", ApiInterface: "rest"}
+	optimizer := provideroptimizer.NewProviderOptimizer(provideroptimizer.StrategyBalanced, time.Second, uint(1), nil, "LAVA")
+	sessionManager := lavasession.NewConsumerSessionManager(
+		rpcEndpoint, optimizer, nil, nil, "test-router",
+		lavasession.NewActiveSubscriptionProvidersStorage())
+
+	rpcss := &RPCSmartRouterServer{
+		chainParser:            chainParser,
+		consistencyConfig:      relaycore.DefaultConsistencyValidationConfig(),
+		smartRouterConsistency: consistency,
+		sessionManager:         sessionManager,
+	}
+	protocolMsg := &MockProtocolMessage{
+		api:            &spectypes.Api{Name: "/cosmos/base/tendermint/v1beta1/blocks/latest"},
+		requestedBlock: spectypes.LATEST_BLOCK,
+		userData:       userData,
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	sendErr := rpcss.sendRelayToDirectEndpoints(callCtx, sessionsMap, protocolMsg, relayProcessor, nil)
+	elapsed := time.Since(start)
+
+	require.Less(t, elapsed, time.Second,
+		"fast-fail required (commit 97266e4 regression catch); took %v", elapsed)
+	require.Error(t, sendErr)
+	require.Truef(t, errors.Is(sendErr, lavasession.PairingListEmptyError),
+		"error must wrap PairingListEmptyError so the CV short-circuit in policy.OnSendRelayResult can see it; got: %v", sendErr)
+	require.Equal(t, 0, usedProviders.CurrentlyUsed(),
+		"surviving valid sessions leaked into CurrentlyUsed — commit 97266e4 regression: validateReturnCondition will block on this and the request will stall processingTimeout")
+	require.Equal(t, 0, usedProviders.SessionsLatestBatch(),
+		"SessionsLatestBatch leaked — commit a78426a regression: RelayProcessor.checkEndProcessing will wait for responses that never arrive")
 }


### PR DESCRIPTION
# Description

CV stall: fail fast when consistency filter drops sessions below quorum                                                        
                                                                                                                                 
  Bug                                                                                                                            
   
  CrossValidation requests stall ~30 s and return generic context deadline exceeded whenever the pre-request consistency filter  
  drops some — but not all — of the sessions returned by GetSessions. UsedProviders.sessionsLatestBatch stays at the original
  count, so RelayProcessor.checkEndProcessing waits for responses that will never arrive; the precise upstream cause is masked.  
                  
  Fix

  Three load-bearing pieces; only deliver the fast-fail in combination.                                                          
   
  - lavasession / rpcsmartrouter — counter sync + post-filter guard. New UsedProviders.ReleaseFromLatestBatch decrements the     
  counter for sessions dropped pre-dispatch. Wired into the failed-sessions release loop. Adds a post-filter CV guard that
  returns PairingListEmptyError with a precise message (sessionsAcquired / sessionsAfterFilter / sessionsFiltered) when survivors
   fall below AgreementThreshold.
  - relaypolicy — CV short-circuit on batch errors. Without it, batch errors route through SendRetry with NumOfProviders=1,
  silently violating quorum and re-masking the error. OnSendRelayResult gains a Selection parameter and short-circuits to        
  SendStop in CV mode.
  - rpcsmartrouter — release surviving sessions in the early-return path. The post-filter guard must release the surviving valid 
  sessions before returning, not just the failed ones. The state machine's validateReturnCondition requires CurrentlyUsed() == 0;
   without this release the request still stalls the full timeout. Discovered during the integration repro.
                                                                                                                                 
  Plus tests + comment cleanup: integration test that exercises the full path (3 sessions, AT=2, filter drops 2) and pins all    
  four invariants — < 1 s, error wraps PairingListEmptyError, CurrentlyUsed() == 0, SessionsLatestBatch() == 0. Verified to fail
  when the surviving-session release is removed. Updates a stale comment that no longer matches the post-short-circuit behavior. 
                  
  Reproduction / measurement                                                                                                     
   
  Three direct-rpc REST endpoints — one healthy, two via testutils/mock_node_proxy against the same upstream. Bootstrap,         
  set-block?height=5, advance seenBlock past EndpointLagThreshold, send a CV request with max-participants=3,
  agreement-threshold=2.                                                                                                         
                  
  End-to-end wall clock: 30.067 s → 0.085 s. Response now carries insufficient sessions for cross-validation consensus after     
  consistency filter with the diagnostic fields, instead of context deadline exceeded.
                                                                                                                                 
  Test plan       

  - lavasession, relaypolicy, relaycore, rpcsmartrouter all green.
  - Unit tests for the new primitives (TestReleaseFromLatestBatch,
  TestOnSendRelayResult/CrossValidation_stops_immediately_on_any_error).                                                         
  - Integration test verified to fail without the surviving-session release and pass with it.
  - Manual end-to-end repro on the proxy setup confirms 30 s → ~85 ms.                                                           
                                                                                                                                 
  Compatibility                                                                                                                  
                                                                                                                                 
  RelayPolicyInf.OnSendRelayResult signature gains a Selection parameter. Single production call site updated; test call sites   
  pass Stateless where appropriate.