### PR TITLE
fix(chainlib): detect malformed upstream responses for retry

### DIFF
--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCEnvelopeScanner.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCEnvelopeScanner.go
@@ -1,0 +1,283 @@
+package rpcInterfaceMessages
+
+import (
+	"errors"
+	"fmt"
+)
+
+// jsonrpcScanResult holds presence flags and byte ranges for the top-level
+// "error" and "result" fields of a JSON-RPC envelope. Byte slices are
+// sub-slices of the input data — no copying — and are valid only as long
+// as the caller retains a reference to that data.
+type jsonrpcScanResult struct {
+	hasError    bool
+	errorBytes  []byte
+	hasResult   bool
+	resultBytes []byte
+}
+
+// scanJsonrpcEnvelope walks data as a single JSON object and records the
+// presence and byte range of the top-level "error" and "result" fields.
+// Other keys are skipped without allocation. The walk is depth-aware and
+// string-aware: braces inside string values do not affect nesting.
+//
+// Returns a non-nil error when the input is not a syntactically well-formed
+// JSON object (truncated bytes, top-level array/scalar, structural break).
+// Keys are matched by literal byte comparison; spec-legal but exotic
+// spellings like "result" for "result"
+// are not decoded and will not be recognized.
+func scanJsonrpcEnvelope(data []byte) (jsonrpcScanResult, error) {
+	var res jsonrpcScanResult
+	pos := skipWhitespace(data, 0)
+	if pos >= len(data) {
+		return res, errors.New("empty input")
+	}
+	if data[pos] != '{' {
+		return res, fmt.Errorf("expected '{' at position %d, got %q", pos, data[pos])
+	}
+	pos++
+	pos = skipWhitespace(data, pos)
+	if pos < len(data) && data[pos] == '}' {
+		return res, nil
+	}
+	for {
+		if pos >= len(data) {
+			return res, errors.New("truncated: expected key")
+		}
+		if data[pos] != '"' {
+			return res, fmt.Errorf("expected string key at position %d, got %q", pos, data[pos])
+		}
+		keyStart := pos + 1
+		keyEnd, next, err := scanString(data, pos)
+		if err != nil {
+			return res, fmt.Errorf("key: %w", err)
+		}
+		pos = next
+		pos = skipWhitespace(data, pos)
+		if pos >= len(data) || data[pos] != ':' {
+			return res, fmt.Errorf("expected ':' at position %d", pos)
+		}
+		pos++
+		pos = skipWhitespace(data, pos)
+		valueStart := pos
+		valueEnd, err := skipValue(data, pos)
+		if err != nil {
+			return res, fmt.Errorf("value: %w", err)
+		}
+		key := data[keyStart:keyEnd]
+		// The string(key) == "literal" pattern is optimized to a direct
+		// comparison without allocation by the Go compiler.
+		if string(key) == "error" {
+			res.hasError = true
+			res.errorBytes = data[valueStart:valueEnd]
+		} else if string(key) == "result" {
+			res.hasResult = true
+			res.resultBytes = data[valueStart:valueEnd]
+		}
+		pos = skipWhitespace(data, valueEnd)
+		if pos >= len(data) {
+			return res, errors.New("truncated: expected ',' or '}'")
+		}
+		if data[pos] == '}' {
+			return res, nil
+		}
+		if data[pos] != ',' {
+			return res, fmt.Errorf("expected ',' or '}' at position %d, got %q", pos, data[pos])
+		}
+		pos++
+		pos = skipWhitespace(data, pos)
+	}
+}
+
+// scanJsonrpcBatchElements walks data as a JSON array and invokes fn once
+// for each element with the element's byte range (a sub-slice of data).
+// If fn returns false, iteration stops without error.
+//
+// Returns a non-nil error when data is not a syntactically well-formed
+// JSON array.
+func scanJsonrpcBatchElements(data []byte, fn func(elementBytes []byte) bool) error {
+	pos := skipWhitespace(data, 0)
+	if pos >= len(data) {
+		return errors.New("empty input")
+	}
+	if data[pos] != '[' {
+		return fmt.Errorf("expected '[' at position %d, got %q", pos, data[pos])
+	}
+	pos++
+	pos = skipWhitespace(data, pos)
+	if pos < len(data) && data[pos] == ']' {
+		return nil
+	}
+	for {
+		if pos >= len(data) {
+			return errors.New("truncated: expected element")
+		}
+		elementStart := pos
+		elementEnd, err := skipValue(data, pos)
+		if err != nil {
+			return fmt.Errorf("element: %w", err)
+		}
+		if !fn(data[elementStart:elementEnd]) {
+			return nil
+		}
+		pos = skipWhitespace(data, elementEnd)
+		if pos >= len(data) {
+			return errors.New("truncated: expected ',' or ']'")
+		}
+		if data[pos] == ']' {
+			return nil
+		}
+		if data[pos] != ',' {
+			return fmt.Errorf("expected ',' or ']' at position %d, got %q", pos, data[pos])
+		}
+		pos++
+		pos = skipWhitespace(data, pos)
+	}
+}
+
+func skipWhitespace(data []byte, pos int) int {
+	for pos < len(data) {
+		switch data[pos] {
+		case ' ', '\t', '\n', '\r':
+			pos++
+		default:
+			return pos
+		}
+	}
+	return pos
+}
+
+// scanString consumes a JSON string starting at data[pos] (which must be
+// '"'). Returns the index of the closing quote (= end of string content)
+// and the index just past the closing quote (= start of the next token).
+func scanString(data []byte, pos int) (contentEnd int, tokenEnd int, err error) {
+	if pos >= len(data) || data[pos] != '"' {
+		return 0, 0, fmt.Errorf("expected '\"' at position %d", pos)
+	}
+	i := pos + 1
+	for i < len(data) {
+		b := data[i]
+		switch b {
+		case '"':
+			return i, i + 1, nil
+		case '\\':
+			if i+1 >= len(data) {
+				return 0, 0, errors.New("truncated escape sequence")
+			}
+			esc := data[i+1]
+			switch esc {
+			case '"', '\\', '/', 'b', 'f', 'n', 'r', 't':
+				i += 2
+			case 'u':
+				if i+6 > len(data) {
+					return 0, 0, errors.New("truncated \\u escape")
+				}
+				i += 6
+			default:
+				return 0, 0, fmt.Errorf("invalid escape \\%c at position %d", esc, i+1)
+			}
+		default:
+			i++
+		}
+	}
+	return 0, 0, errors.New("truncated string")
+}
+
+// skipValue consumes one JSON value starting at data[pos] (with leading
+// whitespace already stripped by the caller) and returns the index just
+// past it.
+func skipValue(data []byte, pos int) (int, error) {
+	if pos >= len(data) {
+		return 0, errors.New("truncated value")
+	}
+	b := data[pos]
+	switch {
+	case b == '"':
+		_, end, err := scanString(data, pos)
+		return end, err
+	case b == '{' || b == '[':
+		return skipContainer(data, pos)
+	case b == 't':
+		return skipLiteral(data, pos, "true")
+	case b == 'f':
+		return skipLiteral(data, pos, "false")
+	case b == 'n':
+		return skipLiteral(data, pos, "null")
+	case b == '-' || (b >= '0' && b <= '9'):
+		return skipNumber(data, pos), nil
+	default:
+		return 0, fmt.Errorf("unexpected byte %q at position %d", b, pos)
+	}
+}
+
+// skipContainer consumes an object or array starting at data[pos] (which
+// must be '{' or '[') and returns the index just past the matching close.
+// Walks once, tracking depth and respecting string literals so braces
+// inside strings do not affect nesting.
+func skipContainer(data []byte, pos int) (int, error) {
+	if pos >= len(data) {
+		return 0, errors.New("truncated container")
+	}
+	opener := data[pos]
+	var closer byte
+	switch opener {
+	case '{':
+		closer = '}'
+	case '[':
+		closer = ']'
+	default:
+		return 0, fmt.Errorf("expected '{' or '[' at position %d", pos)
+	}
+	depth := 1
+	i := pos + 1
+	for i < len(data) {
+		switch data[i] {
+		case '"':
+			_, end, err := scanString(data, i)
+			if err != nil {
+				return 0, err
+			}
+			i = end
+		case '{', '[':
+			depth++
+			i++
+		case '}', ']':
+			b := data[i]
+			depth--
+			i++
+			if depth == 0 {
+				if b != closer {
+					return 0, fmt.Errorf("mismatched bracket at position %d", i-1)
+				}
+				return i, nil
+			}
+		default:
+			i++
+		}
+	}
+	return 0, errors.New("truncated container")
+}
+
+func skipLiteral(data []byte, pos int, lit string) (int, error) {
+	end := pos + len(lit)
+	if end > len(data) || string(data[pos:end]) != lit {
+		return 0, fmt.Errorf("expected literal %q at position %d", lit, pos)
+	}
+	return end, nil
+}
+
+// skipNumber consumes a JSON number starting at data[pos] and returns the
+// index just past it. Does not strictly validate structure — malformed
+// numbers will be caught later when the value is actually decoded.
+func skipNumber(data []byte, pos int) int {
+	i := pos
+	for i < len(data) {
+		b := data[i]
+		if (b >= '0' && b <= '9') || b == '-' || b == '+' || b == '.' || b == 'e' || b == 'E' {
+			i++
+			continue
+		}
+		break
+	}
+	return i
+}

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCEnvelopeScanner.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCEnvelopeScanner.go
@@ -23,9 +23,11 @@ type jsonrpcScanResult struct {
 //
 // Returns a non-nil error when the input is not a syntactically well-formed
 // JSON object (truncated bytes, top-level array/scalar, structural break).
-// Keys are matched by literal byte comparison; spec-legal but exotic
-// spellings like "result" for "result"
-// are not decoded and will not be recognized.
+// Keys are matched by literal byte comparison against the raw bytes inside
+// the quotes — JSON-escape-encoded spellings of the same key (e.g. the
+// "result" key written with each character as a six-byte hex escape) are
+// spec-legal but will not be recognized. No production upstream is known
+// to emit them.
 func scanJsonrpcEnvelope(data []byte) (jsonrpcScanResult, error) {
 	var res jsonrpcScanResult
 	pos := skipWhitespace(data, 0)

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCEnvelopeScanner_test.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCEnvelopeScanner_test.go
@@ -1,0 +1,307 @@
+package rpcInterfaceMessages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanJsonrpcEnvelope_ValidWithResult(t *testing.T) {
+	data := []byte(`{"jsonrpc":"2.0","id":1,"result":"0x12a7b5c"}`)
+	res, err := scanJsonrpcEnvelope(data)
+	require.NoError(t, err)
+	require.True(t, res.hasResult)
+	require.False(t, res.hasError)
+	require.Equal(t, `"0x12a7b5c"`, string(res.resultBytes))
+}
+
+func TestScanJsonrpcEnvelope_ValidWithError(t *testing.T) {
+	data := []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found"}}`)
+	res, err := scanJsonrpcEnvelope(data)
+	require.NoError(t, err)
+	require.False(t, res.hasResult)
+	require.True(t, res.hasError)
+	require.Equal(t, `{"code":-32601,"message":"method not found"}`, string(res.errorBytes))
+}
+
+func TestScanJsonrpcEnvelope_NullResult(t *testing.T) {
+	// {"result": null} is a valid JSON-RPC response — null is a legal result value.
+	data := []byte(`{"jsonrpc":"2.0","id":1,"result":null}`)
+	res, err := scanJsonrpcEnvelope(data)
+	require.NoError(t, err)
+	require.True(t, res.hasResult, "result:null must register as present")
+	require.Equal(t, `null`, string(res.resultBytes))
+}
+
+func TestScanJsonrpcEnvelope_MissingBoth(t *testing.T) {
+	// The second shape from the ticket.
+	data := []byte(`{"jsonrpc":"2.0","id":1}`)
+	res, err := scanJsonrpcEnvelope(data)
+	require.NoError(t, err, "valid JSON should parse")
+	require.False(t, res.hasResult)
+	require.False(t, res.hasError)
+}
+
+func TestScanJsonrpcEnvelope_BothPresent(t *testing.T) {
+	// Spec says a response must have exactly one of result/error, but we
+	// shouldn't crash on both. Record both presences.
+	data := []byte(`{"jsonrpc":"2.0","id":1,"result":1,"error":{"code":0,"message":"x"}}`)
+	res, err := scanJsonrpcEnvelope(data)
+	require.NoError(t, err)
+	require.True(t, res.hasResult)
+	require.True(t, res.hasError)
+}
+
+func TestScanJsonrpcEnvelope_EmptyObject(t *testing.T) {
+	data := []byte(`{}`)
+	res, err := scanJsonrpcEnvelope(data)
+	require.NoError(t, err)
+	require.False(t, res.hasResult)
+	require.False(t, res.hasError)
+}
+
+func TestScanJsonrpcEnvelope_TruncatedMidValue(t *testing.T) {
+	// First shape from the ticket: TCP cut mid-write.
+	data := []byte(`{"jsonrpc":"2.0","id":1,"resu`)
+	_, err := scanJsonrpcEnvelope(data)
+	require.Error(t, err)
+}
+
+func TestScanJsonrpcEnvelope_TruncatedMidString(t *testing.T) {
+	data := []byte(`{"jsonrpc":"2.0","id":1,"result":"0x12a7b5`)
+	_, err := scanJsonrpcEnvelope(data)
+	require.Error(t, err)
+}
+
+func TestScanJsonrpcEnvelope_TruncatedMidEscape(t *testing.T) {
+	data := []byte(`{"result":"abc\`)
+	_, err := scanJsonrpcEnvelope(data)
+	require.Error(t, err)
+}
+
+func TestScanJsonrpcEnvelope_TruncatedMidUnicodeEscape(t *testing.T) {
+	data := []byte(`{"result":"\u003`)
+	_, err := scanJsonrpcEnvelope(data)
+	require.Error(t, err)
+}
+
+func TestScanJsonrpcEnvelope_TruncatedAtClose(t *testing.T) {
+	data := []byte(`{"jsonrpc":"2.0","id":1`)
+	_, err := scanJsonrpcEnvelope(data)
+	require.Error(t, err)
+}
+
+func TestScanJsonrpcEnvelope_EscapedQuoteInString(t *testing.T) {
+	// Inner quote inside the error message must not terminate the string.
+	data := []byte(`{"error":{"code":1,"message":"got \"x\" instead of \"y\""}}`)
+	res, err := scanJsonrpcEnvelope(data)
+	require.NoError(t, err)
+	require.True(t, res.hasError)
+	require.Equal(t, `{"code":1,"message":"got \"x\" instead of \"y\""}`, string(res.errorBytes))
+}
+
+func TestScanJsonrpcEnvelope_EscapedBackslashInString(t *testing.T) {
+	// A lone backslash before " must not be mistaken for an escape.
+	data := []byte(`{"result":"path\\"}`)
+	res, err := scanJsonrpcEnvelope(data)
+	require.NoError(t, err)
+	require.True(t, res.hasResult)
+	require.Equal(t, `"path\\"`, string(res.resultBytes))
+}
+
+func TestScanJsonrpcEnvelope_BraceInsideString(t *testing.T) {
+	// `}` inside a string value must not pop the depth counter.
+	data := []byte(`{"result":"a}b{c"}`)
+	res, err := scanJsonrpcEnvelope(data)
+	require.NoError(t, err)
+	require.True(t, res.hasResult)
+	require.Equal(t, `"a}b{c"`, string(res.resultBytes))
+}
+
+func TestScanJsonrpcEnvelope_NestedObjectResult(t *testing.T) {
+	data := []byte(`{"result":{"number":"0x1","parentHash":"0xabc"}}`)
+	res, err := scanJsonrpcEnvelope(data)
+	require.NoError(t, err)
+	require.True(t, res.hasResult)
+	require.Equal(t, `{"number":"0x1","parentHash":"0xabc"}`, string(res.resultBytes))
+}
+
+func TestScanJsonrpcEnvelope_NestedArrayResult(t *testing.T) {
+	data := []byte(`{"result":[{"blockNumber":"0x1"},{"blockNumber":"0x2"}]}`)
+	res, err := scanJsonrpcEnvelope(data)
+	require.NoError(t, err)
+	require.True(t, res.hasResult)
+	require.Equal(t, `[{"blockNumber":"0x1"},{"blockNumber":"0x2"}]`, string(res.resultBytes))
+}
+
+func TestScanJsonrpcEnvelope_DeeplyNestedResult(t *testing.T) {
+	data := []byte(`{"result":{"a":{"b":{"c":[1,[2,[3,{"d":"e"}]]]}}}}`)
+	res, err := scanJsonrpcEnvelope(data)
+	require.NoError(t, err)
+	require.True(t, res.hasResult)
+}
+
+func TestScanJsonrpcEnvelope_TopLevelArray(t *testing.T) {
+	// scanJsonrpcEnvelope must reject arrays — that's the batch path.
+	data := []byte(`[{"jsonrpc":"2.0","id":1,"result":1}]`)
+	_, err := scanJsonrpcEnvelope(data)
+	require.Error(t, err)
+}
+
+func TestScanJsonrpcEnvelope_TopLevelScalar(t *testing.T) {
+	data := []byte(`"just a string"`)
+	_, err := scanJsonrpcEnvelope(data)
+	require.Error(t, err)
+}
+
+func TestScanJsonrpcEnvelope_LeadingWhitespace(t *testing.T) {
+	data := []byte(" \n\t\r {\"result\":1}")
+	res, err := scanJsonrpcEnvelope(data)
+	require.NoError(t, err)
+	require.True(t, res.hasResult)
+}
+
+func TestScanJsonrpcEnvelope_WhitespaceBetweenTokens(t *testing.T) {
+	data := []byte(`{  "jsonrpc" : "2.0" , "id" : 1 , "result" : { "x" : 1 } }`)
+	res, err := scanJsonrpcEnvelope(data)
+	require.NoError(t, err)
+	require.True(t, res.hasResult)
+}
+
+func TestScanJsonrpcEnvelope_EmptyInput(t *testing.T) {
+	_, err := scanJsonrpcEnvelope(nil)
+	require.Error(t, err)
+	_, err = scanJsonrpcEnvelope([]byte{})
+	require.Error(t, err)
+	_, err = scanJsonrpcEnvelope([]byte("   "))
+	require.Error(t, err)
+}
+
+func TestScanJsonrpcEnvelope_TrailingCommaRejected(t *testing.T) {
+	// Strict JSON: trailing commas are invalid.
+	data := []byte(`{"result":1,}`)
+	_, err := scanJsonrpcEnvelope(data)
+	require.Error(t, err)
+}
+
+func TestScanJsonrpcEnvelope_MismatchedBracket(t *testing.T) {
+	data := []byte(`{"result":[1,2}`)
+	_, err := scanJsonrpcEnvelope(data)
+	require.Error(t, err)
+}
+
+func TestScanJsonrpcEnvelope_NumberResult(t *testing.T) {
+	data := []byte(`{"result":-1.5e10}`)
+	res, err := scanJsonrpcEnvelope(data)
+	require.NoError(t, err)
+	require.True(t, res.hasResult)
+	require.Equal(t, `-1.5e10`, string(res.resultBytes))
+}
+
+func TestScanJsonrpcEnvelope_BoolResult(t *testing.T) {
+	data := []byte(`{"result":true,"id":1}`)
+	res, err := scanJsonrpcEnvelope(data)
+	require.NoError(t, err)
+	require.True(t, res.hasResult)
+	require.Equal(t, `true`, string(res.resultBytes))
+}
+
+func TestScanJsonrpcEnvelope_NonStringKey(t *testing.T) {
+	// JSON requires string keys — bare identifiers are invalid.
+	data := []byte(`{result:1}`)
+	_, err := scanJsonrpcEnvelope(data)
+	require.Error(t, err)
+}
+
+func TestScanJsonrpcEnvelope_KeysWithSimilarNames(t *testing.T) {
+	// "results" and "errors" must NOT match — only exact "result" and "error".
+	data := []byte(`{"results":[1,2],"errors":[]}`)
+	res, err := scanJsonrpcEnvelope(data)
+	require.NoError(t, err)
+	require.False(t, res.hasResult)
+	require.False(t, res.hasError)
+}
+
+func TestScanJsonrpcBatchElements_Multi(t *testing.T) {
+	data := []byte(`[{"id":1,"result":1},{"id":2,"result":2},{"id":3,"result":3}]`)
+	var collected []string
+	err := scanJsonrpcBatchElements(data, func(b []byte) bool {
+		collected = append(collected, string(b))
+		return true
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		`{"id":1,"result":1}`,
+		`{"id":2,"result":2}`,
+		`{"id":3,"result":3}`,
+	}, collected)
+}
+
+func TestScanJsonrpcBatchElements_Empty(t *testing.T) {
+	data := []byte(`[]`)
+	count := 0
+	err := scanJsonrpcBatchElements(data, func(b []byte) bool {
+		count++
+		return true
+	})
+	require.NoError(t, err)
+	require.Zero(t, count)
+}
+
+func TestScanJsonrpcBatchElements_Single(t *testing.T) {
+	data := []byte(`[{"id":1,"result":1}]`)
+	var collected []string
+	err := scanJsonrpcBatchElements(data, func(b []byte) bool {
+		collected = append(collected, string(b))
+		return true
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{`{"id":1,"result":1}`}, collected)
+}
+
+func TestScanJsonrpcBatchElements_Truncated(t *testing.T) {
+	data := []byte(`[{"id":1,"result":1},{"id":2,"result"`)
+	err := scanJsonrpcBatchElements(data, func(b []byte) bool { return true })
+	require.Error(t, err)
+}
+
+func TestScanJsonrpcBatchElements_TopLevelObject(t *testing.T) {
+	data := []byte(`{"id":1,"result":1}`)
+	err := scanJsonrpcBatchElements(data, func(b []byte) bool { return true })
+	require.Error(t, err)
+}
+
+func TestScanJsonrpcBatchElements_EarlyExit(t *testing.T) {
+	data := []byte(`[{"id":1,"result":1},{"id":2,"result":2},{"id":3,"result":3}]`)
+	count := 0
+	err := scanJsonrpcBatchElements(data, func(b []byte) bool {
+		count++
+		return count < 2
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+}
+
+func TestScanJsonrpcBatchElements_LeadingWhitespace(t *testing.T) {
+	data := []byte("\n\t [{\"id\":1,\"result\":1}]")
+	count := 0
+	err := scanJsonrpcBatchElements(data, func(b []byte) bool {
+		count++
+		return true
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}
+
+func TestScanJsonrpcBatchElements_HeterogeneousElements(t *testing.T) {
+	// Scanner doesn't validate elements — they may be any JSON value.
+	// Schema validation is the caller's responsibility.
+	data := []byte(`[{"id":1,"result":1},42,"string","array",null,true]`)
+	count := 0
+	err := scanJsonrpcBatchElements(data, func(b []byte) bool {
+		count++
+		return true
+	})
+	require.NoError(t, err)
+	require.Equal(t, 6, count)
+}

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCMessage.go
@@ -62,6 +62,18 @@ func isJSONNull(data []byte) bool {
 	return len(data) == 4 && string(data) == "null"
 }
 
+// maxLoggedBodyBytes caps the size of the malformed-response body included in
+// warning logs. A persistently flaky upstream returning megabyte-scale garbage
+// would otherwise saturate the log pipeline.
+const maxLoggedBodyBytes = 2048
+
+func truncateForLog(data []byte) string {
+	if len(data) <= maxLoggedBodyBytes {
+		return string(data)
+	}
+	return string(data[:maxLoggedBodyBytes]) + "...[truncated]"
+}
+
 // checkJsonrpcEnvelope runs the JSON-RPC envelope shape check shared by both
 // JsonrpcMessage and TendermintrpcMessage. It distinguishes three outcomes:
 //
@@ -83,7 +95,7 @@ func isJSONNull(data []byte) bool {
 func checkJsonrpcEnvelope(data []byte, kind string) (hasError bool, errorMessage string, resultBytes []byte) {
 	scan, err := scanJsonrpcEnvelope(data)
 	if err != nil {
-		utils.LavaFormatWarning("malformed "+kind+" response", err, utils.LogAttr("data", string(data)))
+		utils.LavaFormatWarning("malformed "+kind+" response", err, utils.LogAttr("data", truncateForLog(data)))
 		return true, fmt.Sprintf("malformed %s response: %v", kind, err), nil
 	}
 	hasErr := scan.hasError && !isJSONNull(scan.errorBytes)
@@ -351,7 +363,7 @@ func CheckResponseErrorForJsonRpcBatch(data []byte, httpStatusCode int) (hasErro
 	})
 
 	if walkErr != nil {
-		utils.LavaFormatWarning("malformed JSON-RPC batch response", walkErr, utils.LogAttr("data", string(data)))
+		utils.LavaFormatWarning("malformed JSON-RPC batch response", walkErr, utils.LogAttr("data", truncateForLog(data)))
 		return true, fmt.Sprintf("malformed JSON-RPC batch response: %v", walkErr)
 	}
 

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCMessage.go
@@ -2,6 +2,7 @@ package rpcInterfaceMessages
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/goccy/go-json"
 
@@ -54,26 +55,67 @@ func (jm *JsonrpcMessage) GetRawRequestHash() ([]byte, error) {
 	return sigs.HashMsg(append(append(methodByteArray, paramsByteArray...), headersByteArray...)), nil
 }
 
-// returns if error exists and
-func (jm JsonrpcMessage) CheckResponseError(data []byte, httpStatusCode int) (hasError bool, errorMessage string) {
-	// Use a temporary struct that omits the Result field to avoid allocating memory for large results
-	// when we only need to check for errors
-	var result struct {
-		Error *rpcclient.JsonError `json:"error,omitempty"`
-	}
-	err := json.Unmarshal(data, &result)
-	if err != nil {
-		utils.LavaFormatWarning("Failed unmarshalling CheckError", err, utils.LogAttr("data", string(data)))
-		return false, ""
-	}
-	if result.Error == nil { // no error
-		return false, ""
-	}
-	if result.Error.Message == "" {
-		return false, ""
-	}
+// isJSONNull reports whether data is the JSON literal `null`. Scanner output
+// for value bytes already has surrounding whitespace stripped, so a direct
+// length+content check is correct without TrimSpace overhead.
+func isJSONNull(data []byte) bool {
+	return len(data) == 4 && string(data) == "null"
+}
 
-	return true, result.Error.Message
+// checkJsonrpcEnvelope runs the JSON-RPC envelope shape check shared by both
+// JsonrpcMessage and TendermintrpcMessage. It distinguishes three outcomes:
+//
+//   - hasError=true with a non-empty message → caller propagates as a
+//     node-error verdict (scanner parse failure, schema violation, or a
+//     real error object on the wire)
+//   - hasError=false, resultBytes != nil    → envelope success. Caller may
+//     inspect resultBytes for protocol-specific inner errors (e.g.
+//     Tendermint's response.code/log)
+//   - hasError=false, resultBytes == nil    → envelope success with no
+//     result content to inspect (rare; happens when "error" was present
+//     with an empty message)
+//
+// kind is woven into synthetic error messages — "JSON-RPC" or "Tendermint RPC".
+//
+// Edge case: "error": null is treated as if the error key were absent, since
+// JSON-RPC clients can't act on a null error. A response that has neither a
+// result nor a real error is still flagged as a schema violation.
+func checkJsonrpcEnvelope(data []byte, kind string) (hasError bool, errorMessage string, resultBytes []byte) {
+	scan, err := scanJsonrpcEnvelope(data)
+	if err != nil {
+		utils.LavaFormatWarning("malformed "+kind+" response", err, utils.LogAttr("data", string(data)))
+		return true, fmt.Sprintf("malformed %s response: %v", kind, err), nil
+	}
+	hasErr := scan.hasError && !isJSONNull(scan.errorBytes)
+	if !scan.hasResult && !hasErr {
+		return true, fmt.Sprintf("malformed %s response: missing both 'result' and 'error' fields", kind), nil
+	}
+	if !hasErr {
+		return false, "", scan.resultBytes
+	}
+	var je struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(scan.errorBytes, &je); err != nil {
+		return true, fmt.Sprintf("malformed %s response: error field is not a valid object", kind), nil
+	}
+	if je.Message == "" {
+		return false, "", scan.resultBytes
+	}
+	return true, je.Message, nil
+}
+
+// CheckResponseError classifies a JSON-RPC response body for the smart-router
+// retry pipeline. See checkJsonrpcEnvelope for the verdict rules; this method
+// is a thin wrapper since JsonrpcMessage has no protocol-specific inner-error
+// inspection (Tendermint does).
+//
+// Direct callers in direct_rpc_relay.go short-circuit truncated wire-level
+// failures via json.Valid before reaching here; this method's parse-failure
+// branch remains as a backstop for callers that bypass that check.
+func (jm JsonrpcMessage) CheckResponseError(data []byte, httpStatusCode int) (hasError bool, errorMessage string) {
+	hasErr, msg, _ := checkJsonrpcEnvelope(data, "JSON-RPC")
+	return hasErr, msg
 }
 
 func ConvertJsonRPCMsg(rpcMsg *rpcclient.JsonrpcMessage) (*JsonrpcMessage, error) {
@@ -273,49 +315,53 @@ func NewBatchMessage(msgs []JsonrpcMessage) (JsonrpcBatchMessage, error) {
 	return JsonrpcBatchMessage{batch: batch}, nil
 }
 
-// returns if error exists and
-// Behavior controlled by BatchNodeErrorOnAny flag:
-// - false (default): batch is an error only if ALL sub-requests failed
-// - true: batch is an error if ANY sub-request failed (strict mode)
+// CheckResponseErrorForJsonRpcBatch classifies a JSON-RPC batch response body.
+// Aggregation is controlled by BatchNodeErrorOnAny:
+//   - false (default): the batch is an error only when no sub-request succeeded
+//     AND at least one was faulty (had an error or was malformed)
+//   - true (strict):  the batch is an error whenever any sub-request was faulty
+//
+// A malformed sub-element (unparseable, or missing both 'result' and 'error')
+// is treated as a faulty element. A malformed top-level array (truncated, not
+// an array) is itself classified as a wrong-data verdict so the relay pipeline
+// can retry against another provider. Sub-element classification reuses
+// checkJsonrpcEnvelope so the rules stay in lockstep with the single path,
+// including the error:null edge case.
 func CheckResponseErrorForJsonRpcBatch(data []byte, httpStatusCode int) (hasError bool, errorMessage string) {
-	// Use a temporary struct that checks for both error and result presence
-	var result []struct {
-		Error  *rpcclient.JsonError `json:"error,omitempty"`
-		Result json.RawMessage      `json:"result,omitempty"`
+	var (
+		hasAnySuccess bool
+		aggregated    strings.Builder
+	)
+	appendFault := func(msg string) {
+		if aggregated.Len() > 0 {
+			aggregated.WriteString(",-,") // unique separator between sub-messages
+		}
+		aggregated.WriteString(msg)
 	}
-	err := json.Unmarshal(data, &result)
-	if err != nil {
-		utils.LavaFormatWarning("Failed unmarshalling CheckError", err, utils.LogAttr("data", string(data)))
+
+	walkErr := scanJsonrpcBatchElements(data, func(element []byte) bool {
+		elemHasErr, elemMsg, _ := checkJsonrpcEnvelope(element, "JSON-RPC batch element")
+		if elemHasErr {
+			appendFault(elemMsg)
+			return true
+		}
+		// Envelope success — element has a result (possibly null).
+		hasAnySuccess = true
+		return true
+	})
+
+	if walkErr != nil {
+		utils.LavaFormatWarning("malformed JSON-RPC batch response", walkErr, utils.LogAttr("data", string(data)))
+		return true, fmt.Sprintf("malformed JSON-RPC batch response: %v", walkErr)
+	}
+
+	// Default mode: a single success masks any sibling faults.
+	if !BatchNodeErrorOnAny && hasAnySuccess {
 		return false, ""
 	}
-
-	hasAnySuccess := false
-	hasAnyError := false
-	aggregatedErrors := ""
-
-	for _, batchResult := range result {
-		if batchResult.Error == nil && len(batchResult.Result) > 0 {
-			hasAnySuccess = true
-		}
-		if batchResult.Error != nil && batchResult.Error.Message != "" {
-			hasAnyError = true
-			if aggregatedErrors != "" {
-				aggregatedErrors += ",-," // add a unique comma separator between results
-			}
-			aggregatedErrors += batchResult.Error.Message
-		}
-	}
-
-	// BatchNodeErrorOnAny=true (strict): error if ANY sub-request failed
-	// BatchNodeErrorOnAny=false (default): error only if ALL sub-requests failed
-	if BatchNodeErrorOnAny {
-		// Strict mode: any error means batch failed
-		return hasAnyError, aggregatedErrors
-	}
-
-	// Default mode: only error if no successes at all
-	if hasAnySuccess {
+	if aggregated.Len() == 0 {
+		// No successes and no faults — typically the empty-batch case.
 		return false, ""
 	}
-	return aggregatedErrors != "", aggregatedErrors
+	return true, aggregated.String()
 }

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCMessage_test.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCMessage_test.go
@@ -479,6 +479,8 @@ func TestCheckResponseErrorForJsonRpcBatch_MalformedElements(t *testing.T) {
 	})
 
 	t.Run("partial_success_with_malformed_sibling_default_mode", func(t *testing.T) {
+		originalValue := BatchNodeErrorOnAny
+		defer func() { BatchNodeErrorOnAny = originalValue }()
 		BatchNodeErrorOnAny = false
 		data := []byte(`[{"jsonrpc":"2.0","id":1,"result":1},{"jsonrpc":"2.0","id":2}]`)
 		hasError, _ := CheckResponseErrorForJsonRpcBatch(data, 200)

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCMessage_test.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCMessage_test.go
@@ -300,11 +300,15 @@ func TestCheckResponseErrorForJsonRpcBatch(t *testing.T) {
 		require.Empty(t, errorMsg)
 	})
 
-	t.Run("invalid_json_no_error", func(t *testing.T) {
+	t.Run("invalid_json_is_malformed", func(t *testing.T) {
+		// Previously this asserted (false, "") under a "fail-open" rationale.
+		// That silently propagated truncated upstream bodies to clients; the
+		// router now classifies a malformed batch envelope as a wrong-data
+		// verdict so the relay pipeline retries against another provider.
 		data := []byte(`not valid json`)
 		hasError, errorMsg := CheckResponseErrorForJsonRpcBatch(data, 200)
-		require.False(t, hasError, "Invalid JSON should not return error (fail-open)")
-		require.Empty(t, errorMsg)
+		require.True(t, hasError, "malformed batch envelope must be flagged for retry")
+		require.Contains(t, errorMsg, "malformed JSON-RPC batch response")
 	})
 
 	t.Run("null_result_with_no_error_is_success", func(t *testing.T) {
@@ -373,5 +377,121 @@ func TestCheckResponseErrorForJsonRpcBatch_StrictMode(t *testing.T) {
 		]`)
 		hasError, _ := CheckResponseErrorForJsonRpcBatch(data, 200)
 		require.False(t, hasError, "Default mode: partial success should not be an error")
+	})
+}
+
+// TestJsonrpcMessage_CheckResponseError_MalformedShapes covers MAG-1718 Phase 1.6
+// wrong-data cases at the application layer: a body that omits both result and
+// error fields, and an unparseable body as a backstop. Truncated wire-level
+// failures are caught at the transport layer in direct_rpc_relay.go via
+// json.Valid; this is the in-function defense for malformed shapes.
+func TestJsonrpcMessage_CheckResponseError_MalformedShapes(t *testing.T) {
+	jm := JsonrpcMessage{}
+
+	t.Run("missing_both_result_and_error", func(t *testing.T) {
+		// Schema violation: spec requires exactly one of result or error.
+		hasError, msg := jm.CheckResponseError([]byte(`{"jsonrpc":"2.0","id":1}`), 200)
+		require.True(t, hasError, "missing both fields must be flagged")
+		require.Contains(t, msg, "missing both 'result' and 'error'")
+	})
+
+	t.Run("truncated_body_is_flagged_as_backstop", func(t *testing.T) {
+		// Direct callers should catch this earlier via json.Valid; flagged here as defense.
+		hasError, msg := jm.CheckResponseError([]byte(`{"jsonrpc":"2.0","id":1,"resu`), 200)
+		require.True(t, hasError)
+		require.Contains(t, msg, "malformed JSON-RPC response")
+	})
+
+	t.Run("null_result_is_success", func(t *testing.T) {
+		// result:null is a legal JSON-RPC response — eth_getTransactionByHash
+		// for an unknown hash returns null, for example.
+		hasError, msg := jm.CheckResponseError([]byte(`{"jsonrpc":"2.0","id":1,"result":null}`), 200)
+		require.False(t, hasError)
+		require.Empty(t, msg)
+	})
+
+	t.Run("normal_result_is_success", func(t *testing.T) {
+		hasError, _ := jm.CheckResponseError([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x12a7b5c"}`), 200)
+		require.False(t, hasError)
+	})
+
+	t.Run("error_with_message_returns_message", func(t *testing.T) {
+		hasError, msg := jm.CheckResponseError(
+			[]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found"}}`),
+			200,
+		)
+		require.True(t, hasError)
+		require.Equal(t, "method not found", msg)
+	})
+
+	t.Run("error_with_empty_message_is_not_flagged", func(t *testing.T) {
+		// Preserves the previous behavior: an error object with an empty
+		// message is not surfaced as an error.
+		hasError, _ := jm.CheckResponseError(
+			[]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":0,"message":""}}`),
+			200,
+		)
+		require.False(t, hasError)
+	})
+
+	t.Run("top_level_scalar_body", func(t *testing.T) {
+		hasError, msg := jm.CheckResponseError([]byte(`"just a string"`), 200)
+		require.True(t, hasError)
+		require.Contains(t, msg, "malformed JSON-RPC response")
+	})
+
+	t.Run("empty_body", func(t *testing.T) {
+		hasError, _ := jm.CheckResponseError(nil, 200)
+		require.True(t, hasError)
+	})
+
+	t.Run("error_null_and_no_result_is_malformed", func(t *testing.T) {
+		// "error": null is semantically equivalent to no error key. Combined
+		// with a missing result it's a schema violation — must be flagged so
+		// the relay pipeline doesn't forward a useless body to the client.
+		hasError, msg := jm.CheckResponseError([]byte(`{"jsonrpc":"2.0","id":1,"error":null}`), 200)
+		require.True(t, hasError, "error:null + no result must be flagged as malformed")
+		require.Contains(t, msg, "missing both 'result' and 'error'")
+	})
+
+	t.Run("error_null_with_result_is_success", func(t *testing.T) {
+		// "error": null alongside a real result is a (mildly off-spec but)
+		// healthy response. Some upstreams emit this shape.
+		hasError, _ := jm.CheckResponseError(
+			[]byte(`{"jsonrpc":"2.0","id":1,"result":"0x12a7b5c","error":null}`),
+			200,
+		)
+		require.False(t, hasError, "error:null alongside a result must not be flagged")
+	})
+}
+
+// TestCheckResponseErrorForJsonRpcBatch_MalformedElements covers the
+// analogous cases at the batch level: a batch where every element is
+// malformed must NOT slip through as "no errors" the way it did before.
+func TestCheckResponseErrorForJsonRpcBatch_MalformedElements(t *testing.T) {
+	t.Run("all_elements_missing_both_fields", func(t *testing.T) {
+		// Previously this returned (false, "") because the aggregator only
+		// collected sub-messages from elements with a non-nil error object.
+		data := []byte(`[{"jsonrpc":"2.0","id":1},{"jsonrpc":"2.0","id":2}]`)
+		hasError, errorMsg := CheckResponseErrorForJsonRpcBatch(data, 200)
+		require.True(t, hasError, "all-malformed batch must be flagged for retry")
+		require.Contains(t, errorMsg, "missing both 'result' and 'error'")
+	})
+
+	t.Run("partial_success_with_malformed_sibling_default_mode", func(t *testing.T) {
+		BatchNodeErrorOnAny = false
+		data := []byte(`[{"jsonrpc":"2.0","id":1,"result":1},{"jsonrpc":"2.0","id":2}]`)
+		hasError, _ := CheckResponseErrorForJsonRpcBatch(data, 200)
+		require.False(t, hasError, "a success masks a malformed sibling in default mode")
+	})
+
+	t.Run("partial_success_with_malformed_sibling_strict_mode", func(t *testing.T) {
+		originalValue := BatchNodeErrorOnAny
+		defer func() { BatchNodeErrorOnAny = originalValue }()
+		BatchNodeErrorOnAny = true
+		data := []byte(`[{"jsonrpc":"2.0","id":1,"result":1},{"jsonrpc":"2.0","id":2}]`)
+		hasError, errorMsg := CheckResponseErrorForJsonRpcBatch(data, 200)
+		require.True(t, hasError, "strict mode flags any fault, including malformed elements")
+		require.Contains(t, errorMsg, "missing both 'result' and 'error'")
 	})
 }

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/tendermintRPCMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/tendermintRPCMessage.go
@@ -59,26 +59,24 @@ type TendermintMessageResponse struct {
 	Response TendermintMessageResponseBody `json:"response,omitempty"`
 }
 
-// returns if error exists and
+// CheckResponseError classifies a Tendermint JSON-RPC response. The envelope
+// shape check (malformed bytes, missing-both-fields, error:null normalisation,
+// top-level error extraction) is delegated to checkJsonrpcEnvelope; this
+// method adds the Tendermint-specific success-path inspection of the embedded
+// `{"response": {"code": N, "log": M}}` payload that Tendermint nodes use to
+// signal application-level errors over an otherwise-200 envelope.
 func (jm TendermintrpcMessage) CheckResponseError(data []byte, httpStatusCode int) (hasError bool, errorMessage string) {
-	result := &JsonrpcMessage{}
-	err := json.Unmarshal(data, result)
-	if err != nil {
-		utils.LavaFormatWarning("Failed unmarshalling CheckError", err, utils.LogAttr("data", string(data)))
-		return false, ""
+	hasErr, msg, resultBytes := checkJsonrpcEnvelope(data, "Tendermint RPC")
+	if hasErr || resultBytes == nil {
+		return hasErr, msg
 	}
-
-	if result.Error == nil { // no error
-		if result.Result != nil { // check if we got a tendermint error
-			tendermintResponse := &TendermintMessageResponse{}
-			err := json.Unmarshal(result.Result, tendermintResponse)
-			if err == nil {
-				return (tendermintResponse.Response.Code != 0 && tendermintResponse.Response.Log != ""), tendermintResponse.Response.Log
-			}
+	var inner TendermintMessageResponse
+	if err := json.Unmarshal(resultBytes, &inner); err == nil {
+		if inner.Response.Code != 0 && inner.Response.Log != "" {
+			return true, inner.Response.Log
 		}
-		return false, ""
 	}
-	return result.Error.Message != "", result.Error.Message
+	return false, ""
 }
 
 func (tm TendermintrpcMessage) GetResult() json.RawMessage {

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/tendermintRPCMessage_test.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/tendermintRPCMessage_test.go
@@ -337,3 +337,63 @@ func TestJSONRPCID(t *testing.T) {
 		t.Errorf("Expected %q, but got %q", expected, intID.String())
 	}
 }
+
+// TestTendermintrpcMessage_CheckResponseError mirrors the JSON-RPC envelope
+// checks for malformed/missing-fields detection while preserving the
+// Tendermint-specific inner-error inspection on
+// {"result":{"response":{"code":N,"log":M}}}.
+func TestTendermintrpcMessage_CheckResponseError(t *testing.T) {
+	tm := TendermintrpcMessage{}
+
+	t.Run("truncated_body", func(t *testing.T) {
+		hasError, msg := tm.CheckResponseError([]byte(`{"jsonrpc":"2.0","id":1,"resu`), 200)
+		require.True(t, hasError)
+		require.Contains(t, msg, "malformed Tendermint RPC response")
+	})
+
+	t.Run("missing_both_result_and_error", func(t *testing.T) {
+		hasError, msg := tm.CheckResponseError([]byte(`{"jsonrpc":"2.0","id":1}`), 200)
+		require.True(t, hasError)
+		require.Contains(t, msg, "missing both 'result' and 'error'")
+	})
+
+	t.Run("envelope_error_with_message", func(t *testing.T) {
+		hasError, msg := tm.CheckResponseError(
+			[]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found"}}`),
+			200,
+		)
+		require.True(t, hasError)
+		require.Equal(t, "method not found", msg)
+	})
+
+	t.Run("inner_tendermint_error_surfaces_log", func(t *testing.T) {
+		// The Tendermint-specific embedded-error shape — must be preserved.
+		data := []byte(`{"jsonrpc":"2.0","id":1,"result":{"response":{"code":5,"log":"insufficient fees"}}}`)
+		hasError, msg := tm.CheckResponseError(data, 200)
+		require.True(t, hasError, "non-zero inner code must surface")
+		require.Equal(t, "insufficient fees", msg)
+	})
+
+	t.Run("inner_tendermint_code_zero_is_success", func(t *testing.T) {
+		data := []byte(`{"jsonrpc":"2.0","id":1,"result":{"response":{"code":0,"log":""}}}`)
+		hasError, _ := tm.CheckResponseError(data, 200)
+		require.False(t, hasError)
+	})
+
+	t.Run("plain_result_no_inner_response_is_success", func(t *testing.T) {
+		data := []byte(`{"jsonrpc":"2.0","id":1,"result":{"block_height":"12345"}}`)
+		hasError, _ := tm.CheckResponseError(data, 200)
+		require.False(t, hasError)
+	})
+
+	t.Run("null_result_is_success", func(t *testing.T) {
+		hasError, _ := tm.CheckResponseError([]byte(`{"jsonrpc":"2.0","id":1,"result":null}`), 200)
+		require.False(t, hasError)
+	})
+
+	t.Run("error_null_and_no_result_is_malformed", func(t *testing.T) {
+		hasError, msg := tm.CheckResponseError([]byte(`{"jsonrpc":"2.0","id":1,"error":null}`), 200)
+		require.True(t, hasError)
+		require.Contains(t, msg, "missing both 'result' and 'error'")
+	})
+}

--- a/protocol/rpcsmartrouter/direct_rpc_integration_test.go
+++ b/protocol/rpcsmartrouter/direct_rpc_integration_test.go
@@ -2,6 +2,7 @@ package rpcsmartrouter
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -65,6 +66,140 @@ func TestDirectRPCRelaySender_SendDirectRelay(t *testing.T) {
 
 	// Verify response data
 	assert.Contains(t, string(result.Reply.Data), "0x1234")
+}
+
+// TestDirectRPCRelaySender_MalformedJSONResponseRoutesAsTransportError pins
+// the wrong-data fix for MAG-1718: when an upstream returns 2xx with a body
+// that fails json.Valid (truncated bytes, corrupted upstream encoder), the
+// router must classify it as a transport-level failure — same bucket as a
+// connection RST — and return an error from SendDirectRelay rather than a
+// healthy-looking RelayResult. This means the relay pipeline retries against
+// another provider and the failure is attributed as a ProtocolError, not a
+// NodeError, so per-provider health dashboards correctly identify flaky
+// upstreams. A regression here would re-introduce the silent-forwarding bug.
+//
+// The test also asserts that the returned error wraps a *common.LavaError so a
+// future refactor that bypasses classifyAndWrap (and loses the protocol-error
+// classification) would be caught.
+func TestDirectRPCRelaySender_MalformedJSONResponseRoutesAsTransportError(t *testing.T) {
+	assertTransportError := func(t *testing.T, err error, bodyKind string) {
+		t.Helper()
+		require.Error(t, err, "%s body must surface as transport-level error, not a RelayResult", bodyKind)
+		require.Contains(t, err.Error(), "malformed")
+		var wrapped *common.LavaWrappedError
+		require.True(t, errors.As(err, &wrapped),
+			"transport error must be wrapped via classifyAndWrap so the protocol-error classifier sees it")
+		require.NotNil(t, wrapped.LavaErr, "wrapped error must carry a classified LavaError")
+	}
+
+	t.Run("jsonrpc_truncated_body", func(t *testing.T) {
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			// Truncated mid-write — the shape from the ticket.
+			w.Write([]byte(`{"jsonrpc":"2.0","id":1,"resu`))
+		}))
+		defer mockServer.Close()
+
+		ctx := context.Background()
+		directConn, err := lavasession.NewDirectRPCConnection(ctx, common.NodeUrl{Url: mockServer.URL}, 5, "")
+		require.NoError(t, err)
+
+		sender := &DirectRPCRelaySender{
+			directConnection: directConn,
+			endpointName:     "truncated-upstream",
+			chainFamily:      common.ChainFamilyEVM,
+		}
+		chainMessage := createMockChainMessage(t, `{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}`)
+
+		result, err := sender.SendDirectRelay(ctx, chainMessage, 5*time.Second)
+		require.Nil(t, result, "no RelayResult is built on the transport-error path")
+		assertTransportError(t, err, "truncated JSON-RPC")
+	})
+
+	t.Run("jsonrpc_garbage_body", func(t *testing.T) {
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`<html>upstream proxy error</html>`))
+		}))
+		defer mockServer.Close()
+
+		ctx := context.Background()
+		directConn, err := lavasession.NewDirectRPCConnection(ctx, common.NodeUrl{Url: mockServer.URL}, 5, "")
+		require.NoError(t, err)
+
+		sender := &DirectRPCRelaySender{
+			directConnection: directConn,
+			endpointName:     "garbage-upstream",
+			chainFamily:      common.ChainFamilyEVM,
+		}
+		chainMessage := createMockChainMessage(t, `{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}`)
+
+		result, err := sender.SendDirectRelay(ctx, chainMessage, 5*time.Second)
+		require.Nil(t, result)
+		assertTransportError(t, err, "non-JSON JSON-RPC")
+	})
+
+	t.Run("rest_truncated_body", func(t *testing.T) {
+		// REST's malformed-JSON detection is gated on looksLikeJSONOpening,
+		// so a body that opens with '{' but is truncated must be flagged.
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"height":"12345","tx_respo`))
+		}))
+		defer mockServer.Close()
+
+		ctx := context.Background()
+		directConn, err := lavasession.NewDirectRPCConnection(ctx, common.NodeUrl{Url: mockServer.URL}, 5, "")
+		require.NoError(t, err)
+
+		sender := &DirectRPCRelaySender{
+			directConnection: directConn,
+			endpointName:     "truncated-rest-upstream",
+			chainFamily:      common.ChainFamilyEVM,
+		}
+		chainMessage := createMockRESTChainMessage(t, "/cosmos/bank/v1beta1/balances/lava1foo")
+
+		result, err := sender.SendDirectRelay(ctx, chainMessage, 5*time.Second)
+		require.Nil(t, result)
+		assertTransportError(t, err, "truncated REST")
+		require.Contains(t, err.Error(), "REST", "synthetic error message must identify the transport")
+	})
+
+	t.Run("rest_non_json_body_passes_through", func(t *testing.T) {
+		// REST endpoints can legitimately serve plain text or binary content.
+		// The looksLikeJSONOpening gate must skip the json.Valid check in
+		// that case so we don't false-flag healthy non-JSON responses.
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`raw text response from a non-JSON endpoint`))
+		}))
+		defer mockServer.Close()
+
+		ctx := context.Background()
+		directConn, err := lavasession.NewDirectRPCConnection(ctx, common.NodeUrl{Url: mockServer.URL}, 5, "")
+		require.NoError(t, err)
+
+		sender := &DirectRPCRelaySender{
+			directConnection: directConn,
+			endpointName:     "plain-text-rest-upstream",
+			chainFamily:      common.ChainFamilyEVM,
+		}
+		chainMessage := createMockRESTChainMessage(t, "/some/non-json/endpoint")
+
+		result, err := sender.SendDirectRelay(ctx, chainMessage, 5*time.Second)
+		require.NoError(t, err, "non-JSON REST bodies must pass through, not be flagged as malformed")
+		require.NotNil(t, result)
+	})
+
+	// Note: the schema-incomplete case (well-formed JSON missing both fields)
+	// is detected at the application layer by JsonrpcMessage.CheckResponseError
+	// and stays on the node-error path. That distinction is covered in the
+	// jsonRPCMessage_test.go unit tests since exercising the real chain message
+	// here would require full chain-parser construction.
 }
 
 func TestDirectRPCRelaySender_SendDirectRelay_Timeout(t *testing.T) {
@@ -398,6 +533,18 @@ func createMockChainMessage(t *testing.T, requestData string) chainlib.ChainMess
 	}
 }
 
+// createMockRESTChainMessage creates a mock ChainMessage configured for the
+// REST API interface with a GET request to the given path. Used by tests that
+// exercise sendRESTRelay (e.g. transport-level malformed detection).
+func createMockRESTChainMessage(t *testing.T, path string) chainlib.ChainMessage {
+	t.Helper()
+	return &mockChainMessage{
+		apiInterface: "rest",
+		httpMethod:   "GET",
+		rpcMessage:   &rpcInterfaceMessages.RestMessage{Path: path},
+	}
+}
+
 // createMockBatchChainMessage creates a mock ChainMessage for batch requests
 func createMockBatchChainMessage(t *testing.T, requestData []byte) chainlib.ChainMessage {
 	t.Helper()
@@ -414,12 +561,24 @@ func createMockBatchChainMessage(t *testing.T, requestData []byte) chainlib.Chai
 type mockChainMessage struct {
 	requestData []byte
 	api         *spectypes.Api
+	// apiInterface defaults to "jsonrpc" — set to "rest" / "grpc" to route
+	// through the corresponding sendXXXRelay branch in direct_rpc_relay.go.
+	apiInterface string
+	// httpMethod is surfaced as ApiCollection.CollectionData.Type, which the
+	// REST path consults; only meaningful when apiInterface == "rest".
+	httpMethod string
+	// rpcMessage, when non-nil, replaces the default mockGenericMessage —
+	// REST tests need a real *RestMessage so the path/body extraction works.
+	rpcMessage rpcInterfaceMessages.GenericMessage
 	// checkResponseError, when non-nil, overrides the default (false, "") so
 	// tests can drive the call site's hasError branch with a custom message.
 	checkResponseError func(data []byte, httpStatusCode int) (bool, string)
 }
 
 func (m *mockChainMessage) GetRPCMessage() rpcInterfaceMessages.GenericMessage {
+	if m.rpcMessage != nil {
+		return m.rpcMessage
+	}
 	return &mockGenericMessage{data: m.requestData}
 }
 
@@ -438,9 +597,14 @@ func (m *mockChainMessage) CheckResponseError(data []byte, httpStatusCode int) (
 }
 
 func (m *mockChainMessage) GetApiCollection() *spectypes.ApiCollection {
+	iface := m.apiInterface
+	if iface == "" {
+		iface = "jsonrpc"
+	}
 	return &spectypes.ApiCollection{
 		CollectionData: spectypes.CollectionData{
-			ApiInterface: "jsonrpc",
+			ApiInterface: iface,
+			Type:         m.httpMethod,
 		},
 	}
 }

--- a/protocol/rpcsmartrouter/direct_rpc_relay.go
+++ b/protocol/rpcsmartrouter/direct_rpc_relay.go
@@ -378,6 +378,25 @@ func (d *DirectRPCRelaySender) sendJSONRPCRelay(
 		utils.LogAttr("response_size", len(responseData)),
 	)
 
+	// Transport-level malformed detection. A JSON-RPC upstream that responds
+	// with 2xx + a body that fails json.Valid (truncated bytes, corrupted
+	// content) is classified as a transport failure here so it flows through
+	// the same retry/MarkUnhealthy plumbing as a connection RST or EOF — and
+	// gets attributed as a ProtocolError in dashboards rather than a node
+	// error. Schema-level malformation (well-formed JSON missing required
+	// fields) is detected later by CheckResponseError on the node-error path.
+	if statusCode >= 200 && statusCode < 300 && len(responseData) > 0 && !json.Valid(responseData) {
+		utils.LavaFormatDebug("direct RPC response is not valid JSON",
+			utils.LogAttr("endpoint", endpointIdentifier),
+			utils.LogAttr("status_code", statusCode),
+			utils.LogAttr("response_size", len(responseData)),
+		)
+		return nil, classifyAndWrap(
+			fmt.Errorf("malformed JSON-RPC response: body is not valid JSON"),
+			d.chainFamily, common.TransportJsonRPC,
+		)
+	}
+
 	// STEP 4: Check response for errors using chainMessage (with actual HTTP status)
 	hasError, errorMessage := chainMessage.CheckResponseError(responseData, statusCode)
 	if hasError {
@@ -513,6 +532,24 @@ func (d *DirectRPCRelaySender) sendRESTRelay(
 	if err != nil {
 		tracing.RecordError(span, err)
 		return nil, classifyAndWrap(err, d.chainFamily, common.TransportREST)
+	}
+
+	// Transport-level malformed detection for REST 2xx responses. Unlike
+	// JSON-RPC, REST endpoints can legitimately return non-JSON content
+	// (plain text, binary), so we gate on "body opens with `{` or `[`"
+	// before invoking json.Valid — a body that looks like JSON but isn't
+	// parseable is treated as a transport failure (truncated bytes or
+	// corrupted upstream encoder).
+	if response.StatusCode >= 200 && response.StatusCode < 300 && looksLikeJSONOpening(response.Body) && !json.Valid(response.Body) {
+		utils.LavaFormatDebug("direct REST response opens as JSON but is not valid",
+			utils.LogAttr("endpoint", d.endpointName),
+			utils.LogAttr("status_code", response.StatusCode),
+			utils.LogAttr("response_size", len(response.Body)),
+		)
+		return nil, classifyAndWrap(
+			fmt.Errorf("malformed REST response: body is not valid JSON"),
+			d.chainFamily, common.TransportREST,
+		)
 	}
 
 	// Proper error classification (don't treat all 4xx as node errors)
@@ -761,6 +798,24 @@ func joinURLPath(base, path string) (string, error) {
 
 	// Relative path: use ResolveReference (handles ., .., query params)
 	return baseURL.ResolveReference(pathURL).String(), nil
+}
+
+// looksLikeJSONOpening returns true when the first non-whitespace byte of
+// data is a JSON structural opener ('{' or '['). Used to skip JSON validity
+// checks on REST endpoints that legitimately return non-JSON content (plain
+// text, binary) so they don't get false-flagged as malformed.
+func looksLikeJSONOpening(data []byte) bool {
+	for _, b := range data {
+		switch b {
+		case ' ', '\t', '\n', '\r':
+			continue
+		case '{', '[':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 // convertHTTPHeadersToMetadata converts http.Header to pairingtypes.Metadata


### PR DESCRIPTION
## Summary
Upstream JSON-RPC and REST responses that were truncated mid-write or missing required envelope fields (`result` / `error`) were forwarded to clients as HTTP 200 successes with no retry — the router was the protection layer that wasn't protecting. This PR adds two complementary defenses so those bodies are caught and routed through the existing retry pipeline against another provider.

## What changed

**1. Transport-level detection — `protocol/rpcsmartrouter/direct_rpc_relay.go`**
- `sendJSONRPCRelay`: every 2xx response with a non-empty body is passed through `json.Valid`. Failures are wrapped via `classifyAndWrap(..., common.TransportJsonRPC)` so the relay pipeline treats them as protocol errors (same bucket as a connection RST), not node errors — flaky upstreams stay attributable in per-provider dashboards.
- `sendRESTRelay`: same check, but gated on `looksLikeJSONOpening` (first non-whitespace byte is `{` or `[`) so REST endpoints serving legitimate plain-text or binary content aren't false-flagged. Wrapped as `common.TransportREST`.
- gRPC path is unchanged — binary wire format means truncation surfaces at the HTTP/2 transport layer below this code.

**2. Application-level envelope shape check — `protocol/chainlib/chainproxy/rpcInterfaceMessages/`**
- New `jsonRPCEnvelopeScanner.go`: a single-pass, depth-aware, string-aware byte scanner that records the presence and byte range of the top-level `result` / `error` fields. Zero-allocation on the value bytes (sub-slicing, not copying), preserving the optimization the previous implementation captured by omitting `Result` from its decode struct.
- `jsonRPCMessage.go`: shared `checkJsonrpcEnvelope` helper distinguishes three outcomes — malformed bytes, schema-incomplete (missing both fields, including `error: null` with no result), and healthy. `JsonrpcMessage.CheckResponseError` and `CheckResponseErrorForJsonRpcBatch` both call into it so the rules stay in lockstep.
- `tendermintRPCMessage.go`: `TendermintrpcMessage.CheckResponseError` reuses `checkJsonrpcEnvelope` for the envelope check and adds Tendermint's `{"response":{"code":N,"log":M}}` inner-error inspection on top.

Signatures of `CheckResponseError` and `CheckResponseErrorForJsonRpcBatch` are unchanged — `(hasError bool, errorMessage string)`. The verdict refactor is internal to `checkJsonrpcEnvelope`.

## Behavior change worth flagging

`{"error": null}` with no `result` previously decoded as `result.Error == nil` and was silently returned to the client as `(false, "")`. It is now classified as a schema violation and routed through the retry pipeline. Any upstream that emits this shape (rare; some custom RPCs) will start triggering retries. Symmetric case `{"result": X, "error": null}` is preserved as healthy.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./protocol/...` clean
- [x] New scanner unit tests (37 cases) cover truncation mid-value/string/escape, escape handling, depth tracking with braces in strings, top-level array/scalar rejection, whitespace tolerance.
- [x] New `CheckResponseError` unit tests cover the two ticket shapes (truncated bytes, missing both fields) for JSON-RPC single, JSON-RPC batch, and Tendermint, plus the `error: null` edge cases.
- [x] New integration test `TestDirectRPCRelaySender_MalformedJSONResponseRoutesAsTransportError` asserts that truncated/garbage 2xx bodies surface as errors wrapped in `*common.LavaWrappedError` (so a future refactor bypassing `classifyAndWrap` would be caught), and that non-JSON REST bodies still pass through.
- [x] Two pre-existing tests flipped from documenting the bug (`Invalid JSON should not return error (fail-open)`) to asserting the fixed behavior, with comments explaining the inversion.

## Unblocks
- MAG-1718 Phase 1.6 wrong-data cases (truncated, missing-fields) in the smart-router-automation simulator — those xfails can flip once this lands.

## Follow-ups (not in this PR)
- **`RelayResult.IsMalformed` field + Prometheus counter**: would let dashboards slice retries by `malformed` vs `node_error`. The transport-level detection already attributes correctly to `ProtocolError`; this would add per-provider granularity.
- **WebSocket bypass**: `results_manager.go` still skips `CheckResponseError` for `Subscribe`-tagged responses. WS retry semantics differ (re-subscribe vs re-request) — separate ticket.
- **REST `IsNodeError` escalation**: this PR keeps REST malformed detection at the transport layer (returns an error from `sendRESTRelay`). The pre-existing pattern where Cosmos tx errors (HTTP 200, non-zero code) are detected but don't drive `IsNodeError` is preserved — separate ticket if anyone wants retry on those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)