### PR TITLE
fix(rpcsmartrouter): honor force-cache-refresh on retry path

### DIFF
--- a/protocol/relaycore/archive_extension_test.go
+++ b/protocol/relaycore/archive_extension_test.go
@@ -1,0 +1,131 @@
+package relaycore
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/chainlib"
+	"github.com/magma-Devs/smart-router/protocol/chainlib/extensionslib"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// passthroughRelayParser implements RelayParserInf by re-parsing through the
+// real chainParser, mirroring the production flow.
+type passthroughRelayParser struct {
+	chainParser chainlib.ChainParser
+	calls       int
+}
+
+func (p *passthroughRelayParser) ParseRelay(
+	ctx context.Context,
+	url string,
+	req string,
+	connectionType string,
+	dappID string,
+	consumerIp string,
+	metadata []pairingtypes.Metadata,
+) (chainlib.ProtocolMessage, error) {
+	p.calls++
+
+	directiveHeaders := map[string]string{}
+	filtered := make([]pairingtypes.Metadata, 0, len(metadata))
+	for _, m := range metadata {
+		if _, ok := common.SPECIAL_LAVA_DIRECTIVE_HEADERS[m.Name]; ok {
+			directiveHeaders[m.Name] = m.Value
+		} else {
+			filtered = append(filtered, m)
+		}
+	}
+
+	var extensions extensionslib.ExtensionInfo
+	if extOverride, ok := directiveHeaders[common.EXTENSION_OVERRIDE_HEADER_NAME]; ok && extOverride != "" {
+		extensions = extensionslib.ExtensionInfo{LatestBlock: 0, AdditionalExtensions: []string{extOverride}}
+	}
+
+	chainMsg, err := p.chainParser.ParseMsg(url, []byte(req), connectionType, filtered, extensions)
+	if err != nil {
+		return nil, err
+	}
+
+	relayRequestData := &pairingtypes.RelayPrivateData{
+		ApiUrl:         url,
+		ConnectionType: connectionType,
+		Data:           []byte(req),
+	}
+	return chainlib.NewProtocolMessage(chainMsg, directiveHeaders, relayRequestData, dappID, consumerIp), nil
+}
+
+func newTestProtocolMessage(t *testing.T, directiveHeaders map[string]string, extensions []string, forceCacheRefresh bool) (chainlib.ProtocolMessage, chainlib.ChainParser) {
+	t.Helper()
+	ctx := context.Background()
+	serverHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	chainParser, _, _, closeServer, _, err := chainlib.CreateChainLibMocks(ctx, "LAVA", spectypes.APIInterfaceRest, serverHandler, nil, "../../", nil)
+	if closeServer != nil {
+		t.Cleanup(closeServer)
+	}
+	require.NoError(t, err)
+	chainMsg, err := chainParser.ParseMsg("/cosmos/base/tendermint/v1beta1/blocks/17", nil, http.MethodGet, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+	require.NoError(t, err)
+	chainMsg.SetForceCacheRefresh(forceCacheRefresh)
+
+	relayRequestData := &pairingtypes.RelayPrivateData{
+		ApiUrl:         "/cosmos/base/tendermint/v1beta1/blocks/17",
+		ConnectionType: http.MethodGet,
+		Data:           []byte(""),
+		Extensions:     extensions,
+	}
+	return chainlib.NewProtocolMessage(chainMsg, directiveHeaders, relayRequestData, "dapp", "1.2.3.4"), chainParser
+}
+
+// TestArchiveAddPreservesForceCacheRefresh is a regression for MAG-1653 Bug #1:
+// addArchiveExtension previously rebuilt metadata from scratch with only the
+// extension override, silently dropping lava-force-cache-refresh. The user-set
+// directive must survive into the post-upgrade protocol message.
+func TestArchiveAddPreservesForceCacheRefresh(t *testing.T) {
+	pm, parser := newTestProtocolMessage(t, map[string]string{
+		common.FORCE_CACHE_REFRESH_HEADER_NAME: "true",
+	}, nil, true)
+	relayParser := &passthroughRelayParser{chainParser: parser}
+
+	upgraded := addArchiveExtension(context.Background(), pm, &ArchiveStatus{}, relayParser)
+
+	require.Equal(t, 1, relayParser.calls)
+	require.NotSame(t, pm, upgraded, "upgrade should produce a new protocol message")
+	require.True(t, upgraded.GetForceCacheRefresh(), "lava-force-cache-refresh must be preserved through archive add")
+}
+
+// TestArchiveRemovePreservesForceCacheRefresh is the symmetric regression for
+// removeArchiveExtension.
+func TestArchiveRemovePreservesForceCacheRefresh(t *testing.T) {
+	pm, parser := newTestProtocolMessage(t, map[string]string{
+		common.FORCE_CACHE_REFRESH_HEADER_NAME: "true",
+	}, []string{"archive"}, true)
+	relayParser := &passthroughRelayParser{chainParser: parser}
+
+	archiveStatus := &ArchiveStatus{}
+	archiveStatus.isUpgraded.Store(true) // remove only runs after a prior upgrade
+	archiveStatus.isArchive.Store(true)
+
+	downgraded := removeArchiveExtension(context.Background(), pm, archiveStatus, relayParser)
+
+	require.Equal(t, 1, relayParser.calls)
+	require.NotSame(t, pm, downgraded)
+	require.True(t, downgraded.GetForceCacheRefresh(), "lava-force-cache-refresh must be preserved through archive remove")
+}
+
+// TestArchiveAddDoesNotInventForceCacheRefresh verifies the preserve helper does
+// not flip the directive on for a request that didn't ask for cache bypass.
+func TestArchiveAddDoesNotInventForceCacheRefresh(t *testing.T) {
+	pm, parser := newTestProtocolMessage(t, map[string]string{}, nil, false)
+	relayParser := &passthroughRelayParser{chainParser: parser}
+
+	upgraded := addArchiveExtension(context.Background(), pm, &ArchiveStatus{}, relayParser)
+
+	require.False(t, upgraded.GetForceCacheRefresh(), "must not enable cache bypass when the client did not request it")
+}

--- a/protocol/relaycore/archive_extension_test.go
+++ b/protocol/relaycore/archive_extension_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/magma-Devs/smart-router/protocol/chainlib"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/extensionslib"
@@ -59,7 +60,14 @@ func (p *passthroughRelayParser) ParseRelay(
 	return chainlib.NewProtocolMessage(chainMsg, directiveHeaders, relayRequestData, dappID, consumerIp), nil
 }
 
-func newTestProtocolMessage(t *testing.T, directiveHeaders map[string]string, extensions []string, forceCacheRefresh bool) (chainlib.ProtocolMessage, chainlib.ChainParser) {
+type testProtocolMessageOpts struct {
+	directiveHeaders  map[string]string
+	extensions        []string
+	forceCacheRefresh bool
+	timeoutOverride   time.Duration
+}
+
+func newTestProtocolMessage(t *testing.T, opts testProtocolMessageOpts) (chainlib.ProtocolMessage, chainlib.ChainParser) {
 	t.Helper()
 	ctx := context.Background()
 	serverHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -72,25 +80,31 @@ func newTestProtocolMessage(t *testing.T, directiveHeaders map[string]string, ex
 	require.NoError(t, err)
 	chainMsg, err := chainParser.ParseMsg("/cosmos/base/tendermint/v1beta1/blocks/17", nil, http.MethodGet, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
 	require.NoError(t, err)
-	chainMsg.SetForceCacheRefresh(forceCacheRefresh)
+	chainMsg.SetForceCacheRefresh(opts.forceCacheRefresh)
+	if opts.timeoutOverride != 0 {
+		chainMsg.TimeoutOverride(opts.timeoutOverride)
+	}
 
 	relayRequestData := &pairingtypes.RelayPrivateData{
 		ApiUrl:         "/cosmos/base/tendermint/v1beta1/blocks/17",
 		ConnectionType: http.MethodGet,
 		Data:           []byte(""),
-		Extensions:     extensions,
+		Extensions:     opts.extensions,
 	}
-	return chainlib.NewProtocolMessage(chainMsg, directiveHeaders, relayRequestData, "dapp", "1.2.3.4"), chainParser
+	return chainlib.NewProtocolMessage(chainMsg, opts.directiveHeaders, relayRequestData, "dapp", "1.2.3.4"), chainParser
 }
 
 // TestArchiveAddPreservesForceCacheRefresh is a regression for MAG-1653 Bug #1:
 // addArchiveExtension previously rebuilt metadata from scratch with only the
 // extension override, silently dropping lava-force-cache-refresh. The user-set
-// directive must survive into the post-upgrade protocol message.
+// directive must survive into the post-upgrade protocol message — both on the
+// chainMessage flag (runtime check) and in the directiveHeaders map (parse-time
+// input surface), so the two stay consistent.
 func TestArchiveAddPreservesForceCacheRefresh(t *testing.T) {
-	pm, parser := newTestProtocolMessage(t, map[string]string{
-		common.FORCE_CACHE_REFRESH_HEADER_NAME: "true",
-	}, nil, true)
+	pm, parser := newTestProtocolMessage(t, testProtocolMessageOpts{
+		directiveHeaders:  map[string]string{common.FORCE_CACHE_REFRESH_HEADER_NAME: "true"},
+		forceCacheRefresh: true,
+	})
 	relayParser := &passthroughRelayParser{chainParser: parser}
 
 	upgraded := addArchiveExtension(context.Background(), pm, &ArchiveStatus{}, relayParser)
@@ -98,14 +112,18 @@ func TestArchiveAddPreservesForceCacheRefresh(t *testing.T) {
 	require.Equal(t, 1, relayParser.calls)
 	require.NotSame(t, pm, upgraded, "upgrade should produce a new protocol message")
 	require.True(t, upgraded.GetForceCacheRefresh(), "lava-force-cache-refresh must be preserved through archive add")
+	require.Equal(t, "true", upgraded.GetDirectiveHeaders()[common.FORCE_CACHE_REFRESH_HEADER_NAME],
+		"directiveHeaders map must stay in sync with the chainMessage flag")
 }
 
 // TestArchiveRemovePreservesForceCacheRefresh is the symmetric regression for
 // removeArchiveExtension.
 func TestArchiveRemovePreservesForceCacheRefresh(t *testing.T) {
-	pm, parser := newTestProtocolMessage(t, map[string]string{
-		common.FORCE_CACHE_REFRESH_HEADER_NAME: "true",
-	}, []string{"archive"}, true)
+	pm, parser := newTestProtocolMessage(t, testProtocolMessageOpts{
+		directiveHeaders:  map[string]string{common.FORCE_CACHE_REFRESH_HEADER_NAME: "true"},
+		extensions:        []string{"archive"},
+		forceCacheRefresh: true,
+	})
 	relayParser := &passthroughRelayParser{chainParser: parser}
 
 	archiveStatus := &ArchiveStatus{}
@@ -117,15 +135,78 @@ func TestArchiveRemovePreservesForceCacheRefresh(t *testing.T) {
 	require.Equal(t, 1, relayParser.calls)
 	require.NotSame(t, pm, downgraded)
 	require.True(t, downgraded.GetForceCacheRefresh(), "lava-force-cache-refresh must be preserved through archive remove")
+	require.Equal(t, "true", downgraded.GetDirectiveHeaders()[common.FORCE_CACHE_REFRESH_HEADER_NAME],
+		"directiveHeaders map must stay in sync with the chainMessage flag")
 }
 
 // TestArchiveAddDoesNotInventForceCacheRefresh verifies the preserve helper does
 // not flip the directive on for a request that didn't ask for cache bypass.
 func TestArchiveAddDoesNotInventForceCacheRefresh(t *testing.T) {
-	pm, parser := newTestProtocolMessage(t, map[string]string{}, nil, false)
+	pm, parser := newTestProtocolMessage(t, testProtocolMessageOpts{})
 	relayParser := &passthroughRelayParser{chainParser: parser}
 
 	upgraded := addArchiveExtension(context.Background(), pm, &ArchiveStatus{}, relayParser)
 
 	require.False(t, upgraded.GetForceCacheRefresh(), "must not enable cache bypass when the client did not request it")
+}
+
+// TestArchiveAddPreservesRelayTimeout is the same MAG-1653 shape applied to
+// lava-relay-timeout: a client-set per-attempt timeout override must survive
+// the rebuild, otherwise post-upgrade attempts fall back to the chain default
+// instead of the user's value.
+func TestArchiveAddPreservesRelayTimeout(t *testing.T) {
+	pm, parser := newTestProtocolMessage(t, testProtocolMessageOpts{
+		directiveHeaders: map[string]string{common.RELAY_TIMEOUT_HEADER_NAME: "12s"},
+		timeoutOverride:  12 * time.Second,
+	})
+	relayParser := &passthroughRelayParser{chainParser: parser}
+
+	upgraded := addArchiveExtension(context.Background(), pm, &ArchiveStatus{}, relayParser)
+
+	require.Equal(t, 12*time.Second, upgraded.TimeoutOverride(), "lava-relay-timeout override must be preserved")
+	require.Equal(t, (12 * time.Second).String(), upgraded.GetDirectiveHeaders()[common.RELAY_TIMEOUT_HEADER_NAME],
+		"directiveHeaders map must stay in sync with the chainMessage timeout override")
+}
+
+func TestArchiveAddDoesNotInventRelayTimeout(t *testing.T) {
+	pm, parser := newTestProtocolMessage(t, testProtocolMessageOpts{})
+	relayParser := &passthroughRelayParser{chainParser: parser}
+
+	upgraded := addArchiveExtension(context.Background(), pm, &ArchiveStatus{}, relayParser)
+
+	require.Equal(t, time.Duration(0), upgraded.TimeoutOverride(), "must not synthesize a timeout the client did not request")
+	require.NotContains(t, upgraded.GetDirectiveHeaders(), common.RELAY_TIMEOUT_HEADER_NAME)
+}
+
+// TestArchiveAddPreservesDebugRelay covers the directive-map-only directive.
+// Unlike force-cache-refresh and relay-timeout, this one has no chainMessage
+// field — its presence in the map is what gates emission of debug response
+// headers (rpcsmartrouter_server.go:2339).
+func TestArchiveAddPreservesDebugRelay(t *testing.T) {
+	pm, parser := newTestProtocolMessage(t, testProtocolMessageOpts{
+		directiveHeaders: map[string]string{common.LAVA_DEBUG_RELAY: "true"},
+	})
+	relayParser := &passthroughRelayParser{chainParser: parser}
+
+	upgraded := addArchiveExtension(context.Background(), pm, &ArchiveStatus{}, relayParser)
+
+	require.Contains(t, upgraded.GetDirectiveHeaders(), common.LAVA_DEBUG_RELAY,
+		"lava-debug-relay must be preserved through archive add")
+}
+
+// TestArchiveAddDoesNotPreserveSelectProvider is a guard rail: the failover
+// path may need to fall through to a different provider on retry, so the pin
+// must NOT survive the rebuild. If this test ever fails, double-check the
+// preserve helper hasn't grown a copy of lava-select-provider — that would
+// regress test_2_1_one_provider_down_retry_to_next.
+func TestArchiveAddDoesNotPreserveSelectProvider(t *testing.T) {
+	pm, parser := newTestProtocolMessage(t, testProtocolMessageOpts{
+		directiveHeaders: map[string]string{common.SELECT_PROVIDER_HEADER_NAME: "lava@p1"},
+	})
+	relayParser := &passthroughRelayParser{chainParser: parser}
+
+	upgraded := addArchiveExtension(context.Background(), pm, &ArchiveStatus{}, relayParser)
+
+	require.NotContains(t, upgraded.GetDirectiveHeaders(), common.SELECT_PROVIDER_HEADER_NAME,
+		"lava-select-provider must reset on retry so failover can choose a different provider")
 }

--- a/protocol/relaycore/relay_state.go
+++ b/protocol/relaycore/relay_state.go
@@ -193,6 +193,7 @@ func addArchiveExtension(ctx context.Context, protocolMessage chainlib.ProtocolM
 		utils.LavaFormatError("Failed adding archive extension", err, utils.LogAttr("apiUrl", relayRequestData.ApiUrl))
 		return protocolMessage
 	}
+	preserveForceCacheRefresh(protocolMessage, newProtocolMessage)
 	archiveStatus.isUpgraded.Store(true)
 	archiveStatus.isArchive.Store(true)
 	return newProtocolMessage
@@ -224,8 +225,26 @@ func removeArchiveExtension(ctx context.Context, protocolMessage chainlib.Protoc
 		utils.LavaFormatError("Failed removing archive extension", err, utils.LogAttr("apiUrl", relayRequestData.ApiUrl))
 		return protocolMessage
 	}
+	preserveForceCacheRefresh(protocolMessage, newProtocolMessage)
 	archiveStatus.isArchive.Store(false)
 	return newProtocolMessage
+}
+
+// preserveForceCacheRefresh copies the lava-force-cache-refresh directive from
+// src onto dst. ParseRelay only sees the metadata we hand it (just the new
+// extension override) and so calls SetForceCacheRefresh(false) on dst — without
+// this copy, a client that sent lava-force-cache-refresh: true gets cache-served
+// data on the retry/failover path because the post-archive message no longer
+// carries the directive (MAG-1653). Provider-selection directives like
+// lava-select-provider and lava-stickiness are intentionally NOT copied here:
+// the failover path may need to fall through to a different provider.
+func preserveForceCacheRefresh(src, dst chainlib.ProtocolMessage) {
+	if src == nil || dst == nil {
+		return
+	}
+	if src.GetForceCacheRefresh() {
+		dst.SetForceCacheRefresh(true)
+	}
 }
 
 // cacheBlockHashes marks all requested block hashes as irrelevant for future queries.

--- a/protocol/relaycore/relay_state.go
+++ b/protocol/relaycore/relay_state.go
@@ -193,7 +193,7 @@ func addArchiveExtension(ctx context.Context, protocolMessage chainlib.ProtocolM
 		utils.LavaFormatError("Failed adding archive extension", err, utils.LogAttr("apiUrl", relayRequestData.ApiUrl))
 		return protocolMessage
 	}
-	preserveForceCacheRefresh(protocolMessage, newProtocolMessage)
+	preserveRetrySafeDirectives(protocolMessage, newProtocolMessage)
 	archiveStatus.isUpgraded.Store(true)
 	archiveStatus.isArchive.Store(true)
 	return newProtocolMessage
@@ -225,25 +225,69 @@ func removeArchiveExtension(ctx context.Context, protocolMessage chainlib.Protoc
 		utils.LavaFormatError("Failed removing archive extension", err, utils.LogAttr("apiUrl", relayRequestData.ApiUrl))
 		return protocolMessage
 	}
-	preserveForceCacheRefresh(protocolMessage, newProtocolMessage)
+	preserveRetrySafeDirectives(protocolMessage, newProtocolMessage)
 	archiveStatus.isArchive.Store(false)
 	return newProtocolMessage
 }
 
-// preserveForceCacheRefresh copies the lava-force-cache-refresh directive from
-// src onto dst. ParseRelay only sees the metadata we hand it (just the new
-// extension override) and so calls SetForceCacheRefresh(false) on dst — without
-// this copy, a client that sent lava-force-cache-refresh: true gets cache-served
-// data on the retry/failover path because the post-archive message no longer
-// carries the directive (MAG-1653). Provider-selection directives like
-// lava-select-provider and lava-stickiness are intentionally NOT copied here:
-// the failover path may need to fall through to a different provider.
-func preserveForceCacheRefresh(src, dst chainlib.ProtocolMessage) {
+// preserveRetrySafeDirectives copies consumer-intent directives from src onto
+// dst after an archive add/remove rebuilds the protocolMessage. The rebuild
+// passes only the new extension override into ParseRelay, so every other
+// directive on dst defaults to its zero value — without re-copying, retries
+// silently drop client-set directives (MAG-1653).
+//
+// Both the chainMessage state (runtime source of truth for force-cache-refresh
+// and timeout-override) and the directiveHeaders map (parse-time input surface,
+// where lava-debug-relay lives) are updated so the two stay consistent —
+// otherwise a future caller reaching for the map would silently see the wrong
+// answer.
+//
+// Provider-selection directives (lava-select-provider, lava-stickiness) are
+// deliberately NOT copied: the failover path may need to fall through to a
+// different provider on retry. The block-list (lava-providers-block) is also
+// not handled here because it's already preserved via usedProviders, captured
+// once at the top of ProcessRelaySend from the original protocolMessage.
+func preserveRetrySafeDirectives(src, dst chainlib.ProtocolMessage) {
 	if src == nil || dst == nil {
 		return
 	}
-	if src.GetForceCacheRefresh() {
-		dst.SetForceCacheRefresh(true)
+	preserveForceCacheRefresh(src, dst)
+	preserveRelayTimeout(src, dst)
+	preserveDebugRelay(src, dst)
+}
+
+func preserveForceCacheRefresh(src, dst chainlib.ProtocolMessage) {
+	if !src.GetForceCacheRefresh() {
+		return
+	}
+	dst.SetForceCacheRefresh(true)
+	if hdrs := dst.GetDirectiveHeaders(); hdrs != nil {
+		hdrs[common.FORCE_CACHE_REFRESH_HEADER_NAME] = "true"
+	}
+}
+
+func preserveRelayTimeout(src, dst chainlib.ProtocolMessage) {
+	timeout := src.TimeoutOverride()
+	if timeout == 0 {
+		return
+	}
+	dst.TimeoutOverride(timeout)
+	if hdrs := dst.GetDirectiveHeaders(); hdrs != nil {
+		hdrs[common.RELAY_TIMEOUT_HEADER_NAME] = timeout.String()
+	}
+}
+
+func preserveDebugRelay(src, dst chainlib.ProtocolMessage) {
+	srcHdrs := src.GetDirectiveHeaders()
+	if srcHdrs == nil {
+		return
+	}
+	v, ok := srcHdrs[common.LAVA_DEBUG_RELAY]
+	if !ok {
+		return
+	}
+	if hdrs := dst.GetDirectiveHeaders(); hdrs != nil {
+		hdrs[common.LAVA_DEBUG_RELAY] = v
 	}
 }
 

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2192,11 +2192,13 @@ func (rpcss *RPCSmartRouterServer) appendHeadersToRelayResult(ctx context.Contex
 				go rpcss.rpcSmartRouterLogs.RecordIncidentRetry(chainId, apiInterface, apiName, totalRetries, success)
 			}
 
-			// When there are retries, show all attempted providers (similar to REST behavior)
+			// When there are retries, show all attempted providers (similar to REST behavior).
+			// Keep "Cached" in the list so the entry count matches Lava-Retries — without it,
+			// retries=N and a single provider name disagree on how many actors participated
+			// (MAG-1653 Bug #2).
 			allProvidersMap := make(map[string]bool)
 
-			// Add the current provider (might be from successful result or last error)
-			if providerAddress != "Cached" && providerAddress != "" {
+			if providerAddress != "" {
 				allProvidersMap[providerAddress] = true
 			}
 

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2192,46 +2192,47 @@ func (rpcss *RPCSmartRouterServer) appendHeadersToRelayResult(ctx context.Contex
 				go rpcss.rpcSmartRouterLogs.RecordIncidentRetry(chainId, apiInterface, apiName, totalRetries, success)
 			}
 
-			// When there are retries, show all attempted providers (similar to REST behavior).
-			// Keep "Cached" in the list so the entry count matches Lava-Retries — without it,
-			// retries=N and a single provider name disagree on how many actors participated
-			// (MAG-1653 Bug #2).
-			allProvidersMap := make(map[string]bool)
-
-			if providerAddress != "" {
-				allProvidersMap[providerAddress] = true
-			}
-
-			// Add providers from node errors
-			for _, result := range nodeErrorResults {
-				if result.ProviderInfo.ProviderAddress != "" {
-					allProvidersMap[result.ProviderInfo.ProviderAddress] = true
+			// When there are retries, show all attempted providers in
+			// chronological-ish order (failures before the resolver, the resolver
+			// last). "Cached" stays in the list so the entry count matches
+			// Lava-Retries — without it, retries=N and a single provider name
+			// disagree on how many actors participated (MAG-1653 Bug #2).
+			//
+			// Ordering rule: walk protocol errors → node errors → successes,
+			// then append the resolver (`providerAddress`, which is "Cached"
+			// when relayResult.GetProvider() was empty). A `seen` set
+			// deduplicates without losing first-seen position. Result: errors
+			// chronologically first, the response source last (e.g.
+			// "lava@p1,lava@p2" when p2 succeeded after p1 failed; or
+			// "lava@p1,Cached" when cache resolved a request that p1 failed).
+			// Walking via slices instead of map iteration also makes the
+			// header value deterministic across runs — downstream parsers can
+			// rely on `last entry == response source`.
+			seen := make(map[string]struct{})
+			allProvidersList := make([]string, 0)
+			addProvider := func(addr string) {
+				if addr == "" {
+					return
 				}
-			}
-
-			// Add providers from protocol errors
-			for _, result := range protocolErrorResults {
-				if result.ProviderInfo.ProviderAddress != "" {
-					allProvidersMap[result.ProviderInfo.ProviderAddress] = true
+				if _, ok := seen[addr]; ok {
+					return
 				}
+				seen[addr] = struct{}{}
+				allProvidersList = append(allProvidersList, addr)
 			}
-
-			// Add providers from successful results (in case of partial success)
-			for _, result := range successResults {
-				if result.ProviderInfo.ProviderAddress != "" {
-					allProvidersMap[result.ProviderInfo.ProviderAddress] = true
-				}
+			for _, r := range protocolErrorResults {
+				addProvider(r.ProviderInfo.ProviderAddress)
 			}
+			for _, r := range nodeErrorResults {
+				addProvider(r.ProviderInfo.ProviderAddress)
+			}
+			for _, r := range successResults {
+				addProvider(r.ProviderInfo.ProviderAddress)
+			}
+			addProvider(providerAddress) // resolver — "Cached" or the winning real provider, ends up last
 
-			// Convert to slice and update provider address header with all participating providers
-			if len(allProvidersMap) > 0 {
-				allProvidersList := make([]string, 0, len(allProvidersMap))
-				for provider := range allProvidersMap {
-					allProvidersList = append(allProvidersList, provider)
-				}
+			if len(allProvidersList) > 0 {
 				allProvidersString := strings.Join(allProvidersList, ",")
-
-				// Update the existing PROVIDER_ADDRESS_HEADER_NAME with all providers
 				for i, metadata := range metadataReply {
 					if metadata.Name == common.PROVIDER_ADDRESS_HEADER_NAME {
 						metadataReply[i].Value = allProvidersString

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -524,6 +524,83 @@ func TestRetryCountHeader(t *testing.T) {
 	})
 }
 
+// TestCacheServedResponseHeaders is a regression for MAG-1653 Bug #2: when a
+// relay is resolved by a cache hit during the retry loop, "Cached" must remain
+// in Lava-Provider-Address so the entry count stays consistent with Lava-Retries.
+// (Previously the retry-path rebuild explicitly excluded "Cached", overwriting
+// the header with only the failed provider names.)
+func TestCacheServedResponseHeaders(t *testing.T) {
+	ctx := context.Background()
+
+	findHeader := func(metadata []pairingtypes.Metadata, name string) *pairingtypes.Metadata {
+		for i := range metadata {
+			if metadata[i].Name == name {
+				return &metadata[i]
+			}
+		}
+		return nil
+	}
+
+	t.Run("cache hit with no retries - single Cached address, no retry header", func(t *testing.T) {
+		relayProcessor := &MockRelayProcessorForHeaders{
+			successResults: []common.RelayResult{
+				{ProviderInfo: common.ProviderInfo{ProviderAddress: ""}}, // cache result has no provider
+			},
+			nodeErrors: []common.RelayResult{},
+		}
+
+		relayResult := &common.RelayResult{
+			ProviderInfo: common.ProviderInfo{ProviderAddress: ""},
+			Reply:        &pairingtypes.RelayReply{Metadata: []pairingtypes.Metadata{}},
+		}
+
+		rpcSmartRouterServer := &RPCSmartRouterServer{}
+		rpcSmartRouterServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, &MockProtocolMessage{
+			api: &spectypes.Api{Name: "eth_blockNumber"},
+		}, "eth_blockNumber", nil, true)
+
+		providerHeader := findHeader(relayResult.Reply.Metadata, common.PROVIDER_ADDRESS_HEADER_NAME)
+		require.NotNil(t, providerHeader)
+		require.Equal(t, "Cached", providerHeader.Value)
+
+		retryHeader := findHeader(relayResult.Reply.Metadata, common.RETRY_COUNT_HEADER_NAME)
+		require.Nil(t, retryHeader, "no retries occurred — header should be absent")
+	})
+
+	t.Run("cache hit after two protocol errors - matches MAG-1653 reproduction", func(t *testing.T) {
+		// 2 P1 503s + 1 cache hit = 3 attempts, 2 retries.
+		relayProcessor := &MockRelayProcessorForHeaders{
+			successResults: []common.RelayResult{
+				{ProviderInfo: common.ProviderInfo{ProviderAddress: ""}}, // cache result
+			},
+			nodeErrors: []common.RelayResult{},
+			protocolErrors: []relaycore.RelayError{
+				{ProviderInfo: common.ProviderInfo{ProviderAddress: "lava@simprovider1"}},
+				{ProviderInfo: common.ProviderInfo{ProviderAddress: "lava@simprovider1"}},
+			},
+		}
+
+		relayResult := &common.RelayResult{
+			ProviderInfo: common.ProviderInfo{ProviderAddress: ""},
+			Reply:        &pairingtypes.RelayReply{Metadata: []pairingtypes.Metadata{}},
+		}
+
+		rpcSmartRouterServer := &RPCSmartRouterServer{}
+		rpcSmartRouterServer.appendHeadersToRelayResult(ctx, relayResult, 2, relayProcessor, &MockProtocolMessage{
+			api: &spectypes.Api{Name: "eth_blockNumber"},
+		}, "eth_blockNumber", nil, true)
+
+		retryHeader := findHeader(relayResult.Reply.Metadata, common.RETRY_COUNT_HEADER_NAME)
+		require.NotNil(t, retryHeader)
+		require.Equal(t, "2", retryHeader.Value)
+
+		providerHeader := findHeader(relayResult.Reply.Metadata, common.PROVIDER_ADDRESS_HEADER_NAME)
+		require.NotNil(t, providerHeader)
+		require.Contains(t, providerHeader.Value, "Cached", "cache marker must be preserved on retry path")
+		require.Contains(t, providerHeader.Value, "lava@simprovider1", "failed provider must still be listed")
+	})
+}
+
 // TestStatefulRelayTargetsHeader tests the stateful API header functionality
 func TestStatefulRelayTargetsHeader(t *testing.T) {
 	ctx := context.Background()

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -596,8 +596,9 @@ func TestCacheServedResponseHeaders(t *testing.T) {
 
 		providerHeader := findHeader(relayResult.Reply.Metadata, common.PROVIDER_ADDRESS_HEADER_NAME)
 		require.NotNil(t, providerHeader)
-		require.Contains(t, providerHeader.Value, "Cached", "cache marker must be preserved on retry path")
-		require.Contains(t, providerHeader.Value, "lava@simprovider1", "failed provider must still be listed")
+		// Ordering contract: errors chronologically first, resolver last.
+		// "Cached" sits at the end as the response source.
+		require.Equal(t, "lava@simprovider1,Cached", providerHeader.Value)
 	})
 }
 


### PR DESCRIPTION
addArchiveExtension and removeArchiveExtension rebuild metadata from scratch with only the new extension override. After re-parse the new chainMessage's forceCacheRefresh flag defaults to false, so retries silently consult the cache despite the client setting lava-force-cache-refresh: true. Copy the directive from the source protocolMessage onto the new one after each archive transition.

Also keep "Cached" in the Lava-Provider-Address list when retries occurred — the previous code excluded it, leaving Lava-Retries=N and a single provider name that disagreed on how many actors participated.

Provider-selection directives (lava-select-provider, lava-stickiness) are intentionally not preserved: the failover path may need to fall through to a different provider.

MAG-1653

