### PR TITLE
fix(relaycore): clear consistency seen-block cache on debug reset

### DIFF
--- a/protocol/relaycore/consistency.go
+++ b/protocol/relaycore/consistency.go
@@ -83,6 +83,27 @@ func (cc *ConsistencyImpl) GetSeenBlock(userData common.UserData) (int64, bool) 
 	return cc.GetLatestBlock(cc.Key(userData))
 }
 
+// ResetState flushes every seen-block entry from the cache.
+//
+// Why this is necessary:
+// SetSeenBlockFromKey only writes when the new block is strictly greater than
+// the stored one (see line 62). A test that accidentally sends a millisecond
+// timestamp as a block parameter (~1.7T) poisons the entry, and the monotonic
+// guard then rejects every legitimate ~20M block update until the 5-minute TTL
+// expires — and ongoing traffic keeps refreshing the entry, so the TTL never
+// actually fires. Flushing the whole cache is the only recovery short of a
+// process restart.
+//
+// Intended for the debug /debug/reset-* paths only; ristretto's Clear pauses
+// and restarts the cache's processItems goroutine, so this is not suitable
+// for the hot path.
+func (cc *ConsistencyImpl) ResetState() {
+	if cc == nil || cc.cache == nil {
+		return
+	}
+	cc.cache.Clear()
+}
+
 func NewConsistency(specId string) Consistency {
 	cache, err := ristretto.NewCache(&ristretto.Config[string, any]{NumCounters: CacheNumCounters, MaxCost: CacheMaxCost, BufferItems: 64, IgnoreInternalCost: true})
 	if err != nil {

--- a/protocol/rpcsmartrouter/debug_server_test.go
+++ b/protocol/rpcsmartrouter/debug_server_test.go
@@ -316,17 +316,39 @@ func TestDebugMoveClock_ClearsCorruptedSeenBlock(t *testing.T) {
 }
 
 // TestDebugConsistencyReset_NilMapIsSafe makes sure every reset endpoint is
-// usable from a test fixture that didn't wire a consistencies map.
+// usable from a test fixture that didn't wire a consistencies map — including
+// when the time-warp handler actually takes the needsReset branch (which is
+// where resetAllConsistencies(nil) gets exercised).
+//
+// Important: the time-warp subtest pre-seeds offsetNano to +1h so the posted
+// offset_seconds:0 represents a *decrease* (newNano < prevNano). Without that
+// seed, both nano values are 0, needsReset stays false, and the reset branch
+// is skipped — so the test would cover the handler reaching its 200 OK reply
+// but NOT the resetAllConsistencies(nil) call path. The whole point of this
+// test is the latter.
 func TestDebugConsistencyReset_NilMapIsSafe(t *testing.T) {
 	endpoints := []struct {
 		name string
+		// seed runs before the request so we can put offsetNano in a state
+		// that forces the handler down the needsReset branch.
+		seed func(t *testing.T, offsetNano *atomic.Int64, mux http.Handler)
 		post func(http.Handler) *httptest.ResponseRecorder
 	}{
-		{"time-warp", func(m http.Handler) *httptest.ResponseRecorder {
-			return postTimeWarpRouter(m, `{"offset_seconds":0}`)
-		}},
-		{"reset-scores", postResetScoresRouter},
-		{"reset-all", postResetAllRouter},
+		{
+			name: "time-warp",
+			seed: func(t *testing.T, _ *atomic.Int64, mux http.Handler) {
+				// Going through the mux (rather than poking offsetNano
+				// directly) keeps the seed honest: it uses the same Swap
+				// the handler under test will compare against.
+				rr := postTimeWarpRouter(mux, `{"offset_seconds":3600}`)
+				require.Equal(t, http.StatusOK, rr.Code)
+			},
+			post: func(m http.Handler) *httptest.ResponseRecorder {
+				return postTimeWarpRouter(m, `{"offset_seconds":0}`)
+			},
+		},
+		{name: "reset-scores", post: postResetScoresRouter},
+		{name: "reset-all", post: postResetAllRouter},
 	}
 
 	for _, ep := range endpoints {
@@ -337,6 +359,9 @@ func TestDebugConsistencyReset_NilMapIsSafe(t *testing.T) {
 				offsetNano:    &offsetNano,
 				consistencies: nil,
 			})
+			if ep.seed != nil {
+				ep.seed(t, &offsetNano, mux)
+			}
 			rr := ep.post(mux)
 			require.Equal(t, http.StatusOK, rr.Code)
 		})

--- a/protocol/rpcsmartrouter/debug_server_test.go
+++ b/protocol/rpcsmartrouter/debug_server_test.go
@@ -6,9 +6,11 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
+	"github.com/magma-Devs/smart-router/protocol/relaycore"
 	"github.com/stretchr/testify/require"
 )
 
@@ -146,6 +148,11 @@ func TestDebugResetAll_SmartRouter_ReturnsCapabilityAdvertisement(t *testing.T) 
 	require.Contains(t, body, `"session-manager"`)
 	require.Contains(t, body, `"reported-providers"`)
 	require.Contains(t, body, `"sticky-sessions"`)
+	// seen-block was added so callers know reset-all also flushes the
+	// per-chain consistency cache (where the corrupted seenBlock actually
+	// lives). The simulator framework can probe this key to verify it doesn't
+	// need to fall back to a process restart.
+	require.Contains(t, body, `"seen-block"`)
 }
 
 func TestDebugResetAll_SmartRouter_MethodNotAllowed(t *testing.T) {
@@ -194,4 +201,144 @@ func TestDebugResetAll_SmartRouter_NilRouterIsSafe(t *testing.T) {
 
 	rr := postResetAllRouter(mux)
 	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+// corruptedMsTimestampBlock is the exact value reported in the 2026-05-14
+// MAG-1748 incident — a millisecond timestamp that a test accidentally passed
+// as a block parameter, poisoning the seen-block cache. Keeping this value
+// hard-coded in tests anchors the regression to the original symptom.
+const corruptedMsTimestampBlock int64 = 1778751245068
+
+// newPoisonedConsistencies returns a per-chain consistency map seeded with
+// `corruptedMsTimestampBlock` for every chainID in chainIDs. The poisoned
+// value is verified visible before the helper returns — ristretto buffers
+// writes, so a test that calls reset before the corruption lands would
+// trivially pass.
+func newPoisonedConsistencies(t *testing.T, chainIDs ...string) (*common.SafeSyncMap[string, relaycore.Consistency], map[string]relaycore.Consistency) {
+	t.Helper()
+	m := &common.SafeSyncMap[string, relaycore.Consistency]{}
+	byChain := make(map[string]relaycore.Consistency, len(chainIDs))
+	for _, chainID := range chainIDs {
+		c := relaycore.NewConsistency(chainID)
+		c.SetSeenBlockFromKey(corruptedMsTimestampBlock, "dapp|ip")
+		_, _, err := m.LoadOrStore(chainID, c)
+		require.NoError(t, err)
+		byChain[chainID] = c
+	}
+	for _, chainID := range chainIDs {
+		c := byChain[chainID]
+		require.Eventuallyf(t, func() bool {
+			v, found := c.(*relaycore.ConsistencyImpl).GetLatestBlock("dapp|ip")
+			return found && v == corruptedMsTimestampBlock
+		}, time.Second, 10*time.Millisecond,
+			"corrupted seenBlock for %q should be visible before recovery (ristretto buffers writes)", chainID)
+	}
+	return m, byChain
+}
+
+// requireConsistenciesCleared asserts that every per-chain cache in byChain
+// has dropped its "dapp|ip" entry. Uses Eventually because ristretto's Clear
+// drains buffered writes asynchronously.
+func requireConsistenciesCleared(t *testing.T, byChain map[string]relaycore.Consistency) {
+	t.Helper()
+	for chainID, c := range byChain {
+		require.Eventuallyf(t, func() bool {
+			_, found := c.(*relaycore.ConsistencyImpl).GetLatestBlock("dapp|ip")
+			return !found
+		}, time.Second, 10*time.Millisecond,
+			"%q seenBlock should be cleared after recovery", chainID)
+	}
+}
+
+// TestDebugMoveClock_ClearsCorruptedSeenBlock is the regression test for the
+// 2026-05-14 incident: a test sent hex(int(time.time()*1000)) (~1.7T) as a
+// block parameter and poisoned the consistency cache. Before this fix, both
+// the legacy 4-step move-clock and /debug/reset-all returned HTTP 200 on
+// every step but the corrupted seenBlock survived because the reset paths
+// only touched the optimizer, not the per-chain Consistency cache where
+// seenBlock is actually read from.
+//
+// The monotonic guard in ConsistencyImpl.SetSeenBlockFromKey makes the
+// corruption sticky: no legitimate ~20M block can overwrite a stored ~1.7T
+// value, and ongoing traffic keeps refreshing the 5-min TTL — so the only
+// prior recovery was a process restart.
+//
+// We assert *both* per-chain caches (ETH1 and LAVA) are cleared so the test
+// proves the Range loop actually reaches every chain, not just the first.
+func TestDebugMoveClock_ClearsCorruptedSeenBlock(t *testing.T) {
+	cases := []struct {
+		name string
+		// run drives the recovery procedure end-to-end against the given mux.
+		run func(t *testing.T, mux http.Handler)
+	}{
+		{
+			name: "legacy_four_step_move_clock",
+			run: func(t *testing.T, mux http.Handler) {
+				rr := postTimeWarpRouter(mux, `{"offset_seconds":3600}`)
+				require.Equal(t, http.StatusOK, rr.Code)
+				rr = postTimeWarpRouter(mux, `{"offset_seconds":0}`)
+				require.Equal(t, http.StatusOK, rr.Code)
+				rr = postResetScoresRouter(mux)
+				require.Equal(t, http.StatusOK, rr.Code)
+			},
+		},
+		{
+			name: "reset_scores_alone",
+			run: func(t *testing.T, mux http.Handler) {
+				rr := postResetScoresRouter(mux)
+				require.Equal(t, http.StatusOK, rr.Code)
+			},
+		},
+		{
+			name: "reset_all_single_call",
+			run: func(t *testing.T, mux http.Handler) {
+				rr := postResetAllRouter(mux)
+				require.Equal(t, http.StatusOK, rr.Code)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var offsetNano atomic.Int64
+			consistencies, byChain := newPoisonedConsistencies(t, "ETH1", "LAVA")
+			mux := buildDebugMux(debugMuxDeps{
+				optimizers:    newEmptyOptimizersRouter(),
+				offsetNano:    &offsetNano,
+				consistencies: consistencies,
+			})
+
+			tc.run(t, mux)
+
+			requireConsistenciesCleared(t, byChain)
+		})
+	}
+}
+
+// TestDebugConsistencyReset_NilMapIsSafe makes sure every reset endpoint is
+// usable from a test fixture that didn't wire a consistencies map.
+func TestDebugConsistencyReset_NilMapIsSafe(t *testing.T) {
+	endpoints := []struct {
+		name string
+		post func(http.Handler) *httptest.ResponseRecorder
+	}{
+		{"time-warp", func(m http.Handler) *httptest.ResponseRecorder {
+			return postTimeWarpRouter(m, `{"offset_seconds":0}`)
+		}},
+		{"reset-scores", postResetScoresRouter},
+		{"reset-all", postResetAllRouter},
+	}
+
+	for _, ep := range endpoints {
+		t.Run(ep.name, func(t *testing.T) {
+			var offsetNano atomic.Int64
+			mux := buildDebugMux(debugMuxDeps{
+				optimizers:    newEmptyOptimizersRouter(),
+				offsetNano:    &offsetNano,
+				consistencies: nil,
+			})
+			rr := ep.post(mux)
+			require.Equal(t, http.StatusOK, rr.Code)
+		})
+	}
 }

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -301,9 +301,10 @@ func (rpsr *RPCSmartRouter) Start(ctx context.Context, options *rpcSmartRouterSt
 	if options.cmdFlags.DebugAddress != "" {
 		var currentOffsetNano atomic.Int64
 		debugMux := buildDebugMux(debugMuxDeps{
-			optimizers: optimizers,
-			offsetNano: &currentOffsetNano,
-			router:     rpsr,
+			optimizers:    optimizers,
+			offsetNano:    &currentOffsetNano,
+			consistencies: smartRouterConsistencies,
+			router:        rpsr,
 		})
 		srv := &http.Server{Addr: options.cmdFlags.DebugAddress, Handler: debugMux}
 		// Watcher goroutine: shuts the server down gracefully when ctx is cancelled
@@ -375,9 +376,42 @@ func (rpsr *RPCSmartRouter) Stop(shutdownGracePeriod time.Duration) {
 type debugMuxDeps struct {
 	optimizers *common.SafeSyncMap[string, *provideroptimizer.ProviderOptimizer]
 	offsetNano *atomic.Int64
+	// consistencies is the per-chain seen-block cache map. Optional: nil-safe.
+	// Flushed only from the /debug/* recovery endpoints, never from the relay
+	// hot path — see consistencyResetter below for why this is reached via a
+	// type assertion rather than a public interface method.
+	consistencies *common.SafeSyncMap[string, relaycore.Consistency]
 	// router is optional. When provided, /debug/reset-all also flushes
 	// per-server RelayRetriesManagers and per-CSM transient failure state.
 	router *RPCSmartRouter
+}
+
+// consistencyResetter is the debug-only contract for flushing a Consistency
+// cache. It is *intentionally* not exposed on the public relaycore.Consistency
+// interface so production relay code paths cannot call ResetState by accident.
+// The /debug/* handlers type-assert to reach it; implementations that don't
+// satisfy the assertion (test fakes, future variants) are silently skipped.
+type consistencyResetter interface {
+	ResetState()
+}
+
+// resetAllConsistencies flushes every per-chain seen-block cache that
+// implements consistencyResetter. Why this is necessary: SetSeenBlockFromKey
+// only writes monotonically (consistency.go: `block >= blockSeen → return`),
+// so a poisoned value (e.g. a ms-timestamp accidentally passed as a block
+// number) blocks every legitimate smaller update, and ongoing traffic keeps
+// refreshing the TTL — without an explicit flush, the only recovery is a
+// process restart.
+func resetAllConsistencies(m *common.SafeSyncMap[string, relaycore.Consistency]) {
+	if m == nil {
+		return
+	}
+	m.Range(func(chainID string, c relaycore.Consistency) bool {
+		if r, ok := c.(consistencyResetter); ok {
+			r.ResetState()
+		}
+		return true
+	})
 }
 
 // buildDebugMux constructs the /debug/time-warp, /debug/time, /debug/reset-scores,
@@ -451,6 +485,13 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 			}
 			return true
 		})
+		// Gated on needsReset (same as opt.ResetState above) because the
+		// documented move-clock recovery sets offset_seconds back to 0 — that's
+		// the moment we also want to flush the per-chain seen-block cache. See
+		// resetAllConsistencies for the sticky-corruption reasoning.
+		if needsReset {
+			resetAllConsistencies(deps.consistencies)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"offset_seconds":%v,"applied_to_chains":true}`, body.OffsetSeconds)
 	})
@@ -468,7 +509,9 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 	})
 
 	// POST /debug/reset-scores — clears optimizer score state without changing
-	// current time offset or NowFunc.
+	// current time offset or NowFunc. Also flushes per-chain seen-block caches
+	// so a corrupted seenBlock (e.g. a ms-timestamp accidentally passed as a
+	// block number) can be scrubbed without restarting the process.
 	mux.HandleFunc("/debug/reset-scores", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "POST only", http.StatusMethodNotAllowed)
@@ -480,6 +523,7 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 			count++
 			return true
 		})
+		resetAllConsistencies(deps.consistencies)
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"reset":true,"chains_reset":%d}`, count)
 	})
@@ -509,7 +553,14 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 			return true
 		})
 
-		// 2. Per-server RelayRetriesManagers (6h hash ban cache) and 3. per-CSM
+		// 2. Per-chain seen-block consistency caches. Must be flushed here too,
+		//    not just in /debug/reset-scores: a poisoned huge seenBlock value
+		//    survives the legacy 4-call dance because the monotonic guard in
+		//    SetSeenBlockFromKey refuses smaller writes and ongoing traffic
+		//    keeps refreshing the TTL.
+		resetAllConsistencies(deps.consistencies)
+
+		// 3. Per-server RelayRetriesManagers (6h hash ban cache) and 4. per-CSM
 		//    transient failure state. Both require the router to be present;
 		//    test fixtures without a router still get a useful partial reset
 		//    above and we report which stores actually moved.
@@ -530,9 +581,11 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 
 		// Capability advertisement — hardcoded, not a per-call tally. The test
 		// framework probes the response to decide between this endpoint and
-		// the legacy 4-call dance.
+		// the legacy 4-call dance. "seen-block" is the per-chain consistency
+		// cache flush; without it the move-clock dance can't recover a
+		// poisoned seenBlock value.
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"reset":true,"cleared":["optimizer","ristretto","retries-manager","session-manager","reported-providers","sticky-sessions"]}`)
+		fmt.Fprint(w, `{"reset":true,"cleared":["optimizer","ristretto","retries-manager","session-manager","reported-providers","sticky-sessions","seen-block"]}`)
 	})
 
 	return mux


### PR DESCRIPTION
## Summary

- The 2026-05-14 incident: a test sent `hex(int(time.time()*1000))` (~1.7T) as a block parameter and poisoned the per-chain `Consistency` cache where `seenBlock` is actually read from on every relay (rpcsmartrouter_server.go:530,1148,1629). The 4-step move-clock procedure — and, after #ffa7b9c, `/debug/reset-all` — returned `HTTP 200` on every step but the poisoned value survived because none of the reset paths touched the consistency cache. Only `kubectl rollout restart` recovered.
- Root cause: the monotonic guard in `ConsistencyImpl.SetSeenBlockFromKey` (consistency.go:62) refuses any block smaller than the stored one, and ongoing traffic keeps refreshing the 5-min TTL — so a poisoned ~1.7T value is sticky until the process restarts.
- Fix: `/debug/time-warp`, `/debug/reset-scores`, and `/debug/reset-all` all flush the per-chain consistency caches. `/debug/reset-all` advertises `"seen-block"` in its cleared array so the simulator framework can detect support.

## Scope of the change in production code

To be precise about what this PR does and does not change in production code:

- ✅ **Public `Consistency` interface is unchanged.** No new method is exposed to relay code that holds a `Consistency` value.
- ✅ **Relay hot path is unchanged.** No call to `ResetState` from production request handling.
- ⚠️ **A new exported method is added to the concrete `*ConsistencyImpl` type.** This is necessary because the debug HTTP handlers (which run in the production binary, gated behind `--debug-address`) need to reach it. A future caller in any package could import `relaycore`, type-assert to `*ConsistencyImpl`, and call it — Go's type system can't prevent that. The doc comment marks the method as debug-only.

The debug handlers reach the method via an **unexported** `consistencyResetter` interface and a type assertion in `resetAllConsistencies`, both local to `rpcsmartrouter`. The only call sites are inside the three `mux.HandleFunc("/debug/...")` blocks, themselves gated by `--debug-address`. This matches the existing pattern: `*ProviderOptimizer.ResetState()` is also a concrete-type-only method called only from the same debug handlers.

## Changes

- `protocol/relaycore/consistency.go` — adds `(cc *ConsistencyImpl) ResetState()` calling `cache.Clear()` on the underlying Ristretto cache. Doc comment marks it as debug-only.
- `protocol/rpcsmartrouter/rpcsmartrouter.go` — adds `consistencies` to `debugMuxDeps`, the unexported `consistencyResetter` interface, and `resetAllConsistencies(...)` helper. Wires the flush into all three handlers (time-warp gated on `needsReset`, the other two unconditional). `/debug/reset-all` advertisement now includes `"seen-block"`.
- `protocol/rpcsmartrouter/debug_server_test.go`:
  - `TestDebugMoveClock_ClearsCorruptedSeenBlock` — regression test pre-poisons **two** per-chain caches (ETH1 + LAVA) with the exact `1778751245068` value from the incident, waits for **both** writes to land (ristretto buffers), then asserts every recovery path (legacy 4-step, reset-scores alone, reset-all) clears all chains.
  - `TestDebugConsistencyReset_NilMapIsSafe` — `consistencies=nil` tolerated across all three handlers. The time-warp subtest pre-seeds `offsetNano` to +3600 via the mux so that the posted `offset_seconds:0` actually triggers `needsReset=true` and exercises the `resetAllConsistencies(nil)` branch (the test was otherwise trivially passing without touching that path).
  - `TestDebugResetAll_SmartRouter_ReturnsCapabilityAdvertisement` now also asserts `"seen-block"` appears in the cleared array.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./protocol/rpcsmartrouter/... ./protocol/relaycore/...` — clean
- [x] `go test ./protocol/rpcsmartrouter/ -run TestDebug -count=1 -v` — all subtests pass
- [x] `go test ./protocol/rpcsmartrouter/ -run TestDebug -count=1 -race` — passes under `-race`
- [x] `go test ./protocol/rpcsmartrouter/ -run "TestDebugConsistencyReset_NilMapIsSafe|TestDebugMoveClock_ClearsCorruptedSeenBlock" -count=20 -race` — passes
- [x] `go test ./protocol/relaycore/... ./protocol/rpcsmartrouter/... -count=1 -timeout 180s` — full suites pass
- [ ] Manual: bootstrap (`./scripts/pre_setups/init_lava_smartrouter_eth.sh`), poison `seenBlock` via a ms-timestamp request, run `POST /debug/reset-all` (single call replaces the legacy 4-step dance), confirm next `eth_blockNumber` succeeds.

## Rebase note

Rebased onto current `origin/main` (which added `debugMuxDeps` + `/debug/reset-all` in #ffa7b9c). The initial commit was force-pushed with `--force-with-lease`; subsequent fixups are normal fast-forward pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)