### PR TITLE
fix: [MAG-1889] cache-be entries dropped after every router pod restart.

### DIFF
--- a/protocol/performance/cache.go
+++ b/protocol/performance/cache.go
@@ -108,17 +108,18 @@ func (r *relayerCacheClientStore) reconnectClient() {
 	utils.LavaFormatInfo("cache service reconnection loop started", utils.LogAttr("address", r.address))
 
 	for {
+		// Dial first, sleep only between failed attempts. Otherwise a caller
+		// that just discovered client == nil waits a full reconnectInterval
+		// before any retry happens, leaving the cache silently skipped.
+		if r.connectClient() == nil {
+			utils.LavaFormatInfo("cache service reconnection succeeded, exiting reconnect loop", utils.LogAttr("address", r.address))
+			return
+		}
 		select {
 		case <-r.ctx.Done():
 			utils.LavaFormatInfo("cache service reconnection loop exiting (context cancelled)", utils.LogAttr("address", r.address))
 			return
 		case <-time.After(reconnectInterval):
-			// connectClient() returns nil on success, non-nil error on failure.
-			// Exit the loop on success, keep retrying on failure.
-			if r.connectClient() == nil {
-				utils.LavaFormatInfo("cache service reconnection succeeded, exiting reconnect loop", utils.LogAttr("address", r.address))
-				return
-			}
 		}
 	}
 }
@@ -148,11 +149,18 @@ type Cache struct {
 
 func InitCache(ctx context.Context, addr string) (*Cache, error) {
 	clientStore, err := newRelayerCacheClientStore(ctx, addr)
-	return &Cache{
+	cache := &Cache{
 		clientStore: clientStore,
 		address:     addr,
 		serviceCtx:  ctx,
-	}, err
+	}
+	if err != nil {
+		// Initial dial failed. Start the reconnect loop eagerly so the
+		// cache becomes live as soon as the backend is reachable, instead
+		// of staying cold until the first relay triggers getClient().
+		go clientStore.reconnectClient()
+	}
+	return cache, err
 }
 
 func (cache *Cache) GetEntry(ctx context.Context, relayCacheGet *pairingtypes.RelayCacheGet) (reply *pairingtypes.CacheRelayReply, err error) {

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -1360,6 +1360,20 @@ func (rpcss *RPCSmartRouterServer) initializeChainTrackers(ctx context.Context) 
 	)
 }
 
+// isFinalizedForCacheWrite picks the chain tip used to decide whether a
+// cache-write goes to the long-TTL finalized store or the short-TTL temp
+// store. Reply.LatestBlock is unreliable for methods that echo the requested
+// block (eth_getBlockByNumber returns result.number = requested), so the
+// router's tracked tip (chainTracker / latestBlockEstimator / atomic
+// latestBlockHeight, surfaced via getLatestBlock()) wins when it is higher.
+func isFinalizedForCacheWrite(requestedBlock, replyLatestBlock, trackedLatestBlock, finalizationDistance int64) bool {
+	latest := replyLatestBlock
+	if trackedLatestBlock > latest {
+		latest = trackedLatestBlock
+	}
+	return spectypes.IsFinalizedBlock(requestedBlock, latest, finalizationDistance)
+}
+
 // tryCacheWrite attempts to write a successful relay response to the cache.
 // It runs in a separate goroutine to avoid blocking the relay response.
 // Cache writes are skipped when:
@@ -1449,9 +1463,13 @@ func (rpcss *RPCSmartRouterServer) tryCacheWrite(
 	// Get chain stats for finalization check
 	_, averageBlockTime, blockDistanceForFinalizedData, _ := rpcss.chainParser.ChainBlockStats()
 
-	// Determine if response is finalized
+	// Determine if response is finalized. Prefer the router's tracked chain
+	// tip over Reply.LatestBlock: for eth_getBlockByNumber the per-response
+	// value is the requested block itself (extractBlockHeightFromEVMResponse
+	// reads result.number), so the naive check never marks any historical
+	// block finalized and every entry takes the ~625 ms non-finalized TTL.
 	latestBlock := relayResult.Reply.LatestBlock
-	finalized := spectypes.IsFinalizedBlock(requestedBlock, latestBlock, int64(blockDistanceForFinalizedData))
+	finalized := isFinalizedForCacheWrite(requestedBlock, latestBlock, int64(rpcss.getLatestBlock()), int64(blockDistanceForFinalizedData))
 
 	// Convert LATEST_BLOCK to actual block number for cache key
 	// This must match the logic in cache lookup (sendRelayToEndpoint) to ensure cache hits

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -2427,3 +2427,86 @@ func TestSendRelayToDirectEndpoints_CrossValidationGuardReleasesAllSessions(t *t
 	require.Equal(t, 0, usedProviders.SessionsLatestBatch(),
 		"SessionsLatestBatch leaked — commit a78426a regression: RelayProcessor.checkEndProcessing will wait for responses that never arrive")
 }
+
+// TestIsFinalizedForCacheWrite pins the finalization decision used by
+// tryCacheWrite when choosing between the short non-finalized TTL (~625 ms)
+// and the long finalized TTL (~1.5 h).
+//
+// The regression case it guards: eth_getBlockByNumber(N) responses set
+// Reply.LatestBlock = N (extractBlockHeightFromEVMResponse reads result.number,
+// which for this method is the requested block itself). The naive
+// IsFinalizedBlock(requested, latestFromReply, distance) check can never be
+// satisfied because (N <= N - distance) is false for any positive distance,
+// so every historical-block response gets the short TTL. A 10 s rolling
+// restart then drops every cached entry — the failure mode reported in
+// test_phase2_5_caching.py::test_cache_survives_router_pod_restart.
+//
+// The fix consults the router's tracked chain tip (chainTracker /
+// latestBlockEstimator / atomic latestBlockHeight, surfaced via
+// rpcss.getLatestBlock()) and prefers it when it is ahead of the reply's
+// per-response value.
+func TestIsFinalizedForCacheWrite(t *testing.T) {
+	tests := []struct {
+		name        string
+		requested   int64
+		replyLatest int64
+		tracked     int64
+		distance    int64
+		want        bool
+	}{
+		{
+			name:        "eth_getBlockByNumber historical: reply echoes request, tracker shows real tip",
+			requested:   17500000,
+			replyLatest: 17500000, // simulator (and real providers) echo result.number == requested
+			tracked:     20000000,
+			distance:    64,
+			want:        true,
+		},
+		{
+			name:        "tracker only slightly ahead of requested: not finalized",
+			requested:   20000000,
+			replyLatest: 20000000,
+			tracked:     20000050,
+			distance:    64,
+			want:        false,
+		},
+		{
+			name:        "tracker unavailable, reply carries real tip: falls back to reply",
+			requested:   17500000,
+			replyLatest: 20000000,
+			tracked:     0,
+			distance:    64,
+			want:        true,
+		},
+		{
+			name:        "tracker behind reply: max() keeps the higher reply value",
+			requested:   17500000,
+			replyLatest: 20000000,
+			tracked:     17500000,
+			distance:    64,
+			want:        true,
+		},
+		{
+			name:        "LATEST_BLOCK sentinel (-2): never finalized regardless of tip",
+			requested:   spectypes.LATEST_BLOCK,
+			replyLatest: 20000000,
+			tracked:     20000000,
+			distance:    64,
+			want:        false,
+		},
+		{
+			name:        "exactly on the finalization boundary: finalized",
+			requested:   17500000,
+			replyLatest: 17500000,
+			tracked:     17500064,
+			distance:    64,
+			want:        true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isFinalizedForCacheWrite(tc.requested, tc.replyLatest, tc.tracked, tc.distance)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes MAG-1889 — cache-be entries dropped after every router pod restart.

`tryCacheWrite` was classifying every `eth_getBlockByNumber` response as non-finalized, sending it to `tempCache` with the ~625 ms TTL instead of `finalizedCache` with the ~1.5 h TTL. A 10 s rolling restart blows past 625 ms, so the entry was always gone by Phase 3 of `test_cache_survives_router_pod_restart`.

Root cause: `extractBlockHeightFromEVMResponse` reads `result.number`, which for `eth_getBlockByNumber` *is* the requested block. `Reply.LatestBlock == requestedBlock`, so `IsFinalizedBlock(N, N, d)` is false for any positive `d`.

Fix: prefer the router's tracked chain tip (`getLatestBlock()` → `chainTracker` / `latestBlockEstimator` / atomic `latestBlockHeight`) over `Reply.LatestBlock` when deciding finalization. Extracted as `isFinalizedForCacheWrite()` for direct unit testing.

Also includes cache-client reconnect hardening (eager retry + start-on-init-failure) for the latent-but-real case where `CacheActive()` would silently skip the lookup while reconnecting.

## Test plan

- [x] `go test ./protocol/rpcsmartrouter/...` — 74 s, all green, includes new `TestIsFinalizedForCacheWrite` (6 cases covering the regression, tracker fallback both ways, LATEST_BLOCK sentinel, exact boundary).
- [x] `go vet ./...` clean.
- [x] Reproduced on live cluster with `curl` before fix: same `eth_getBlockByNumber` returned `Cached` at 200 ms gap, fresh `simprovider3` at 2 s gap.
- [ ] Verify on cluster after image promotes: same curl at 2 s gap returns `Cached`; full `test_phase2_5_caching::test_cache_survives_router_pod_restart` passes.
- [ ] Log signal post-deploy: `cache write succeeded` lines now show `"finalized":"true"` for `eth_getBlockByNumber` writes.
