### PR TITLE
fix(MAG-1866): JSON-RPC error response must be Object per spec, not stringified envelope

### DIFF
--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -257,6 +257,11 @@ func addHeadersAndSendBytes(c *fiber.Ctx, metaData []pairingtypes.Metadata, data
 // convertToJsonError returns a JSON-encoded `{"error": errorMsg}` body as raw bytes.
 // Returning []byte (rather than string) lets every error-path caller hand the
 // result straight to addHeadersAndSendBytes / fiber.Ctx.Send with no conversion.
+//
+// NOTE: This helper produces a non-spec error envelope (`error` is a string).
+// It is retained for non-JSON-RPC chain interfaces (REST, Tendermint GET) whose
+// clients do not expect JSON-RPC 2.0 §5.1 shape. For JSON-RPC interfaces use
+// convertToJsonRpcError below.
 func convertToJsonError(errorMsg string) []byte {
 	jsonResponse, err := json.Marshal(fiber.Map{
 		"error": errorMsg,
@@ -265,6 +270,93 @@ func convertToJsonError(errorMsg string) []byte {
 		return []byte(`{"error": "Failed to marshal error response to json"}`)
 	}
 
+	return jsonResponse
+}
+
+// convertToJsonRpcError returns a JSON-RPC 2.0 §5.1 compliant error envelope:
+//
+//	{"jsonrpc":"2.0", "id": <reqID>, "error": {"code": -32000, "message": "...", "data": {...}}}
+//
+// Spec-compliant clients (Web3.py, ethers.js, viem) require `error` to be an
+// Object with `code` (int) and `message` (string). Previously the JSON-RPC
+// error path used convertToJsonError, which set `error` to a stringified
+// envelope — clients crashed reading response.error.code on a string.
+//
+// rawErrorMsg: the JSON string previously produced by GetUniqueGuidResponseForError
+// (shape: {"Error_GUID":"<guid>","Error":"<inner message>"}). We parse it to
+// extract the GUID and the inner error message; the inner message becomes the
+// JSON-RPC `message`, and full context lands under `data` for debugging.
+//
+// requestBody: the raw incoming JSON-RPC request body. We extract `id` from it
+// so the response preserves request correlation. If parsing fails, id is null
+// (still spec-valid).
+//
+// Code -32000 is from JSON-RPC 2.0 §5.1 implementation-defined server-error
+// range (-32000 to -32099). It is the appropriate code for router-synthesized
+// errors that are not parse/method/invalid-params/internal — e.g. "Selected
+// provider not available", retry exhaustion, consistency pre-validation, etc.
+func convertToJsonRpcError(rawErrorMsg string, requestBody []byte) []byte {
+	// Extract id from the original request so the client can correlate.
+	// Fall back to JSON null if the body is malformed or id is absent —
+	// spec-compliant for notifications and unparseable requests.
+	var reqID json.RawMessage
+	if len(requestBody) > 0 {
+		var probe struct {
+			ID json.RawMessage `json:"id"`
+		}
+		if err := json.Unmarshal(requestBody, &probe); err == nil && len(probe.ID) > 0 {
+			reqID = probe.ID
+		}
+	}
+	if len(reqID) == 0 {
+		reqID = json.RawMessage("null")
+	}
+
+	// Parse the stringified envelope produced by GetUniqueGuidResponseForError.
+	// Shape: {"Error_GUID":"<guid>","Error":"<inner-error-message>"}.
+	// Fall back to the raw string if parsing fails — we still produce a valid
+	// JSON-RPC error envelope.
+	var parsed struct {
+		ErrorGUID string `json:"Error_GUID"`
+		Error     string `json:"Error"`
+	}
+	guid := ""
+	message := rawErrorMsg
+	if err := json.Unmarshal([]byte(rawErrorMsg), &parsed); err == nil {
+		guid = parsed.ErrorGUID
+		if parsed.Error != "" {
+			message = parsed.Error
+		}
+	}
+	if message == "" {
+		message = "Internal server error"
+	}
+
+	data := map[string]any{}
+	if guid != "" {
+		data["guid"] = guid
+	}
+	// The inner error message from LavaFormatError already embeds provider
+	// context (selectedProvider, validProviders, addon, extensions, GUID) in
+	// its appended attribute block. Surface it under data.error so the full
+	// context is preserved for debugging without brittle substring parsing.
+	data["error"] = message
+
+	envelope := fiber.Map{
+		"jsonrpc": "2.0",
+		"id":      reqID,
+		"error": fiber.Map{
+			"code":    -32000,
+			"message": message,
+			"data":    data,
+		},
+	}
+
+	jsonResponse, err := json.Marshal(envelope)
+	if err != nil {
+		// Last-resort fallback — still spec-compliant.
+		return []byte(`{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"Failed to marshal error response"}}`)
+	}
 	return jsonResponse
 }
 

--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -326,6 +326,13 @@ func convertToJsonRpcError(rawErrorMsg string, requestBody []byte) []byte {
 		guid = parsed.ErrorGUID
 		if parsed.Error != "" {
 			message = parsed.Error
+		} else if guid != "" {
+			// GetUniqueGuidResponseForError elides the Error field via ,omitempty
+			// when ReturnMaskedErrors == "true". In that mode rawErrorMsg is just
+			// `{"Error_GUID":"<guid>"}` — surfacing it as the JSON-RPC message
+			// would leak a raw JSON envelope into error.message, which is the
+			// exact failure shape this helper was added to avoid.
+			message = "Internal server error"
 		}
 	}
 	if message == "" {

--- a/protocol/chainlib/common_test.go
+++ b/protocol/chainlib/common_test.go
@@ -211,6 +211,46 @@ func TestConvertToJsonRpcError_FallbackOnUnparseable(t *testing.T) {
 	}
 }
 
+// TestConvertToJsonRpcError_MaskedModeOmitsErrorField covers the
+// ReturnMaskedErrors=true path where GetUniqueGuidResponseForError elides
+// the Error field via ,omitempty. Without the masked-mode branch in the
+// helper, error.message would surface the raw `{"Error_GUID":"..."}`
+// envelope — defeating the spec-compliance goal one layer in.
+func TestConvertToJsonRpcError_MaskedModeOmitsErrorField(t *testing.T) {
+	t.Parallel()
+
+	// Masked-mode envelope: Error_GUID only, Error elided by ,omitempty.
+	rawErrMsg := `{"Error_GUID":"3789588031954078542"}`
+	reqBody := []byte(`{"jsonrpc":"2.0","id":42,"method":"engine_getPayloadV3","params":[]}`)
+
+	result := convertToJsonRpcError(rawErrMsg, reqBody)
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v. Result: %s", err, result)
+	}
+
+	errObj, ok := parsed["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("error must be an Object, got %T", parsed["error"])
+	}
+	msg, _ := errObj["message"].(string)
+	if msg == "" {
+		t.Errorf("error.message must be non-empty")
+	}
+	if strings.Contains(msg, "Error_GUID") || strings.Contains(msg, "{") {
+		t.Errorf("error.message must not leak the raw JSON envelope under masking; got %q", msg)
+	}
+	// data.guid is still useful debugging info even when message is generic.
+	data, ok := errObj["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("error.data must be an Object, got %T", errObj["data"])
+	}
+	if g, _ := data["guid"].(string); g != "3789588031954078542" {
+		t.Errorf("expected data.guid to be preserved under masking, got %v", data["guid"])
+	}
+}
+
 func TestAddAttributeToError(t *testing.T) {
 	t.Parallel()
 

--- a/protocol/chainlib/common_test.go
+++ b/protocol/chainlib/common_test.go
@@ -137,6 +137,80 @@ func TestConvertToJsonError(t *testing.T) {
 	}
 }
 
+// TestConvertToJsonRpcError verifies the spec-compliant JSON-RPC 2.0 error
+// envelope: `error` is an Object with code/message, not a stringified envelope.
+// Regression coverage for MAG-1866.
+func TestConvertToJsonRpcError(t *testing.T) {
+	t.Parallel()
+
+	rawErrMsg := `{"Error_GUID":"3789588031954078542","Error":"Selected provider not available {selectedProvider:quicknode1,validProviders:google1,GUID:3789588031954078542}"}`
+	reqBody := []byte(`{"jsonrpc":"2.0","id":42,"method":"engine_getPayloadV3","params":[]}`)
+
+	result := convertToJsonRpcError(rawErrMsg, reqBody)
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v. Result: %s", err, result)
+	}
+
+	if v, _ := parsed["jsonrpc"].(string); v != "2.0" {
+		t.Errorf("expected jsonrpc=\"2.0\", got %v", parsed["jsonrpc"])
+	}
+	// id must round-trip the request id as a JSON number.
+	if v, _ := parsed["id"].(float64); v != 42 {
+		t.Errorf("expected id=42, got %v (%T)", parsed["id"], parsed["id"])
+	}
+
+	errObj, ok := parsed["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("error must be an Object per JSON-RPC 2.0 §5.1, got %T: %v", parsed["error"], parsed["error"])
+	}
+	if code, _ := errObj["code"].(float64); int(code) != -32000 {
+		t.Errorf("expected error.code=-32000, got %v", errObj["code"])
+	}
+	msg, _ := errObj["message"].(string)
+	if msg == "" {
+		t.Errorf("error.message must be a non-empty string, got %v", errObj["message"])
+	}
+	if !strings.Contains(msg, "Selected provider not available") {
+		t.Errorf("error.message should preserve inner error context, got %q", msg)
+	}
+	data, ok := errObj["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("error.data must be an Object, got %T", errObj["data"])
+	}
+	if g, _ := data["guid"].(string); g != "3789588031954078542" {
+		t.Errorf("expected data.guid to be preserved, got %v", data["guid"])
+	}
+}
+
+// TestConvertToJsonRpcError_FallbackOnUnparseable verifies that when the raw
+// error message is not the expected GetUniqueGuidResponseForError shape, the
+// envelope still passes JSON-RPC 2.0 validation.
+func TestConvertToJsonRpcError_FallbackOnUnparseable(t *testing.T) {
+	t.Parallel()
+
+	result := convertToJsonRpcError("plain text error, not JSON", []byte(`{}`))
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	errObj, ok := parsed["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("error must be an Object, got %T", parsed["error"])
+	}
+	if int(errObj["code"].(float64)) != -32000 {
+		t.Errorf("expected error.code=-32000, got %v", errObj["code"])
+	}
+	if msg, _ := errObj["message"].(string); msg != "plain text error, not JSON" {
+		t.Errorf("expected raw message to pass through, got %q", msg)
+	}
+	// id absent in request body → null in response (still spec-valid).
+	if v, exists := parsed["id"]; !exists || v != nil {
+		t.Errorf("expected id=null when request has no id, got %v", v)
+	}
+}
+
 func TestAddAttributeToError(t *testing.T) {
 	t.Parallel()
 

--- a/protocol/chainlib/jsonRPC.go
+++ b/protocol/chainlib/jsonRPC.go
@@ -516,8 +516,10 @@ func (apil *JsonRPCChainListener) Serve(ctx context.Context, cmdFlags common.Con
 				fiberCtx.Status(fiber.StatusInternalServerError)
 			}
 
-			// Construct json response
-			response := convertToJsonError(errMasking)
+			// Construct spec-compliant JSON-RPC 2.0 error envelope (see
+			// convertToJsonRpcError for the rationale — `error` must be an
+			// Object with code/message per §5.1, not a stringified envelope).
+			response := convertToJsonRpcError(errMasking, fiberCtx.Body())
 			// Return error json response
 			return addHeadersAndSendBytes(fiberCtx, reply.GetMetadata(), response)
 		}


### PR DESCRIPTION
## Why

When `lava-select-provider` pins to a provider that's not in the valid-providers list, the router currently returns `error` as a **string** (containing a serialized JSON envelope). JSON-RPC 2.0 §5.1 requires `error` to be an Object with `code` + `message` keys. Spec-compliant clients (Web3.py, ethers.js, viem) crash trying to read `response.error.code` because there's no `.code` attribute on a string.

## What changed

A new helper `convertToJsonRpcError` in `protocol/chainlib/common.go` builds a proper `{jsonrpc, id, error: {code, message, data}}` envelope:

- `code: -32000` (JSON-RPC 2.0 implementation-defined server-error range, §5.1)
- `message`: the inner human-readable error string (e.g. "Selected provider not available {selectedProvider:..., validProviders:..., GUID:...}")
- `data.guid`: the request GUID extracted from the existing stringified envelope
- `data.error`: the full inner error message (preserves provider context for debugging)
- `id`: extracted from the incoming request body so the client can correlate; falls back to JSON `null` for unparseable requests (spec-valid)

Only the JSON-RPC POST error path in `jsonRPC.go` switches to the new helper. The pre-existing `convertToJsonError` and its other callers (REST POST/GET, Tendermint GET) are untouched — those interfaces have different client expectations and changing the shared helper in-place would break them.

`GetUniqueGuidResponseForError` in `protocol/metrics/rpcconsumer_logs.go` is also untouched. The new helper parses its existing JSON-string output rather than forcing a signature change on a metrics-package helper used elsewhere.

## Test plan

- [x] `go test ./protocol/chainlib/... ./protocol/rpcsmartrouter/... ./protocol/metrics/... -count=1` — all pass.
- [x] `go vet ./...` — clean.
- [x] `make lint` — clean (lint target is `go vet`).
- [x] Two new unit tests added (`TestConvertToJsonRpcError`, `TestConvertToJsonRpcError_FallbackOnUnparseable`) covering happy path and parser-fallback.
- [ ] After merge: deploy via `sync_binary.sh` to victoria cluster, then run `pytest tests/product/router_behavior/test_unsupported_method_force_quicknode_retry.py::test_unsupported_method_force_quicknode_yields_retry` — `isinstance(response.error, dict)` should now pass.

## Backward compatibility

Any client expecting `error` to be a string was itself spec-violating; the fix forward is correct. No callers within smart-router treat `error` as a string. REST and Tendermint chains are unaffected — they keep `convertToJsonError`.

Closes MAG-1866.