### PR TITLE
fix(rpcsmartrouter): MAG-1871 keep resolver last in provider header

### DIFF
--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2295,15 +2295,17 @@ func (rpcss *RPCSmartRouterServer) appendHeadersToRelayResult(ctx context.Contex
 			// disagree on how many actors participated (MAG-1653 Bug #2).
 			//
 			// Ordering rule: walk protocol errors → node errors → successes,
-			// then append the resolver (`providerAddress`, which is "Cached"
-			// when relayResult.GetProvider() was empty). A `seen` set
-			// deduplicates without losing first-seen position. Result: errors
-			// chronologically first, the response source last (e.g.
-			// "lava@p1,lava@p2" when p2 succeeded after p1 failed; or
-			// "lava@p1,Cached" when cache resolved a request that p1 failed).
-			// Walking via slices instead of map iteration also makes the
-			// header value deterministic across runs — downstream parsers can
-			// rely on `last entry == response source`.
+			// skipping any entry whose address matches the resolver, then
+			// append the resolver (`providerAddress`, which is "Cached" when
+			// relayResult.GetProvider() was empty). The skip-then-append is
+			// load-bearing: dedup alone preserves first-seen position, so if
+			// the resolver happened to be in successResults[0] (e.g. it
+			// completed before the loser was even recorded), the final
+			// addProvider(providerAddress) would be a no-op and the chain
+			// tail would be a *loser*, violating "last entry == response
+			// source" (MAG-1871). Walking slices makes the value
+			// deterministic across runs; the explicit final append makes
+			// the contract structurally true.
 			seen := make(map[string]struct{})
 			allProvidersList := make([]string, 0)
 			addProvider := func(addr string) {
@@ -2317,15 +2319,24 @@ func (rpcss *RPCSmartRouterServer) appendHeadersToRelayResult(ctx context.Contex
 				allProvidersList = append(allProvidersList, addr)
 			}
 			for _, r := range protocolErrorResults {
+				if r.ProviderInfo.ProviderAddress == providerAddress {
+					continue
+				}
 				addProvider(r.ProviderInfo.ProviderAddress)
 			}
 			for _, r := range nodeErrorResults {
+				if r.ProviderInfo.ProviderAddress == providerAddress {
+					continue
+				}
 				addProvider(r.ProviderInfo.ProviderAddress)
 			}
 			for _, r := range successResults {
+				if r.ProviderInfo.ProviderAddress == providerAddress {
+					continue
+				}
 				addProvider(r.ProviderInfo.ProviderAddress)
 			}
-			addProvider(providerAddress) // resolver — "Cached" or the winning real provider, ends up last
+			addProvider(providerAddress) // resolver — "Cached" or the winning real provider, always last
 
 			if len(allProvidersList) > 0 {
 				allProvidersString := strings.Join(allProvidersList, ",")

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -675,6 +675,133 @@ func TestCacheServedResponseHeaders(t *testing.T) {
 	})
 }
 
+// TestResolverAlwaysLastInProviderHeader hardens the Lava-Provider-Address
+// contract: the last entry in the comma-separated chain must always be the
+// address that resolved the response, even when that address also appears
+// earlier in successResults / nodeErrors (which can happen under hedging
+// or other concurrent dispatch patterns where the winner is recorded before
+// a slower peer's result lands in the same bucket).
+//
+// MAG-1871 context: a stickiness-failover test observed the *down pinned*
+// provider listed last instead of the failover peer. The exact data shape
+// that produced that output has not been traced to a unit-testable code
+// path (per provider_simulator/server.py, a `down` provider returns HTTP
+// 503 → protocol error → protocolErrors bucket — which iterates before
+// successResults and would *not* trigger the dedup bug). This test instead
+// covers the structural class of failure the fix prevents: any data shape
+// where the resolver appears earlier in iteration than another entry.
+// End-to-end verification against the failing simulator test
+// (`test_stickiness_breaks_on_failover_when_pinned_provider_is_unreachable`)
+// is still required to confirm MAG-1871 itself is closed.
+func TestResolverAlwaysLastInProviderHeader(t *testing.T) {
+	ctx := context.Background()
+
+	findHeader := func(metadata []pairingtypes.Metadata, name string) *pairingtypes.Metadata {
+		for i := range metadata {
+			if metadata[i].Name == name {
+				return &metadata[i]
+			}
+		}
+		return nil
+	}
+
+	t.Run("resolver appears earlier in successResults - resolver still last (regression for the fix)", func(t *testing.T) {
+		// Two successes recorded in order [simprovider2, simprovider3] with
+		// simprovider2 being the resolver returned by ProcessingResult.
+		// Before the fix, dedup kept simprovider2 at its first-seen position
+		// and the trailing addProvider(resolver) was a no-op, yielding
+		// "simprovider2,simprovider3" — winner not last, contract broken.
+		// After the fix, the resolver is skipped during iteration and
+		// appended explicitly at the end.
+		relayProcessor := &MockRelayProcessorForHeaders{
+			successResults: []common.RelayResult{
+				{ProviderInfo: common.ProviderInfo{ProviderAddress: "simprovider2"}},
+				{ProviderInfo: common.ProviderInfo{ProviderAddress: "simprovider3"}},
+			},
+			nodeErrors: []common.RelayResult{},
+		}
+
+		relayResult := &common.RelayResult{
+			ProviderInfo: common.ProviderInfo{ProviderAddress: "simprovider2"},
+			Reply:        &pairingtypes.RelayReply{Metadata: []pairingtypes.Metadata{}},
+		}
+
+		rpcSmartRouterServer := &RPCSmartRouterServer{}
+		rpcSmartRouterServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, &MockProtocolMessage{
+			api: &spectypes.Api{Name: "eth_blockNumber"},
+		}, "eth_blockNumber", nil, true)
+
+		providerHeader := findHeader(relayResult.Reply.Metadata, common.PROVIDER_ADDRESS_HEADER_NAME)
+		require.NotNil(t, providerHeader)
+		// Contract: last entry == response source (resolver).
+		require.Equal(t, "simprovider3,simprovider2", providerHeader.Value)
+	})
+
+	t.Run("resolver also recorded as nodeError on an earlier attempt - resolver still last", func(t *testing.T) {
+		// A provider returned a node error on a first attempt then served on
+		// a retry. The retry winner is the resolver; that same address must
+		// still appear last (not at its first-seen nodeErrors position).
+		// Without the fix the dedup keeps the resolver in the nodeErrors
+		// position; the final addProvider is a no-op.
+		relayProcessor := &MockRelayProcessorForHeaders{
+			successResults: []common.RelayResult{
+				{ProviderInfo: common.ProviderInfo{ProviderAddress: "simprovider1"}},
+			},
+			nodeErrors: []common.RelayResult{
+				{ProviderInfo: common.ProviderInfo{ProviderAddress: "simprovider1"}},
+				{ProviderInfo: common.ProviderInfo{ProviderAddress: "simprovider2"}},
+			},
+		}
+
+		relayResult := &common.RelayResult{
+			ProviderInfo: common.ProviderInfo{ProviderAddress: "simprovider1"},
+			Reply:        &pairingtypes.RelayReply{Metadata: []pairingtypes.Metadata{}},
+		}
+
+		rpcSmartRouterServer := &RPCSmartRouterServer{}
+		rpcSmartRouterServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, &MockProtocolMessage{
+			api: &spectypes.Api{Name: "eth_blockNumber"},
+		}, "eth_blockNumber", nil, true)
+
+		providerHeader := findHeader(relayResult.Reply.Metadata, common.PROVIDER_ADDRESS_HEADER_NAME)
+		require.NotNil(t, providerHeader)
+		// Before fix: "simprovider1,simprovider2" (simprovider2 last — wrong).
+		// After fix: simprovider1 (resolver) moved to the end.
+		require.Equal(t, "simprovider2,simprovider1", providerHeader.Value)
+	})
+
+	t.Run("classic failover (winner only in successResults) - already correct, still correct after fix", func(t *testing.T) {
+		// Sanity check: when the winner does not appear in any earlier
+		// bucket, the chain ends with the winner under both old and new
+		// code. This is the data shape that matches a textbook
+		// "stickiness fails over to peer" scenario per the simulator's
+		// down-mode semantics (down → HTTP 503 → protocolErrors).
+		relayProcessor := &MockRelayProcessorForHeaders{
+			successResults: []common.RelayResult{
+				{ProviderInfo: common.ProviderInfo{ProviderAddress: "simprovider2"}},
+			},
+			nodeErrors: []common.RelayResult{},
+			protocolErrors: []relaycore.RelayError{
+				{ProviderInfo: common.ProviderInfo{ProviderAddress: "simprovider3"}},
+			},
+		}
+
+		relayResult := &common.RelayResult{
+			ProviderInfo: common.ProviderInfo{ProviderAddress: "simprovider2"},
+			Reply:        &pairingtypes.RelayReply{Metadata: []pairingtypes.Metadata{}},
+		}
+
+		rpcSmartRouterServer := &RPCSmartRouterServer{}
+		rpcSmartRouterServer.appendHeadersToRelayResult(ctx, relayResult, 1, relayProcessor, &MockProtocolMessage{
+			api: &spectypes.Api{Name: "eth_blockNumber"},
+		}, "eth_blockNumber", nil, true)
+
+		providerHeader := findHeader(relayResult.Reply.Metadata, common.PROVIDER_ADDRESS_HEADER_NAME)
+		require.NotNil(t, providerHeader)
+		require.Equal(t, "simprovider3,simprovider2", providerHeader.Value)
+	})
+}
+
 // TestStatefulRelayTargetsHeader tests the stateful API header functionality
 func TestStatefulRelayTargetsHeader(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- `Lava-Provider-Address` was not guaranteed to end with the address that resolved the response: the iteration walked `protocolErrors → nodeErrors → successResults` and re-added the resolver with a `seen` set, but dedup preserves first-seen position — so when the resolver appeared earlier in any bucket (e.g. `successResults[0]` under concurrent dispatch), the trailing `addProvider(resolver)` was a no-op and a *loser* ended up as the chain tail.
- Fix skips the resolver during iteration and appends it explicitly at the end, making "last entry == response source" structurally true for every data shape.
- Adds `TestResolverAlwaysLastInProviderHeader` with three subtests covering (a) resolver-earlier-in-successResults, (b) resolver-also-in-nodeErrors, (c) classic failover sanity check.

## Honest caveat
This is a structural hardening that fixes the entire *class* of dedup-order bug the ticket describes. However, the exact code path that produced the ticket's specific observation (`simprovider2,simprovider3` with the down pinned provider last) hasn't been pinned down — per `provider_simulator/server.py`, `down` returns HTTP 503 → protocolErrors, which iterates *before* successResults and would already produce winner-last under the old code. So before claiming MAG-1871 closed, the failing simulator test should be re-run against this branch's binary.

If the simulator test still fails post-merge, the next investigation lead is the routing path (hedging / sticky retry in `unified_relay_state_machine.go` or `consumer_session_manager.go:1116-1127`), not the header construction.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./protocol/rpcsmartrouter/...` — clean
- [x] `go test ./protocol/rpcsmartrouter/... -count=1` — pass (77s, includes existing `TestCacheServedResponseHeaders`, `TestHedgeTriggeredHeader`, `TestStatefulRelayTargetsHeader` — no regressions)
- [x] `go test ./protocol/relaycore/... -count=1` — pass
- [x] New regression test `TestResolverAlwaysLastInProviderHeader` (3 subtests) — pass
- [ ] **End-to-end:** run `tests/simulator/production_tests/test_phase2_8_stickiness_pinning_blocklist.py::TestStickinessPinningBlocklist::test_stickiness_breaks_on_failover_when_pinned_provider_is_unreachable` against a build with this patch to confirm MAG-1871 itself is closed.
- [ ] `golangci-lint` (couldn't run locally — Go-version mismatch; CI will exercise the project's `.golangci.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)