### PR TITLE
fix(release): apply GOAMD64=v3 / GOARM64=v8.2 via builds[] not env

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,8 +10,6 @@ metadata:
 
 env:
   - CGO_ENABLED=0
-  - GOAMD64=v3
-  - GOARM64=v8.2
 
 builds:
   - id: smartrouter
@@ -23,6 +21,15 @@ builds:
     goarch:
       - amd64
       - arm64
+    # GOAMD64=v3 (Haswell+: AVX2/BMI2/FMA) and GOARM64=v8.2 (FP16/dotprod)
+    # match smartrouter.yml's dev-image build env. The top-level `env:`
+    # block alone is NOT enough — goreleaser uses these per-build fields
+    # to drive target selection. Without them, snapshot/release produces
+    # baseline v1/v8.0 binaries regardless of `env: GOAMD64=...`.
+    goamd64:
+      - v3
+    goarm64:
+      - v8.2
     ignore:
       - goos: darwin
         goarch: s390x
@@ -44,7 +51,10 @@ archives:
       - smartrouter
     formats:
       - binary
-    name_template: '{{ .Binary }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}-{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
+    # With a single GOAMD64 level (v3) the .Amd64 suffix would land on
+    # every amd64 archive name (smartrouter-v1.0.0-linux-amd64v3). Drop
+    # the suffix clause since v3 is now the standard, not a variant.
+    name_template: '{{ .Binary }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}-{{ . }}{{ end }}'
 
 # dockers_v2 (v2.15+) replaces the per-arch dockers: + docker_manifests:
 # combo with a single block. GoReleaser stages each platform's binary at

--- a/Makefile
+++ b/Makefile
@@ -38,13 +38,14 @@ build:
 BUILDX_BUILDER ?= smartrouter-builder
 export BUILDX_BUILDER
 
-# Idempotently ensure a docker-container-driver buildx builder exists.
+# One-time-per-machine setup. Currently ensures a docker-container-
+# driver buildx builder exists (needed for the multi-arch image build).
 # The default `docker` driver doesn't support --platform / multi-arch,
 # so without this snapshot fails with `unknown flag: --platform`.
 # First run pulls moby/buildkit (~150MB) — about 30s; later runs no-op.
 # Scoped to this invocation via BUILDX_BUILDER env so the user's global
 # default builder is unchanged.
-buildx-setup:
+setup:
 	@if ! docker buildx version >/dev/null 2>&1; then \
 	  echo "ERROR: docker buildx is not installed."; \
 	  echo "  Debian / Ubuntu:  sudo apt install docker-buildx-plugin"; \
@@ -62,7 +63,7 @@ buildx-setup:
 # image, checksums) under dist/ without publishing. Requires GoReleaser
 # (v2+) and Docker. Drives the same .goreleaser.yaml config CI uses, so
 # dist/ matches what a real release would produce for this commit.
-snapshot: buildx-setup
+snapshot: setup
 	goreleaser release --snapshot --clean --skip=publish
 
 # Tests
@@ -82,4 +83,4 @@ lint:
 clean:
 	rm -rf build/ dist/
 
-.PHONY: install install-all install-smartrouter build build-all buildx-setup snapshot test test-short tidy lint clean
+.PHONY: install install-all install-smartrouter build build-all setup snapshot test test-short tidy lint clean

--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,17 @@ export BUILDX_BUILDER
 setup:
 	@if ! docker buildx version >/dev/null 2>&1; then \
 	  echo "ERROR: docker buildx is not installed."; \
-	  echo "  Debian / Ubuntu:  sudo apt install docker-buildx-plugin"; \
-	  echo "  WSL2:             enable Docker Desktop's WSL2 integration"; \
-	  echo "  macOS:            install Docker Desktop"; \
+	  echo "  Official install guide: https://docs.docker.com/build/buildx/install/"; \
+	  echo ""; \
+	  echo "  Common paths:"; \
+	  echo "    - Docker Desktop (macOS / Windows / WSL2): buildx is included."; \
+	  echo "    - docker-ce on Linux (Docker's official apt repo):"; \
+	  echo "        sudo apt install docker-buildx-plugin"; \
+	  echo "    - docker.io from Ubuntu repos: does NOT include buildx — install as a"; \
+	  echo "      CLI plugin manually:"; \
+	  echo "        mkdir -p ~/.docker/cli-plugins"; \
+	  echo "        curl -L https://github.com/docker/buildx/releases/latest/download/buildx-\$$(curl -s https://api.github.com/repos/docker/buildx/releases/latest | grep tag_name | cut -d '\"' -f 4).linux-amd64 -o ~/.docker/cli-plugins/docker-buildx"; \
+	  echo "        chmod +x ~/.docker/cli-plugins/docker-buildx"; \
 	  exit 1; \
 	fi
 	@if ! docker buildx inspect $(BUILDX_BUILDER) >/dev/null 2>&1; then \

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,10 @@ export BUILDX_BUILDER
 # default builder is unchanged.
 buildx-setup:
 	@if ! docker buildx version >/dev/null 2>&1; then \
-	  echo "ERROR: docker buildx not installed. See README → 'One-time Docker buildx setup'."; \
+	  echo "ERROR: docker buildx is not installed."; \
+	  echo "  Debian / Ubuntu:  sudo apt install docker-buildx-plugin"; \
+	  echo "  WSL2:             enable Docker Desktop's WSL2 integration"; \
+	  echo "  macOS:            install Docker Desktop"; \
 	  exit 1; \
 	fi
 	@if ! docker buildx inspect $(BUILDX_BUILDER) >/dev/null 2>&1; then \

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,31 @@ build-all: build
 build:
 	go build $(GOFLAGS) -o build/smartrouter ./cmd/smartrouter
 
+BUILDX_BUILDER ?= smartrouter-builder
+export BUILDX_BUILDER
+
+# Idempotently ensure a docker-container-driver buildx builder exists.
+# The default `docker` driver doesn't support --platform / multi-arch,
+# so without this snapshot fails with `unknown flag: --platform`.
+# First run pulls moby/buildkit (~150MB) — about 30s; later runs no-op.
+# Scoped to this invocation via BUILDX_BUILDER env so the user's global
+# default builder is unchanged.
+buildx-setup:
+	@if ! docker buildx version >/dev/null 2>&1; then \
+	  echo "ERROR: docker buildx not installed. See README → 'One-time Docker buildx setup'."; \
+	  exit 1; \
+	fi
+	@if ! docker buildx inspect $(BUILDX_BUILDER) >/dev/null 2>&1; then \
+	  echo "Creating buildx builder '$(BUILDX_BUILDER)' (docker-container driver, pulls ~150MB moby/buildkit on first use)..."; \
+	  docker buildx create --name $(BUILDX_BUILDER) --driver docker-container >/dev/null; \
+	  docker buildx inspect --bootstrap $(BUILDX_BUILDER) >/dev/null; \
+	fi
+
 # Produce every release artifact locally (4 binaries, multi-arch Docker
 # image, checksums) under dist/ without publishing. Requires GoReleaser
 # (v2+) and Docker. Drives the same .goreleaser.yaml config CI uses, so
 # dist/ matches what a real release would produce for this commit.
-snapshot:
+snapshot: buildx-setup
 	goreleaser release --snapshot --clean --skip=publish
 
 # Tests
@@ -59,4 +79,4 @@ lint:
 clean:
 	rm -rf build/ dist/
 
-.PHONY: install install-all install-smartrouter build build-all snapshot test test-short tidy lint clean
+.PHONY: install install-all install-smartrouter build build-all buildx-setup snapshot test test-short tidy lint clean

--- a/README.md
+++ b/README.md
@@ -115,13 +115,28 @@ The version string is injected at build time from the git tag — `smartrouter v
 
 ### Reproducing a release locally
 
-Install [GoReleaser](https://goreleaser.com/install/) and Docker, then run:
+Install [GoReleaser](https://goreleaser.com/install/) and Docker, set up Docker buildx (one-time, see below), then run:
 
 ```bash
 make snapshot   # shortcut for: goreleaser release --snapshot --clean --skip=publish
 ```
 
 This produces every release artifact — the four binaries, the multi-arch Docker image, and the checksum file — under `dist/`, without pushing anything to GitHub or GHCR. Because the release pipeline runs a single `go build` per arch (via `.goreleaser.yaml`'s `builds:` block) and feeds that binary into both the standalone archive and the Docker image, a local snapshot build produces the same bytes CI would for the same commit.
+
+#### One-time Docker buildx setup
+
+`make snapshot` builds a multi-arch Docker image (`linux/amd64` + `linux/arm64`) and needs `docker buildx` configured with the `docker-container` driver. Without it, the build fails with `unknown flag: --platform` because the default `docker` driver doesn't support cross-platform builds. Set it up once per machine:
+
+```bash
+docker buildx version   # confirm buildx is installed; if it errors:
+                        #   sudo apt install docker-buildx-plugin   (debian / ubuntu)
+                        #   or install Docker Desktop with WSL2 integration
+
+docker buildx create --use --name smartrouter-builder --driver docker-container
+docker buildx inspect --bootstrap   # pulls moby/buildkit, ~30s first time
+```
+
+The builder persists across reboots; this is one-time-per-machine setup, not per-build.
 
 ### Tag conventions
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The version string is injected at build time from the git tag — `smartrouter v
 
 ### Reproducing a release locally
 
-Install [GoReleaser](https://goreleaser.com/install/) and Docker, set up Docker buildx (one-time, see below), then run:
+Install [GoReleaser](https://goreleaser.com/install/) and Docker, then run:
 
 ```bash
 make snapshot   # shortcut for: goreleaser release --snapshot --clean --skip=publish
@@ -123,20 +123,7 @@ make snapshot   # shortcut for: goreleaser release --snapshot --clean --skip=pub
 
 This produces every release artifact — the four binaries, the multi-arch Docker image, and the checksum file — under `dist/`, without pushing anything to GitHub or GHCR. Because the release pipeline runs a single `go build` per arch (via `.goreleaser.yaml`'s `builds:` block) and feeds that binary into both the standalone archive and the Docker image, a local snapshot build produces the same bytes CI would for the same commit.
 
-#### One-time Docker buildx setup
-
-`make snapshot` builds a multi-arch Docker image (`linux/amd64` + `linux/arm64`) and needs `docker buildx` configured with the `docker-container` driver. Without it, the build fails with `unknown flag: --platform` because the default `docker` driver doesn't support cross-platform builds. Set it up once per machine:
-
-```bash
-docker buildx version   # confirm buildx is installed; if it errors:
-                        #   sudo apt install docker-buildx-plugin   (debian / ubuntu)
-                        #   or install Docker Desktop with WSL2 integration
-
-docker buildx create --use --name smartrouter-builder --driver docker-container
-docker buildx inspect --bootstrap   # pulls moby/buildkit, ~30s first time
-```
-
-The builder persists across reboots; this is one-time-per-machine setup, not per-build.
+On first run, `make snapshot` creates a `smartrouter-builder` Docker buildx instance with the `docker-container` driver (needed for the multi-arch `--platform` build; the default `docker` driver doesn't support it). The setup is idempotent, takes ~30s only the first time (pulls `moby/buildkit`, ~150MB), and is scoped via `BUILDX_BUILDER` so it doesn't change your global default builder. If `docker buildx` itself is missing, `make snapshot` errors with a pointer to install it — on Debian/Ubuntu: `sudo apt install docker-buildx-plugin`; on WSL2: enable Docker Desktop's WSL2 integration.
 
 ### Tag conventions
 


### PR DESCRIPTION
## Summary

Caught by running `make snapshot` locally against `main` after PR #29 + #30 merged:

\`\`\`
target=linux_amd64_v1    ← should be v3
target=linux_arm64_v8.0  ← should be v8.2
target=darwin_amd64_v1   ← should be v3
target=darwin_arm64_v8.0 ← should be v8.2
\`\`\`

The microarch flags I'd put in \`.goreleaser.yaml\`'s top-level \`env:\` block don't propagate to build-target selection. Goreleaser uses per-build fields \`goamd64:\` / \`goarm64:\` to choose microarch variants; the top-level env only seeds shell env passed to \`go build\` (and \`CGO_ENABLED=0\` happens to work because Go reads the env var directly).

## Fix

- Move \`GOAMD64=v3\` and \`GOARM64=v8.2\` from \`env:\` into \`builds[].goamd64:\` and \`builds[].goarm64:\` lists. Goreleaser now builds at v3 / v8.2 explicitly.
- Drop the \`{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}\` clause from \`archives.name_template\`. With a single standardized microarch (v3), that clause would otherwise append \`v3\` to every amd64 archive filename (\`smartrouter-vX.Y.Z-linux-amd64v3\`). The suffix made sense when multiple microarch variants coexisted; with one standard it's noise.

\`CGO_ENABLED=0\` stays at the top \`env:\` level — that propagates correctly.

## Verification

- [ ] After merge: \`make snapshot\` on main shows \`target=linux_amd64_v3\` etc. for all four builds.
- [ ] Archive filenames stay as \`smartrouter-vX.Y.Z-{linux,darwin}-{amd64,arm64}\` — no \`v3\` suffix.
- [ ] \`goreleaser check\` job passes (validates the new \`goamd64:\` / \`goarm64:\` fields).

## How this slipped past PR #29 + PR #30

The \`goreleaser check\` job validates schema, not target output. The release pipeline has never actually fired on a tag, so the wrong target naming wasn't visible until \`make snapshot\` ran locally. This is exactly the kind of bug the throwaway-tag exercise (v0.0.1-test) would have caught — minus the local-snapshot step that turned up first.