### PR TITLE
feat: Added spec re-verification

### DIFF
--- a/protocol/chainlib/chainlib.go
+++ b/protocol/chainlib/chainlib.go
@@ -100,6 +100,26 @@ type ChainParser interface {
 	ParseDirectiveEnabled() bool
 }
 
+// CloneChainParserForValidation returns a parser instance safe to pass into
+// GetChainRouter / NewChainProxy for one-shot verification (e.g., the spec
+// re-verification loop) WITHOUT mutating the live serving parser.
+//
+// For gRPC: NewGrpcChainProxy calls (*GrpcChainParser).setupForProvider, which
+// replaces the parser's registry and codec fields with ones bound to the
+// verification connection's lifetime. If the live parser is passed and the
+// verification context is later cancelled (e.g. a per-attempt WithTimeout),
+// the connection backing those fields dies and live gRPC relays panic on a
+// nil connector. Cloning isolates the mutation.
+//
+// For non-gRPC parsers no equivalent mutation occurs during chain-proxy
+// construction, so the original parser is returned unchanged.
+func CloneChainParserForValidation(parser ChainParser) ChainParser {
+	if grpc, ok := parser.(*GrpcChainParser); ok {
+		return grpc.cloneForValidation()
+	}
+	return parser
+}
+
 type ChainMessage interface {
 	SubscriptionIdExtractor(reply *rpcclient.JsonrpcMessage) string
 	RequestedBlock() (latest int64, earliest int64)

--- a/protocol/chainlib/grpc.go
+++ b/protocol/chainlib/grpc.go
@@ -60,6 +60,48 @@ func NewGrpcChainParser() (chainParser *GrpcChainParser, err error) {
 	return &GrpcChainParser{}, nil
 }
 
+// cloneForValidation returns a *GrpcChainParser with isolated registry/codec
+// fields so callers (one-shot verification flows) can safely pass the result
+// into NewGrpcChainProxy → setupForProvider without mutating the live parser.
+//
+// Read-only-after-init data on BaseChainParser is aliased — including the
+// inner contents of `spec` (a protobuf with nested slices/maps), which is
+// copied by value but whose nested fields remain shared. This is sound only
+// because the live serving path treats spec as immutable post-init; the rare
+// SetSpec / SetPolicy / UpdateBlockTime mutators run at init or at known
+// quiescent moments.
+//
+// The new BaseChainParser is constructed via struct literal, so its rwLock
+// is a fresh zero-value — no mutex is copied. Note the trade-off: because the
+// clone has a *separate* mutex from the live parser, the two cannot
+// synchronize. If a live-path SetSpec / UpdateBlockTime were to race with a
+// validation reader on the clone, the clone could observe a torn write of
+// nested spec fields. We accept that risk since the alternative — sharing the
+// parser instance — corrupts the live registry/codec when validation's bounded
+// context is cancelled, panicking gRPC relays on a nil connector.
+//
+// registry/codec are aliased initially; setupForProvider on the clone will
+// replace the *clone's* fields, leaving the live parser untouched.
+func (apip *GrpcChainParser) cloneForValidation() *GrpcChainParser {
+	return &GrpcChainParser{
+		BaseChainParser: BaseChainParser{
+			internalPaths:     apip.internalPaths,
+			taggedApis:        apip.taggedApis,
+			spec:              apip.spec,
+			serverApis:        apip.serverApis,
+			apiCollections:    apip.apiCollections,
+			headers:           apip.headers,
+			verifications:     apip.verifications,
+			allowedAddons:     apip.allowedAddons,
+			allowedExtensions: apip.allowedExtensions,
+			extensionParser:   apip.extensionParser,
+			active:            apip.active,
+		},
+		registry: apip.registry,
+		codec:    apip.codec,
+	}
+}
+
 func (bcp *GrpcChainParser) GetUniqueName() string {
 	return "grpc_chain_parser"
 }

--- a/protocol/chainlib/grpc_test.go
+++ b/protocol/chainlib/grpc_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcInterfaceMessages"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/extensionslib"
+	"github.com/magma-Devs/smart-router/protocol/chainlib/grpcproxy/dyncodec"
 	"github.com/magma-Devs/smart-router/protocol/parser"
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
 	spectypes "github.com/magma-Devs/smart-router/types/spec"
@@ -300,4 +301,57 @@ func TestGrpcChainListener_Shutdown_NilServer(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	require.NoError(t, listener.Shutdown(ctx))
+}
+
+// TestCloneChainParserForValidation_GrpcIsolation locks in the invariant that
+// CloneChainParserForValidation returns a *GrpcChainParser whose registry and
+// codec fields are independent of the live parser's. This is the property
+// that prevents NewGrpcChainProxy -> setupForProvider from breaking the live
+// parser when called from the spec re-verification path.
+func TestCloneChainParserForValidation_GrpcIsolation(t *testing.T) {
+	live, err := NewGrpcChainParser()
+	require.NoError(t, err)
+
+	// Set sentinel registry/codec values on the live parser so we can detect
+	// whether mutating the clone leaks back.
+	liveRegistry := &dyncodec.Registry{}
+	liveCodec := &dyncodec.Codec{}
+	live.registry = liveRegistry
+	live.codec = liveCodec
+
+	cloned := CloneChainParserForValidation(live)
+	clonedGrpc, ok := cloned.(*GrpcChainParser)
+	require.True(t, ok, "clone of a *GrpcChainParser must remain a *GrpcChainParser")
+	require.NotSame(t, live, clonedGrpc, "clone must be a distinct *GrpcChainParser instance")
+
+	// Clone should start with the same registry/codec values as the original.
+	require.Same(t, liveRegistry, clonedGrpc.registry, "clone initially aliases the live registry")
+	require.Same(t, liveCodec, clonedGrpc.codec, "clone initially aliases the live codec")
+
+	// Simulate setupForProvider on the clone (the actual mutation NewGrpcChainProxy
+	// would perform after we hand it the cloned parser).
+	clonedGrpc.registry = &dyncodec.Registry{}
+	clonedGrpc.codec = &dyncodec.Codec{}
+
+	// The live parser's fields must be untouched.
+	require.Same(t, liveRegistry, live.registry, "mutating clone.registry must not affect live.registry")
+	require.Same(t, liveCodec, live.codec, "mutating clone.codec must not affect live.codec")
+}
+
+// TestCloneChainParserForValidation_NonGrpcReturnsOriginal documents that
+// non-gRPC parsers don't have setupForProvider-style mutation, so the helper
+// returns them unchanged. Adding a new parser type that mutates during
+// chain-proxy construction would require extending the type-switch.
+func TestCloneChainParserForValidation_NonGrpcReturnsOriginal(t *testing.T) {
+	jrpcParser, err := NewJrpcChainParser()
+	require.NoError(t, err)
+	require.Same(t, ChainParser(jrpcParser), CloneChainParserForValidation(jrpcParser), "non-gRPC parser must be returned as-is")
+
+	restParser, err := NewRestChainParser()
+	require.NoError(t, err)
+	require.Same(t, ChainParser(restParser), CloneChainParserForValidation(restParser), "non-gRPC parser must be returned as-is")
+
+	tmParser, err := NewTendermintRpcChainParser()
+	require.NoError(t, err)
+	require.Same(t, ChainParser(tmParser), CloneChainParserForValidation(tmParser), "non-gRPC parser must be returned as-is")
 }

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -2106,8 +2106,8 @@ func (rpsr *RPCSmartRouter) updateEpoch(ctx context.Context, epoch uint64) {
 		if inputs := rpsr.reverifyInputs[chainKey]; inputs != nil {
 			reverifyStart := time.Now()
 			var demotedStatic, demotedBackup []*lavasession.ConsumerSessionsWithProvider
-			freshProviderSessions, demotedStatic = applyReverification(ctx, inputs, freshProviderSessions, reverifyTierStatic, epoch, nil)
-			freshBackupSessions, demotedBackup = applyReverification(ctx, inputs, freshBackupSessions, reverifyTierBackup, epoch, nil)
+			freshProviderSessions, demotedStatic = applyReverification(ctx, inputs, freshProviderSessions, reverifyTierStatic, epoch)
+			freshBackupSessions, demotedBackup = applyReverification(ctx, inputs, freshBackupSessions, reverifyTierBackup, epoch)
 			demotedSessions = append(demotedStatic, demotedBackup...)
 			// Per-chain re-verify is internally bounded by SpecReVerifyConcurrency,
 			// but updateEpoch iterates chains serially. Surfacing per-chain duration

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -163,6 +163,15 @@ type RPCSmartRouter struct {
 
 	// Server references for per-endpoint ChainTracker cleanup on epoch updates
 	rpcServers map[string]*RPCSmartRouterServer // key: chainID-apiInterface
+
+	// reverifyInputs holds the per-chain inputs applyReverification needs
+	// (chain parser, configured static/backup lists, the convertProvidersToSessions
+	// closure built in CreateSmartRouterEndpoint). Populated under rpsr.mu in
+	// CreateSmartRouterEndpoint (parallel goroutines per endpoint); after Start's
+	// wg.Wait the map is read-only, so updateEpoch reads it without locking. Absent
+	// for tests that build RPCSmartRouter directly — updateEpoch then runs the
+	// original freshen-from-old loops without a reverification post-pass.
+	reverifyInputs map[string]*chainReverifyInputs // key: chainID-apiInterface
 }
 
 type rpcSmartRouterStartOptions struct {
@@ -196,6 +205,7 @@ func (rpsr *RPCSmartRouter) Start(ctx context.Context, options *rpcSmartRouterSt
 	rpsr.backupProviderSessions = make(map[string]map[uint64]*lavasession.ConsumerSessionsWithProvider)
 	rpsr.failedStaticProviders = make(map[string][]*lavasession.RPCStaticProviderEndpoint)
 	rpsr.rpcServers = make(map[string]*RPCSmartRouterServer)
+	rpsr.reverifyInputs = make(map[string]*chainReverifyInputs)
 
 	// RPCSmartRouter always runs in standalone mode with time-based epochs
 	epochDuration := options.cmdFlags.EpochDuration
@@ -285,8 +295,12 @@ func (rpsr *RPCSmartRouter) Start(ctx context.Context, options *rpcSmartRouterSt
 
 	// Start epoch timer after all endpoints are set up
 	// Register ONE global epoch callback that updates ALL session managers
-	// This prevents multiple UpdateAllProviders calls with the same epoch to the same session manager
-	rpsr.epochTimer.RegisterCallback(rpsr.updateEpoch)
+	// This prevents multiple UpdateAllProviders calls with the same epoch to the same session manager.
+	// Capture ctx in the closure rather than stashing it on rpsr (storing context.Context in a struct is
+	// idiomatically discouraged); the EpochTimer's callback signature is fixed at func(uint64).
+	rpsr.epochTimer.RegisterCallback(func(epoch uint64) {
+		rpsr.updateEpoch(ctx, epoch)
+	})
 
 	// Log that epoch timer is configured for all session managers
 	utils.LavaFormatInfo("RPCSmartRouter: Registered epoch timer callback for all session managers",
@@ -1207,6 +1221,21 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 		}
 	}
 
+	// Register the inputs updateEpoch needs every epoch tick: chain parser, the
+	// convert closure built above (it carries ctx, rpcEndpoint,
+	// smartRouterMetricsManager), and the full configured lists. There is no
+	// separate goroutine — re-validation runs synchronously from the epoch
+	// callback, bounded by SpecReVerifyConcurrency.
+	rpsr.mu.Lock()
+	rpsr.reverifyInputs[sessionManagerKey] = &chainReverifyInputs{
+		chainParser:                chainParser,
+		rpcEndpoint:                rpcEndpoint,
+		convertProvidersToSessions: convertProvidersToSessions,
+		configuredStatic:           relevantStaticProviderList,
+		configuredBackup:           relevantBackupProviderList,
+	}
+	rpsr.mu.Unlock()
+
 	// ============================================================================
 	// Session Registration (after validation — only healthy providers)
 	// ============================================================================
@@ -1960,7 +1989,7 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	return cmdRPCSmartRouter
 }
 
-func (rpsr *RPCSmartRouter) updateEpoch(epoch uint64) {
+func (rpsr *RPCSmartRouter) updateEpoch(ctx context.Context, epoch uint64) {
 	// Copy session manager keys under lock to avoid iterating the map
 	// concurrently with retryFailedStaticProviders which writes to rpsr maps under rpsr.mu.
 	rpsr.mu.Lock()
@@ -2065,10 +2094,44 @@ func (rpsr *RPCSmartRouter) updateEpoch(epoch uint64) {
 				utils.LogAttr("chainKey", chainKeyLog))
 		}
 
-		// Update stored sessions with fresh objects
+		// Re-verify configured providers and reconcile against the fresh maps:
+		// drop entries whose provider failed validation (demote), and append
+		// new sessions for configured providers that pass but weren't active
+		// (promote — recovering from failed-init). Skipped when inputs are
+		// absent (test path constructs RPCSmartRouter directly). Demoted
+		// sessions are collected and their direct connections closed *after*
+		// UpdateAllProviders below — closing earlier would race in-flight
+		// relays still holding pointers to the prior pairing.
+		var demotedSessions []*lavasession.ConsumerSessionsWithProvider
+		if inputs := rpsr.reverifyInputs[chainKey]; inputs != nil {
+			reverifyStart := time.Now()
+			var demotedStatic, demotedBackup []*lavasession.ConsumerSessionsWithProvider
+			freshProviderSessions, demotedStatic = applyReverification(ctx, inputs, freshProviderSessions, reverifyTierStatic, epoch, nil)
+			freshBackupSessions, demotedBackup = applyReverification(ctx, inputs, freshBackupSessions, reverifyTierBackup, epoch, nil)
+			demotedSessions = append(demotedStatic, demotedBackup...)
+			// Per-chain re-verify is internally bounded by SpecReVerifyConcurrency,
+			// but updateEpoch iterates chains serially. Surfacing per-chain duration
+			// gives operators a signal when total tick time approaches epoch length —
+			// the cross-chain bound is Σ ⌈N_chain/conc⌉ × SpecReVerifyAttemptTimeout.
+			if elapsed := time.Since(reverifyStart); elapsed > SpecReVerifyAttemptTimeout {
+				utils.LavaFormatWarning("re-verify: cycle exceeded single-attempt timeout — consider tuning SpecReVerifyConcurrency", nil,
+					utils.LogAttr("chainKey", chainKeyLog),
+					utils.LogAttr("elapsed", elapsed.String()),
+					utils.LogAttr("attemptTimeout", SpecReVerifyAttemptTimeout.String()),
+				)
+			}
+		}
+
+		// Update stored sessions with fresh objects.
+		// When re-verification demotes every backup the map can be empty (not nil).
+		// In that case clear the entry so rpsr.backupProviderSessions stays consistent
+		// with what we hand UpdateAllProviders below — otherwise the stored field would
+		// retain the prior cycle's map.
 		rpsr.providerSessions[chainKey] = freshProviderSessions
 		if len(freshBackupSessions) > 0 {
 			rpsr.backupProviderSessions[chainKey] = freshBackupSessions
+		} else {
+			delete(rpsr.backupProviderSessions, chainKey)
 		}
 		server := rpsr.rpcServers[chainKey]
 
@@ -2086,6 +2149,15 @@ func (rpsr *RPCSmartRouter) updateEpoch(epoch uint64) {
 				utils.LogAttr("epoch", epoch),
 				utils.LogAttr("chainKey", chainKeyLog),
 			)
+		}
+
+		// Now that the session manager is on the new pairing, drop the
+		// DirectRPCConnections that belonged to demoted providers. The session
+		// manager's own purge path closes endpoint.Connections but not
+		// endpoint.DirectConnections — those are smart-router-owned transports
+		// and would otherwise leak across a flap (active → demoted → active rebuilds).
+		if len(demotedSessions) > 0 {
+			go closeDemotedDirectConnections(demotedSessions)
 		}
 
 		// cleanupStaleTrackers is the genuinely heavy work (tracker teardown +

--- a/protocol/rpcsmartrouter/rpcsmartrouter_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_test.go
@@ -834,3 +834,392 @@ func TestRPCSmartRouterCobraCommand_HelpStillRenders(t *testing.T) {
 		require.Contains(t, out, want, "--help output missing %q", want)
 	}
 }
+
+// reverifyTestRig is the shared scaffolding for the TestUpdateEpoch_Reverify* tests.
+// They differ only in how reverifyInputs is populated and what they assert post-update;
+// hoisting the boilerplate keeps each test focused on the behavior it actually covers.
+type reverifyTestRig struct {
+	rpsr     *RPCSmartRouter
+	chainKey string
+	endpoint *lavasession.RPCEndpoint
+}
+
+func newReverifyTestRig(t *testing.T, chainID, networkAddress string) *reverifyTestRig {
+	t.Helper()
+	rand.InitRandomSeed()
+	rpcEndpoint := &lavasession.RPCEndpoint{
+		ChainID:        chainID,
+		ApiInterface:   "tendermintrpc",
+		NetworkAddress: networkAddress,
+	}
+	optimizer := provideroptimizer.NewProviderOptimizer(provideroptimizer.StrategyBalanced, time.Second, uint(1), nil, chainID)
+	chainKey := rpcEndpoint.Key()
+	rpsr := &RPCSmartRouter{
+		sessionManagers:        make(map[string]*lavasession.ConsumerSessionManager),
+		providerSessions:       make(map[string]map[uint64]*lavasession.ConsumerSessionsWithProvider),
+		backupProviderSessions: make(map[string]map[uint64]*lavasession.ConsumerSessionsWithProvider),
+		rpcServers:             make(map[string]*RPCSmartRouterServer),
+		reverifyInputs:         make(map[string]*chainReverifyInputs),
+	}
+	rpsr.sessionManagers[chainKey] = lavasession.NewConsumerSessionManager(
+		rpcEndpoint, optimizer, nil, nil, "test-router", lavasession.NewActiveSubscriptionProvidersStorage(),
+	)
+	return &reverifyTestRig{rpsr: rpsr, chainKey: chainKey, endpoint: rpcEndpoint}
+}
+
+// makeReverifyProvider builds a configured static-provider entry whose Name and
+// ApiInterface match the rig's endpoint. applyReverification keys the active-set
+// lookup off provider.Name == session.PublicLavaAddress.
+func makeReverifyProvider(name, chainID string) *lavasession.RPCStaticProviderEndpoint {
+	return &lavasession.RPCStaticProviderEndpoint{
+		Name:         name,
+		ChainID:      chainID,
+		ApiInterface: "tendermintrpc",
+	}
+}
+
+// makeReverifySession builds a session matching one a freshen pass would produce:
+// PublicLavaAddress == provider name, StaticProvider true, single trivial endpoint
+// (UpdateAllProviders only requires non-empty endpoints).
+func makeReverifySession(name string, epoch uint64) *lavasession.ConsumerSessionsWithProvider {
+	s := lavasession.NewConsumerSessionWithProvider(
+		name,
+		[]*lavasession.Endpoint{{NetworkAddress: "http://" + name + ":8080", Enabled: true}},
+		100, epoch, int64(1),
+	)
+	s.StaticProvider = true
+	return s
+}
+
+// fakeConvertSessions is the convertProvidersToSessions stub used by promote-path
+// tests. The production closure (see CreateSmartRouterEndpoint) opens real
+// DirectRPCConnections; tests only need session shape, not transport.
+func fakeConvertSessions(epoch uint64) func([]*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+	return func(providers []*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+		out := make(map[uint64]*lavasession.ConsumerSessionsWithProvider, len(providers))
+		for i, p := range providers {
+			out[uint64(i)] = makeReverifySession(p.Name, epoch)
+		}
+		return out
+	}
+}
+
+// TestUpdateEpoch_ReverifyDemotesFailingStatic verifies the demote orchestration:
+// a session live in the prior cycle whose provider now fails validation must be
+// dropped from rpsr.providerSessions[chainKey] after updateEpoch returns. This
+// covers the post-condition that lives only in updateEpoch (assignment of the
+// applyReverification result back into the router's map at rpcsmartrouter.go:1771).
+func TestUpdateEpoch_ReverifyDemotesFailingStatic(t *testing.T) {
+	rig := newReverifyTestRig(t, "LAVA_REVERIFY_DEMOTE", "127.0.0.1:3340")
+	rpsr, chainKey := rig.rpsr, rig.chainKey
+
+	const providerName = "lava@A"
+	rpsr.providerSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: makeReverifySession(providerName, uint64(1)),
+	}
+	rpsr.reverifyInputs[chainKey] = &chainReverifyInputs{
+		rpcEndpoint:                rig.endpoint,
+		configuredStatic:           []*lavasession.RPCStaticProviderEndpoint{makeReverifyProvider(providerName, rig.endpoint.ChainID)},
+		convertProvidersToSessions: fakeConvertSessions(uint64(2)),
+		validateFn: func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+			return errors.New("re-verify failure")
+		},
+	}
+
+	rpsr.updateEpoch(context.Background(), uint64(2))
+
+	require.Empty(t, rpsr.providerSessions[chainKey],
+		"failed-validation provider must be dropped from rpsr.providerSessions after updateEpoch — applyReverification returned the demote, updateEpoch is responsible for storing it")
+	// End-to-end check: the post-reverify map must reach the session manager too,
+	// not just rpsr's own cache. validAddresses is built from pairingAddresses in
+	// UpdateAllProviders, so a count of 0 here confirms updateEpoch handed the
+	// demoted-out map to UpdateAllProviders rather than e.g. the pre-demote one.
+	require.Equal(t, 0, rpsr.sessionManagers[chainKey].GetNumberOfValidProviders(),
+		"session manager must reflect the post-reverify (empty) pairing")
+}
+
+// TestUpdateEpoch_ReverifyPromotesRecoveredStatic verifies the promote orchestration:
+// a configured provider absent from the prior cycle (failed-init / quarantined)
+// whose validation now passes must appear in rpsr.providerSessions[chainKey] with
+// PairingEpoch == newEpoch. The PairingEpoch assertion is the integration analogue
+// of the per-session check in TestApplyReverification — here we verify the value
+// survives the updateEpoch storage round-trip.
+func TestUpdateEpoch_ReverifyPromotesRecoveredStatic(t *testing.T) {
+	rig := newReverifyTestRig(t, "LAVA_REVERIFY_PROMOTE", "127.0.0.1:3341")
+	rpsr, chainKey := rig.rpsr, rig.chainKey
+
+	const providerName = "lava@A"
+	const newEpoch = uint64(2)
+
+	// No prior session: simulates failed-init or a provider that was quarantined
+	// last cycle. Freshen loop produces an empty map; applyReverification must
+	// promote A through convertProvidersToSessions.
+	rpsr.providerSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{}
+	rpsr.reverifyInputs[chainKey] = &chainReverifyInputs{
+		rpcEndpoint:                rig.endpoint,
+		configuredStatic:           []*lavasession.RPCStaticProviderEndpoint{makeReverifyProvider(providerName, rig.endpoint.ChainID)},
+		convertProvidersToSessions: fakeConvertSessions(newEpoch),
+		validateFn: func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+			return nil
+		},
+	}
+
+	rpsr.updateEpoch(context.Background(), newEpoch)
+
+	require.Len(t, rpsr.providerSessions[chainKey], 1,
+		"recovered provider must be promoted into rpsr.providerSessions after updateEpoch")
+	var promoted *lavasession.ConsumerSessionsWithProvider
+	for _, s := range rpsr.providerSessions[chainKey] {
+		promoted = s
+	}
+	require.Equal(t, providerName, promoted.PublicLavaAddress, "promoted session address must match configured provider name")
+	require.Equal(t, newEpoch, promoted.PairingEpoch,
+		"promoted session must carry the new epoch — applyReverification stamps it, updateEpoch must preserve it through storage")
+	// End-to-end checks: data must flow through to the session manager. The count
+	// confirms validAddresses was rebuilt from the post-reverify pairing, and
+	// IsStaticProvider confirms the promoted address landed in csm.pairing rather
+	// than getting stranded in rpsr's cache.
+	require.Equal(t, 1, rpsr.sessionManagers[chainKey].GetNumberOfValidProviders(),
+		"session manager validAddresses must contain exactly the promoted provider")
+	require.True(t, rpsr.sessionManagers[chainKey].IsStaticProvider(providerName),
+		"promoted provider must be queryable via IsStaticProvider — confirms it reached csm.pairing")
+}
+
+// TestUpdateEpoch_ReverifyMixedDemoteAndPromote covers the mixed case: in a single
+// updateEpoch tick one provider is demoted and another (previously failed-init) is
+// promoted. Asserts on the resulting map composition by name — the survivor set
+// after one full orchestration cycle.
+func TestUpdateEpoch_ReverifyMixedDemoteAndPromote(t *testing.T) {
+	rig := newReverifyTestRig(t, "LAVA_REVERIFY_MIXED", "127.0.0.1:3342")
+	rpsr, chainKey := rig.rpsr, rig.chainKey
+
+	const (
+		failingName   = "lava@A"
+		recoveredName = "lava@B"
+		newEpoch      = uint64(2)
+	)
+	rpsr.providerSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: makeReverifySession(failingName, uint64(1)),
+	}
+	rpsr.reverifyInputs[chainKey] = &chainReverifyInputs{
+		rpcEndpoint: rig.endpoint,
+		configuredStatic: []*lavasession.RPCStaticProviderEndpoint{
+			makeReverifyProvider(failingName, rig.endpoint.ChainID),
+			makeReverifyProvider(recoveredName, rig.endpoint.ChainID),
+		},
+		convertProvidersToSessions: fakeConvertSessions(newEpoch),
+		validateFn: func(_ context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
+			if p.Name == failingName {
+				return errors.New("re-verify failure")
+			}
+			return nil
+		},
+	}
+
+	rpsr.updateEpoch(context.Background(), newEpoch)
+
+	gotNames := map[string]*lavasession.ConsumerSessionsWithProvider{}
+	for _, s := range rpsr.providerSessions[chainKey] {
+		gotNames[s.PublicLavaAddress] = s
+	}
+	require.Len(t, gotNames, 1, "exactly one provider must survive: failing demoted, recovered promoted")
+	require.NotContains(t, gotNames, failingName, "demoted provider must be absent from rpsr.providerSessions")
+	require.Contains(t, gotNames, recoveredName, "recovered provider must be present in rpsr.providerSessions")
+	require.Equal(t, newEpoch, gotNames[recoveredName].PairingEpoch, "promoted session must carry new epoch")
+	// End-to-end: only the recovered provider must reach the session manager.
+	require.Equal(t, 1, rpsr.sessionManagers[chainKey].GetNumberOfValidProviders(),
+		"session manager validAddresses must contain only the surviving (recovered) provider")
+}
+
+// TestUpdateEpoch_ReverifyEmptyBackupTierDeletes guards the delete-empty-map
+// invariant at rpcsmartrouter.go:1772-1776: when re-verification demotes every
+// backup, updateEpoch must DELETE rpsr.backupProviderSessions[chainKey] rather
+// than leave behind an empty map. An empty map would make the chain look like it
+// "has backups" to consumers iterating the outer map, so the delete branch is
+// load-bearing.
+func TestUpdateEpoch_ReverifyEmptyBackupTierDeletes(t *testing.T) {
+	rig := newReverifyTestRig(t, "LAVA_REVERIFY_BACKUP_DELETE", "127.0.0.1:3343")
+	rpsr, chainKey := rig.rpsr, rig.chainKey
+
+	const providerName = "lava@backup-A"
+	rpsr.backupProviderSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: makeReverifySession(providerName, uint64(1)),
+	}
+	rpsr.reverifyInputs[chainKey] = &chainReverifyInputs{
+		rpcEndpoint:                rig.endpoint,
+		configuredBackup:           []*lavasession.RPCStaticProviderEndpoint{makeReverifyProvider(providerName, rig.endpoint.ChainID)},
+		convertProvidersToSessions: fakeConvertSessions(uint64(2)),
+		validateFn: func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+			return errors.New("backup re-verify failure")
+		},
+	}
+
+	rpsr.updateEpoch(context.Background(), uint64(2))
+
+	_, present := rpsr.backupProviderSessions[chainKey]
+	require.False(t, present,
+		"when every backup demotes, rpsr.backupProviderSessions[chainKey] must be DELETED, not stored as an empty map — otherwise outer-map iteration sees a phantom backup entry for the chain")
+}
+
+// TestUpdateEpoch_ReverifyBackupPartialDemote covers the backup-tier counterpart
+// to the static-mixed test: when re-verification leaves at least one backup
+// healthy, updateEpoch must take the assign branch at rpcsmartrouter.go:1772-1773
+// (not the delete branch) and store only the survivors. This is the path the
+// "backup tier produces a non-empty result post-reverify" case touches — the
+// empty-result delete path is covered separately above.
+func TestUpdateEpoch_ReverifyBackupPartialDemote(t *testing.T) {
+	rig := newReverifyTestRig(t, "LAVA_REVERIFY_BACKUP_PARTIAL", "127.0.0.1:3344")
+	rpsr, chainKey := rig.rpsr, rig.chainKey
+
+	const (
+		failingName  = "lava@backup-A"
+		survivorName = "lava@backup-B"
+		newEpoch     = uint64(2)
+	)
+	rpsr.backupProviderSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: makeReverifySession(failingName, uint64(1)),
+		1: makeReverifySession(survivorName, uint64(1)),
+	}
+	rpsr.reverifyInputs[chainKey] = &chainReverifyInputs{
+		rpcEndpoint: rig.endpoint,
+		configuredBackup: []*lavasession.RPCStaticProviderEndpoint{
+			makeReverifyProvider(failingName, rig.endpoint.ChainID),
+			makeReverifyProvider(survivorName, rig.endpoint.ChainID),
+		},
+		convertProvidersToSessions: fakeConvertSessions(newEpoch),
+		validateFn: func(_ context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
+			if p.Name == failingName {
+				return errors.New("backup re-verify failure")
+			}
+			return nil
+		},
+	}
+
+	rpsr.updateEpoch(context.Background(), newEpoch)
+
+	stored, present := rpsr.backupProviderSessions[chainKey]
+	require.True(t, present, "partial-demote must take the assign branch, not delete")
+	gotNames := map[string]struct{}{}
+	for _, s := range stored {
+		gotNames[s.PublicLavaAddress] = struct{}{}
+	}
+	require.NotContains(t, gotNames, failingName, "demoted backup must be absent")
+	require.Contains(t, gotNames, survivorName, "healthy backup must be retained")
+	require.Len(t, gotNames, 1, "only the healthy backup must survive")
+}
+
+// TestUpdateEpoch_ReverifyPromotesRecoveredBackup mirrors the static promote test
+// for the backup tier: a configured backup absent from the prior cycle whose
+// validation now passes must appear in rpsr.backupProviderSessions[chainKey] with
+// PairingEpoch == newEpoch. Backup-tier code is almost-but-not-quite a copy of
+// the static path (the delete-empty-map branch differs), so a dedicated test
+// guards against copy-paste drift in the promote half.
+func TestUpdateEpoch_ReverifyPromotesRecoveredBackup(t *testing.T) {
+	rig := newReverifyTestRig(t, "LAVA_REVERIFY_BACKUP_PROMOTE", "127.0.0.1:3345")
+	rpsr, chainKey := rig.rpsr, rig.chainKey
+
+	const providerName = "lava@backup-A"
+	const newEpoch = uint64(2)
+
+	rpsr.backupProviderSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{}
+	rpsr.reverifyInputs[chainKey] = &chainReverifyInputs{
+		rpcEndpoint:                rig.endpoint,
+		configuredBackup:           []*lavasession.RPCStaticProviderEndpoint{makeReverifyProvider(providerName, rig.endpoint.ChainID)},
+		convertProvidersToSessions: fakeConvertSessions(newEpoch),
+		validateFn: func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+			return nil
+		},
+	}
+
+	rpsr.updateEpoch(context.Background(), newEpoch)
+
+	stored, present := rpsr.backupProviderSessions[chainKey]
+	require.True(t, present, "recovered backup must take the assign branch, not delete")
+	require.Len(t, stored, 1, "exactly one backup must be promoted")
+	var promoted *lavasession.ConsumerSessionsWithProvider
+	for _, s := range stored {
+		promoted = s
+	}
+	require.Equal(t, providerName, promoted.PublicLavaAddress, "promoted backup address must match configured provider name")
+	require.Equal(t, newEpoch, promoted.PairingEpoch,
+		"promoted backup must carry the new epoch — applyReverification stamps it via toAdmit, updateEpoch must preserve it through storage to backupProviderSessions")
+	// End-to-end: the promoted backup must reach the session manager's
+	// backupProviders map. IsStaticProvider walks pairing → backupProviders →
+	// pairingPurge, so a true result here confirms the address is in one of
+	// those (and since pairing/pairingPurge stayed empty, it must be in backupProviders).
+	require.True(t, rpsr.sessionManagers[chainKey].IsStaticProvider(providerName),
+		"promoted backup must be queryable via IsStaticProvider — confirms it reached csm.backupProviders")
+}
+
+// TestUpdateEpoch_ReverifyCrossEpochDemoteThenPromote exercises the multi-epoch
+// scenario only this kind of integration test catches: a provider active in
+// epoch 1, demoted in epoch 2, then re-promoted in epoch 3. Catches regressions
+// where:
+//   - the previous-epoch blocking machinery (UpdateAllProviders'
+//     previousEpochBlockedProviders preservation) accidentally quarantines a
+//     provider that re-validates clean
+//   - applyReverification's toAdmit path fails to produce a fresh session for an
+//     address that previously existed in csm.pairing (and is now in pairingPurge)
+//   - rpsr.providerSessions[chainKey] state from a prior demote isn't cleared
+//     before the freshen loop runs, double-feeding the next epoch
+//
+// The test uses a mutable bool over closure so we can flip the validateFn
+// outcome between epochs without rebuilding inputs (mirrors the real flow:
+// the same chainReverifyInputs is used across every epoch tick).
+func TestUpdateEpoch_ReverifyCrossEpochDemoteThenPromote(t *testing.T) {
+	rig := newReverifyTestRig(t, "LAVA_REVERIFY_CROSS_EPOCH", "127.0.0.1:3346")
+	rpsr, chainKey := rig.rpsr, rig.chainKey
+	sm := rpsr.sessionManagers[chainKey]
+
+	const providerName = "lava@A"
+
+	shouldFail := false
+	rpsr.providerSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{}
+	rpsr.reverifyInputs[chainKey] = &chainReverifyInputs{
+		rpcEndpoint:                rig.endpoint,
+		configuredStatic:           []*lavasession.RPCStaticProviderEndpoint{makeReverifyProvider(providerName, rig.endpoint.ChainID)},
+		convertProvidersToSessions: fakeConvertSessions(uint64(0)), // epoch on the fake is overwritten by applyReverification's PairingEpoch stamp
+		validateFn: func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+			if shouldFail {
+				return errors.New("re-verify failure")
+			}
+			return nil
+		},
+	}
+
+	// Epoch 1: A is configured and validates clean → promote into pairing.
+	rpsr.updateEpoch(context.Background(), uint64(1))
+	require.Equal(t, 1, sm.GetNumberOfValidProviders(), "epoch 1: A must be in pairing after first promote")
+	require.True(t, sm.IsStaticProvider(providerName), "epoch 1: A must be in csm.pairing")
+	require.Len(t, rpsr.providerSessions[chainKey], 1, "epoch 1: rpsr cache must hold A")
+	var epoch1Session *lavasession.ConsumerSessionsWithProvider
+	for _, s := range rpsr.providerSessions[chainKey] {
+		epoch1Session = s
+	}
+	require.Equal(t, uint64(1), epoch1Session.PairingEpoch, "epoch 1: PairingEpoch must be 1")
+
+	// Epoch 2: validate flips to failing → A demoted out of pairing.
+	shouldFail = true
+	rpsr.updateEpoch(context.Background(), uint64(2))
+	require.Equal(t, 0, sm.GetNumberOfValidProviders(), "epoch 2: A demoted, validAddresses must be empty")
+	require.Empty(t, rpsr.providerSessions[chainKey], "epoch 2: rpsr cache must reflect the demote")
+
+	// Epoch 3: validate passes again → A re-promoted. The critical assertion:
+	// previousEpochBlockedProviders machinery must NOT permanently quarantine A
+	// (it was demoted via reverify, not via OnSessionFailure, so it should never
+	// have entered currentlyBlockedProviderAddresses), and the new fresh session
+	// must carry PairingEpoch == 3.
+	shouldFail = false
+	rpsr.updateEpoch(context.Background(), uint64(3))
+	require.Equal(t, 1, sm.GetNumberOfValidProviders(), "epoch 3: A re-promoted, validAddresses must hold one entry")
+	require.True(t, sm.IsStaticProvider(providerName), "epoch 3: re-promoted A must be in csm.pairing")
+	require.Len(t, rpsr.providerSessions[chainKey], 1, "epoch 3: rpsr cache must hold the re-promoted A")
+	var epoch3Session *lavasession.ConsumerSessionsWithProvider
+	for _, s := range rpsr.providerSessions[chainKey] {
+		epoch3Session = s
+	}
+	require.NotSame(t, epoch1Session, epoch3Session,
+		"epoch 3: re-promoted session must be a fresh object, not a resurrected pointer from epoch 1 — applyReverification's toAdmit path goes through convertProvidersToSessions for absent-from-fresh providers")
+	require.Equal(t, uint64(3), epoch3Session.PairingEpoch,
+		"epoch 3: re-promoted session must carry PairingEpoch=3")
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_test.go
@@ -131,7 +131,7 @@ func TestUpdateEpoch_FreshSessions(t *testing.T) {
 
 	// 4. Trigger Epoch Update
 	newEpoch := uint64(2)
-	rpsr.updateEpoch(newEpoch)
+	rpsr.updateEpoch(context.Background(), newEpoch)
 
 	// 5. Verify results
 	// Get the updated session map
@@ -209,7 +209,7 @@ func TestUpdateEpoch_ResetsDisabledEndpoints(t *testing.T) {
 	rpsr.providerSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{0: providerSession}
 	rpsr.backupProviderSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{0: backupSession}
 
-	rpsr.updateEpoch(uint64(2))
+	rpsr.updateEpoch(context.Background(), uint64(2))
 
 	// Direct field reads below are safe without mu: updateEpoch is synchronous and
 	// has fully returned, so no other goroutine holds or can acquire the endpoint lock.
@@ -307,7 +307,7 @@ func TestUpdateEpoch_ResetsHealthMetric(t *testing.T) {
 	rpsr.providerSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{0: primarySession}
 	rpsr.backupProviderSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{0: backupSession}
 
-	rpsr.updateEpoch(uint64(2))
+	rpsr.updateEpoch(context.Background(), uint64(2))
 
 	// Struct-level reset still holds (regression guard for #2256).
 	require.True(t, disabledPrimaryEndpoint.Enabled, "primary endpoint should be re-enabled")
@@ -370,7 +370,7 @@ func TestUpdateEpoch_NilListenEndpointDoesNotPanic(t *testing.T) {
 	session.StaticProvider = true
 	rpsr.providerSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{0: session}
 
-	require.NotPanics(t, func() { rpsr.updateEpoch(uint64(2)) },
+	require.NotPanics(t, func() { rpsr.updateEpoch(context.Background(), uint64(2)) },
 		"updateEpoch must tolerate a server with nil listenEndpoint rather than nil-deref during metric resolution")
 
 	// Even without the metric reset, the in-memory struct reset (from commit 1559d6b29) must still run.
@@ -406,7 +406,7 @@ func TestGracefulFailure_AllProvidersHealthy_NoRetryLaunched(t *testing.T) {
 	require.Len(t, rpsr.providerSessions[chainKey], 2)
 
 	// Verify: epoch update works and preserves both providers
-	rpsr.updateEpoch(2)
+	rpsr.updateEpoch(context.Background(), 2)
 	require.Len(t, rpsr.providerSessions[chainKey], 2)
 	require.Equal(t, "providerA", rpsr.providerSessions[chainKey][0].PublicLavaAddress)
 	require.Equal(t, "providerB", rpsr.providerSessions[chainKey][1].PublicLavaAddress)
@@ -433,7 +433,7 @@ func TestGracefulFailure_EpochDoesNotResurrectFailedProviders(t *testing.T) {
 	}
 
 	// Trigger epoch update
-	rpsr.updateEpoch(2)
+	rpsr.updateEpoch(context.Background(), 2)
 
 	// Verify: only A and C in sessions — B was NOT resurrected
 	sessions := rpsr.providerSessions[chainKey]
@@ -693,7 +693,7 @@ func TestGracefulFailure_ConcurrentEpochAndRetry(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 50; i++ {
-			rpsr.updateEpoch(uint64(10 + i))
+			rpsr.updateEpoch(context.Background(), uint64(10 + i))
 			time.Sleep(time.Millisecond)
 		}
 	}()
@@ -764,9 +764,9 @@ func TestGracefulFailure_EpochBeforeRetry_OnlyHealthyProviders(t *testing.T) {
 	}
 
 	// Epoch fires multiple times before retry runs
-	rpsr.updateEpoch(2)
-	rpsr.updateEpoch(3)
-	rpsr.updateEpoch(4)
+	rpsr.updateEpoch(context.Background(), 2)
+	rpsr.updateEpoch(context.Background(), 3)
+	rpsr.updateEpoch(context.Background(), 4)
 
 	// Verify: still only A in sessions after 3 epochs — B never resurrected
 	sessions := rpsr.providerSessions[chainKey]

--- a/protocol/rpcsmartrouter/spec_reverifier.go
+++ b/protocol/rpcsmartrouter/spec_reverifier.go
@@ -49,6 +49,11 @@ type chainReverifyInputs struct {
 	convertProvidersToSessions func([]*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider
 	configuredStatic           []*lavasession.RPCStaticProviderEndpoint
 	configuredBackup           []*lavasession.RPCStaticProviderEndpoint
+	// validateFn is the per-provider validation callback applyReverification
+	// dispatches to. Production leaves it nil and applyReverification falls back
+	// to validateProvider (real network probe). Tests inject a fake to exercise
+	// updateEpoch's orchestration without standing up upstreams.
+	validateFn func(context.Context, *lavasession.RPCStaticProviderEndpoint) error
 }
 
 // applyReverification revalidates configured providers for one tier and
@@ -64,9 +69,10 @@ type chainReverifyInputs struct {
 //     configured providers that pass but were absent from `fresh` (returning
 //     from failed-init / quarantine).
 //
-// Production callers pass nil for `validate`, which dispatches to
-// validateProvider (real network probe). Tests inject a fake to exercise the
-// reconciliation logic without standing up upstreams.
+// The per-provider check is inputs.validateFn; production leaves it nil and we
+// fall back to validateProvider (real network probe). Tests inject a fake via
+// inputs.validateFn to exercise the reconciliation logic — and updateEpoch's
+// orchestration around it — without standing up upstreams.
 //
 // Validations run in parallel, capped by SpecReVerifyConcurrency, so a worst-
 // case cycle is bounded by ⌈N/conc⌉ × SpecReVerifyAttemptTimeout instead of
@@ -82,7 +88,6 @@ func applyReverification(
 	fresh map[uint64]*lavasession.ConsumerSessionsWithProvider,
 	tier reverifyTier,
 	epoch uint64,
-	validate func(context.Context, *lavasession.RPCStaticProviderEndpoint) error,
 ) (map[uint64]*lavasession.ConsumerSessionsWithProvider, []*lavasession.ConsumerSessionsWithProvider) {
 	var configured []*lavasession.RPCStaticProviderEndpoint
 	switch tier {
@@ -94,6 +99,7 @@ func applyReverification(
 	if len(configured) == 0 {
 		return fresh, nil
 	}
+	validate := inputs.validateFn
 	if validate == nil {
 		validate = func(c context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
 			return validateProvider(c, p, inputs.chainParser, SpecReVerifyAttemptTimeout)

--- a/protocol/rpcsmartrouter/spec_reverifier.go
+++ b/protocol/rpcsmartrouter/spec_reverifier.go
@@ -1,0 +1,284 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/chainlib"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/utils"
+)
+
+// SpecReVerifyConcurrency caps the number of providers validated in parallel
+// per cycle. With many configured upstreams a fully serial cycle can exceed
+// the epoch tick (worst case: N × SpecReVerifyAttemptTimeout). Exported for
+// tests; not flag-bound.
+var SpecReVerifyConcurrency = 5
+
+// SpecReVerifyAttemptTimeout bounds a single Validate call. Not flag-bound —
+// implementation detail rarely useful to operators. Exported for tests.
+var SpecReVerifyAttemptTimeout = 30 * time.Second
+
+// reverifyTier discriminates which configured list applyReverification operates
+// on. A typed enum prevents the silent miss-routing a stringly-typed tier could
+// cause if a caller ever typoed "back-up" or "primary".
+type reverifyTier int
+
+const (
+	reverifyTierStatic reverifyTier = iota
+	reverifyTierBackup
+)
+
+func (t reverifyTier) String() string {
+	switch t {
+	case reverifyTierStatic:
+		return "static"
+	case reverifyTierBackup:
+		return "backup"
+	}
+	return "unknown"
+}
+
+// chainReverifyInputs captures the per-chain values applyReverification needs
+// each epoch tick.
+type chainReverifyInputs struct {
+	chainParser                chainlib.ChainParser
+	rpcEndpoint                *lavasession.RPCEndpoint
+	convertProvidersToSessions func([]*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider
+	configuredStatic           []*lavasession.RPCStaticProviderEndpoint
+	configuredBackup           []*lavasession.RPCStaticProviderEndpoint
+}
+
+// applyReverification revalidates configured providers for one tier and
+// reconciles the result against the freshly-built active map. It does two
+// things, in order:
+//
+//   - Demote: drop entries from `fresh` whose provider failed validation
+//     (these were active last cycle but are no longer healthy). The demoted
+//     sessions are returned so the caller can close their DirectRPCConnections
+//     after UpdateAllProviders has swung over to the new map — closing inline
+//     would race in-flight relays still holding a pointer to the prior map.
+//   - Promote: build new sessions via inputs.convertProvidersToSessions for
+//     configured providers that pass but were absent from `fresh` (returning
+//     from failed-init / quarantine).
+//
+// Production callers pass nil for `validate`, which dispatches to
+// validateProvider (real network probe). Tests inject a fake to exercise the
+// reconciliation logic without standing up upstreams.
+//
+// Validations run in parallel, capped by SpecReVerifyConcurrency, so a worst-
+// case cycle is bounded by ⌈N/conc⌉ × SpecReVerifyAttemptTimeout instead of
+// N × timeout. Pure with respect to RPCSmartRouter state — no field mutation,
+// no UpdateAllProviders, no tracker reconcile; updateEpoch owns those.
+//
+// Configured lists are pre-filtered by chain+ApiInterface at startup (see
+// relevantStaticProviderList in rpcsmartrouter.go), so no further filter is
+// needed here.
+func applyReverification(
+	ctx context.Context,
+	inputs *chainReverifyInputs,
+	fresh map[uint64]*lavasession.ConsumerSessionsWithProvider,
+	tier reverifyTier,
+	epoch uint64,
+	validate func(context.Context, *lavasession.RPCStaticProviderEndpoint) error,
+) (map[uint64]*lavasession.ConsumerSessionsWithProvider, []*lavasession.ConsumerSessionsWithProvider) {
+	var configured []*lavasession.RPCStaticProviderEndpoint
+	switch tier {
+	case reverifyTierStatic:
+		configured = inputs.configuredStatic
+	case reverifyTierBackup:
+		configured = inputs.configuredBackup
+	}
+	if len(configured) == 0 {
+		return fresh, nil
+	}
+	if validate == nil {
+		validate = func(c context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
+			return validateProvider(c, p, inputs.chainParser, SpecReVerifyAttemptTimeout)
+		}
+	}
+
+	// WaitGroup + buffered-channel semaphore. Replaces an earlier errgroup —
+	// the goroutines never return non-nil errors (results are stored in
+	// `results[i]`), so errgroup's first-error cancellation was inert. Plain
+	// WaitGroup makes that contract explicit and removes the trap of a future
+	// edit accidentally short-circuiting validation.
+	results := make([]error, len(configured))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, SpecReVerifyConcurrency)
+	for i, p := range configured {
+		i, p := i, p
+		sem <- struct{}{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			results[i] = validate(ctx, p)
+		}()
+	}
+	wg.Wait()
+
+	activeNames := byName(fresh)
+	healthyNames := make(map[string]struct{}, len(configured))
+	var toAdmit []*lavasession.RPCStaticProviderEndpoint
+	for i, p := range configured {
+		err := results[i]
+		_, wasActive := activeNames[p.Name]
+		if err == nil {
+			healthyNames[p.Name] = struct{}{}
+			if !wasActive {
+				toAdmit = append(toAdmit, p)
+				utils.LavaFormatInfo("re-verify: "+tier.String()+" provider recovered",
+					utils.LogAttr("chain", inputs.rpcEndpoint.ChainID),
+					utils.LogAttr("provider", p.Name),
+				)
+			}
+			continue
+		}
+		if wasActive {
+			utils.LavaFormatWarning("re-verify: demoting active "+tier.String(), err,
+				utils.LogAttr("chain", inputs.rpcEndpoint.ChainID),
+				utils.LogAttr("provider", p.Name),
+			)
+		} else {
+			utils.LavaFormatDebug("re-verify: failed-init "+tier.String()+" still failing",
+				utils.LogAttr("chain", inputs.rpcEndpoint.ChainID),
+				utils.LogAttr("provider", p.Name),
+				utils.LogAttr("err", err.Error()),
+			)
+		}
+	}
+
+	// Demote: drop fresh entries whose provider is unhealthy. Keep their
+	// original keys to minimise churn for entries that survive — preserves the
+	// freshen-loop's idx semantics. Demoted sessions are surfaced to the caller
+	// (not closed here) so connection teardown happens *after* the session
+	// manager has swung to the new pairing — see updateEpoch.
+	next := make(map[uint64]*lavasession.ConsumerSessionsWithProvider, len(fresh))
+	var demoted []*lavasession.ConsumerSessionsWithProvider
+	for idx, s := range fresh {
+		if _, ok := healthyNames[s.PublicLavaAddress]; !ok {
+			demoted = append(demoted, s)
+			continue
+		}
+		next[idx] = s
+	}
+
+	// Promote: append fresh sessions for healthy providers absent from `fresh`.
+	// Pick keys that don't collide with surviving entries.
+	if len(toAdmit) > 0 {
+		nextIdx := uint64(0)
+		for k := range next {
+			if k >= nextIdx {
+				nextIdx = k + 1
+			}
+		}
+		for _, s := range inputs.convertProvidersToSessions(toAdmit) {
+			s.Lock.Lock()
+			s.PairingEpoch = epoch
+			s.Lock.Unlock()
+			next[nextIdx] = s
+			nextIdx++
+		}
+	}
+
+	return next, demoted
+}
+
+// byName builds a name → session lookup so callers can answer
+// "is this provider currently active" in O(1).
+func byName(sessions map[uint64]*lavasession.ConsumerSessionsWithProvider) map[string]*lavasession.ConsumerSessionsWithProvider {
+	out := make(map[string]*lavasession.ConsumerSessionsWithProvider, len(sessions))
+	for _, s := range sessions {
+		out[s.PublicLavaAddress] = s
+	}
+	return out
+}
+
+// closeDemotedDirectConnections releases the DirectRPCConnection objects
+// attached to sessions removed by re-verification. The session manager's own
+// purge path (closePurgedUnusedPairingsConnections) closes endpoint.Connections
+// but not endpoint.DirectConnections — those are the smart-router-owned
+// transports, and without this call they leak whenever a provider flaps active
+// → demoted across an epoch.
+//
+// Intentionally fire-and-forget from a goroutine after UpdateAllProviders has
+// returned: the new pairing is already live, so any in-flight relay holds a
+// session pointer from the *new* map, and dropping the old transports is safe.
+func closeDemotedDirectConnections(demoted []*lavasession.ConsumerSessionsWithProvider) {
+	for _, s := range demoted {
+		for _, ep := range s.Endpoints {
+			for _, dc := range ep.DirectConnections {
+				if dc == nil {
+					continue
+				}
+				if err := dc.Close(); err != nil {
+					utils.LavaFormatDebug("re-verify: error closing demoted direct connection",
+						utils.LogAttr("provider", s.PublicLavaAddress),
+						utils.LogAttr("url", dc.GetURL()),
+						utils.LogAttr("err", err.Error()),
+					)
+				}
+			}
+		}
+	}
+}
+
+// validateProvider runs a single spec-verification pass against one provider.
+// It builds a fresh ChainRouter + ChainFetcher under a bounded attempt context
+// (so a hung upstream cannot stall a whole reconcile cycle), calls Validate,
+// and tears the temporary resources down regardless of outcome.
+func validateProvider(
+	ctx context.Context,
+	provider *lavasession.RPCStaticProviderEndpoint,
+	chainParser chainlib.ChainParser,
+	timeout time.Duration,
+) error {
+	// Expand addon URLs the same way startup PHASE 1 does — chain_router.go
+	// requires both with-addon and without-addon routes for routing flexibility.
+	verificationNodeUrls := make([]common.NodeUrl, 0, len(provider.NodeUrls)*2)
+	for _, nodeUrl := range provider.NodeUrls {
+		verificationNodeUrls = append(verificationNodeUrls, nodeUrl)
+		if len(nodeUrl.Addons) > 0 {
+			noAddonUrl := nodeUrl
+			noAddonUrl.Addons = []string{}
+			verificationNodeUrls = append(verificationNodeUrls, noAddonUrl)
+		}
+	}
+
+	verificationEndpoint := &lavasession.RPCProviderEndpoint{
+		NetworkAddress: provider.NetworkAddress,
+		ChainID:        provider.ChainID,
+		ApiInterface:   provider.ApiInterface,
+		Geolocation:    provider.Geolocation,
+		NodeUrls:       verificationNodeUrls,
+	}
+
+	attemptCtx, attemptCancel := context.WithTimeout(ctx, timeout)
+	defer attemptCancel()
+
+	// Isolate the live chainParser from any mutation NewChainProxy might
+	// perform during verification. For gRPC, NewGrpcChainProxy replaces the
+	// parser's registry/codec with ones bound to the verification connection;
+	// when attemptCtx is cancelled the connection dies and live gRPC relays
+	// would hit a nil connector. For non-gRPC interfaces this is a no-op
+	// (returns the original parser).
+	validationParser := chainlib.CloneChainParserForValidation(chainParser)
+
+	parallelConnections := uint(lavasession.DefaultMaximumStreamsOverASingleConnection)
+	verificationRouter, err := chainlib.GetChainRouter(attemptCtx, parallelConnections, verificationEndpoint, validationParser)
+	if err != nil {
+		return err
+	}
+
+	verificationFetcher := chainlib.NewChainFetcher(attemptCtx, &chainlib.ChainFetcherOptions{
+		ChainRouter: verificationRouter,
+		ChainParser: validationParser,
+		Endpoint:    verificationEndpoint,
+		Cache:       nil,
+	})
+
+	return verificationFetcher.Validate(attemptCtx)
+}

--- a/protocol/rpcsmartrouter/spec_reverifier_test.go
+++ b/protocol/rpcsmartrouter/spec_reverifier_test.go
@@ -139,9 +139,10 @@ func TestApplyReverification(t *testing.T) {
 				rpcEndpoint:                rpc,
 				convertProvidersToSessions: convert,
 				configuredStatic:           configured,
+				validateFn:                 validate,
 			}
 
-			got, demoted := applyReverification(context.Background(), inputs, fresh, reverifyTierStatic, uint64(42), validate)
+			got, demoted := applyReverification(context.Background(), inputs, fresh, reverifyTierStatic, uint64(42))
 			gotNames := collectNames(got)
 
 			require.Len(t, gotNames, len(tt.want), "result size, tc #%d", i)
@@ -201,9 +202,10 @@ func TestApplyReverification_BackupTierReadsBackupList(t *testing.T) {
 		convertProvidersToSessions: fakeConvert,
 		configuredStatic:           staticOnly,
 		configuredBackup:           backupOnly,
+		validateFn:                 validate,
 	}
 
-	_, _ = applyReverification(context.Background(), inputs, map[uint64]*lavasession.ConsumerSessionsWithProvider{}, reverifyTierBackup, 1, validate)
+	_, _ = applyReverification(context.Background(), inputs, map[uint64]*lavasession.ConsumerSessionsWithProvider{}, reverifyTierBackup, 1)
 	require.Equal(t, []string{"B"}, calls, "backup tier must validate the backup list")
 }
 

--- a/protocol/rpcsmartrouter/spec_reverifier_test.go
+++ b/protocol/rpcsmartrouter/spec_reverifier_test.go
@@ -1,0 +1,259 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/chainlib"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func makeSession(name string) *lavasession.ConsumerSessionsWithProvider {
+	return lavasession.NewConsumerSessionWithProvider(name, nil, 1, 1, 0)
+}
+
+func makeProvider(name string) *lavasession.RPCStaticProviderEndpoint {
+	return &lavasession.RPCStaticProviderEndpoint{Name: name, ApiInterface: "rest"}
+}
+
+// fakeConvert mimics the closure built in CreateSmartRouterEndpoint: turn a
+// list of providers into a session map. Used only by the promote path.
+func fakeConvert(p []*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+	out := map[uint64]*lavasession.ConsumerSessionsWithProvider{}
+	for i, ep := range p {
+		out[uint64(i)] = makeSession(ep.Name)
+	}
+	return out
+}
+
+func collectNames(m map[uint64]*lavasession.ConsumerSessionsWithProvider) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, s := range m {
+		out[s.PublicLavaAddress] = struct{}{}
+	}
+	return out
+}
+
+func TestApplyReverification(t *testing.T) {
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "rest"}
+
+	tests := []struct {
+		name        string
+		configured  []string
+		fresh       []string        // names already present in the freshened active map
+		failing     map[string]bool // by provider name; absent => passes validate
+		want        []string        // expected names in the returned map
+		wantAdmits  []string        // names that must come from convertProvidersToSessions (promotions)
+		wantDemoted []string        // names that must surface in the demoted return slice
+	}{
+		{
+			name:       "steady-state healthy",
+			configured: []string{"A", "B"},
+			fresh:      []string{"A", "B"},
+			want:       []string{"A", "B"},
+		},
+		{
+			name:       "promote: failed-init now passing",
+			configured: []string{"A", "B"},
+			fresh:      []string{"A"},
+			want:       []string{"A", "B"},
+			wantAdmits: []string{"B"},
+		},
+		{
+			name:        "demote: active now failing",
+			configured:  []string{"A", "B"},
+			fresh:       []string{"A", "B"},
+			failing:     map[string]bool{"B": true},
+			want:        []string{"A"},
+			wantDemoted: []string{"B"},
+		},
+		{
+			name:       "still-failing failed-init stays out",
+			configured: []string{"A", "B"},
+			fresh:      []string{"A"},
+			failing:    map[string]bool{"B": true},
+			want:       []string{"A"},
+		},
+		{
+			name:        "mixed: promote + demote in one cycle",
+			configured:  []string{"A", "B", "C"},
+			fresh:       []string{"A", "B"},
+			failing:     map[string]bool{"B": true},
+			want:        []string{"A", "C"},
+			wantAdmits:  []string{"C"},
+			wantDemoted: []string{"B"},
+		},
+		{
+			name:        "all configured failing wipes fresh",
+			configured:  []string{"A", "B"},
+			fresh:       []string{"A", "B"},
+			failing:     map[string]bool{"A": true, "B": true},
+			want:        nil,
+			wantDemoted: []string{"A", "B"},
+		},
+		{
+			name:       "empty configured returns fresh unchanged",
+			configured: nil,
+			fresh:      []string{"A"},
+			want:       []string{"A"},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fresh := map[uint64]*lavasession.ConsumerSessionsWithProvider{}
+			freshByName := map[string]*lavasession.ConsumerSessionsWithProvider{}
+			for j, n := range tt.fresh {
+				s := makeSession(n)
+				fresh[uint64(j)] = s
+				freshByName[n] = s
+			}
+			configured := make([]*lavasession.RPCStaticProviderEndpoint, len(tt.configured))
+			for j, n := range tt.configured {
+				configured[j] = makeProvider(n)
+			}
+
+			// Track what convertProvidersToSessions is called with — promotions must
+			// flow through it; survivors must not.
+			var convertCalls []string
+			convert := func(p []*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+				for _, ep := range p {
+					convertCalls = append(convertCalls, ep.Name)
+				}
+				return fakeConvert(p)
+			}
+
+			validate := func(_ context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
+				if tt.failing[p.Name] {
+					return errors.New("mock failure")
+				}
+				return nil
+			}
+
+			inputs := &chainReverifyInputs{
+				rpcEndpoint:                rpc,
+				convertProvidersToSessions: convert,
+				configuredStatic:           configured,
+			}
+
+			got, demoted := applyReverification(context.Background(), inputs, fresh, reverifyTierStatic, uint64(42), validate)
+			gotNames := collectNames(got)
+
+			require.Len(t, gotNames, len(tt.want), "result size, tc #%d", i)
+			for _, n := range tt.want {
+				require.Contains(t, gotNames, n, "missing expected provider %q, tc #%d", n, i)
+			}
+
+			require.ElementsMatch(t, tt.wantAdmits, convertCalls, "convertProvidersToSessions call set, tc #%d", i)
+
+			demotedNames := make([]string, 0, len(demoted))
+			for _, s := range demoted {
+				demotedNames = append(demotedNames, s.PublicLavaAddress)
+			}
+			require.ElementsMatch(t, tt.wantDemoted, demotedNames, "demoted set, tc #%d", i)
+
+			// Survivors must keep their original session pointer (no recreation).
+			admits := map[string]struct{}{}
+			for _, n := range tt.wantAdmits {
+				admits[n] = struct{}{}
+			}
+			gotByName := map[string]*lavasession.ConsumerSessionsWithProvider{}
+			for _, s := range got {
+				gotByName[s.PublicLavaAddress] = s
+			}
+			for n := range gotByName {
+				if _, isAdmit := admits[n]; isAdmit {
+					continue
+				}
+				require.Same(t, freshByName[n], gotByName[n], "survivor %q must reuse the fresh session pointer, tc #%d", n, i)
+			}
+
+			// Promoted sessions must carry the current epoch.
+			for n := range admits {
+				require.Equal(t, uint64(42), gotByName[n].PairingEpoch, "promoted %q must carry current epoch, tc #%d", n, i)
+			}
+		})
+	}
+}
+
+// TestApplyReverification_BackupTierReadsBackupList confirms the typed-tier
+// switch picks inputs.configuredBackup (not configuredStatic) when invoked
+// with reverifyTierBackup. The static path is exercised by the table tests
+// above; this ensures the discriminator actually routes.
+func TestApplyReverification_BackupTierReadsBackupList(t *testing.T) {
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "rest"}
+	staticOnly := []*lavasession.RPCStaticProviderEndpoint{makeProvider("S")}
+	backupOnly := []*lavasession.RPCStaticProviderEndpoint{makeProvider("B")}
+
+	var calls []string
+	validate := func(_ context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
+		calls = append(calls, p.Name)
+		return nil
+	}
+
+	inputs := &chainReverifyInputs{
+		rpcEndpoint:                rpc,
+		convertProvidersToSessions: fakeConvert,
+		configuredStatic:           staticOnly,
+		configuredBackup:           backupOnly,
+	}
+
+	_, _ = applyReverification(context.Background(), inputs, map[uint64]*lavasession.ConsumerSessionsWithProvider{}, reverifyTierBackup, 1, validate)
+	require.Equal(t, []string{"B"}, calls, "backup tier must validate the backup list")
+}
+
+func TestByName(t *testing.T) {
+	sessions := map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		3: makeSession("X"),
+		7: makeSession("Y"),
+	}
+	got := byName(sessions)
+	require.Len(t, got, 2)
+	require.Contains(t, got, "X")
+	require.Contains(t, got, "Y")
+}
+
+// TestValidateProvider_SmokeWiring exercises validateProvider end-to-end:
+// clone-isolation lookup, GetChainRouter, ChainFetcher construction, and
+// Validate dispatch. It uses an empty REST spec (so GetVerifications returns
+// nothing and Validate succeeds without hitting the wire), which means a
+// fully-broken function — wrong chainParser threading, GetChainRouter
+// signature drift, NewChainFetcher option struct mismatch, etc. — would fail
+// here even though no real network probe is performed. The cancellable-ctx
+// argument ensures a regression that ignored ctx couldn't pass the timeout
+// bound silently.
+//
+// A deeper hung-server / cancellation-propagation test would require a Spec
+// with at least one Verification triggering FetchLatestBlockNum, which is
+// significantly more setup for marginal additional coverage over what the
+// applyReverification table-tests already provide.
+func TestValidateProvider_SmokeWiring(t *testing.T) {
+	parser, err := chainlib.NewRestChainParser()
+	require.NoError(t, err)
+	parser.SetSpec(spectypes.Spec{})
+
+	provider := &lavasession.RPCStaticProviderEndpoint{
+		ChainID:      "TEST",
+		ApiInterface: "rest",
+		NodeUrls:     []common.NodeUrl{{Url: "http://127.0.0.1:1"}},
+	}
+
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		defer close(done)
+		_ = validateProvider(context.Background(), provider, parser, 2*time.Second)
+	}()
+
+	select {
+	case <-done:
+		require.Less(t, time.Since(start), 3*time.Second, "validateProvider must complete within the timeout bound")
+	case <-time.After(5 * time.Second):
+		t.Fatal("validateProvider hung past its timeout argument — wiring regression")
+	}
+}


### PR DESCRIPTION
## Summary

Adds **periodic re-verification of statically-configured upstreams** to the smart router. On every epoch tick, the router now re-validates each provider in the `direct-rpc` and `backup-direct-rpc` pools, demotes the ones that fail, and promotes recovered ones back into the active set — so a flapping upstream no longer stays unusable until the process restarts.

## What's in the change

- **New re-verifier** — runs synchronously from the existing epoch callback, bounded by `SpecReVerifyConcurrency = 5` and `SpecReVerifyAttemptTimeout = 30s`. Logs a warning when a per-chain cycle exceeds the attempt timeout so operators can spot ticks approaching epoch length.
- **Demote / promote reconciliation** — `updateEpoch` now diffs re-verified results against the freshly built session maps for both static and backup tiers. Demoted sessions' `DirectRPCConnections` are closed _after_ `UpdateAllProviders` to avoid racing in-flight relays.
- **Safe parser cloning for gRPC validation** — `NewGrpcChainProxy → setupForProvider` mutates the parser's `registry`/`codec` to the verification connection's lifetime; reusing the live parser would panic gRPC relays on a nil connector when the per-attempt context cancels. `CloneChainParserForValidation` isolates that mutation; non-gRPC parsers pass through unchanged.

## Tests
- demote, promote, mixed-tier, and timeout paths.
- verifies `cloneForValidation` produces an isolated parser.