### PR TITLE
test(smart-router): MAG-1872 config-flag coverage backfill (9 tests, 5 packages)

### DIFF
--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -1491,6 +1491,68 @@ func TestBackupProviderOptimizerSelection(t *testing.T) {
 	require.Error(t, err, "expected error when all backup providers are exhausted")
 }
 
+// TestBackupProviderOptimizerSelection_EndpointCountBoundaries backfills
+// MAG-1872 item 12: the existing TestBackupProviderOptimizerSelection
+// hardcodes 2 backup endpoints, exercising the round-robin loop at only one
+// pool size. This parametrizes the count at 1 (minimum) and 5 (a larger
+// pool) to cover both the trivial single-iteration case and the multi-call
+// round-robin path that exhausts after exactly N iterations.
+func TestBackupProviderOptimizerSelection_EndpointCountBoundaries(t *testing.T) {
+	cases := []struct {
+		name        string
+		backupCount int
+	}{
+		{name: "single_backup", backupCount: 1},
+		{name: "five_backups", backupCount: 5},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			csm := CreateConsumerSessionManager()
+
+			backupList := make(map[uint64]*ConsumerSessionsWithProvider, tc.backupCount)
+			for i := 0; i < tc.backupCount; i++ {
+				addr := fmt.Sprintf("backup-%d", i)
+				backup := NewConsumerSessionWithProvider(addr, []*Endpoint{{NetworkAddress: grpcListener, Enabled: true, Connections: []*EndpointConnection{}}}, 999999, firstEpochHeight, int64(0))
+				backup.StaticProvider = true
+				backupList[uint64(i)] = backup
+			}
+
+			require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, nil, backupList))
+
+			ignoredProv := &ignoredProviders{
+				providers:    make(map[string]struct{}),
+				currentEpoch: firstEpochHeight,
+			}
+
+			// Drain the pool: exactly backupCount calls should each return
+			// one distinct backup.
+			seen := make(map[string]struct{})
+			for call := 0; call < tc.backupCount; call++ {
+				result, err := csm.getValidConsumerSessionsWithProviderFromBackupProviderList(
+					ctx, ignoredProv, cuForFirstRequest, servicedBlockNumber, "",
+					[]string{}, 0, 0, NewUsedProviders(nil))
+				require.NoError(t, err, "call #%d of %d must succeed", call+1, tc.backupCount)
+				require.Len(t, result, 1, "exactly one backup per call (got %d)", len(result))
+				for addr := range result {
+					_, dup := seen[addr]
+					require.False(t, dup, "call #%d returned duplicate backup %q", call+1, addr)
+					seen[addr] = struct{}{}
+				}
+			}
+			require.Len(t, seen, tc.backupCount,
+				"every backup must be returned exactly once across %d calls", tc.backupCount)
+
+			// One more call exhausts the pool.
+			_, err := csm.getValidConsumerSessionsWithProviderFromBackupProviderList(
+				ctx, ignoredProv, cuForFirstRequest, servicedBlockNumber, "",
+				[]string{}, 0, 0, NewUsedProviders(nil))
+			require.Error(t, err, "expected exhaustion error after %d backups served", tc.backupCount)
+		})
+	}
+}
+
 // TestGetReportedProviders_EpochTransitionRace reproduces the race between
 // GetReportedProviders and UpdateAllProviders that causes the error
 // "Failed to find a reported provider in pairing list".

--- a/protocol/metrics/rpcconsumer_logs_test.go
+++ b/protocol/metrics/rpcconsumer_logs_test.go
@@ -1,8 +1,13 @@
 package metrics
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,6 +16,7 @@ import (
 	websocket2 "github.com/gorilla/websocket"
 	"github.com/magma-Devs/smart-router/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type WebSocketError struct {
@@ -104,4 +110,182 @@ func TestAnalyzeWebSocketErrorAndWriteMessage(t *testing.T) {
 	err = json.Unmarshal([]byte(errObject.ErrorReceived), errData)
 	assert.Nil(t, err)
 	assert.Equal(t, errData.GUID, "seed")
+}
+
+// captureStderr swaps os.Stderr with a pipe while fn runs, returning what was
+// written. Required because utils.LavaFormat* logs via the global zerolog
+// logger bound to os.Stderr at SetGlobalLoggingLevel() time, and is not safe
+// for parallel tests (os.Stderr is process-global).
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		io.Copy(&buf, r)
+		close(done)
+	}()
+
+	fn()
+
+	w.Close()
+	<-done
+	r.Close()
+	os.Stderr = origStderr
+	return buf.String()
+}
+
+// TestSetGlobalLoggingLevel_VolumeChangesAcrossLevels backfills MAG-1872 item
+// 7: --log-level info/debug/warn parametrization. Existing tests in this file
+// only exercise "fatal". This asserts that LavaFormatLog's early-return
+// optimization filters lower-severity messages at higher levels, and emits
+// them at lower levels.
+func TestSetGlobalLoggingLevel_VolumeChangesAcrossLevels(t *testing.T) {
+	origFormat := utils.JsonFormat
+	utils.JsonFormat = true // JSON output is easier to grep deterministically
+	t.Cleanup(func() {
+		utils.JsonFormat = origFormat
+		utils.SetGlobalLoggingLevel("info")
+	})
+
+	const (
+		debugMarker = "level-test-debug-marker"
+		infoMarker  = "level-test-info-marker"
+		warnMarker  = "level-test-warning-marker"
+	)
+
+	cases := []struct {
+		level     string
+		wantDebug bool
+		wantInfo  bool
+		wantWarn  bool
+	}{
+		{level: "debug", wantDebug: true, wantInfo: true, wantWarn: true},
+		{level: "info", wantDebug: false, wantInfo: true, wantWarn: true},
+		{level: "warn", wantDebug: false, wantInfo: false, wantWarn: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.level, func(t *testing.T) {
+			out := captureStderr(t, func() {
+				utils.SetGlobalLoggingLevel(tc.level)
+				utils.LavaFormatDebug(debugMarker)
+				utils.LavaFormatInfo(infoMarker)
+				utils.LavaFormatWarning(warnMarker, nil)
+			})
+			assert.Equal(t, tc.wantDebug, strings.Contains(out, debugMarker),
+				"debug visibility wrong at level=%s, output=%s", tc.level, out)
+			assert.Equal(t, tc.wantInfo, strings.Contains(out, infoMarker),
+				"info visibility wrong at level=%s, output=%s", tc.level, out)
+			assert.Equal(t, tc.wantWarn, strings.Contains(out, warnMarker),
+				"warn visibility wrong at level=%s, output=%s", tc.level, out)
+		})
+	}
+}
+
+// TestSetGlobalLoggingLevel_TextVsJsonFormat backfills MAG-1872 item 8:
+// --log-format text|json flag. The flag is wired at
+// protocol/rpcsmartrouter/rpcsmartrouter.go and consumed via utils.JsonFormat,
+// which gates the writer choice in SetGlobalLoggingLevel. This asserts that
+// the produced output is JSON-parseable iff JsonFormat=true.
+func TestSetGlobalLoggingLevel_TextVsJsonFormat(t *testing.T) {
+	origFormat := utils.JsonFormat
+	t.Cleanup(func() {
+		utils.JsonFormat = origFormat
+		utils.SetGlobalLoggingLevel("info")
+	})
+
+	const marker = "format-test-marker"
+
+	cases := []struct {
+		name string
+		json bool
+	}{
+		{name: "json_format", json: true},
+		{name: "text_format", json: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			utils.JsonFormat = tc.json
+			out := captureStderr(t, func() {
+				utils.SetGlobalLoggingLevel("info")
+				utils.LavaFormatInfo(marker)
+			})
+
+			var markerLine string
+			for _, line := range strings.Split(out, "\n") {
+				if strings.Contains(line, marker) {
+					markerLine = line
+					break
+				}
+			}
+			require.NotEmpty(t, markerLine, "marker line not captured, output=%s", out)
+
+			var parsed map[string]interface{}
+			err := json.Unmarshal([]byte(markerLine), &parsed)
+			if tc.json {
+				require.NoError(t, err, "json format must produce parseable JSON, line=%s", markerLine)
+				assert.Equal(t, "info", parsed["level"], "json format must carry structured level field")
+				assert.Equal(t, marker, parsed["message"], "json format must carry structured message field")
+			} else {
+				require.Error(t, err, "text format must NOT parse as JSON, line=%s", markerLine)
+				assert.Contains(t, markerLine, "INF",
+					"console format must contain abbreviated level marker, line=%s", markerLine)
+			}
+		})
+	}
+}
+
+// TestLavaFormat_GUIDAttachedToNormalLogPaths backfills MAG-1872 item 9: GUID
+// presence in non-error log lines. Existing tests assert Error_GUID in error
+// JSON only; this asserts that utils.LogAttr("GUID", ctx) on an Info log
+// surfaces the GUID as a top-level field via utils.StrValueForLog's GUID
+// extraction path (utils/lavalog.go:182).
+func TestLavaFormat_GUIDAttachedToNormalLogPaths(t *testing.T) {
+	origFormat := utils.JsonFormat
+	utils.JsonFormat = true
+	t.Cleanup(func() {
+		utils.JsonFormat = origFormat
+		utils.SetGlobalLoggingLevel("info")
+	})
+
+	const (
+		testGUID uint64 = 0xDEADBEEFCAFE
+		marker          = "guid-on-normal-path-marker"
+	)
+	ctx := utils.WithUniqueIdentifier(context.Background(), testGUID)
+
+	out := captureStderr(t, func() {
+		utils.SetGlobalLoggingLevel("info")
+		utils.LavaFormatInfo(marker, utils.LogAttr("GUID", ctx))
+	})
+
+	var markerLine string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, marker) {
+			markerLine = line
+			break
+		}
+	}
+	require.NotEmpty(t, markerLine, "marker line not captured, output=%s", out)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(markerLine), &parsed),
+		"info log must be JSON parseable, line=%s", markerLine)
+
+	// StrValueForLog stringifies the GUID via strconv.FormatUint(guid, 10).
+	guidStr, ok := parsed["GUID"].(string)
+	require.True(t, ok, "GUID field must be a string in JSON output, got %T (line=%s)", parsed["GUID"], markerLine)
+	assert.Equal(t, "244837814094590", guidStr,
+		"GUID field must equal decimal-stringified context GUID")
+
+	// Contrast with the error-path tests above which look for Error_GUID; the
+	// normal-path key is the literal "GUID".
+	_, hasErrorGUID := parsed["Error_GUID"]
+	assert.False(t, hasErrorGUID, "normal-path log must not carry Error_GUID field")
 }

--- a/protocol/rpcsmartrouter/cache_skip_paths_test.go
+++ b/protocol/rpcsmartrouter/cache_skip_paths_test.go
@@ -1,0 +1,109 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsFinalizedForCacheWrite_FinalizationBoundary backfills MAG-1872 item 4:
+// cache-write behaviour must differ based on whether the requested block is
+// finalized. The smart router picks the long-TTL finalized cache store when
+// this function returns true and the short-TTL temp store otherwise.
+// Beyond the basic IsFinalizedBlock() contract, this function picks the
+// higher of (replyLatestBlock, trackedLatestBlock) so a stale Reply.LatestBlock
+// from an echoing RPC (e.g. eth_getBlockByNumber) does not flip a finalized
+// block into the non-finalized branch.
+func TestIsFinalizedForCacheWrite_FinalizationBoundary(t *testing.T) {
+	cases := []struct {
+		name                 string
+		requestedBlock       int64
+		replyLatestBlock     int64
+		trackedLatestBlock   int64
+		finalizationDistance int64
+		want                 bool
+	}{
+		{
+			name:                 "block_clearly_finalized_far_behind_tip",
+			requestedBlock:       100,
+			replyLatestBlock:     200,
+			trackedLatestBlock:   200,
+			finalizationDistance: 10,
+			want:                 true,
+		},
+		{
+			name:                 "block_at_tip_is_non_finalized",
+			requestedBlock:       200,
+			replyLatestBlock:     200,
+			trackedLatestBlock:   200,
+			finalizationDistance: 10,
+			want:                 false,
+		},
+		{
+			name:                 "block_exactly_at_finalization_distance_is_finalized",
+			requestedBlock:       190,
+			replyLatestBlock:     200,
+			trackedLatestBlock:   200,
+			finalizationDistance: 10,
+			want:                 true,
+		},
+		{
+			name:                 "block_one_short_of_distance_is_non_finalized",
+			requestedBlock:       191,
+			replyLatestBlock:     200,
+			trackedLatestBlock:   200,
+			finalizationDistance: 10,
+			want:                 false,
+		},
+		{
+			// Tracked tip > Reply tip — the higher tracked value must win,
+			// flipping a request that would look non-finalized at the reply
+			// tip into the finalized branch.
+			name:                 "tracked_tip_higher_than_reply_tip_wins",
+			requestedBlock:       190,
+			replyLatestBlock:     195, // alone: 190 > 195-10 → non-finalized
+			trackedLatestBlock:   210, // wins: 190 <= 210-10 → finalized
+			finalizationDistance: 10,
+			want:                 true,
+		},
+		{
+			// Reply tip > Tracked tip — the higher reply value must win.
+			name:                 "reply_tip_higher_than_tracked_tip_wins",
+			requestedBlock:       190,
+			replyLatestBlock:     210, // wins: 190 <= 210-10 → finalized
+			trackedLatestBlock:   195, // alone: 190 > 195-10 → non-finalized
+			finalizationDistance: 10,
+			want:                 true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isFinalizedForCacheWrite(tc.requestedBlock, tc.replyLatestBlock, tc.trackedLatestBlock, tc.finalizationDistance)
+			assert.Equal(t, tc.want, got,
+				"isFinalizedForCacheWrite(req=%d, replyTip=%d, trackedTip=%d, dist=%d) = %v, want %v",
+				tc.requestedBlock, tc.replyLatestBlock, tc.trackedLatestBlock, tc.finalizationDistance, got, tc.want)
+		})
+	}
+}
+
+// TestTryCacheWrite_SkipsWhenCacheBackendUnreachable backfills MAG-1872 item 5:
+// when the external cache backend (--cache-be) is unreachable, the relay hot
+// path must short-circuit cleanly so requests still succeed. (*Cache).CacheActive
+// (protocol/performance/cache.go:183) returns false for both a nil receiver
+// and a non-nil receiver with no connected client; tryCacheWrite must early-
+// return in either case without touching the rest of its arguments. Existing
+// coverage in debug_server_test.go exercises only the /debug/reset-all branch
+// for the same condition.
+func TestTryCacheWrite_SkipsWhenCacheBackendUnreachable(t *testing.T) {
+	rpcss := &RPCSmartRouterServer{cache: nil}
+
+	// The skip-path must fire BEFORE any other field is touched. We pass nil
+	// for both ProtocolMessage and RelayResult — if the early-return is
+	// missing, the next statements would nil-deref and panic.
+	require.NotPanics(t, func() {
+		rpcss.tryCacheWrite(context.Background(), nil, nil)
+	}, "tryCacheWrite must short-circuit when cache is nil/unreachable, not nil-deref into protocolMessage")
+}

--- a/protocol/rpcsmartrouter/static_provider_endpoints_test.go
+++ b/protocol/rpcsmartrouter/static_provider_endpoints_test.go
@@ -1,0 +1,140 @@
+package rpcsmartrouter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseStaticProviderEndpoints_BackupProvidersYAMLLoading backfills
+// MAG-1872 item 1: --backup-providers enabled vs disabled through the
+// YAML-config-loading path. The previous coverage exercised backup-provider
+// selection via the direct API (consumer_session_manager_test.go), but did
+// not validate that the YAML key-presence and absent-key branches both work
+// — the path actually used by the cobra command at
+// rpcsmartrouter.go:1683-1701.
+func TestParseStaticProviderEndpoints_BackupProvidersYAMLLoading(t *testing.T) {
+	// Geolocation is supplied via the CLI --geolocation flag at runtime; the
+	// parser stamps it onto every parsed endpoint regardless of whether the
+	// YAML specifies one.
+	const flagGeolocation uint64 = 7
+
+	cases := []struct {
+		name          string
+		yamlBody      string
+		expectIsSet   bool
+		wantEndpoints int
+	}{
+		{
+			name:          "disabled_absent_key",
+			yamlBody:      "endpoints:\n  - chain-id: ETH1\n",
+			expectIsSet:   false,
+			wantEndpoints: 0,
+		},
+		{
+			name: "enabled_single_backup",
+			yamlBody: "backup-providers:\n" +
+				"  - name: backup-1\n" +
+				"    chain-id: ETH1\n" +
+				"    api-interface: jsonrpc\n" +
+				"    node-urls:\n" +
+				"      - url: https://backup1.example.com\n",
+			expectIsSet:   true,
+			wantEndpoints: 1,
+		},
+		{
+			name: "enabled_multiple_backups",
+			yamlBody: "backup-providers:\n" +
+				"  - name: backup-1\n" +
+				"    chain-id: ETH1\n" +
+				"    api-interface: jsonrpc\n" +
+				"    node-urls:\n" +
+				"      - url: https://backup1.example.com\n" +
+				"  - name: backup-2\n" +
+				"    chain-id: ETH1\n" +
+				"    api-interface: jsonrpc\n" +
+				"    node-urls:\n" +
+				"      - url: https://backup2.example.com\n",
+			expectIsSet:   true,
+			wantEndpoints: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := viper.New()
+			v.SetConfigType("yaml")
+			require.NoError(t, v.ReadConfig(strings.NewReader(tc.yamlBody)))
+
+			require.Equal(t, tc.expectIsSet, v.IsSet(common.BackupProvidersConfigName),
+				"viper.IsSet(backup-providers) must reflect YAML key presence")
+
+			if !tc.expectIsSet {
+				// Disabled branch: caller short-circuits and skips the parser.
+				// No further assertion possible — the absence of the key IS
+				// the contract.
+				return
+			}
+
+			endpoints, err := ParseStaticProviderEndpoints(v, common.BackupProvidersConfigName, flagGeolocation)
+			require.NoError(t, err)
+			require.Len(t, endpoints, tc.wantEndpoints)
+			for i, ep := range endpoints {
+				assert.Equal(t, flagGeolocation, ep.Geolocation,
+					"endpoint #%d must inherit --geolocation flag value, got %d", i, ep.Geolocation)
+				assert.NoError(t, ep.Validate(),
+					"parsed endpoint #%d must satisfy Validate() (chain-id, api-interface, node-urls, name)", i)
+			}
+		})
+	}
+}
+
+// TestParseEndpoints_GeolocationFlagBinding backfills MAG-1872 item 10: the
+// --geolocation CLI flag must propagate to every parsed RPCEndpoint via
+// ParseEndpoints. TestGeoOrdering in protocol/lavasession/common_test.go
+// covers the sort behavior across pre-set geolocations but does NOT exercise
+// the flag → endpoint roundtrip.
+func TestParseEndpoints_GeolocationFlagBinding(t *testing.T) {
+	// lavasession.RPCEndpoint.NetworkAddress is a plain string (HOST:PORT),
+	// unlike RPCProviderEndpoint which carries a nested NetworkAddressData
+	// struct. The YAML schema must match the target field type.
+	const yamlBody = "endpoints:\n" +
+		"  - chain-id: ETH1\n" +
+		"    api-interface: jsonrpc\n" +
+		"    network-address: 127.0.0.1:3333\n" +
+		"  - chain-id: LAV1\n" +
+		"    api-interface: rest\n" +
+		"    network-address: 127.0.0.1:3334\n"
+
+	cases := []struct {
+		name        string
+		geolocation uint64
+	}{
+		{name: "geolocation_1_USC", geolocation: 1},
+		{name: "geolocation_2_USE", geolocation: 2},
+		{name: "geolocation_4_EU", geolocation: 4},
+		{name: "geolocation_65535_all_regions", geolocation: 65535},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := viper.New()
+			v.SetConfigType("yaml")
+			require.NoError(t, v.ReadConfig(strings.NewReader(yamlBody)))
+
+			endpoints, err := ParseEndpoints(v, tc.geolocation)
+			require.NoError(t, err)
+			require.NotEmpty(t, endpoints, "endpoints must be parsed from YAML")
+			for i, ep := range endpoints {
+				assert.Equal(t, tc.geolocation, ep.Geolocation,
+					"endpoint #%d must inherit CLI --geolocation flag value, got %d", i, ep.Geolocation)
+				assert.NotEmpty(t, ep.HealthCheckPath,
+					"endpoint #%d must have default HealthCheckPath populated when YAML omits it", i)
+			}
+		})
+	}
+}

--- a/utils/keeper/spec_aggregation_test.go
+++ b/utils/keeper/spec_aggregation_test.go
@@ -129,6 +129,79 @@ func TestGetAllSpecsFromPath(t *testing.T) {
 	})
 }
 
+// TestGetAllSpecsFromPath_MisconfiguredFailsFast backfills MAG-1872 item 11:
+// --use-static-spec must fail fast on misconfigured paths so the smart router
+// refuses to start with a broken spec set. The existing TestGetAllSpecsFromPath
+// covers only "non-existent path"; this fills the gaps around malformed JSON
+// (in both file and directory inputs) and an unreadable directory.
+func TestGetAllSpecsFromPath_MisconfiguredFailsFast(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	malformedFile := filepath.Join(tmpDir, "malformed.json")
+	require.NoError(t, os.WriteFile(malformedFile, []byte("{not valid json"), 0o644))
+
+	malformedDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(malformedDir, "bad.json"), []byte("{also not valid"), 0o644))
+
+	cases := []struct {
+		name           string
+		path           string
+		wantErrSubstr  string // case-insensitive substring of the returned error; empty = just any error
+		skipIfRootUser bool
+		setup          func(t *testing.T) string
+	}{
+		{
+			name:          "missing_file_returns_error",
+			path:          filepath.Join(tmpDir, "this-file-does-not-exist.json"),
+			wantErrSubstr: "",
+		},
+		{
+			name:          "malformed_json_file_surfaces_parse_error",
+			path:          malformedFile,
+			wantErrSubstr: "json",
+		},
+		{
+			name:          "malformed_json_inside_directory_surfaces_parse_error",
+			path:          malformedDir,
+			wantErrSubstr: "json",
+		},
+		{
+			name:           "unreadable_directory_surfaces_permission_error",
+			skipIfRootUser: true,
+			setup: func(t *testing.T) string {
+				d := t.TempDir()
+				// Strip read permission so directory listing fails. Restore
+				// before t.TempDir cleanup runs or the test framework cannot
+				// remove the directory.
+				require.NoError(t, os.Chmod(d, 0o000))
+				t.Cleanup(func() {
+					_ = os.Chmod(d, 0o755)
+				})
+				return d
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.skipIfRootUser && os.Geteuid() == 0 {
+				t.Skip("permission-denied behavior cannot be exercised as root")
+			}
+			path := tc.path
+			if tc.setup != nil {
+				path = tc.setup(t)
+			}
+
+			_, err := GetAllSpecsFromPath(path)
+			require.Error(t, err, "misconfigured spec path %q must fail fast", path)
+			if tc.wantErrSubstr != "" {
+				require.Contains(t, strings.ToLower(err.Error()), tc.wantErrSubstr,
+					"error message should hint at root cause; got: %s", err.Error())
+			}
+		})
+	}
+}
+
 func TestExpandSpecWithDependencies(t *testing.T) {
 	// Create specs map with base and derived specs
 	specs := map[string]types.Spec{


### PR DESCRIPTION
## Summary

Backfills the Go unit-test gaps surfaced by the MAG-1872 audit (which itself
unblocks MAG-1723's smaller integration tier). 9 tests landed, 3 items closed
without code per the ticket's explicit allowance.

## What landed

One commit per sub-group (bundled per the ticket's option B):

| Commit | Items | New tests |
|---|---|---|
| `test(metrics): …` | 7, 8, 9 | log-level filtering, text-vs-json format, GUID on normal-path |
| `test(rpcsmartrouter): YAML endpoint + backup-providers …` | 1, 10 | `ParseStaticProviderEndpoints` enabled/disabled YAML, `ParseEndpoints` --geolocation flag binding |
| `test(rpcsmartrouter): finalization boundary + cache-be skip-path` | 4, 5 | `isFinalizedForCacheWrite` boundary, `tryCacheWrite` short-circuit on `CacheActive()=false` |
| `test(lavasession): parametrize backup-provider count` | 12 | `TestBackupProviderOptimizerSelection_EndpointCountBoundaries` at 1 and 5 |
| `test(keeper): --use-static-spec misconfigured-path` | 11 | malformed JSON in file + dir, unreadable directory |

## Items closed without code

The ticket explicitly authorizes closing each of these; closing inline so the
reviewer doesn't have to re-open the audit:

- **Item 2 — RelayRetryLimit=1**: `policy_test.go` already covers `0` (disabled)
  and `2` (at/over boundary). The intermediate value `1` doesn't change
  coverage semantics. Closed as "boundary 2 is sufficient" per the ticket.
- **Item 3 — MinSelectionChance variants**: `weighted_selector_test.go`
  parametrizes `0.01 / 0.123 / 0.222 / 0.333 / 0.444` across five test
  functions, including `TestMinSelectionChanceIsAWeightFloorNotAProbabilityGuarantee`
  which explicitly documents the probability-floor semantics. The ticket's
  `0.05 / 0.1 / 0.2` are interior values redundant to the existing spread.
- **Item 6 — Cache TTL variants**: `ecosystem/cache/server.go` uses ristretto v2
  with no clock-injection seam. Unit-testing TTL eviction would require either
  real-time waits (slow + flaky) or upstream patches. Deferred to the
  ecosystem/cache integration tier (smoke + cache-metrics observation).

## Re-anchors from the audit

The audit was at commit `569e368`; HEAD is now several commits later, and a
few file pointers had drifted.

- **Items 1 + 10**: audit pointed at `protocol/lavasession/`; both
  `ParseStaticProviderEndpoints` and `ParseEndpoints` actually live in
  `protocol/rpcsmartrouter/`, so the test file lives there.
- **Items 4 + 5**: audit pointed at `protocol/cache/` which does not exist in
  this repo. The cache hooks (`tryCacheRead`, `tryCacheWrite`,
  `isFinalizedForCacheWrite`, `CacheActive`) live in
  `protocol/rpcsmartrouter/rpcsmartrouter_server.go`. New file:
  `cache_skip_paths_test.go`.

## Acceptance criteria status

- ✅ Each of the 9 implemented tests passes locally via `go test ./...`. The
  full repo `go test ./...` is clean.
- ⚠️ `go test -race ./...` surfaces flakes in **pre-existing** tests, not in
  any test added by this PR. The same failures reproduce on `origin/main`
  before these commits. Each new test in this PR is race-clean when run in
  isolation. Affected pre-existing tests:
  - `protocol/lavasession`: `TestPairingResetWithMultipleFailures`,
    `TestSessionFailureAndGetReportedProviders`,
    `TestAllProvidersEndpointsDisabled`, `TestPairingWithExtensions`,
    `TestPairingWithStateful`
  - `protocol/metrics`: `TestHappyFlow` (`relays_monitor_test.go` line 14
    reads `isHealthy` from a goroutine while line 39 writes it from the test
    goroutine — closure capture race, no synchronization)
  - `protocol/rpcsmartrouter`: `TestSmartRouterStateMachineCircuitBreakerOnPairingErrors`
    et al. (state-machine tests in `smartrouter_relay_state_machine_test.go`)

  Reproduction recipe for any one of them:
  ```
  git stash
  go test -race ./protocol/lavasession/ -run TestPairingResetWithMultipleFailures
  ```
- ✅ Each new test uses table-driven parametrization where the audit lists
  multiple variants.
- ✅ Test names reference the audit findings
  (e.g. `TestBackupProviderOptimizerSelection_EndpointCountBoundaries`).

## Test plan

- [ ] CI: `make test` green
- [ ] CI: `make lint` (golangci-lint) green
- [ ] Reviewer: confirm closed items 2/3/6 align with the ticket's explicit
      "close" allowances
- [ ] Reviewer: confirm re-anchored items 1/4/5/10 land in the right package
- [ ] Reviewer: confirm scope of pre-existing -race flakes is acceptable;
      tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)