### PR TITLE
feat(rpcsmartrouter): expose CSM state-store sizes as Prometheus gauges (MAG-1762)

### DIFF
--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -2039,6 +2039,7 @@ func NewConsumerSessionManager(
 	csm.providerOptimizer = providerOptimizer
 	csm.activeSubscriptionProvidersStorage = activeSubscriptionProvidersStorage
 	csm.stickySessions = NewStickySessionStore()
+	csm.startStateSizesPublisher()
 	return csm
 }
 
@@ -2085,4 +2086,71 @@ func (csm *ConsumerSessionManager) ResetTransientFailureState() {
 	if csm.reportedProviders != nil {
 		csm.reportedProviders.Reset()
 	}
+
+	// Emit the state-size gauges immediately so /debug/reset-all callers see
+	// the post-condition (everything at 0) on the very next /metrics scrape,
+	// without waiting for the periodic publisher tick.
+	csm.publishStateSizes()
+}
+
+// stateSizesPublishInterval drives the periodic CSM state-size gauge tick.
+// Variable (not const) so unit tests can shorten it to deterministic timing
+// without exposing the goroutine internals.
+var stateSizesPublishInterval = time.Second
+
+// publishStateSizes reads the current size of every black-box state store
+// that /debug/reset-all promises to clear and emits them as Prometheus gauges
+// (MAG-1762). Safe to call from any goroutine: takes its locks lazily.
+//
+// Callers MUST NOT hold csm.lock — this function takes csm.lock.RLock
+// internally for the two map reads and then defers to the external stores
+// (which carry their own locks).
+func (csm *ConsumerSessionManager) publishStateSizes() {
+	if csm == nil || csm.consumerMetricsManager == nil || csm.rpcEndpoint == nil {
+		return
+	}
+
+	csm.lock.RLock()
+	blockedCount := len(csm.previousEpochBlockedProviders)
+	blockedBackupCount := len(csm.blockedBackupProviders)
+	csm.lock.RUnlock()
+
+	var stickyCount, reportedCount int
+	if csm.stickySessions != nil {
+		stickyCount = csm.stickySessions.Len()
+	}
+	if csm.reportedProviders != nil {
+		reportedCount = csm.reportedProviders.Len()
+	}
+
+	chainID := csm.rpcEndpoint.ChainID
+	apiInterface := csm.rpcEndpoint.ApiInterface
+	csm.consumerMetricsManager.SetCSMBlockedProvidersCount(chainID, apiInterface, blockedCount)
+	csm.consumerMetricsManager.SetCSMBlockedBackupProvidersCount(chainID, apiInterface, blockedBackupCount)
+	csm.consumerMetricsManager.SetCSMStickySessionsCount(chainID, apiInterface, stickyCount)
+	csm.consumerMetricsManager.SetCSMReportedProvidersCount(chainID, apiInterface, reportedCount)
+}
+
+// startStateSizesPublisher kicks off the periodic gauge tick. Per-CSM
+// goroutine, follows the same shape as the ReconnectProviders ticker in
+// reported_providers.go (no stop channel — bound to process lifetime).
+//
+// Skipped when the metrics manager is the NoOp variant — SafeMetrics(nil)
+// wraps a typed NoOp into the interface, so a plain nil check is never true;
+// we detect the NoOp explicitly to avoid spinning a useless goroutine in
+// every test that passes nil metrics.
+func (csm *ConsumerSessionManager) startStateSizesPublisher() {
+	if csm == nil || csm.consumerMetricsManager == nil {
+		return
+	}
+	if _, isNoOp := csm.consumerMetricsManager.(metrics.NoOpConsumerMetrics); isNoOp {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(stateSizesPublishInterval)
+		defer ticker.Stop()
+		for range ticker.C {
+			csm.publishStateSizes()
+		}
+	}()
 }

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -9,10 +9,12 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/metrics"
 	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
 	spectypes "github.com/magma-Devs/smart-router/types/spec"
@@ -2168,6 +2170,123 @@ func TestProbeDirectRPCEndpoints_RespectsDisabledEndpoint(t *testing.T) {
 	_, _, probeErr := csm.probeDirectRPCEndpoints(ctx, cswp, cswp.PublicLavaAddress)
 	require.Error(t, probeErr,
 		"a disabled endpoint must cause the direct RPC probe to fail, even though HTTPDirectRPCConnection.IsHealthy starts optimistically true")
+}
+
+// stateSizeRecorder is a minimal ConsumerMetricsManagerInf used to observe
+// publishStateSizes() emissions under test. Embedding NoOpConsumerMetrics
+// satisfies every method the interface requires without forcing us to stub
+// the ones the test doesn't care about.
+type stateSizeRecorder struct {
+	metrics.NoOpConsumerMetrics
+	mu                  sync.Mutex
+	blockedProviders    int
+	blockedBackup       int
+	stickySessionsCount int
+	reportedProviders   int
+}
+
+func (r *stateSizeRecorder) SetCSMBlockedProvidersCount(_, _ string, c int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.blockedProviders = c
+}
+
+func (r *stateSizeRecorder) SetCSMBlockedBackupProvidersCount(_, _ string, c int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.blockedBackup = c
+}
+
+func (r *stateSizeRecorder) SetCSMStickySessionsCount(_, _ string, c int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stickySessionsCount = c
+}
+
+func (r *stateSizeRecorder) SetCSMReportedProvidersCount(_, _ string, c int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reportedProviders = c
+}
+
+func (r *stateSizeRecorder) snapshot() (int, int, int, int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.blockedProviders, r.blockedBackup, r.stickySessionsCount, r.reportedProviders
+}
+
+// createConsumerSessionManagerWithMetrics builds a CSM wired to the given
+// metrics implementation so state-size emissions can be observed in tests.
+func createConsumerSessionManagerWithMetrics(m metrics.ConsumerMetricsManagerInf) *ConsumerSessionManager {
+	rand.InitRandomSeed()
+	optimizer := provideroptimizer.NewProviderOptimizer(provideroptimizer.StrategyBalanced, 0, 1, nil, "dontcare")
+	optimizer.SetDeterministicSeed(1234567)
+	return NewConsumerSessionManager(&RPCEndpoint{"stub", "stub", "stub", false, "/", 0}, optimizer, m, nil, "lava@test", NewActiveSubscriptionProvidersStorage())
+}
+
+// TestPublishStateSizes_PopulateThenReset verifies that publishStateSizes
+// reflects the current size of every observed store, and that
+// ResetTransientFailureState drives all four counts back to zero — the
+// post-condition integration tests assert against /metrics (MAG-1762).
+func TestPublishStateSizes_PopulateThenReset(t *testing.T) {
+	rec := &stateSizeRecorder{}
+	csm := createConsumerSessionManagerWithMetrics(rec)
+
+	csm.lock.Lock()
+	csm.previousEpochBlockedProviders = map[string]struct{}{"a": {}, "b": {}}
+	csm.blockedBackupProviders = map[string]struct{}{"backup-bad": {}}
+	csm.lock.Unlock()
+	csm.stickySessions.Set("client-1", &StickySession{Provider: "p1", Epoch: 1})
+	csm.stickySessions.Set("client-2", &StickySession{Provider: "p2", Epoch: 1})
+	csm.stickySessions.Set("client-3", &StickySession{Provider: "p3", Epoch: 1})
+	csm.reportedProviders.ReportProvider("reported-1", 1, 0, nil, nil)
+
+	csm.publishStateSizes()
+	blocked, blockedBackup, sticky, reported := rec.snapshot()
+	require.Equal(t, 2, blocked, "previousEpochBlockedProviders count must equal map size")
+	require.Equal(t, 1, blockedBackup, "blockedBackupProviders count must equal map size")
+	require.Equal(t, 3, sticky, "stickySessions count must equal store size")
+	require.Equal(t, 1, reported, "reportedProviders count must equal register size")
+
+	csm.ResetTransientFailureState()
+
+	blocked, blockedBackup, sticky, reported = rec.snapshot()
+	require.Equal(t, 0, blocked, "ResetTransientFailureState must zero previousEpochBlockedProviders gauge")
+	require.Equal(t, 0, blockedBackup, "ResetTransientFailureState must zero blockedBackupProviders gauge")
+	require.Equal(t, 0, sticky, "ResetTransientFailureState must zero stickySessions gauge")
+	require.Equal(t, 0, reported, "ResetTransientFailureState must zero reportedProviders gauge")
+}
+
+// TestPublishStateSizes_NilSafety ensures the publisher tolerates the
+// SafeMetrics(nil)→NoOp fall-through used by tests that pass a nil metrics
+// manager — it must not panic and must do nothing observable.
+func TestPublishStateSizes_NilSafety(t *testing.T) {
+	csm := CreateConsumerSessionManager() // nil metrics → NoOp
+	require.NotPanics(t, func() {
+		csm.publishStateSizes()
+		csm.ResetTransientFailureState()
+	})
+}
+
+// TestStateSizeStores_LenAccessors verifies the Len() accessors added to the
+// external stores so the publisher can read them without touching internals.
+func TestStateSizeStores_LenAccessors(t *testing.T) {
+	store := NewStickySessionStore()
+	require.Equal(t, 0, store.Len())
+	store.Set("a", &StickySession{Provider: "p", Epoch: 1})
+	store.Set("b", &StickySession{Provider: "p", Epoch: 1})
+	require.Equal(t, 2, store.Len())
+	store.Delete("a")
+	require.Equal(t, 1, store.Len())
+	store.Clear()
+	require.Equal(t, 0, store.Len())
+
+	rp := NewReportedProviders(nil, "stub")
+	require.Equal(t, 0, rp.Len())
+	rp.ReportProvider("provider-x", 1, 0, nil, nil)
+	require.Equal(t, 1, rp.Len())
+	rp.RemoveReport("provider-x")
+	require.Equal(t, 0, rp.Len())
 }
 
 // TestResetTransientFailureState verifies the /debug/reset-all helper clears

--- a/protocol/lavasession/reported_providers.go
+++ b/protocol/lavasession/reported_providers.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	metrics "github.com/magma-Devs/smart-router/protocol/metrics"
-	"github.com/magma-Devs/smart-router/utils"
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
+	"github.com/magma-Devs/smart-router/utils"
 )
 
 const (

--- a/protocol/lavasession/reported_providers.go
+++ b/protocol/lavasession/reported_providers.go
@@ -98,6 +98,14 @@ func (rp *ReportedProviders) IsReported(address string) bool {
 	return ok
 }
 
+// Len returns the current number of providers in the unresponsiveness register.
+// Used by the CSM state-size gauge publisher (MAG-1762).
+func (rp *ReportedProviders) Len() int {
+	rp.lock.RLock()
+	defer rp.lock.RUnlock()
+	return len(rp.addedToPurgeAndReport)
+}
+
 type reconnectCandidate struct {
 	address     string
 	reconnectCB func() error

--- a/protocol/lavasession/sticky_sessions.go
+++ b/protocol/lavasession/sticky_sessions.go
@@ -59,3 +59,12 @@ func (s *StickySessionStore) Clear() {
 	defer s.lock.Unlock()
 	s.sessions = make(map[string]*StickySession)
 }
+
+// Len returns the current number of sticky-session affinities. Used by the
+// CSM state-size gauge publisher (MAG-1762) so integration tests can verify
+// /debug/reset-all emptied the store.
+func (s *StickySessionStore) Len() int {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return len(s.sessions)
+}

--- a/protocol/metrics/consumer_metrics_manager.go
+++ b/protocol/metrics/consumer_metrics_manager.go
@@ -689,6 +689,15 @@ func (pme *ConsumerMetricsManager) ResetBlockedProvidersMetrics(chainId, apiInte
 	}
 }
 
+// SetCSMBlockedProvidersCount is a no-op on the legacy ConsumerMetricsManager.
+// The CSM state-store gauges are exposed by SmartRouterMetricsManager only
+// (MAG-1762); this stub exists solely so the type still satisfies
+// ConsumerMetricsManagerInf for the WebSocket subscription manager tests.
+func (pme *ConsumerMetricsManager) SetCSMBlockedProvidersCount(string, string, int)       {}
+func (pme *ConsumerMetricsManager) SetCSMBlockedBackupProvidersCount(string, string, int) {}
+func (pme *ConsumerMetricsManager) SetCSMStickySessionsCount(string, string, int)         {}
+func (pme *ConsumerMetricsManager) SetCSMReportedProvidersCount(string, string, int)      {}
+
 func (pme *ConsumerMetricsManager) SetVersion(version string) {
 	if pme == nil {
 		return

--- a/protocol/metrics/consumer_metrics_manager.go
+++ b/protocol/metrics/consumer_metrics_manager.go
@@ -10,8 +10,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/magma-Devs/smart-router/utils"
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
+	"github.com/magma-Devs/smart-router/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )

--- a/protocol/metrics/consumer_metrics_manager_inf.go
+++ b/protocol/metrics/consumer_metrics_manager_inf.go
@@ -34,6 +34,10 @@ func (NoOpConsumerMetrics) SetQOSMetrics(string, string, string, string, *pairin
 }
 func (NoOpConsumerMetrics) ResetSessionRelatedMetrics()                                    {}
 func (NoOpConsumerMetrics) ResetBlockedProvidersMetrics(string, string, map[string]string) {}
+func (NoOpConsumerMetrics) SetCSMBlockedProvidersCount(string, string, int)                {}
+func (NoOpConsumerMetrics) SetCSMBlockedBackupProvidersCount(string, string, int)          {}
+func (NoOpConsumerMetrics) SetCSMStickySessionsCount(string, string, int)                  {}
+func (NoOpConsumerMetrics) SetCSMReportedProvidersCount(string, string, int)               {}
 func (NoOpConsumerMetrics) SetWsSubscriptionRequestMetric(string, string)                  {}
 func (NoOpConsumerMetrics) SetFailedWsSubscriptionRequestMetric(string, string)            {}
 func (NoOpConsumerMetrics) SetWebSocketConnectionActive(string, string, bool)              {}
@@ -89,6 +93,15 @@ type ConsumerMetricsManagerInf interface {
 	// --- Session (ConsumerSessionManager) ---
 	ResetSessionRelatedMetrics()
 	ResetBlockedProvidersMetrics(chainId, apiInterface string, providers map[string]string)
+
+	// --- CSM state-store sizes (ConsumerSessionManager) ---
+	// Gauges that expose the current size of black-box state stores so
+	// integration tests can verify /debug/reset-all actually emptied them.
+	// All four go to zero after ResetTransientFailureState (MAG-1762).
+	SetCSMBlockedProvidersCount(chainId, apiInterface string, count int)
+	SetCSMBlockedBackupProvidersCount(chainId, apiInterface string, count int)
+	SetCSMStickySessionsCount(chainId, apiInterface string, count int)
+	SetCSMReportedProvidersCount(chainId, apiInterface string, count int)
 
 	// --- WebSocket (DirectWSSubscriptionManager) ---
 	SetWsSubscriptionRequestMetric(chainId string, apiInterface string)

--- a/protocol/metrics/smartrouter_metrics_manager.go
+++ b/protocol/metrics/smartrouter_metrics_manager.go
@@ -103,6 +103,14 @@ type SmartRouterMetricsManager struct {
 	cacheFailedTotalMetric   *prometheus.CounterVec   // lava_rpcsmartrouter_cache_failed_total
 	cacheLatencyHistogram    *prometheus.HistogramVec // lava_rpcsmartrouter_cache_latency_milliseconds
 
+	// CSM state-store size gauges (labels: spec, apiInterface). Expose otherwise
+	// black-box internal state so integration tests can verify /debug/reset-all
+	// emptied each store. See MAG-1762.
+	csmBlockedProvidersCount       *prometheus.GaugeVec // lava_rpcsmartrouter_csm_blocked_providers
+	csmBlockedBackupProvidersCount *prometheus.GaugeVec // lava_rpcsmartrouter_csm_blocked_backup_providers
+	csmStickySessionsCount         *prometheus.GaugeVec // lava_rpcsmartrouter_csm_sticky_sessions
+	csmReportedProvidersCount      *prometheus.GaugeVec // lava_rpcsmartrouter_csm_reported_providers
+
 	// Router-scoped request group metrics (labels: spec, apiInterface, provider_address, method)
 	routerRequestsTotal      *prometheus.CounterVec
 	routerRequestsSuccess    *prometheus.CounterVec
@@ -389,6 +397,30 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	}, incidentMethodLabels)
 
 	// =========================================================================
+	// CSM state-store size gauges (MAG-1762)
+	// One gauge per black-box state store that /debug/reset-all promises to
+	// clear. Tests scrape these via /metrics to verify the post-condition
+	// without firing a probe relay (which could repopulate the same stores).
+	// =========================================================================
+	csmStateLabels := []string{"spec", "apiInterface"}
+	csmBlockedProvidersCount := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "lava_rpcsmartrouter_csm_blocked_providers",
+		Help: "Size of ConsumerSessionManager.previousEpochBlockedProviders (cross-epoch known-bad provider memory). Goes to 0 after /debug/reset-all.",
+	}, csmStateLabels)
+	csmBlockedBackupProvidersCount := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "lava_rpcsmartrouter_csm_blocked_backup_providers",
+		Help: "Size of ConsumerSessionManager.blockedBackupProviders (per-epoch backup-provider failure memory). Goes to 0 after /debug/reset-all.",
+	}, csmStateLabels)
+	csmStickySessionsCount := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "lava_rpcsmartrouter_csm_sticky_sessions",
+		Help: "Number of live sticky-session affinities tracked by the smart router. Goes to 0 after /debug/reset-all.",
+	}, csmStateLabels)
+	csmReportedProvidersCount := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "lava_rpcsmartrouter_csm_reported_providers",
+		Help: "Number of providers currently in the ReportedProviders unresponsiveness register. Goes to 0 after /debug/reset-all.",
+	}, csmStateLabels)
+
+	// =========================================================================
 	// Request group metrics
 	// =========================================================================
 	routerRequestLabels := []string{"spec", "apiInterface", "provider_address", "method"}
@@ -487,6 +519,10 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	cacheSuccessTotalMetric = registerOrReuse(cacheSuccessTotalMetric)
 	cacheFailedTotalMetric = registerOrReuse(cacheFailedTotalMetric)
 	cacheLatencyHistogram = registerOrReuse(cacheLatencyHistogram)
+	csmBlockedProvidersCount = registerOrReuse(csmBlockedProvidersCount)
+	csmBlockedBackupProvidersCount = registerOrReuse(csmBlockedBackupProvidersCount)
+	csmStickySessionsCount = registerOrReuse(csmStickySessionsCount)
+	csmReportedProvidersCount = registerOrReuse(csmReportedProvidersCount)
 
 	manager := &SmartRouterMetricsManager{
 		// Endpoint-scoped (with function)
@@ -559,6 +595,12 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 		cacheSuccessTotalMetric:  cacheSuccessTotalMetric,
 		cacheFailedTotalMetric:   cacheFailedTotalMetric,
 		cacheLatencyHistogram:    cacheLatencyHistogram,
+
+		// CSM state-store gauges
+		csmBlockedProvidersCount:       csmBlockedProvidersCount,
+		csmBlockedBackupProvidersCount: csmBlockedBackupProvidersCount,
+		csmStickySessionsCount:         csmStickySessionsCount,
+		csmReportedProvidersCount:      csmReportedProvidersCount,
 
 		// Internal state
 		endpointsHealthChecksOk: 1,
@@ -1111,6 +1153,39 @@ func (m *SmartRouterMetricsManager) SetQOSMetrics(chainId string, apiInterface s
 func (m *SmartRouterMetricsManager) ResetSessionRelatedMetrics() {}
 
 func (m *SmartRouterMetricsManager) ResetBlockedProvidersMetrics(string, string, map[string]string) {
+}
+
+// SetCSMBlockedProvidersCount publishes the size of csm.previousEpochBlockedProviders.
+// Used by integration tests to verify /debug/reset-all emptied the store (MAG-1762).
+func (m *SmartRouterMetricsManager) SetCSMBlockedProvidersCount(chainId, apiInterface string, count int) {
+	if m == nil {
+		return
+	}
+	m.csmBlockedProvidersCount.WithLabelValues(chainId, apiInterface).Set(float64(count))
+}
+
+// SetCSMBlockedBackupProvidersCount publishes the size of csm.blockedBackupProviders.
+func (m *SmartRouterMetricsManager) SetCSMBlockedBackupProvidersCount(chainId, apiInterface string, count int) {
+	if m == nil {
+		return
+	}
+	m.csmBlockedBackupProvidersCount.WithLabelValues(chainId, apiInterface).Set(float64(count))
+}
+
+// SetCSMStickySessionsCount publishes the number of live sticky-session affinities.
+func (m *SmartRouterMetricsManager) SetCSMStickySessionsCount(chainId, apiInterface string, count int) {
+	if m == nil {
+		return
+	}
+	m.csmStickySessionsCount.WithLabelValues(chainId, apiInterface).Set(float64(count))
+}
+
+// SetCSMReportedProvidersCount publishes the size of the ReportedProviders register.
+func (m *SmartRouterMetricsManager) SetCSMReportedProvidersCount(chainId, apiInterface string, count int) {
+	if m == nil {
+		return
+	}
+	m.csmReportedProvidersCount.WithLabelValues(chainId, apiInterface).Set(float64(count))
 }
 
 // SetRelayMetrics is a no-op for SmartRouter.


### PR DESCRIPTION
## Summary

Exposes four `lava_rpcsmartrouter_csm_*` Prometheus gauges so integration tests can verify `/debug/reset-all` empties every transient ConsumerSessionManager state store without firing a probe relay (which would re-populate sticky/reported state under measurement).

- `lava_rpcsmartrouter_csm_blocked_providers` — size of `previousEpochBlockedProviders`
- `lava_rpcsmartrouter_csm_blocked_backup_providers` — size of `blockedBackupProviders`
- `lava_rpcsmartrouter_csm_sticky_sessions` — size of the sticky-session store
- `lava_rpcsmartrouter_csm_reported_providers` — size of the unresponsiveness register

A per-CSM publisher goroutine ticks every second; `ResetTransientFailureState` also emits explicitly so the post-reset zero appears on the next `/metrics` scrape without waiting for the tick.

## Why gauges instead of response headers

The ticket proposed either response headers or Prometheus gauges per store. Gauges win for this acceptance flow: response headers only appear on relay responses, so reading them requires firing a probe relay *after* reset — and that probe can repopulate the very stores you're checking (a sticky-header probe re-creates a sticky session; a probe that hits a half-broken provider re-populates ReportedProviders). Gauges scraped from `/metrics` have no such interference.

Store #4 ("pairing / backup maps" in the ticket) is interpreted as `blockedBackupProviders` (transient backup-block memory cleared by reset-all) — not live pairing tables (which reset-all intentionally preserves so the next relay can route normally).

## Design notes

- **Periodic publisher** mirrors the existing `ReconnectProviders` ticker in `reported_providers.go` — one goroutine per CSM, no stop channel (bound to process lifetime).
- **NoOp-aware gate**: `SafeMetrics(nil)` wraps a typed NoOp into the interface (not a nil interface value), so a plain `nil` check never fires. The publisher type-asserts against `metrics.NoOpConsumerMetrics` and skips when metrics are disabled — avoids leaking a goroutine in every test that passes `nil`.
- **Lock-ordering safe**: `publishStateSizes()` takes `csm.lock.RLock()` for two field reads, releases, then calls `stickySessions.Len()` and `reportedProviders.Len()` (which take their own internal locks). Matches the documented pattern in `ResetTransientFailureState`.

## Test plan

- [x] Go unit tests: `TestPublishStateSizes_PopulateThenReset` (covers wiring for all 4 stores via a `stateSizeRecorder` spy), `TestPublishStateSizes_NilSafety`, `TestStateSizeStores_LenAccessors`
- [x] `make test-short` passes
- [x] `make lint` (go vet) clean
- [x] Race detector clean
- [x] Goleak-enforced tests still pass (publisher is NoOp-gated)
- [ ] Companion simulator test on `smart-router-automation` `test/MAG-1762-csm-state-size-gauges` exercises `/debug/reset-all → /metrics` end-to-end against a deployed router

## Refs

- MAG-1762 — this ticket
- MAG-1658 — `/debug/reset-all` (whose post-condition this makes observable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)