### PR TITLE
feat(rpcsmartrouter): flush external cache-be pod from /debug/reset-all (MAG-1764)

### DIFF
--- a/ecosystem/cache/flush_test.go
+++ b/ecosystem/cache/flush_test.go
@@ -1,0 +1,94 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/ristretto/v2"
+	"github.com/stretchr/testify/require"
+	emptypb "google.golang.org/protobuf/types/known/emptypb"
+)
+
+// newRistrettoForTest builds a small ristretto cache suitable for a unit test.
+// Mirrors the config used by CacheServer.InitCache but with tiny capacity and
+// without the OnEvict metrics callback — the flush test only cares that
+// entries become Get-misses after Clear.
+func newRistrettoForTest(t *testing.T) *ristretto.Cache[string, any] {
+	t.Helper()
+	c, err := ristretto.NewCache(&ristretto.Config[string, any]{
+		NumCounters: 1024,
+		MaxCost:     1 << 20,
+		BufferItems: 64,
+	})
+	require.NoError(t, err)
+	return c
+}
+
+func setAndWait(t *testing.T, c *ristretto.Cache[string, any], key string, val any) {
+	t.Helper()
+	require.True(t, c.SetWithTTL(key, val, 1, time.Minute))
+	c.Wait()
+}
+
+// TestRelayerCacheServer_FlushCache_ClearsAllStores backs the smart router's
+// /debug/reset-all promise: after FlushCache, every entry across the three
+// Ristretto stores (tempCache, finalizedCache, blocksHashesToHeightsCache)
+// must be a Get-miss. This is the MAG-1764 invariant — without it the
+// router's "cache cleared" advertisement is a lie on cache-be deployments.
+func TestRelayerCacheServer_FlushCache_ClearsAllStores(t *testing.T) {
+	cs := &CacheServer{
+		tempCache:                  newRistrettoForTest(t),
+		finalizedCache:             newRistrettoForTest(t),
+		blocksHashesToHeightsCache: newRistrettoForTest(t),
+	}
+	setAndWait(t, cs.tempCache, "temp-key", "temp-val")
+	setAndWait(t, cs.finalizedCache, "fin-key", "fin-val")
+	setAndWait(t, cs.blocksHashesToHeightsCache, "hash-key", "hash-val")
+
+	if _, ok := cs.tempCache.Get("temp-key"); !ok {
+		t.Fatal("precondition: temp-key must be present before FlushCache")
+	}
+	if _, ok := cs.finalizedCache.Get("fin-key"); !ok {
+		t.Fatal("precondition: fin-key must be present before FlushCache")
+	}
+	if _, ok := cs.blocksHashesToHeightsCache.Get("hash-key"); !ok {
+		t.Fatal("precondition: hash-key must be present before FlushCache")
+	}
+
+	srv := &RelayerCacheServer{CacheServer: cs}
+	resp, err := srv.FlushCache(context.Background(), &emptypb.Empty{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	if _, ok := cs.tempCache.Get("temp-key"); ok {
+		t.Errorf("tempCache still serves entries after FlushCache")
+	}
+	if _, ok := cs.finalizedCache.Get("fin-key"); ok {
+		t.Errorf("finalizedCache still serves entries after FlushCache")
+	}
+	if _, ok := cs.blocksHashesToHeightsCache.Get("hash-key"); ok {
+		t.Errorf("blocksHashesToHeightsCache still serves entries after FlushCache")
+	}
+}
+
+// TestRelayerCacheServer_FlushCache_NilStoresAreSafe makes sure a partially
+// initialised CacheServer (e.g. a test fixture that skipped InitCache for
+// one of the stores) doesn't panic. The router's reset path must never
+// crash the cache pod just because one ristretto field is nil.
+func TestRelayerCacheServer_FlushCache_NilStoresAreSafe(t *testing.T) {
+	srv := &RelayerCacheServer{CacheServer: &CacheServer{}}
+	resp, err := srv.FlushCache(context.Background(), &emptypb.Empty{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+// TestRelayerCacheServer_FlushCache_NilCacheServer is the defensive contract
+// for the same reason — if the embedded CacheServer pointer itself is nil,
+// FlushCache should still return cleanly rather than nil-deref.
+func TestRelayerCacheServer_FlushCache_NilCacheServer(t *testing.T) {
+	srv := &RelayerCacheServer{}
+	resp, err := srv.FlushCache(context.Background(), &emptypb.Empty{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}

--- a/ecosystem/cache/handlers.go
+++ b/ecosystem/cache/handlers.go
@@ -385,6 +385,36 @@ func (s *RelayerCacheServer) Health(ctx context.Context, req *emptypb.Empty) (*r
 	return &relaytypes.CacheUsage{}, nil
 }
 
+// FlushCache empties every Ristretto store on this cache server. Reached only
+// from the smart router's /debug/reset-all handler so black-box tests can drop
+// stale entries without restarting the pod. Ristretto's Clear() is not atomic
+// and assumes no concurrent Set/Get; Wait() drains the asynchronous Set buffer
+// so a Set in flight at Clear time can't survive the flush and serve a hit on
+// the next Get. Caveat: this guarantee only holds when the test framework
+// stops issuing relay traffic before calling /debug/reset-all — a concurrent
+// Set buffered during the Clear/Wait window can still resurface as a hit
+// after Wait returns. Production callers (the simulator harness) honour
+// that invariant by design.
+func (s *RelayerCacheServer) FlushCache(ctx context.Context, req *emptypb.Empty) (*emptypb.Empty, error) {
+	if s.CacheServer == nil {
+		return &emptypb.Empty{}, nil
+	}
+	if c := s.CacheServer.tempCache; c != nil {
+		c.Clear()
+		c.Wait()
+	}
+	if c := s.CacheServer.finalizedCache; c != nil {
+		c.Clear()
+		c.Wait()
+	}
+	if c := s.CacheServer.blocksHashesToHeightsCache; c != nil {
+		c.Clear()
+		c.Wait()
+	}
+	utils.LavaFormatInfo("cache server flushed by FlushCache RPC")
+	return &emptypb.Empty{}, nil
+}
+
 func (s *RelayerCacheServer) cacheHit(ctx context.Context) {
 	atomic.AddUint64(&s.cacheHits, 1)
 	s.PrintCacheStats(ctx, "[+] cache hit")

--- a/protocol/performance/cache.go
+++ b/protocol/performance/cache.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type relayerCacheClientStore struct {
@@ -186,6 +187,28 @@ func (cache *Cache) SetEntry(ctx context.Context, cacheSet *pairingtypes.RelayCa
 	}
 
 	_, err := client.SetRelay(ctx, cacheSet)
+	if err != nil {
+		cache.clientStore.resetOnConnectionError(err)
+	}
+	return err
+}
+
+// Flush asks the cache-be server to drop every entry it holds. Reached only
+// from the router's /debug/reset-all handler — never from the relay hot path.
+// Returns NotInitializedError when --cache-be is not configured and
+// NotConnectedError while the gRPC client is reconnecting; callers can treat
+// both as "no external cache to flush" and proceed.
+func (cache *Cache) Flush(ctx context.Context) error {
+	if cache == nil {
+		return NotInitializedError
+	}
+
+	client := cache.clientStore.getClient()
+	if client == nil {
+		return NotConnectedError
+	}
+
+	_, err := client.FlushCache(ctx, &emptypb.Empty{})
 	if err != nil {
 		cache.clientStore.resetOnConnectionError(err)
 	}

--- a/protocol/rpcsmartrouter/debug_server_test.go
+++ b/protocol/rpcsmartrouter/debug_server_test.go
@@ -1,6 +1,8 @@
 package rpcsmartrouter
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,7 +14,27 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
 	"github.com/magma-Devs/smart-router/protocol/relaycore"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+// fakeCacheFlusher records Flush calls so /debug/reset-all tests can verify
+// the external cache-be branch fires. active controls CacheActive(); err
+// controls Flush()'s return value.
+type fakeCacheFlusher struct {
+	active     bool
+	err        error
+	flushCalls int
+}
+
+func (f *fakeCacheFlusher) CacheActive() bool {
+	return f.active
+}
+
+func (f *fakeCacheFlusher) Flush(_ context.Context) error {
+	f.flushCalls++
+	return f.err
+}
 
 func newEmptyOptimizersRouter() *common.SafeSyncMap[string, *provideroptimizer.ProviderOptimizer] {
 	return &common.SafeSyncMap[string, *provideroptimizer.ProviderOptimizer]{}
@@ -366,4 +388,100 @@ func TestDebugConsistencyReset_NilMapIsSafe(t *testing.T) {
 			require.Equal(t, http.StatusOK, rr.Code)
 		})
 	}
+}
+
+// TestDebugResetAll_SmartRouter_NoCacheBe verifies the default (no --cache-be)
+// deployment: cleared advertisement omits "cache-be" and no flush is attempted.
+func TestDebugResetAll_SmartRouter_NoCacheBe(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{
+		optimizers: newEmptyOptimizersRouter(),
+		offsetNano: &offsetNano,
+		cache:      nil,
+	})
+
+	rr := postResetAllRouter(mux)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotContains(t, rr.Body.String(), `"cache-be"`)
+}
+
+// TestDebugResetAll_SmartRouter_CacheBeInactive verifies that a configured
+// cache whose gRPC client is currently disconnected (CacheActive=false)
+// does NOT advertise "cache-be" — honesty about what was actually cleared.
+func TestDebugResetAll_SmartRouter_CacheBeInactive(t *testing.T) {
+	var offsetNano atomic.Int64
+	flusher := &fakeCacheFlusher{active: false}
+	mux := buildDebugMux(debugMuxDeps{
+		optimizers: newEmptyOptimizersRouter(),
+		offsetNano: &offsetNano,
+		cache:      flusher,
+	})
+
+	rr := postResetAllRouter(mux)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, 0, flusher.flushCalls, "Flush must not be called when CacheActive() is false")
+	require.NotContains(t, rr.Body.String(), `"cache-be"`)
+}
+
+// TestDebugResetAll_SmartRouter_CacheBeActive_AdvertisesAndFlushes is the
+// MAG-1764 acceptance check at the Go level: when --cache-be is configured
+// and reachable, /debug/reset-all calls Flush and advertises "cache-be" in
+// the cleared list. The end-to-end "next request hits a provider" assertion
+// lives in the Python harness.
+func TestDebugResetAll_SmartRouter_CacheBeActive_AdvertisesAndFlushes(t *testing.T) {
+	var offsetNano atomic.Int64
+	flusher := &fakeCacheFlusher{active: true}
+	mux := buildDebugMux(debugMuxDeps{
+		optimizers: newEmptyOptimizersRouter(),
+		offsetNano: &offsetNano,
+		cache:      flusher,
+	})
+
+	rr := postResetAllRouter(mux)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, 1, flusher.flushCalls, "Flush must be called exactly once")
+	require.Contains(t, rr.Body.String(), `"cache-be"`)
+}
+
+// TestDebugResetAll_SmartRouter_CacheBeFlushError_Returns500 verifies the
+// fail-loud semantics: when cache-be is configured and Flush returns an
+// error, the endpoint must NOT swallow it and pretend the cache cleared.
+// The test framework reads the status code to surface the failure.
+func TestDebugResetAll_SmartRouter_CacheBeFlushError_Returns500(t *testing.T) {
+	var offsetNano atomic.Int64
+	flusher := &fakeCacheFlusher{active: true, err: errors.New("cache-be unreachable")}
+	mux := buildDebugMux(debugMuxDeps{
+		optimizers: newEmptyOptimizersRouter(),
+		offsetNano: &offsetNano,
+		cache:      flusher,
+	})
+
+	rr := postResetAllRouter(mux)
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	require.Equal(t, 1, flusher.flushCalls)
+	require.Contains(t, rr.Body.String(), "cache-be flush failed")
+}
+
+// TestDebugResetAll_SmartRouter_CacheBeUnimplemented_DegradesGracefully
+// covers the rolling-deploy seam: a new router talking to an old cache pod
+// that doesn't yet expose FlushCache returns codes.Unimplemented. The
+// handler must still return 200 (in-process Ristretto cleared, debug
+// endpoint usable) but omit "cache-be" from the cleared list to keep the
+// advertisement honest.
+func TestDebugResetAll_SmartRouter_CacheBeUnimplemented_DegradesGracefully(t *testing.T) {
+	var offsetNano atomic.Int64
+	flusher := &fakeCacheFlusher{
+		active: true,
+		err:    status.Error(codes.Unimplemented, "FlushCache not implemented"),
+	}
+	mux := buildDebugMux(debugMuxDeps{
+		optimizers: newEmptyOptimizersRouter(),
+		offsetNano: &offsetNano,
+		cache:      flusher,
+	})
+
+	rr := postResetAllRouter(mux)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, 1, flusher.flushCalls)
+	require.NotContains(t, rr.Body.String(), `"cache-be"`)
 }

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -49,6 +49,8 @@ import (
 	scoreutils "github.com/magma-Devs/smart-router/utils/score"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -305,6 +307,7 @@ func (rpsr *RPCSmartRouter) Start(ctx context.Context, options *rpcSmartRouterSt
 			offsetNano:    &currentOffsetNano,
 			consistencies: smartRouterConsistencies,
 			router:        rpsr,
+			cache:         options.cache,
 		})
 		srv := &http.Server{Addr: options.cmdFlags.DebugAddress, Handler: debugMux}
 		// Watcher goroutine: shuts the server down gracefully when ctx is cancelled
@@ -384,6 +387,21 @@ type debugMuxDeps struct {
 	// router is optional. When provided, /debug/reset-all also flushes
 	// per-server RelayRetriesManagers and per-CSM transient failure state.
 	router *RPCSmartRouter
+	// cache is the optional external cache-be client. When non-nil and
+	// CacheActive(), /debug/reset-all also flushes the cache-be pod via
+	// RelayerCache.FlushCache — without it the in-process Ristretto reset is a
+	// lie on any deployment running with --cache-be (MAG-1764). Reached
+	// through cacheFlusher rather than the concrete *performance.Cache so
+	// tests can inject a fake without standing up a gRPC client.
+	cache cacheFlusher
+}
+
+// cacheFlusher is the minimal surface /debug/reset-all needs from the cache-be
+// client. *performance.Cache satisfies it; tests substitute a fake that
+// records the Flush call.
+type cacheFlusher interface {
+	CacheActive() bool
+	Flush(ctx context.Context) error
 }
 
 // consistencyResetter is the debug-only contract for flushing a Consistency
@@ -528,15 +546,21 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 		fmt.Fprintf(w, `{"reset":true,"chains_reset":%d}`, count)
 	})
 
-	// POST /debug/reset-all — flush every in-process state store the test
-	// framework cares about in a single call. Equivalent to the legacy
-	// time-warp(+3600) → time-warp(0) → reset-scores dance plus clearing
-	// state that survives it (relay retry bans, sticky sessions, reported
-	// providers, cross-epoch blocked-provider memory).
+	// POST /debug/reset-all — flush every state store the test framework
+	// cares about in a single call: in-process Ristretto, optimizer scores,
+	// per-chain seen-block consistency caches, relay retry bans, sticky
+	// sessions, reported providers, cross-epoch blocked-provider memory,
+	// and — when --cache-be is configured — the external cache-be pod
+	// (MAG-1764). Equivalent to the legacy time-warp(+3600) → time-warp(0)
+	// → reset-scores dance plus the surviving state above.
 	//
 	// "Live pairing" (pairing tables, valid/backup addresses) is intentionally
 	// left intact: we want the next relay to route normally without waiting
 	// for an epoch transition.
+	//
+	// Returns 500 if cache-be is configured and its flush RPC fails — a
+	// silent failure here would advertise a capability the deployment did
+	// not actually fulfill.
 	mux.HandleFunc("/debug/reset-all", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "POST only", http.StatusMethodNotAllowed)
@@ -579,13 +603,50 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 			deps.router.mu.Unlock()
 		}
 
-		// Capability advertisement — hardcoded, not a per-call tally. The test
-		// framework probes the response to decide between this endpoint and
-		// the legacy 4-call dance. "seen-block" is the per-chain consistency
-		// cache flush; without it the move-clock dance can't recover a
-		// poisoned seenBlock value.
+		// 5. External cache-be pod (MAG-1764). When --cache-be is configured,
+		//    the in-process Ristretto reset above is not the cache callers
+		//    actually hit — the real cache lives in a separate pod. Flush it
+		//    via RPC; on real failure return 500 so the test framework fails
+		//    loud instead of trusting a misleading capability advertisement.
+		//
+		//    The codes.Unimplemented branch is the rolling-deploy escape:
+		//    a new router talking to an old cache pod (no FlushCache RPC
+		//    yet) must not break /debug/reset-all. We degrade quietly —
+		//    in-process Ristretto cleared, "cache-be" omitted from cleared
+		//    so the advertisement stays honest.
+		//
+		//    Bounded by a short context: a slow cache pod must not stall the
+		//    debug handler. CacheActive() gates both the call and the
+		//    capability advertisement so deployments without --cache-be don't
+		//    advertise a key they didn't fulfill.
+		cacheBeFlushed := false
+		if deps.cache != nil && deps.cache.CacheActive() {
+			flushCtx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+			err := deps.cache.Flush(flushCtx)
+			cancel()
+			switch {
+			case err == nil:
+				cacheBeFlushed = true
+			case status.Code(err) == codes.Unimplemented:
+				utils.LavaFormatWarning("cache-be does not implement FlushCache; treating as legacy pod", err)
+			default:
+				http.Error(w, fmt.Sprintf("cache-be flush failed: %v", err), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		// Capability advertisement — hardcoded for in-process stores, plus a
+		// conditional "cache-be" key when the external pod was actually
+		// flushed. The test framework probes this body to decide between this
+		// endpoint and the legacy 4-call dance; "seen-block" was added to
+		// signal the per-chain consistency-cache flush, "cache-be" signals
+		// MAG-1764 end-to-end coverage.
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"reset":true,"cleared":["optimizer","ristretto","retries-manager","session-manager","reported-providers","sticky-sessions","seen-block"]}`)
+		if cacheBeFlushed {
+			fmt.Fprint(w, `{"reset":true,"cleared":["optimizer","ristretto","retries-manager","session-manager","reported-providers","sticky-sessions","seen-block","cache-be"]}`)
+		} else {
+			fmt.Fprint(w, `{"reset":true,"cleared":["optimizer","ristretto","retries-manager","session-manager","reported-providers","sticky-sessions","seen-block"]}`)
+		}
 	})
 
 	return mux

--- a/types/relay/grpc_service.go
+++ b/types/relay/grpc_service.go
@@ -203,6 +203,7 @@ type RelayerCacheClient interface {
 	GetRelay(ctx context.Context, in *RelayCacheGet, opts ...grpc.CallOption) (*CacheRelayReply, error)
 	SetRelay(ctx context.Context, in *RelayCacheSet, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	Health(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*CacheUsage, error)
+	FlushCache(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
 // RelayerCacheServer is the server API for the RelayerCache service.
@@ -210,6 +211,9 @@ type RelayerCacheServer interface {
 	GetRelay(context.Context, *RelayCacheGet) (*CacheRelayReply, error)
 	SetRelay(context.Context, *RelayCacheSet) (*emptypb.Empty, error)
 	Health(context.Context, *emptypb.Empty) (*CacheUsage, error)
+	// FlushCache drops every entry across the cache server's stores. Intended
+	// for /debug/reset-all on the smart router; never called on the hot path.
+	FlushCache(context.Context, *emptypb.Empty) (*emptypb.Empty, error)
 }
 
 // UnimplementedRelayerCacheServer must be embedded to satisfy RelayerCacheServer
@@ -226,6 +230,10 @@ func (UnimplementedRelayerCacheServer) SetRelay(_ context.Context, _ *RelayCache
 
 func (UnimplementedRelayerCacheServer) Health(_ context.Context, _ *emptypb.Empty) (*CacheUsage, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Health not implemented")
+}
+
+func (UnimplementedRelayerCacheServer) FlushCache(_ context.Context, _ *emptypb.Empty) (*emptypb.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method FlushCache not implemented")
 }
 
 // relayerCacheClient wraps a grpc.ClientConnInterface for the RelayerCache service.
@@ -259,6 +267,15 @@ func (c *relayerCacheClient) SetRelay(ctx context.Context, in *RelayCacheSet, op
 func (c *relayerCacheClient) Health(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*CacheUsage, error) {
 	out := new(CacheUsage)
 	err := c.cc.Invoke(ctx, "/lavanet.lava.pairing.RelayerCache/Health", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *relayerCacheClient) FlushCache(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, "/lavanet.lava.pairing.RelayerCache/FlushCache", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -324,6 +341,24 @@ func _RelayerCache_Health_Handler(srv interface{}, ctx context.Context, dec func
 	return interceptor(ctx, in, info, handler)
 }
 
+func _RelayerCache_FlushCache_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(emptypb.Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RelayerCacheServer).FlushCache(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/lavanet.lava.pairing.RelayerCache/FlushCache",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RelayerCacheServer).FlushCache(ctx, req.(*emptypb.Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _RelayerCache_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "lavanet.lava.pairing.RelayerCache",
 	HandlerType: (*RelayerCacheServer)(nil),
@@ -339,6 +374,10 @@ var _RelayerCache_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Health",
 			Handler:    _RelayerCache_Health_Handler,
+		},
+		{
+			MethodName: "FlushCache",
+			Handler:    _RelayerCache_FlushCache_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},


### PR DESCRIPTION
## Summary

The `/debug/reset-all` endpoint (MAG-1658) advertised `ristretto cleared` but only cleared the in-process Ristretto buffer. On deployments running with `--cache-be` the real cache lives in a separate `router-cache` pod, so a follow-up request still hit `Lava-Provider-Address: Cached`. Any black-box test relying on *"reset wipes the cache"* was therefore wrong on the production topology — the bug surfaced as a MAG-1761 Case 2 `xfail`.

This PR extends the `RelayerCache` gRPC service with a `FlushCache` RPC, implements it on the cache server, exposes a `Flush(ctx)` helper on `*performance.Cache`, and calls it from `/debug/reset-all` when `--cache-be` is configured. Jira: https://magmadevs.atlassian.net/browse/MAG-1764

## What changed

- **New gRPC method** `RelayerCache.FlushCache(Empty) → Empty` in `types/relay/grpc_service.go`. Hand-rolled like the rest of this file (no `.proto` regen workflow); appended to the existing service descriptor so the existing methods are bit-for-bit unchanged.
- **Cache-server handler** in `ecosystem/cache/handlers.go::FlushCache` calls `Clear()` then `Wait()` on `tempCache`, `finalizedCache`, and `blocksHashesToHeightsCache`. The `Wait()` is deliberate: Ristretto `Clear()` doesn't drain the async Set buffer, so without it a Set in flight at flush time can resurface as a hit on the next Get. Caveat documented in the handler doc-comment.
- **Client helper** `performance.Cache.Flush(ctx)` mirrors the nil/not-connected guards of `GetEntry` / `SetEntry` and uses the same `resetOnConnectionError` reconnection path.
- **Wired into `/debug/reset-all`** via a new `cacheFlusher` interface on `debugMuxDeps` so tests can inject a fake without a real gRPC client.

## Safety semantics

- **Honest advertisement.** `cache-be` is added to the response's `cleared` list **only** when `CacheActive()` is true and the flush actually succeeded. Deployments without `--cache-be` don't advertise a key they didn't fulfill.
- **Fail loud on real errors.** Any non-`Unimplemented` gRPC error (Unavailable, DeadlineExceeded, etc.) returns HTTP 500 instead of silently 200, so the test framework surfaces the failure.
- **Rolling-deploy escape hatch.** `codes.Unimplemented` is treated as *"old cache pod, FlushCache not yet shipped"* — degrade quietly to HTTP 200 with `cache-be` omitted from `cleared`, log a warning. This lets the new router roll out before the cache-pod bump without breaking `/debug/reset-all` during the window.

## Containment — only the debug server is affected

The relay hot path is **not** modified:

- `buildDebugMux` is only invoked when `--debug-address` is non-empty (off by default in production), so on a normal deploy none of the new router code runs at all.
- Existing `Cache.GetEntry` / `Cache.SetEntry` and the cache server's `GetRelay` / `SetRelay` / `Health` handlers are untouched.
- The gRPC service descriptor change is append-only; gRPC dispatches by method name, so adding a fourth entry cannot redirect any of the existing three.

## Tests

All passing locally (`go test ./protocol/rpcsmartrouter/... ./ecosystem/cache/... -count=1`):

- `ecosystem/cache/flush_test.go` — `FlushCache` clears all three Ristretto stores; nil-safe when stores or `CacheServer` are nil.
- `protocol/rpcsmartrouter/debug_server_test.go` — adds four new cases:
  - `NoCacheBe` — body omits `cache-be` when `cache` is nil.
  - `CacheBeInactive` — body omits `cache-be` and `Flush` is not called when `CacheActive()` is false.
  - `CacheBeActive_AdvertisesAndFlushes` — body includes `cache-be` and `Flush` was called when active.
  - `CacheBeFlushError_Returns500` — real flush errors fail loud.
  - `CacheBeUnimplemented_DegradesGracefully` — `codes.Unimplemented` returns 200 without `cache-be`.

## Sibling work (separate PRs)

Not in this PR — flagged here so they don't get forgotten:

- [ ] `smart-router-automation`: flip the MAG-1761 Case 2 `xfail` to a passing assertion (the body now contains `cache-be` and the next request hits a provider, not `Cached`).
- [ ] `tests/simulator/helpers.py::deep_reset_router` docstring: drop the *"in-process only"* caveat.
- [ ] `context.md §13.10` release-readiness checklist: drop the MAG-1764 gap row.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./protocol/rpcsmartrouter/... ./ecosystem/cache/... ./protocol/performance/... ./types/relay/... -count=1` passes (full new + existing suite)
- [ ] Manual: deploy this branch to a cluster running `router-cache` (with the matching cache-pod bump), call `POST /debug/reset-all`, send a previously-cached request, confirm `Lava-Provider-Address: <real provider>` rather than `Cached`
- [ ] Manual: same call with no `--cache-be` configured — confirm response body still `200` and `cache-be` is absent from `cleared`
- [ ] Manual (rolling-deploy simulation): point the new router at an old cache pod — confirm 200 + `cache-be` absent + warning logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)