### PR TITLE
fix(rpcsmartrouter): drain blocked providers in /debug/reset-all (MAG-1810)

### DIFF
--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -2093,6 +2093,66 @@ func (csm *ConsumerSessionManager) ResetTransientFailureState() {
 	csm.publishStateSizes()
 }
 
+// ResetBlockedProviders is the direct-rpc-mode escape hatch for
+// /debug/reset-all. It bypasses the epoch-boundary invariant documented on
+// ResetTransientFailureState by atomically restoring every
+// currentlyBlockedProviderAddresses entry back to validAddresses, then
+// resetting the per-provider redemption flag.
+//
+// Why ResetTransientFailureState alone is not enough:
+// The lava-pairing-network mode relies on UpdateAllProviders firing on every
+// epoch transition to repopulate validAddresses from pairingAddresses — that
+// is the only path that drains currentlyBlockedProviderAddresses without
+// stranding addresses in routing limbo. In direct-rpc mode the pairing list
+// is loaded once from YAML and never refreshed, so currentlyBlockedProvider
+// Addresses grows monotonically as tests trigger blockProvider, and the
+// pool of routable providers shrinks until tests cascade.
+//
+// We pair the three state changes (clear blocked list, refill valid list,
+// purge addon cache) inside a single lock-held block so observers never see
+// the "blocked-but-not-valid" state that the original doc warned against.
+// The addon-cache purge mirrors what removeAddressFromValidAddresses and
+// validateAndReturnBlockedProviderToValidAddressesListLocked already do on
+// every single-provider mutation.
+func (csm *ConsumerSessionManager) ResetBlockedProviders() {
+	csm.lock.Lock()
+	hadBlocked := len(csm.currentlyBlockedProviderAddresses) > 0
+	if hadBlocked {
+		// setValidAddressesToDefaultValue("", nil, ctx) refills validAddresses
+		// from pairingAddresses but does NOT touch addonAddresses in the
+		// no-addon branch. RemoveAddonAddresses("", nil) wipes the whole map
+		// so the next request rebuilds against the restored pool.
+		csm.setValidAddressesToDefaultValue("", nil, context.Background())
+		csm.RemoveAddonAddresses("", nil)
+	}
+	pairing := csm.pairing
+	endpoint := csm.RPCEndpoint()
+	csm.lock.Unlock()
+
+	if !hadBlocked {
+		return
+	}
+
+	// Clear the per-provider redemption flag for every entry returned to
+	// validAddresses. blockProvider sets this to Used in the second-chance
+	// path; without resetting, future failures see a "Used" status and skip
+	// retry logic. Done outside csm.lock — atomicWriteBlockedStatus does not
+	// take csm.lock, and the metric goroutine must not hold it either.
+	for addr, provider := range pairing {
+		if provider == nil {
+			continue
+		}
+		provider.atomicWriteBlockedStatus(BlockedProviderSessionUnusedStatus)
+		if csm.consumerMetricsManager != nil && len(provider.Endpoints) > 0 {
+			go func(networkAddress, chainID, apiInterface, providerAddress string) {
+				csm.consumerMetricsManager.SetBlockedProvider(chainID, apiInterface, providerAddress, networkAddress, false)
+			}(provider.Endpoints[0].NetworkAddress, endpoint.ChainID, endpoint.ApiInterface, addr)
+		}
+	}
+
+	csm.publishStateSizes()
+}
+
 // stateSizesPublishInterval drives the periodic CSM state-size gauge tick.
 // Variable (not const) so unit tests can shorten it to deterministic timing
 // without exposing the goroutine internals.

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -2337,3 +2337,80 @@ func TestResetTransientFailureState(t *testing.T) {
 	require.False(t, stickyExists, "stickySessions must be cleared")
 	require.False(t, csm.reportedProviders.IsReported("reported-bad"), "reportedProviders must be cleared")
 }
+
+// TestResetBlockedProviders is the MAG-1810 regression test. In direct-rpc
+// mode there are no epoch transitions, so currentlyBlockedProviderAddresses
+// accumulates monotonically as tests trigger blockProvider — eventually
+// shrinking validAddresses to nothing and producing the cascading bundle
+// failure (115 → 59 → 3 across consecutive runs).
+//
+// ResetBlockedProviders is the explicit direct-rpc escape hatch for the
+// /debug/reset-all path: it atomically restores every blocked address back
+// to validAddresses (using setValidAddressesToDefaultValue), purges the
+// addon cache (RemoveAddonAddresses("", nil) inside the helper), and resets
+// the per-provider redemption flag.
+func TestResetBlockedProviders(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+
+	// Seed a pairing of three providers; block two of them so validAddresses
+	// has one entry and currentlyBlockedProviderAddresses has two.
+	csm.lock.Lock()
+	csm.pairing = map[string]*ConsumerSessionsWithProvider{
+		"provider-a": {PublicLavaAddress: "provider-a", Endpoints: []*Endpoint{{NetworkAddress: "addr-a"}}},
+		"provider-b": {PublicLavaAddress: "provider-b", Endpoints: []*Endpoint{{NetworkAddress: "addr-b"}}},
+		"provider-c": {PublicLavaAddress: "provider-c", Endpoints: []*Endpoint{{NetworkAddress: "addr-c"}}},
+	}
+	csm.pairingAddresses = map[uint64]string{
+		0: "provider-a",
+		1: "provider-b",
+		2: "provider-c",
+	}
+	csm.pairingAddressesLength = 3
+	csm.validAddresses = []string{"provider-a"}
+	csm.currentlyBlockedProviderAddresses = []string{"provider-b", "provider-c"}
+	// Seed a stale addon cache containing only one of the blocked providers —
+	// the post-condition is that this cache is purged so the next request
+	// sees the full restored pool.
+	csm.addonAddresses = map[string][]string{"": {"provider-a"}}
+	// Simulate the second-chance redemption flag being set on a blocked
+	// provider; ResetBlockedProviders must clear it back to Unused.
+	csm.pairing["provider-b"].atomicWriteBlockedStatus(BlockedProviderSessionUsedStatus)
+	csm.lock.Unlock()
+
+	csm.ResetBlockedProviders()
+
+	csm.lock.RLock()
+	defer csm.lock.RUnlock()
+	require.Empty(t, csm.currentlyBlockedProviderAddresses,
+		"currentlyBlockedProviderAddresses must be drained in direct-rpc mode reset")
+	require.ElementsMatch(t, []string{"provider-a", "provider-b", "provider-c"}, csm.validAddresses,
+		"validAddresses must be restored to the full pairingAddresses set")
+	require.Empty(t, csm.addonAddresses,
+		"addonAddresses must be purged so the next request rebuilds against the restored validAddresses")
+	require.Equal(t, BlockedProviderSessionUnusedStatus, csm.pairing["provider-b"].atomicReadBlockedStatus(),
+		"per-provider redemption flag must be reset to Unused")
+}
+
+// TestResetBlockedProviders_NoBlockedIsNoOp verifies the cheap-exit path:
+// when no providers are blocked, the helper returns without taking the heavy
+// setValidAddressesToDefaultValue path and without spawning metric
+// goroutines. validAddresses must be left exactly as it was.
+func TestResetBlockedProviders_NoBlockedIsNoOp(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+
+	csm.lock.Lock()
+	csm.pairing = map[string]*ConsumerSessionsWithProvider{
+		"provider-a": {PublicLavaAddress: "provider-a", Endpoints: []*Endpoint{{NetworkAddress: "addr-a"}}},
+	}
+	csm.pairingAddresses = map[uint64]string{0: "provider-a"}
+	csm.validAddresses = []string{"provider-a"}
+	csm.currentlyBlockedProviderAddresses = nil
+	csm.lock.Unlock()
+
+	csm.ResetBlockedProviders()
+
+	csm.lock.RLock()
+	defer csm.lock.RUnlock()
+	require.Equal(t, []string{"provider-a"}, csm.validAddresses, "validAddresses must be untouched on a no-op reset")
+	require.Empty(t, csm.currentlyBlockedProviderAddresses)
+}

--- a/protocol/rpcsmartrouter/debug_server_test.go
+++ b/protocol/rpcsmartrouter/debug_server_test.go
@@ -175,6 +175,11 @@ func TestDebugResetAll_SmartRouter_ReturnsCapabilityAdvertisement(t *testing.T) 
 	// lives). The simulator framework can probe this key to verify it doesn't
 	// need to fall back to a process restart.
 	require.Contains(t, body, `"seen-block"`)
+	// blocked-providers (MAG-1810): in direct-rpc mode there are no epoch
+	// transitions, so currentlyBlockedProviderAddresses can only grow as
+	// tests trigger blockProvider. reset-all must restore the list to
+	// pairingAddresses for the test bundle to recover.
+	require.Contains(t, body, `"blocked-providers"`)
 }
 
 func TestDebugResetAll_SmartRouter_MethodNotAllowed(t *testing.T) {

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -584,10 +584,21 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 		//    keeps refreshing the TTL.
 		resetAllConsistencies(deps.consistencies)
 
-		// 3. Per-server RelayRetriesManagers (6h hash ban cache) and 4. per-CSM
-		//    transient failure state. Both require the router to be present;
-		//    test fixtures without a router still get a useful partial reset
-		//    above and we report which stores actually moved.
+		// 3. Per-server RelayRetriesManagers (6h hash ban cache), 4. per-CSM
+		//    transient failure state, and 4b. per-CSM blocked-providers list.
+		//    All require the router to be present; test fixtures without a
+		//    router still get a useful partial reset above and we report which
+		//    stores actually moved.
+		//
+		//    Why ResetBlockedProviders runs separately from
+		//    ResetTransientFailureState:
+		//    ResetTransientFailureState deliberately preserves
+		//    currentlyBlockedProviderAddresses because in lava-pairing-network
+		//    mode unblocking is an epoch-boundary operation. In direct-rpc mode
+		//    (this fork's default) there are no epoch transitions, so blocked
+		//    providers can only accumulate across test runs unless we mass-
+		//    restore here. ResetBlockedProviders is the explicit escape hatch
+		//    for /debug/* paths; production relay paths never reach it.
 		if deps.router != nil {
 			deps.router.mu.Lock()
 			for _, server := range deps.router.rpcServers {
@@ -598,6 +609,7 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 			for _, csm := range deps.router.sessionManagers {
 				if csm != nil {
 					csm.ResetTransientFailureState()
+					csm.ResetBlockedProviders()
 				}
 			}
 			deps.router.mu.Unlock()
@@ -640,12 +652,15 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 		// flushed. The test framework probes this body to decide between this
 		// endpoint and the legacy 4-call dance; "seen-block" was added to
 		// signal the per-chain consistency-cache flush, "cache-be" signals
-		// MAG-1764 end-to-end coverage.
+		// MAG-1764 end-to-end coverage, "blocked-providers" signals MAG-1810
+		// (currentlyBlockedProviderAddresses is now restored to
+		// pairingAddresses, the per-provider redemption flag is reset, and the
+		// addon cache is purged).
 		w.Header().Set("Content-Type", "application/json")
 		if cacheBeFlushed {
-			fmt.Fprint(w, `{"reset":true,"cleared":["optimizer","ristretto","retries-manager","session-manager","reported-providers","sticky-sessions","seen-block","cache-be"]}`)
+			fmt.Fprint(w, `{"reset":true,"cleared":["optimizer","ristretto","retries-manager","session-manager","reported-providers","sticky-sessions","seen-block","blocked-providers","cache-be"]}`)
 		} else {
-			fmt.Fprint(w, `{"reset":true,"cleared":["optimizer","ristretto","retries-manager","session-manager","reported-providers","sticky-sessions","seen-block"]}`)
+			fmt.Fprint(w, `{"reset":true,"cleared":["optimizer","ristretto","retries-manager","session-manager","reported-providers","sticky-sessions","seen-block","blocked-providers"]}`)
 		}
 	})
 


### PR DESCRIPTION
## Tickets

Closes [MAG-1810](https://magmadevs.atlassian.net/browse/MAG-1810) and [MAG-1811](https://magmadevs.atlassian.net/browse/MAG-1811) — same regression filed from two different symptom signatures (`seenBlock:1778...` poison hypothesis vs `"No pairings available"` retry failure). The audit triggered by MAG-1810 ruled out the original async-clear hypothesis and surfaced the real cause, which is precisely what MAG-1811 documents. (Also related: MAG-1812, already Done, linked as `is duplicated by` on MAG-1811.)

## Summary

- Adds `ConsumerSessionManager.ResetBlockedProviders()` — a direct-rpc-mode escape hatch that restores `validAddresses` from `pairingAddresses`, purges the addon cache, and resets the per-provider redemption flag.
- Wires it into `/debug/reset-all` after `ResetTransientFailureState()` so the test framework's reset between bundles actually drains the blocked-providers list.
- Advertises a new `"blocked-providers"` key in the `cleared` JSON array.

## Why this is a sibling method, not a change to `ResetTransientFailureState`

`ResetTransientFailureState`'s doc comment explicitly preserves `currentlyBlockedProviderAddresses` because in lava-pairing-network mode (vestigial but still in the code per `CLAUDE.md`) unblocking is an epoch-boundary operation paired with `UpdateAllProviders`. Modifying it would change the cross-mode contract. A sibling method called only from `/debug/*` handlers leaves the contract intact and the existing `TestResetTransientFailureState` assertion (`currentlyBlockedProviderAddresses` survives the call) is unchanged.

This differs from MAG-1811's proposed inline edit but achieves the same observable behavior with cleaner separation between debug-only and production-mode contracts (per advisor review).

## Why this is the bug

In direct-rpc mode there are no epoch transitions — `UpdateAllProviders` runs once at startup. Every `blockProvider` call permanently shrinks `validAddresses` and grows `currentlyBlockedProviderAddresses`. Across a test bundle, the routable pool monotonically shrinks until tests cascade. The 115 → 59 → 3 pattern is the signature of this leak; the `"No pairings available"` HTTP 500 in MAG-1811 is what tests hit once the pool is empty.

The original MAG-1810 hypothesis (async `ristretto.Clear()`) does not hold — `Clear()` in ristretto v2.3.0 is **synchronous** (it drains `setBuf` and waits on `processItems` via `<-c.done` before returning). The reporter's followup comment on MAG-1810 empirically failed to reproduce the async-clear behavior and flagged other suspects, which led to this audit.

## Acceptance criteria mapping

MAG-1811 lists three measurable acceptance criteria — all covered by `TestResetBlockedProviders` against a pre-blocked CSM:

| MAG-1811 criterion | Test assertion |
|---|---|
| `len(csm.currentlyBlockedProviderAddresses) == 0` | `require.Empty(t, csm.currentlyBlockedProviderAddresses, ...)` |
| `csm.validAddresses == csm.pairingAddresses` (full pool restored) | `require.ElementsMatch(t, []string{"provider-a","provider-b","provider-c"}, csm.validAddresses, ...)` |
| `addonAddresses` cache invalidated | `require.Empty(t, csm.addonAddresses, ...)` against a pre-seeded stale entry |

Joint exit criterion (both tickets): `pytest tests/simulator/production_tests/ -q --tb=no` returns to 110+ green after deploy.

## Scope honesty

Closes the identified gap. If the regression persists after deploy, candidates from MAG-1810's followup comment are: sim-control history retention, response-cache key surface, and any state outside the five subsystems already wired into `/debug/reset-all`.

## Followup (not blocking this PR)

The existing `lava_rpcsmartrouter_csm_blocked_providers` gauge publishes `len(previousEpochBlockedProviders)`, not `len(currentlyBlockedProviderAddresses)` — so the operator-facing signal doesn't reflect the leak this PR fixes. Worth a separate ticket to add a `currentlyBlockedProviderAddresses` gauge.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./protocol/lavasession/ ./protocol/rpcsmartrouter/ ./protocol/lavaprotocol/` clean
- [x] `go test ./protocol/lavasession/ -count=1` ok (25.0s, full suite)
- [x] `go test ./protocol/rpcsmartrouter/ -count=1` ok (75.9s, full suite)
- [x] `TestResetBlockedProviders` (new, lavasession) — full lifecycle
- [x] `TestResetBlockedProviders_NoBlockedIsNoOp` (new, lavasession) — cheap-exit path
- [x] `TestResetTransientFailureState` (existing, lavasession) — unchanged, still asserts the lava-pairing-network contract
- [x] `TestDebugResetAll_SmartRouter_ReturnsCapabilityAdvertisement` (extended) — requires `"blocked-providers"` in cleared array
- [ ] Deploy to `victoria.magmadevs.com` and rerun `pytest tests/simulator/production_tests/ -q --tb=no` — expect 110+ passed (pre-deploy baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MAG-1810]: https://magmadevs.atlassian.net/browse/MAG-1810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAG-1811]: https://magmadevs.atlassian.net/browse/MAG-1811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ