### PR TITLE
feat(rpcsmartrouter): add lava-hedge-triggered header (MAG-1818)

### DIFF
--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -30,6 +30,7 @@ const (
 	STATEFUL_ALL_PROVIDERS_HEADER_NAME              = "lava-fast-tx-participants"
 	REQUESTED_BLOCK_HEADER_NAME                     = "lava-parsed-requested-block"
 	LAVA_IDENTIFIED_NODE_ERROR_HEADER               = "lava-identified-node-error"
+	LAVA_HEDGE_TRIGGERED_HEADER                     = "lava-hedge-triggered"
 	LAVAP_VERSION_HEADER_NAME                       = "Lavap-Version"
 	LAVA_CONSUMER_PROCESS_GUID                      = "lava-consumer-process-guid"
 	// these headers need to be lowercase

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2429,6 +2429,19 @@ func (rpcss *RPCSmartRouterServer) appendHeadersToRelayResult(ctx context.Contex
 			})
 	}
 
+	// MAG-1818: signal that the hedge ticker dispatched at least one speculative
+	// batch on this request. Independent of Lava-Retries, which inclusively counts
+	// canceled hedge primaries — tests need this orthogonal flag to distinguish
+	// "hedge fired" from "classical retry." Omit-when-false convention (no "false"
+	// emitted), mirroring lava-identified-node-error above.
+	if analytics != nil && analytics.HedgeCount > 0 {
+		metadataReply = append(metadataReply,
+			pairingtypes.Metadata{
+				Name:  common.LAVA_HEDGE_TRIGGERED_HEADER,
+				Value: "true",
+			})
+	}
+
 	// fetch trailer information from the provider by using the provider trailer field.
 	rpcss.getMetadataFromRelayTrailer(chainlib.TrailersToAddToHeaderResponse, relayResult)
 

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/lavaprotocol"
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/protocol/metrics"
 	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
 	"github.com/magma-Devs/smart-router/protocol/qos"
 	"github.com/magma-Devs/smart-router/protocol/relaycore"
@@ -521,6 +522,78 @@ func TestRetryCountHeader(t *testing.T) {
 		retryHeader := findHeader(relayResult.Reply.Metadata, common.RETRY_COUNT_HEADER_NAME)
 		require.NotNil(t, retryHeader)
 		require.Equal(t, "1", retryHeader.Value)
+	})
+}
+
+// TestHedgeTriggeredHeader covers MAG-1818: lava-hedge-triggered must appear
+// (Value="true") iff analytics.HedgeCount > 0, and must be omitted otherwise.
+// This signal is independent of Lava-Retries — the test framework needs to
+// distinguish "hedge fired" from "classical retry" without inferring from
+// Lava-Retries + Lava-Provider-Address.
+func TestHedgeTriggeredHeader(t *testing.T) {
+	ctx := context.Background()
+
+	findHeader := func(metadata []pairingtypes.Metadata, name string) *pairingtypes.Metadata {
+		for i := range metadata {
+			if metadata[i].Name == name {
+				return &metadata[i]
+			}
+		}
+		return nil
+	}
+
+	newRelayResult := func() *common.RelayResult {
+		return &common.RelayResult{
+			ProviderInfo: common.ProviderInfo{ProviderAddress: "lava@provider1"},
+			Reply:        &pairingtypes.RelayReply{Metadata: []pairingtypes.Metadata{}},
+		}
+	}
+
+	newProcessor := func() *MockRelayProcessorForHeaders {
+		return &MockRelayProcessorForHeaders{
+			successResults: []common.RelayResult{
+				{ProviderInfo: common.ProviderInfo{ProviderAddress: "lava@provider1"}},
+			},
+		}
+	}
+
+	t.Run("hedge fired - header present with value true", func(t *testing.T) {
+		relayResult := newRelayResult()
+		rpcSmartRouterServer := &RPCSmartRouterServer{}
+		analytics := &metrics.RelayMetrics{HedgeCount: 1}
+
+		rpcSmartRouterServer.appendHeadersToRelayResult(ctx, relayResult, 0, newProcessor(), &MockProtocolMessage{
+			api: &spectypes.Api{Name: "eth_blockNumber"},
+		}, "eth_blockNumber", analytics, true)
+
+		hedgeHeader := findHeader(relayResult.Reply.Metadata, common.LAVA_HEDGE_TRIGGERED_HEADER)
+		require.NotNil(t, hedgeHeader, "hedge header must be set when HedgeCount > 0")
+		require.Equal(t, "true", hedgeHeader.Value)
+	})
+
+	t.Run("hedge count zero - header absent", func(t *testing.T) {
+		relayResult := newRelayResult()
+		rpcSmartRouterServer := &RPCSmartRouterServer{}
+		analytics := &metrics.RelayMetrics{HedgeCount: 0}
+
+		rpcSmartRouterServer.appendHeadersToRelayResult(ctx, relayResult, 0, newProcessor(), &MockProtocolMessage{
+			api: &spectypes.Api{Name: "eth_blockNumber"},
+		}, "eth_blockNumber", analytics, true)
+
+		hedgeHeader := findHeader(relayResult.Reply.Metadata, common.LAVA_HEDGE_TRIGGERED_HEADER)
+		require.Nil(t, hedgeHeader, "hedge header must be omitted when HedgeCount == 0 (no \"false\" value ever emitted)")
+	})
+
+	t.Run("nil analytics - header absent", func(t *testing.T) {
+		relayResult := newRelayResult()
+		rpcSmartRouterServer := &RPCSmartRouterServer{}
+
+		rpcSmartRouterServer.appendHeadersToRelayResult(ctx, relayResult, 0, newProcessor(), &MockProtocolMessage{
+			api: &spectypes.Api{Name: "eth_blockNumber"},
+		}, "eth_blockNumber", nil, true)
+
+		hedgeHeader := findHeader(relayResult.Reply.Metadata, common.LAVA_HEDGE_TRIGGERED_HEADER)
+		require.Nil(t, hedgeHeader, "hedge header must be omitted when analytics is nil")
 	})
 }
 


### PR DESCRIPTION
## Summary

- Adds a dedicated response header `lava-hedge-triggered: true` whenever the hedge ticker dispatched at least one speculative batch on the request. Omitted entirely otherwise.
- The signal is **independent of `Lava-Retries`** — that header inclusively counts canceled hedge primaries (every per-peer goroutine `defer`s `SetResponse(context.Canceled)` into `protocolErrorResults`), so a classical retry and a hedge fire look identical today. Tests need this orthogonal flag to tell them apart.
- Purely additive: `Lava-Retries` arithmetic at `rpcsmartrouter_server.go:2275-2283` is **unchanged**.

Closes [MAG-1818](https://magmadevs.atlassian.net/browse/MAG-1818).

## Why now

The smart-router-automation consumer PR ([smart-router-automation#88](https://github.com/Magma-Devs/smart-router-automation/pull/88)) currently infers hedge-fired from `Lava-Retries >= 1` AND a comma-separated `Lava-Provider-Address` — a fragile inference the PR body itself calls out as a known weakness. Once this lands, that inference fallback can be replaced with a direct header assertion.

## Implementation notes

The ticket warned the hedge-fire state might not propagate to the response-write step — that turned out to be moot in this fork. `analytics.HedgeCount` is already incremented in the ticker case at `unified_relay_state_machine.go:376-378` and is already in scope at the header-write site (the existing `RecordIncidentHedgeResult` metric call at `rpcsmartrouter_server.go:2351` reads it). So this is a one-line condition, no plumbing.

**Placement is load-bearing.** The new `append` lands *after* the `if relayResult == nil { return }` guard at line 2361, alongside the existing `lava-identified-node-error` block at line 2424. Putting it next to the hedge metric (line 2350) — the most obvious-looking neighbor — would have silently dropped the header on the cross-validation-failure early-return path. The unit tests don't exercise that branch, so this would have shipped quietly.

## Two ticket deviations to flag

1. **Constant identifier**: ticket spelled it `LavaHedgeTriggered`, but every existing constant in `endpoints.go` is `UPPER_SNAKE_CASE`. Used `LAVA_HEDGE_TRIGGERED_HEADER` to match the file. The ticket's own \"Casing\" guidance says \"match the file's existing pattern.\"
2. **Wire value casing**: ticket's AC bullet wrote `Lava-Hedge-Triggered`, but the two precedents the ticket explicitly cites (`lava-identified-node-error`, `lava-cross-validation-status`) are lowercase. HTTP headers are case-insensitive over the wire so functionally identical, but the lowercase form is consistent with the cited precedents. Happy to switch if you intended PascalCase.

## Test plan

- [x] `go build ./protocol/common/... ./protocol/rpcsmartrouter/...` — clean
- [x] `go test ./protocol/rpcsmartrouter -run 'TestHedgeTriggeredHeader|TestRetryCountHeader|TestAppendHeadersToRelayResultIntegration|TestCacheServedResponseHeaders' -count=1 -v` — 18/18 subtests pass (3 new + 15 adjacent, no regression)
- [x] `make test-short` — full `./protocol/rpcsmartrouter/...` package green (76s)
- [x] `go vet ./protocol/common/... ./protocol/rpcsmartrouter/...` — clean
- [ ] Optional manual smoke: run `./scripts/pre_setups/init_lava_smartrouter_eth.sh`, fire a request likely to hit the hedge ticker (high `--concurrent-providers`, slow primary), `curl -i` and confirm `lava-hedge-triggered: true` is present; confirm a normal fast request omits it entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MAG-1818]: https://magmadevs.atlassian.net/browse/MAG-1818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ