### PR TITLE
chore(protocol): bump ConsumerTarget to 6.2.0

### DIFF
--- a/types/protocol/params.go
+++ b/types/protocol/params.go
@@ -7,5 +7,5 @@ type Version struct {
 
 // DefaultVersion is the version embedded in binary releases.
 var DefaultVersion = Version{
-	ConsumerTarget: "6.1.0",
+	ConsumerTarget: "6.2.0",
 }


### PR DESCRIPTION
## Summary
- Bump `DefaultVersion.ConsumerTarget` in `types/protocol/params.go` from `6.1.0` to `6.2.0`.

## Test plan
- [ ] CI build passes
- [ ] Verify embedded version reported by binary matches `6.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)