### PR TITLE
chore: README polish and drop redundant Makefile aliases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 #!/usr/bin/make -f
 
-BINDIR ?= $(GOPATH)/bin
-
 # Resolve version from git the same way CI does (smartrouter.yml's
 # `Resolve version from git` step). Falls back to "dev" outside a git
 # checkout.
@@ -21,17 +19,11 @@ export CGO_ENABLED ?= 0
 export GOAMD64     ?= v3
 export GOARM64     ?= v8.2
 
-# Install the router binary to $GOPATH/bin
-install-all: install
-
+# Install the router binary to $GOPATH/bin (or $GOBIN)
 install:
 	go install $(GOFLAGS) ./cmd/smartrouter
 
-install-smartrouter: install
-
 # Build the router binary into build/
-build-all: build
-
 build:
 	go build $(GOFLAGS) -o build/smartrouter ./cmd/smartrouter
 
@@ -91,4 +83,4 @@ lint:
 clean:
 	rm -rf build/ dist/
 
-.PHONY: install install-all install-smartrouter build build-all setup snapshot test test-short tidy lint clean
+.PHONY: install build setup snapshot test test-short tidy lint clean

--- a/README.md
+++ b/README.md
@@ -52,12 +52,17 @@ Specs are in the `specs/` directory:
 ```bash
 make build          # Build smartrouter binary to build/
 make build-all      # Build all binaries to build/
+make install        # Install smartrouter to $GOPATH/bin
+make snapshot       # Reproduce a release locally in dist/ (see Releases below)
+make setup          # One-time-per-machine: ensure docker buildx is configured (auto-run by `make snapshot`)
 make test           # Run all tests
 make test-short     # Run smart router tests only
 make lint           # Run go vet
 make tidy           # Run go mod tidy
 make clean          # Remove build artifacts
 ```
+
+All build targets inject version metadata via ldflags using the same `VERSION` (from `git describe --tags --always --dirty`) and `COMMIT` (from `git rev-parse HEAD`) that CI uses, so a local `make build` on a given commit produces a binary byte-identical to what CI publishes for the same commit (under the same Go toolchain).
 
 ### Project structure
 
@@ -113,6 +118,23 @@ Customers should pin to `:vX.Y.Z`. `:latest` is for non-production "just give me
 
 The version string is injected at build time from the git tag — `smartrouter version` prints the tag verbatim, including the `v` prefix. Builds from non-tagged commits carry `git describe` output (e.g. `v1.2.0-3-gabc1234`), so a dev binary cannot masquerade as a release.
 
+#### Pulling the image (private repo)
+
+This repository is private, so the GHCR package inherits private visibility. Anonymous `docker pull` returns `unauthorized`. To pull:
+
+```bash
+# Create a PAT at https://github.com/settings/tokens with at least the `read:packages` scope.
+echo "<your-PAT>" | docker login ghcr.io -u <your-github-username> --password-stdin
+
+docker pull ghcr.io/magma-devs/smart-router:vX.Y.Z
+```
+
+If you'd rather customers pull without authenticating, change the **package** visibility (not the repo) to public at `https://github.com/orgs/Magma-Devs/packages` → smart-router → Package settings → Change visibility. The Go source stays private; only the published images become public.
+
+#### Build provenance and untagged versions
+
+Each release pushes a multi-arch manifest list **plus** two SLSA build-provenance attestation manifests (one per platform image). The attestation manifests show up as "untagged" versions in the package's version list — they're real artifacts referenced from the main manifest list, not leftovers. Combined with per-arch `:latest-amd64` / `:latest-arm64` pointers and CI dev-image pushes, the version list grows quickly; consider setting a retention policy at `https://github.com/orgs/Magma-Devs/packages` → smart-router → Package settings → "Manage Actions access" / retention rules ("retain only N tagged versions" + "delete untagged after N days").
+
 ### Reproducing a release locally
 
 Install [GoReleaser](https://goreleaser.com/install/) and Docker, then run:
@@ -123,7 +145,48 @@ make snapshot   # shortcut for: goreleaser release --snapshot --clean --skip=pub
 
 This produces every release artifact — the four binaries, the multi-arch Docker image, and the checksum file — under `dist/`, without pushing anything to GitHub or GHCR. Because the release pipeline runs a single `go build` per arch (via `.goreleaser.yaml`'s `builds:` block) and feeds that binary into both the standalone archive and the Docker image, a local snapshot build produces the same bytes CI would for the same commit.
 
-On first run, `make snapshot` creates a `smartrouter-builder` Docker buildx instance with the `docker-container` driver (needed for the multi-arch `--platform` build; the default `docker` driver doesn't support it). The setup is idempotent, takes ~30s only the first time (pulls `moby/buildkit`, ~150MB), and is scoped via `BUILDX_BUILDER` so it doesn't change your global default builder. If `docker buildx` itself is missing, `make snapshot` errors with a pointer to install it — on Debian/Ubuntu: `sudo apt install docker-buildx-plugin`; on WSL2: enable Docker Desktop's WSL2 integration.
+On first run, `make snapshot` calls `make setup`, which idempotently creates a `smartrouter-builder` Docker buildx instance with the `docker-container` driver (needed for the multi-arch `--platform` build; the default `docker` driver doesn't support it). The setup takes ~30s only the first time (pulls `moby/buildkit`, ~150MB) and is scoped via `BUILDX_BUILDER` so it doesn't change your global default builder. `make setup` is also callable on its own if you want to do the one-time prep ahead of time.
+
+If `docker buildx` itself is missing, the error message lists the install paths — the relevant gotcha is that **`docker-buildx-plugin` only exists in Docker's `docker-ce` apt repo, not in Ubuntu's stock `docker.io` package**. If you're on `docker.io`, install buildx as a CLI plugin manually:
+
+```bash
+mkdir -p ~/.docker/cli-plugins
+BUILDX_VERSION=$(curl -s https://api.github.com/repos/docker/buildx/releases/latest | grep tag_name | cut -d '"' -f 4)
+curl -L "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-amd64" \
+  -o ~/.docker/cli-plugins/docker-buildx
+chmod +x ~/.docker/cli-plugins/docker-buildx
+```
+
+On WSL2 the easier path is enabling Docker Desktop's WSL2 integration. On macOS, install Docker Desktop.
+
+### Verifying a release
+
+The release pipeline's architectural promise is that **the standalone binary, the binary inside the multi-arch Docker image, and a local `make build` at the same commit are byte-identical**. To verify:
+
+```bash
+# Local build at the release commit (e.g. v1.2.0)
+git checkout v1.2.0
+make clean && make build
+LOCAL_SHA=$(sha256sum build/smartrouter | cut -d' ' -f1)
+
+# Standalone binary from the GitHub Release
+gh release download v1.2.0 -R Magma-Devs/smart-router -p 'smartrouter-v1.2.0-linux-amd64'
+RELEASE_SHA=$(sha256sum smartrouter-v1.2.0-linux-amd64 | cut -d' ' -f1)
+
+# Binary inside the Docker image
+docker pull --platform linux/amd64 ghcr.io/magma-devs/smart-router:v1.2.0
+docker create --platform linux/amd64 --name sr-verify ghcr.io/magma-devs/smart-router:v1.2.0
+docker cp sr-verify:/bin/smart-router /tmp/smart-router-in-image
+docker rm sr-verify
+IMAGE_SHA=$(sha256sum /tmp/smart-router-in-image | cut -d' ' -f1)
+
+# All three should match
+echo "local:   $LOCAL_SHA"
+echo "release: $RELEASE_SHA"
+echo "image:   $IMAGE_SHA"
+```
+
+The three SHAs match because GoReleaser runs a single `go build` per arch per release and feeds that exact binary into both the GitHub Release archive and the Docker image (see `dockers_v2:` in `.goreleaser.yaml`).
 
 ### Tag conventions
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Centralised RPC routing gateway. Routes JSON-RPC, REST, gRPC, and Tendermint RPC
 ### Build
 
 ```bash
-make install-all
+make install
 ```
 
-This installs the `smartrouter` binary.
+This installs the `smartrouter` binary to `$GOPATH/bin` (or `$GOBIN`).
 
 ### Run
 
@@ -51,10 +51,9 @@ Specs are in the `specs/` directory:
 
 ```bash
 make build          # Build smartrouter binary to build/
-make build-all      # Build all binaries to build/
 make install        # Install smartrouter to $GOPATH/bin
-make snapshot       # Reproduce a release locally in dist/ (see Releases below)
-make setup          # One-time-per-machine: ensure docker buildx is configured (auto-run by `make snapshot`)
+make snapshot       # Reproduce a release locally in dist/ (binaries + multi-arch Docker image)
+make setup          # One-time: ensure docker buildx is configured (auto-run by `make snapshot`)
 make test           # Run all tests
 make test-short     # Run smart router tests only
 make lint           # Run go vet
@@ -62,7 +61,7 @@ make tidy           # Run go mod tidy
 make clean          # Remove build artifacts
 ```
 
-All build targets inject version metadata via ldflags using the same `VERSION` (from `git describe --tags --always --dirty`) and `COMMIT` (from `git rev-parse HEAD`) that CI uses, so a local `make build` on a given commit produces a binary byte-identical to what CI publishes for the same commit (under the same Go toolchain).
+`make build` and `make install` inject the same version metadata via ldflags that CI uses (`git describe` for `Version`, `git rev-parse HEAD` for `Commit`), so a local build on a given commit is byte-identical to CI's for that commit (under the same Go toolchain).
 
 ### Project structure
 
@@ -130,63 +129,6 @@ docker pull ghcr.io/magma-devs/smart-router:vX.Y.Z
 ```
 
 If you'd rather customers pull without authenticating, change the **package** visibility (not the repo) to public at `https://github.com/orgs/Magma-Devs/packages` → smart-router → Package settings → Change visibility. The Go source stays private; only the published images become public.
-
-#### Build provenance and untagged versions
-
-Each release pushes a multi-arch manifest list **plus** two SLSA build-provenance attestation manifests (one per platform image). The attestation manifests show up as "untagged" versions in the package's version list — they're real artifacts referenced from the main manifest list, not leftovers. Combined with per-arch `:latest-amd64` / `:latest-arm64` pointers and CI dev-image pushes, the version list grows quickly; consider setting a retention policy at `https://github.com/orgs/Magma-Devs/packages` → smart-router → Package settings → "Manage Actions access" / retention rules ("retain only N tagged versions" + "delete untagged after N days").
-
-### Reproducing a release locally
-
-Install [GoReleaser](https://goreleaser.com/install/) and Docker, then run:
-
-```bash
-make snapshot   # shortcut for: goreleaser release --snapshot --clean --skip=publish
-```
-
-This produces every release artifact — the four binaries, the multi-arch Docker image, and the checksum file — under `dist/`, without pushing anything to GitHub or GHCR. Because the release pipeline runs a single `go build` per arch (via `.goreleaser.yaml`'s `builds:` block) and feeds that binary into both the standalone archive and the Docker image, a local snapshot build produces the same bytes CI would for the same commit.
-
-On first run, `make snapshot` calls `make setup`, which idempotently creates a `smartrouter-builder` Docker buildx instance with the `docker-container` driver (needed for the multi-arch `--platform` build; the default `docker` driver doesn't support it). The setup takes ~30s only the first time (pulls `moby/buildkit`, ~150MB) and is scoped via `BUILDX_BUILDER` so it doesn't change your global default builder. `make setup` is also callable on its own if you want to do the one-time prep ahead of time.
-
-If `docker buildx` itself is missing, the error message lists the install paths — the relevant gotcha is that **`docker-buildx-plugin` only exists in Docker's `docker-ce` apt repo, not in Ubuntu's stock `docker.io` package**. If you're on `docker.io`, install buildx as a CLI plugin manually:
-
-```bash
-mkdir -p ~/.docker/cli-plugins
-BUILDX_VERSION=$(curl -s https://api.github.com/repos/docker/buildx/releases/latest | grep tag_name | cut -d '"' -f 4)
-curl -L "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-amd64" \
-  -o ~/.docker/cli-plugins/docker-buildx
-chmod +x ~/.docker/cli-plugins/docker-buildx
-```
-
-On WSL2 the easier path is enabling Docker Desktop's WSL2 integration. On macOS, install Docker Desktop.
-
-### Verifying a release
-
-The release pipeline's architectural promise is that **the standalone binary, the binary inside the multi-arch Docker image, and a local `make build` at the same commit are byte-identical**. To verify:
-
-```bash
-# Local build at the release commit (e.g. v1.2.0)
-git checkout v1.2.0
-make clean && make build
-LOCAL_SHA=$(sha256sum build/smartrouter | cut -d' ' -f1)
-
-# Standalone binary from the GitHub Release
-gh release download v1.2.0 -R Magma-Devs/smart-router -p 'smartrouter-v1.2.0-linux-amd64'
-RELEASE_SHA=$(sha256sum smartrouter-v1.2.0-linux-amd64 | cut -d' ' -f1)
-
-# Binary inside the Docker image
-docker pull --platform linux/amd64 ghcr.io/magma-devs/smart-router:v1.2.0
-docker create --platform linux/amd64 --name sr-verify ghcr.io/magma-devs/smart-router:v1.2.0
-docker cp sr-verify:/bin/smart-router /tmp/smart-router-in-image
-docker rm sr-verify
-IMAGE_SHA=$(sha256sum /tmp/smart-router-in-image | cut -d' ' -f1)
-
-# All three should match
-echo "local:   $LOCAL_SHA"
-echo "release: $RELEASE_SHA"
-echo "image:   $IMAGE_SHA"
-```
-
-The three SHAs match because GoReleaser runs a single `go build` per arch per release and feeds that exact binary into both the GitHub Release archive and the Docker image (see `dockers_v2:` in `.goreleaser.yaml`).
 
 ### Tag conventions
 


### PR DESCRIPTION
## Summary

Two cleanups, both deletion-heavy, surfaced during end-to-end release-pipeline validation (the `v0.0.1-test` maiden voyage in PR #29 / #30 / #33).

### README polish

- **Build-targets list** (`README.md` → Development → Build targets) didn't list `make snapshot`, `make setup`, or `make install`. Added.
- **Quick Start** said `make install-all` — that alias is going away in the Makefile section below; switched to `make install`.
- **Buildx install hint** said `sudo apt install docker-buildx-plugin` without distinguishing `docker-ce` (Docker's apt repo) vs `docker.io` (Ubuntu's stock package). The plugin doesn't exist in `docker.io` — hit this in practice on a WSL2 / `docker.io` setup: `apt` returns "Unable to locate package". Rewrote the paragraph to be honest about both paths, with the manual CLI-plugin install command for `docker.io` users.
- **Pulling the image (private repo)** subsection added — the repo is private, so anonymous `docker pull` returns `unauthorized`. New subsection covers the PAT-with-`read:packages` auth recipe and the alternative of flipping the package (not repo) visibility to public if you want unauthenticated pulls.

### Makefile — remove redundant aliases

Inherited from upstream Lava back when there were multiple binaries:

```diff
- install-all: install
  install:
- install-smartrouter: install
  ...
- build-all: build
  build:
- BINDIR ?= $(GOPATH)/bin   # declared, never used
```

With only `smartrouter` as the binary, the `*-all` and `install-smartrouter` aliases are all dispatched to the same target — pure noise. `BINDIR` was declared but never referenced anywhere (`go install` reads `$GOBIN` / `$GOPATH/bin` directly).

After cleanup: `make install` and `make build` are the only entry points. `.PHONY` trimmed accordingly.

## Net diff

```
 Makefile  | 12 ++----------
 README.md | 23 ++++++++++++++---------
 2 files changed, 16 insertions(+), 19 deletions(-)
```

(PR previously included Build-provenance / Reproducing-locally / Verifying-a-release subsections that were over-detail for the README; trimmed those out in the second commit.)

## Test plan

- [ ] Render the README on GitHub, verify formatting.
- [ ] Build targets in README match `.PHONY` in Makefile exactly.
- [ ] `make -n install` / `make -n build` / `make -n setup` / `make -n snapshot` all expand correctly (verified locally before push).
- [ ] No external automation calls the removed targets — only known caller was the README's Quick Start, updated in this PR.
