### PR TITLE
fix: [MAG-1891] silence cobra --help dump on fatal startup error (noisy logs)

### DIFF
--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -1512,6 +1512,11 @@ func CreateRPCSmartRouterCobraCommand() *cobra.Command {
 	cmdRPCSmartRouter := &cobra.Command{
 		Use:   "rpcsmartrouter [config-file] | { {listen-ip:listen-port spec-chain-id api-interface} ... }",
 		Short: `rpcsmartrouter sets up a centralized server with static providers to perform api requests`,
+		// On startup failure (e.g. all static providers failed verification)
+		// cobra otherwise dumps the full --help text after the error line,
+		// swamping kubectl logs in a CrashLoopBackOff. Operators need to see
+		// the error, not the flag catalogue.
+		SilenceUsage: true,
 		Long: `rpcsmartrouter sets up a centralized server with static and backup providers to perform api requests through the lava protocol.
 		This is the smart router mode that uses pre-configured static providers instead of dynamically discovering providers on-chain.
 		all configs should be located in the local running directory /config or ` + lavaDefaultNodeHome + `

--- a/protocol/rpcsmartrouter/rpcsmartrouter_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_test.go
@@ -1,7 +1,9 @@
 package rpcsmartrouter
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -12,6 +14,7 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
 	"github.com/magma-Devs/smart-router/utils/rand"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -774,4 +777,60 @@ func TestGracefulFailure_EpochBeforeRetry_OnlyHealthyProviders(t *testing.T) {
 	// Verify: failed list unchanged
 	require.Len(t, rpsr.failedStaticProviders[chainKey], 1)
 	require.Equal(t, "providerB", rpsr.failedStaticProviders[chainKey][0].Name)
+}
+
+// When the smart-router exits with a startup error, cobra's default behaviour
+// is to dump the full --help text (Usage:, Flags:, Available Commands:,
+// Examples:) after the error line. In CrashLoopBackOff the help text swamps
+// `kubectl logs` and the real error scrolls off the top.
+//
+// The contract: cobra's error path on the smart-router root command must not
+// emit usage text. SilenceUsage is set on the command construction site.
+func TestRPCSmartRouterCobraCommand_StartupErrorDoesNotDumpUsage(t *testing.T) {
+	cmd := CreateRPCSmartRouterCobraCommand()
+
+	// Replace RunE so we exercise the error-output path without starting the
+	// server. The synthetic error stands in for any real fatal startup failure
+	// (static-provider verification, config parse, missing dependency, etc.).
+	cmd.RunE = func(_ *cobra.Command, _ []string) error {
+		return errors.New("synthetic startup failure")
+	}
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	// Pass the required --geolocation so cobra reaches RunE rather than failing
+	// on required-flag enforcement (which has its own usage-dump path).
+	cmd.SetArgs([]string{"--geolocation", "1"})
+
+	require.Error(t, cmd.Execute(), "expected Execute() to return synthetic error")
+
+	out := buf.String()
+	for _, forbidden := range []string{
+		"Usage:",
+		"Available Commands:",
+		"Examples:",
+		"Flags:",
+	} {
+		require.NotContains(t, out, forbidden,
+			"startup-error output leaked %q — SilenceUsage must be set on the root command", forbidden)
+	}
+}
+
+// Legitimate --help invocations must still render the full usage text;
+// SilenceUsage only suppresses the dump on error, not on explicit help.
+func TestRPCSmartRouterCobraCommand_HelpStillRenders(t *testing.T) {
+	cmd := CreateRPCSmartRouterCobraCommand()
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--help"})
+
+	require.NoError(t, cmd.Execute(), "--help should not return an error")
+
+	out := buf.String()
+	for _, want := range []string{"Usage:", "Flags:"} {
+		require.Contains(t, out, want, "--help output missing %q", want)
+	}
 }


### PR DESCRIPTION
## Summary

On fatal startup error (e.g. "all static providers failed verification"), cobra was dumping the full `--help` text after the error line, swamping `kubectl logs` in a CrashLoopBackOff and burying the real failure.

Set `SilenceUsage: true` on the root cobra command at the construction site (`CreateRPCSmartRouterCobraCommand`). `SilenceErrors` is left at default so cobra still prints the authoritative `Error: <msg>` line.

**Scope:** this only affects startup paths that `return` an error from `RunE` (e.g. invalid endpoints, missing `direct-rpc` config, the "all static providers failed verification" trigger). Other paths in the same `RunE` use `utils.LavaFormatFatal` (config load failure, missing `--geolocation` value, log-level / test-mode / pprof / pyroscope flag parse) and `os.Exit(1)` before cobra's error handler runs — those were never dumping the usage block anyway, and they still emit a structured log without the cobra `Error:` line. Converting those to `return utils.LavaFormatError(...)` for parity is a separate change.

## Changes

- `protocol/rpcsmartrouter/rpcsmartrouter.go` — `SilenceUsage: true` on the root command (one line + comment explaining the operator-visibility motivation).
- `protocol/rpcsmartrouter/rpcsmartrouter_test.go` — regression tests:
  - startup error → no `Usage:` / `Available Commands:` / `Examples:` / `Flags:` in output;
  - `--help` still renders the full usage text.

## Test plan

- [ ] `go test ./protocol/rpcsmartrouter/ -run TestRPCSmartRouterCobraCommand -v` — both new tests pass.
- [ ] `go build ./cmd/smartrouter/` — binary still builds.
- [ ] Manual: invoke `smartrouter` with no `--geolocation` (or a deliberately broken config) and confirm only the structured error log + `Error: <msg>` appear — no `Usage:` block.
- [ ] Manual: `smartrouter --help` still prints the full flag catalogue.

Origin: Sebastian's MAG-1879 sim-crashloop investigation on 2026-05-17.