### PR TITLE
fix(rpcsmartrouter): make HTTP status authoritative for 4xx (MAG-1870)

### DIFF
--- a/protocol/common/error_classifier.go
+++ b/protocol/common/error_classifier.go
@@ -290,6 +290,7 @@ var genericErrorMappings = map[TransportType][]errorMapping{
 // These are used for REST transport where the error code is the HTTP status code itself.
 func httpStatusCodeMappings() []errorMapping {
 	return []errorMapping{
+		{CodeEquals(401), LavaErrorNodeUnauthorized},
 		{CodeEquals(404), LavaErrorNodeEndpointNotFound},
 		{CodeEquals(405), LavaErrorNodeMethodNotAllowed},
 		{CodeEquals(413), LavaErrorUserRequestTooLarge},
@@ -315,6 +316,7 @@ func httpStatusCodeMappings() []errorMapping {
 // These match status codes appearing as substrings in error messages (e.g., "HTTP status 429").
 func httpStatusMessageMappings() []errorMapping {
 	return []errorMapping{
+		{HTTPStatusContains(401), LavaErrorNodeUnauthorized},
 		{HTTPStatusContains(404), LavaErrorNodeEndpointNotFound},
 		{HTTPStatusContains(405), LavaErrorNodeMethodNotAllowed},
 		{HTTPStatusContains(413), LavaErrorUserRequestTooLarge},

--- a/protocol/common/error_codes.go
+++ b/protocol/common/error_codes.go
@@ -250,6 +250,14 @@ var (
 		Code: 2015, Name: "NODE_BAD_GATEWAY", Category: CategoryExternal,
 		Description: "Bad gateway (HTTP 502 from provider)", Retryable: true,
 	})
+	// NODE_UNAUTHORIZED: upstream rejected the smart-router's credentials
+	// (HTTP 401). Non-retryable because the same credentials are reused on
+	// every attempt — retrying just multiplies the same auth failure across
+	// providers. Operator must fix the auth-config for the affected endpoint.
+	LavaErrorNodeUnauthorized = registerError(&LavaError{
+		Code: 2016, Name: "NODE_UNAUTHORIZED", Category: CategoryExternal,
+		Description: "Upstream rejected router credentials (HTTP 401)", Retryable: false,
+	})
 
 	// Bitcoin/UTXO node errors (2100-2149)
 	// Source: Bitcoin Core src/rpc/protocol.h

--- a/protocol/rpcsmartrouter/direct_rpc_integration_test.go
+++ b/protocol/rpcsmartrouter/direct_rpc_integration_test.go
@@ -3,6 +3,7 @@ package rpcsmartrouter
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -400,6 +401,105 @@ func TestDirectRPCRelaySender_HTTPStatusPrefixSkippedOn2xx(t *testing.T) {
 	// through HTTP-status matchers.
 	assert.False(t, result.IsNonRetryable,
 		"2xx responses must not be classified via HTTP-status matchers")
+}
+
+// TestDirectRPCRelaySender_HTTPStatusOverridesRetryableBodyCode_MAG1870 covers
+// the gap MAG-1666 left behind: an upstream that returns HTTP 4xx alongside a
+// proper JSON-RPC envelope whose error.code is a REGISTERED RETRYABLE code
+// (e.g. -32603 → LavaErrorNodeInternalError, -32000 → LavaErrorNodeServerError).
+//
+// The previous fix prepended "HTTP <status>: " to the classifier message so a
+// substring matcher (HTTPStatusContains) could fire. But matcher iteration is
+// "code-based first, message-based second" — so when the body's error.code is
+// a registered code, CodeEquals matches first and HTTPStatusContains never
+// runs. The router sees IsNonRetryable=false and retries, even though the
+// HTTP layer said 404/405/413 (non-retryable).
+//
+// The MAG-1666 test (TestDirectRPCRelaySender_HTTPStatusPrefixReachesClassifier_MAG1666)
+// uses error.code=-1 specifically to dodge code matchers, which is why it
+// passes but doesn't catch the production case.
+func TestDirectRPCRelaySender_HTTPStatusOverridesRetryableBodyCode_MAG1870(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		bodyCode   int // a REGISTERED retryable code in genericErrorMappings[JsonRPC]
+	}{
+		// HTTP 401 was named in the duplicate MAG-1858 but had no registry
+		// entry at all prior to this patch; covered here because the same
+		// simulator test cluster fails on it.
+		{name: "HTTP 401 + body -32603 (new NODE_UNAUTHORIZED mapping)", statusCode: 401, bodyCode: -32603},
+		{name: "HTTP 404 + body -32603 (NODE_INTERNAL_ERROR)", statusCode: 404, bodyCode: -32603},
+		{name: "HTTP 405 + body -32603", statusCode: 405, bodyCode: -32603},
+		{name: "HTTP 413 + body -32603", statusCode: 413, bodyCode: -32603},
+		{name: "HTTP 404 + body -32000 (NODE_SERVER_ERROR, server-defined)", statusCode: 404, bodyCode: -32000},
+		// Pin the already-non-retryable body-code path: the first pass
+		// classifies via CodeEquals(-32601) → NODE_METHOD_NOT_FOUND
+		// (Retryable: false) and the second pass is skipped on the
+		// !IsNonRetryable guard. Surface a future regression that would
+		// flip this verdict before adding any second-pass logic.
+		{name: "HTTP 404 + body -32601 (already non-retryable, no second pass needed)", statusCode: 404, bodyCode: -32601},
+	}
+
+	// Sanity-pin the discriminator: each body code must classify as RETRYABLE
+	// on its own (no HTTP prefix). If a future change makes -32603 / -32000
+	// non-retryable in the registry, this test's premise dissolves and the
+	// assertion below would pass for the wrong reason.
+	for _, bodyCode := range []int{-32603, -32000} {
+		require.False(t,
+			common.IsNonRetryableNodeErrorWithContext(
+				common.ChainFamilyEVM, common.TransportJsonRPC,
+				bodyCode, "primary repeatedly errors"),
+			"body code %d must be retryable on its own — otherwise this test cannot prove the HTTP status flipped the verdict",
+			bodyCode)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errMsg := "primary repeatedly errors"
+			body := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"error":{"code":%d,"message":"%s"}}`, tt.bodyCode, errMsg)
+
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(body))
+			}))
+			defer mockServer.Close()
+
+			ctx := context.Background()
+			nodeUrl := common.NodeUrl{Url: mockServer.URL}
+
+			directConn, err := lavasession.NewDirectRPCConnection(ctx, nodeUrl, 5, "")
+			require.NoError(t, err)
+
+			sender := &DirectRPCRelaySender{
+				directConnection: directConn,
+				endpointName:     "test-http-status-overrides-body-code",
+				chainFamily:      common.ChainFamilyEVM,
+			}
+
+			chainMessage := &mockChainMessage{
+				requestData: []byte(`{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}`),
+				// Mirror what the real CheckResponseError extracts from a
+				// proper JSON-RPC error envelope: hasError=true, message =
+				// error.message. Crucially the bareErrorMessage MUST NOT
+				// contain "404"/"405"/"413" — otherwise the substring
+				// matcher could fire on the raw message and mask the bug.
+				checkResponseError: func(_ []byte, _ int) (bool, string) {
+					return true, errMsg
+				},
+			}
+
+			result, err := sender.SendDirectRelay(ctx, chainMessage, 5*time.Second)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.statusCode, result.StatusCode)
+			assert.True(t, result.IsNodeError, "hasError branch must have fired")
+			assert.True(t, result.IsNonRetryable,
+				"HTTP %d is non-retryable per the registry; a retryable body code (%d) "+
+					"must not mask the HTTP-status verdict",
+				tt.statusCode, tt.bodyCode)
+		})
+	}
 }
 
 func TestDirectRPCRelaySender_SendDirectRelay_BatchRequest(t *testing.T) {

--- a/protocol/rpcsmartrouter/direct_rpc_relay.go
+++ b/protocol/rpcsmartrouter/direct_rpc_relay.go
@@ -451,13 +451,36 @@ func (d *DirectRPCRelaySender) sendJSONRPCRelay(
 		// JSON-RPC code like -32601 continues to classify the same way.
 		// The prefix only changes the verdict for HTTP 4xx/5xx responses
 		// that carry a JSON-RPC body with a generic/vendor code where the
-		// HTTP status is the authoritative signal. 
-
+		// HTTP status is the authoritative signal.
 		classifierMessage := errorMessage
 		if statusCode < 200 || statusCode >= 300 {
 			classifierMessage = fmt.Sprintf("HTTP %d: %s", statusCode, errorMessage)
 		}
 		result.IsNonRetryable = common.IsNonRetryableNodeErrorWithContext(d.chainFamily, common.TransportJsonRPC, errorCode, classifierMessage)
+
+		// MAG-1870 — HTTP status must be authoritative for 4xx-class transport
+		// errors. The single-pass classification above iterates matchers in
+		// declaration order: code-based matchers first, message-based after.
+		// When the body carries a registered RETRYABLE code (e.g. -32603
+		// NODE_INTERNAL_ERROR, -32000 NODE_SERVER_ERROR) AND the upstream
+		// returned a non-retryable HTTP status (404/405/413), the body-code
+		// matcher fires first and HTTPStatusContains never runs — so the
+		// retryable body code masks the non-retryable HTTP verdict and the
+		// router retries pointlessly.
+		//
+		// A second classification pass with the raw HTTP statusCode as the
+		// errorCode resolves the conflict: when the HTTP layer says the
+		// upstream rejected the request shape itself (not a node-internal
+		// hiccup), trust that verdict. We only escalate to non-retryable —
+		// never demote — so 2xx body errors keep their existing semantics
+		// and 5xx (which already map to retryable LavaErrors) are unaffected.
+		//
+		// The statusCode != errorCode guard skips the redundant pass in the
+		// bare-body fallback case where ExtractJSONRPCErrorCode returned 0
+		// and the first pass already ran with errorCode = statusCode.
+		if !result.IsNonRetryable && (statusCode < 200 || statusCode >= 300) && statusCode != errorCode {
+			result.IsNonRetryable = common.IsNonRetryableNodeErrorWithContext(d.chainFamily, common.TransportJsonRPC, statusCode, classifierMessage)
+		}
 	}
 
 	return result, nil


### PR DESCRIPTION
## Summary

- Adds a second classification pass at `direct_rpc_relay.go::sendJSONRPCRelay` using the raw HTTP statusCode when the first pass came back retryable and the response is non-2xx. Resolves the masking bug where a registered retryable JSON-RPC body code (e.g. `-32603` `NODE_INTERNAL_ERROR`) caused the router to retry HTTP 404/405/413, despite the registry marking those statuses non-retryable.
- Registers a new `LavaErrorNodeUnauthorized` (Code 2016, Retryable: false) and wires HTTP 401 into both `httpStatusCodeMappings` (REST `CodeEquals`) and `httpStatusMessageMappings` (`HTTPStatusContains` for JsonRPC/REST/gRPC). 401 had **no** registry entry prior to this patch — closes the 401 row from the duplicate cluster [MAG-1858](https://magmadevs.atlassian.net/browse/MAG-1858).
- Adds `TestDirectRPCRelaySender_HTTPStatusOverridesRetryableBodyCode_MAG1870` covering 401/404/405/413 × retryable body codes (`-32603`, `-32000`), plus a `-32601` pin for the already-non-retryable path (proves the second-pass guard doesn't disturb correct verdicts).

## Root cause

Matchers in `genericErrorMappings[TransportJsonRPC]` iterate code-based-first, message-based-after. With a proper JSON-RPC envelope `{"error":{"code":-32603,...}}` + HTTP 404, `CodeEquals(-32603) → NODE_INTERNAL_ERROR (Retryable: true)` matched before `HTTPStatusContains(404)` could run. [MAG-1666](https://magmadevs.atlassian.net/browse/MAG-1666)'s `"HTTP <status>: "` prefix fixed the bare-body fallback (no `error.code`) but couldn't help when a registered code beat the substring matcher to the punch.

## Why the fix is narrow

Only escalates to non-retryable, never demotes. The `statusCode != errorCode` guard short-circuits the redundant pass when the bare-body fallback already populated `errorCode = statusCode`. 2xx responses are skipped via the `statusCode < 200 || statusCode >= 300` gate, so body-code classification on success-shape 200 responses is untouched.

## Test plan

- [x] `go test ./protocol/rpcsmartrouter -run 'TestDirectRPCRelaySender_HTTPStatus' -count=1 -v` — 7 subtests pass (401/404/405/413 × retryable codes, plus already-non-retryable pin, plus MAG-1666 prefix + 2xx-skip pins).
- [x] `go test ./protocol/common ./protocol/rpcsmartrouter ./protocol/relaycore ./protocol/relaypolicy -count=1 -timeout 180s` — all green.
- [ ] **Redeploy required before the Python simulator suite clears.** `tests/simulator/production_tests/test_http_status_code_classifier.py` runs against the deployed binary; merging this PR doesn't unblock those tests until the binary is rebuilt and rolled out. Ticket's hypothesis #1 (deploy lag) still needs an ops follow-up.

## Out of scope

- **gRPC sender** at `direct_rpc_relay.go:763` has the same shape of latent risk: it passes `response.StatusCode` as `errorCode` for gRPC, but only `HTTPStatusContains` matchers are registered for that transport, and the matcher ignores the int. A gRPC upstream returning HTTP 4xx without status digits in the error string would hit the same retry-by-default behavior. Worth a separate ticket if gRPC providers are in scope for this classifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MAG-1858]: https://magmadevs.atlassian.net/browse/MAG-1858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAG-1666]: https://magmadevs.atlassian.net/browse/MAG-1666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ