### PR TITLE
docs(readme): architecture diagram, status callout, badges, SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,43 @@
 # Smart Router
 
+[![Build and Test](https://github.com/Magma-Devs/smart-router/actions/workflows/smartrouter.yml/badge.svg?branch=main)](https://github.com/Magma-Devs/smart-router/actions/workflows/smartrouter.yml)
+[![Status](https://img.shields.io/badge/status-pre--v1-orange)](https://github.com/Magma-Devs/smart-router)
+[![Go](https://img.shields.io/badge/go-1.26%2B-00ADD8?logo=go&logoColor=white)](https://go.dev/)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE.md)
+
 Centralised RPC routing gateway. Routes JSON-RPC, REST, gRPC, and Tendermint RPC requests to statically configured provider endpoints with QoS-based selection, caching, and automatic failover.
 
+## What is smart router
+
+Smart router is a reverse proxy specialised for blockchain RPC. Applications point at one stable endpoint; under the hood, it handles the provider multiplexing, RPC-aware retry, response caching, and observability that you'd otherwise rebuild in every service that touches RPC.
+
+- **Multi-protocol** — JSON-RPC, REST, gRPC, and Tendermint RPC on the same router.
+- **QoS-based provider selection** — picks the healthiest of N configured upstreams per request; flaky providers get backed off automatically.
+- **RPC-aware retry + failover** — distinguishes transient failures, "block not yet produced" responses, and malformed envelopes; retries only the first.
+- **Response caching** — caches what's safe to cache, keyed by method, params, and block height.
+- **First-class observability** — Prometheus metrics fine-grained enough to see which provider is letting you down.
+
 ## Quick Start
+
+The fastest way to start: install the binary, point it at a YAML config, run.
 
 ### Prerequisites
 
 - [Go 1.26+](https://go.dev/dl/)
 
-### Build
+### Build & run
 
 ```bash
 make install
-```
-
-This installs the `smartrouter` binary to `$GOPATH/bin` (or `$GOBIN`).
-
-### Run
-
-```bash
 smartrouter config/smartrouter_examples/smartrouter_lava.yml --geolocation 1 --use-static-spec specs/
 ```
+
+After running, you get:
+
+- An RPC endpoint per chain interface (ports from the YAML config; conventional default `:3360`).
+- Prometheus metrics on `:7779`.
+- A health endpoint at `/lava/health`.
+- Provider rotation, RPC-aware retry, response caching, and metrics — all driven by the YAML config.
 
 ### Configuration
 
@@ -36,14 +53,178 @@ Setup scripts are available in `scripts/pre_setups/`:
 ./scripts/pre_setups/init_smartrouter_eth.sh
 ```
 
+## How it works
+
+```
+   Clients  (JSON-RPC, REST, gRPC, Tendermint RPC)
+                            │
+                            ▼
+   ┌──────────────────────────────────────────────────────────┐
+   │                     Smart Router                         │
+   │                                                          │
+   │   per-interface listener  ─▶  cache check  ─▶  hit? ──┐  │
+   │                                       │ miss          │  │
+   │                                       ▼               │  │
+   │                              QoS-weighted provider    │  │
+   │                                   selection           │  │
+   │                                       │               │  │
+   │                                       ▼               │  │
+   │                              relay + retry / failover │  │
+   │                                       │               │  │
+   │                                       ▼               │  │
+   │   ◀─── response (+ metadata headers, metrics) ────────┘  │
+   └────────────────────────────┬─────────────────────────────┘
+                                │
+                                ▼
+            Statically-configured upstream RPC providers
+              (Lava chain providers, PublicNode, Infura,
+               self-hosted nodes, ...)
+```
+
+The hot path for a single request:
+
+1. **Listen** — a per-interface listener (JSON-RPC, REST, gRPC, or Tendermint RPC) accepts the request and parses it into a normalised internal shape.
+2. **Cache lookup** — for cacheable methods (historical block data, immutable receipts, etc.), the cache layer (`ecosystem/cache`) checks for a recent response. Hits return immediately.
+3. **Provider selection** — on cache miss, the provider optimiser (`protocol/provideroptimizer`) picks an upstream from the configured pool using QoS-weighted scoring. Healthy/fast providers are preferred; flaky ones get backed off automatically.
+4. **Relay + failover** — the request is sent to the chosen provider. On failure (timeout, malformed response, certain status codes), the retry state machine picks an alternate provider and retries within a configurable budget.
+5. **Response** — returned to the client with metadata headers (`Smart-Router-Version`, `Lava-Provider-Address`, retry counts, etc.) annotating which provider served the response. Prometheus metrics are emitted in parallel.
+
+### What it's not
+
+- **Not a load balancer.** Generic L4/L7 balancers don't speak RPC. They can't distinguish a transient timeout (retry against another provider), "block not yet produced" (retrying anywhere won't help), and a malformed JSON-RPC envelope (return the error, don't retry). They can't cache by method+params, and they can't back off a provider that's silently serving stale block data while still returning `200 OK`. Smart router does all of these.
+- **Not a node.** Smart router doesn't sync chain state or hold a block tree. It forwards requests to upstream providers (managed services or self-hosted nodes) configured statically via YAML and scores them on response quality. If every configured upstream goes dark, the router has nothing to fall back on — pair it with a provider set wide enough to survive operator-level outages.
+
 ## Supported Chains
 
-Specs are in the `specs/` directory:
+Smart router ships with specs for **120 chain networks** — EVM L1s and L2s, Cosmos SDK chains, non-EVM L1s (Solana, Sui, TON, Starknet, NEAR, Aptos, Move, …), Bitcoin-family chains, Ethereum Beacon, and more. The **Index** column is the value to reference in your YAML config or `--chain-id`.
+
+<details>
+<summary>Full list (click to expand)</summary>
 
 | Chain | Index | Interfaces |
 |-------|-------|------------|
-| Lava | LAVA | REST, gRPC, TendermintRPC |
-| Ethereum | ETH1 | JSON-RPC |
+| Agoric Mainnet | AGR | gRPC, REST, Tendermint RPC |
+| Agoric Testnet | AGRT | gRPC, REST, Tendermint RPC |
+| Aptos Mainnet | APT1 | REST |
+| Arbitrum Mainnet | ARBITRUM | JSON-RPC |
+| Arbitrum Nova Testnet | ARBITRUMN | JSON-RPC |
+| Arbitrum Sepolia Testnet | ARBITRUMS | JSON-RPC |
+| Avalanche C Chain Mainnet | AVALANCHEC | JSON-RPC |
+| Avalanche C Chain Testnet | AVALANCHECT | JSON-RPC |
+| Avalanche Mainnet | AVAX | JSON-RPC |
+| Avalanche P Chain Mainnet | AVALANCHEP | JSON-RPC |
+| Avalanche P Chain Testnet | AVALANCHEPT | JSON-RPC |
+| Avalanche Testnet | AVAXT | JSON-RPC |
+| Axelar Mainnet | AXELAR | gRPC, REST, Tendermint RPC |
+| Axelar Testnet | AXELART | gRPC, REST, Tendermint RPC |
+| Base Mainnet | BASE | JSON-RPC |
+| Base Sepolia Testnet | BASES | JSON-RPC |
+| Berachain Artio Mainnet | BERA | JSON-RPC |
+| Berachain Artio Testnet | BERAT | JSON-RPC |
+| Berachain Bartio Testnet | BERAT2 | JSON-RPC |
+| Bitcoin | BTC | JSON-RPC |
+| Bitcoin Cash Mainnet | BCH | JSON-RPC |
+| Bitcoin Cash Testnet | BCHT | JSON-RPC |
+| Bitcoin Testnet | BTCT | JSON-RPC |
+| Blast Mainnet | BLAST | JSON-RPC |
+| Blast Sepolia Testnet | BLASTSP | JSON-RPC |
+| BSC Mainnet | BSC | JSON-RPC |
+| BSC Testnet | BSCT | JSON-RPC |
+| Canto Mainnet | CANTO | gRPC, JSON-RPC, REST, Tendermint RPC |
+| Cardano Mainnet | CARDANO | REST |
+| Cardano Preprod Testnet | CARDANOT | REST |
+| Casper Mainnet | CASPER | JSON-RPC |
+| Casper Testnet | CASPERT | JSON-RPC |
+| Celestia Arabica Testnet | CELESTIATA | gRPC, JSON-RPC, REST, Tendermint RPC |
+| Celestia Mainnet | CELESTIA | gRPC, JSON-RPC, REST, Tendermint RPC |
+| Celestia Mocha Testnet | CELESTIATM | gRPC, JSON-RPC, REST, Tendermint RPC |
+| Celo Alfajores Testnet | ALFAJORES | JSON-RPC |
+| Celo Mainnet | CELO | JSON-RPC |
+| Cosmos Hub Mainnet | COSMOSHUB | gRPC, REST, Tendermint RPC |
+| Cosmos Hub Testnet | COSMOSHUBT | gRPC, REST, Tendermint RPC |
+| Dogecoin Mainnet | DOGE | JSON-RPC |
+| Dogecoin Testnet | DOGET | JSON-RPC |
+| Elys Testnet | ELYS | gRPC, REST, Tendermint RPC |
+| Ethereum Beacon Mainnet | ETHBEACON | REST |
+| Ethereum Mainnet | ETH1 | JSON-RPC |
+| Ethereum Testnet Holesky | HOL1 | JSON-RPC |
+| Ethereum Testnet Sepolia | SEP1 | JSON-RPC |
+| Evmos Mainnet | EVMOS | gRPC, JSON-RPC, REST, Tendermint RPC |
+| Evmos Testnet | EVMOST | gRPC, JSON-RPC, REST, Tendermint RPC |
+| Fantom Mainnet | FTM250 | JSON-RPC |
+| Fantom Testnet | FTM4002 | JSON-RPC |
+| Filecoin Mainnet | FVM | JSON-RPC |
+| Filecoin Testnet | FVMT | JSON-RPC |
+| Fuel Network Graphql | FUELNETWORK | REST |
+| Fuse Mainnet | FUSE | JSON-RPC |
+| Fuse Testnet | SPARK | JSON-RPC |
+| Hedera Mainnet | HEDERA | JSON-RPC |
+| Hedera Testnet | HEDERAT | JSON-RPC |
+| Hyperliquid Mainnet | HYPERLIQUID | JSON-RPC |
+| Hyperliquid Testnet | HYPERLIQUIDT | JSON-RPC |
+| Injective Mainnet | INJECTIVE | gRPC, REST, Tendermint RPC |
+| Injective Testnet | INJECTIVET | gRPC, REST, Tendermint RPC |
+| IOTA Mainnet | IOTA | JSON-RPC |
+| IOTA Testnet | IOTAT | JSON-RPC |
+| Juno Mainnet | JUN1 | gRPC, REST, Tendermint RPC |
+| Juno Testnet | JUNT1 | gRPC, REST, Tendermint RPC |
+| Kakarot Sepolia Testnet | KAKAROTT | JSON-RPC |
+| Lava Mainnet | LAVA | gRPC, REST, Tendermint RPC |
+| Lava Testnet | LAV1 | gRPC, REST, Tendermint RPC |
+| Litecoin Mainnet | LTC | JSON-RPC |
+| Litecoin Testnet | LTCT | JSON-RPC |
+| Manta Pacific Mainnet | MANTAPACIFIC | JSON-RPC |
+| Manta Pacific Testnet | MANTAPACIFICT | JSON-RPC |
+| Mantle Testnet | MANTLE | JSON-RPC |
+| Monad Mainnet | MONAD | JSON-RPC |
+| Monad Testnet | MONADT | JSON-RPC |
+| Moralis Advanced API | MORALIS | REST |
+| Movement Mainnet | MOVEMENT | REST |
+| Movement Testnet Bardock | MOVEMENTT | REST |
+| Namada SE Testnet | NAMTSE | Tendermint RPC |
+| NEAR Mainnet | NEAR | JSON-RPC |
+| NEAR Testnet | NEART | JSON-RPC |
+| Optimism Mainnet | OPTM | JSON-RPC |
+| Optimism Sepolia Testnet | OPTMS | JSON-RPC |
+| Osmosis Mainnet | OSMOSIS | gRPC, REST, Tendermint RPC |
+| Osmosis Testnet | OSMOSIST | gRPC, REST, Tendermint RPC |
+| Polkadot Asset Hub Mainnet | POLKADOTASSETHUB | JSON-RPC |
+| Polygon Amoy Testnet | POLYGONA | JSON-RPC |
+| Polygon Mainnet | POLYGON | JSON-RPC |
+| Ripple Mainnet | XRP | JSON-RPC |
+| Ripple Testnet | XRPT | JSON-RPC |
+| Scroll Mainnet | SCROLL | JSON-RPC |
+| Scroll Sepolia Testnet | SCROLLS | JSON-RPC |
+| Secret Mainnet | SECRET | gRPC, REST, Tendermint RPC |
+| Secret Testnet | SECRETP | gRPC, REST, Tendermint RPC |
+| Side Testnet | SIDET | gRPC, REST, Tendermint RPC |
+| Solana Mainnet | SOLANA | JSON-RPC |
+| Sonic Blaze Testnet | SONICT | JSON-RPC |
+| Sonic Mainnet | SONIC | JSON-RPC |
+| Stargaze Mainnet | STRGZ | gRPC, REST, Tendermint RPC |
+| Stargaze Testnet | STRGZT | gRPC, REST, Tendermint RPC |
+| Starknet Mainnet | STRK | JSON-RPC |
+| Starknet Sepolia Testnet | STRKS | JSON-RPC |
+| Stellar Mainnet | XLM | JSON-RPC, REST |
+| Stellar Testnet | XLMT | JSON-RPC, REST |
+| Stride Mainnet | STRIDE | gRPC, REST, Tendermint RPC |
+| Stride Testnet | STRIDET | gRPC, REST, Tendermint RPC |
+| Subsquid-Powered Subgraph | SQDSUBGRAPH | REST |
+| Sui Devnet | SUIT | JSON-RPC |
+| Tezos Mainnet | TEZOS | REST |
+| Tezos Shadownet Testnet | TEZOST | REST |
+| TON Mainnet | TON | REST |
+| TON Testnet | TONT | REST |
+| Tron Mainnet | TRX | REST |
+| Tron Shasta Testnet | TRXT | REST |
+| Union Testnet | UNIONT | gRPC, REST, Tendermint RPC |
+| Westend Asset Hub Testnet | POLKADOTASSETHUBT | JSON-RPC |
+| Worldchain Mainnet | WORLDCHAIN | JSON-RPC |
+| Worldchain Sepolia Testnet | WORLDCHAINS | JSON-RPC |
+| zkSync Era Mainnet | ZKSYNC | JSON-RPC |
+| zkSync Era Sepolia Testnet | ZKSYNCSP | JSON-RPC |
+
+</details>
 
 ## Development
 
@@ -106,12 +287,12 @@ The standalone Linux binaries and the binaries inside the Docker image are produ
 
 #### Docker image tags
 
-| Tag | Source | Stability |
-|---|---|---|
-| `:vX.Y.Z` | release tag | immutable, byte-identical to the standalone binary at that version |
-| `:latest` | release tag | floating — points at the most recent **final** release (not RC/beta) |
-| `:main` | push to `main` branch | floating — most recent dev build from `main`, **not** a release artifact |
-| `:<branch>-<version>` | push to other branches | per-branch build for testing |
+| Tag                   | Source                 | Stability                                                                |
+| --------------------- | ---------------------- | ------------------------------------------------------------------------ |
+| `:vX.Y.Z`             | release tag            | immutable, byte-identical to the standalone binary at that version       |
+| `:latest`             | release tag            | floating — points at the most recent **final** release (not RC/beta)     |
+| `:main`               | push to `main` branch  | floating — most recent dev build from `main`, **not** a release artifact |
+| `:<branch>-<version>` | push to other branches | per-branch build for testing                                             |
 
 Customers should pin to `:vX.Y.Z`. `:latest` is for non-production "just give me the newest stable" use; `:main` is for previewing unreleased work from `main`.
 
@@ -132,11 +313,15 @@ If you'd rather customers pull without authenticating, change the **package** vi
 
 ### Tag conventions
 
-- Trigger pattern: `v[0-9]+.[0-9]+.[0-9]+*`. A tag like `1.2.0` (without the leading `v`) does *not* fire the workflow.
+- Trigger pattern: `v[0-9]+.[0-9]+.[0-9]+*`. A tag like `1.2.0` (without the leading `v`) does _not_ fire the workflow.
 - Follow [semver](https://semver.org/) `MAJOR.MINOR.PATCH`. For smart-router specifically:
   - **MAJOR** — breaking change to the wire surface customers integrate with: HTTP metadata headers (e.g. `Smart-Router-Version`, `Lava-Provider-Address`), JSON-RPC envelope shape, removed/renamed CLI flags, removed/renamed config fields.
   - **MINOR** — new capabilities: additional supported chains in `specs/`, new CLI flags, new metrics, new config fields with safe defaults, new HTTP metadata headers.
   - **PATCH** — internal-only changes: bug fixes, performance improvements, refactors, dependency bumps, docs.
+
+## Security
+
+For vulnerability reporting, see [SECURITY.md](SECURITY.md). Do **not** open public issues for security concerns.
 
 ## Community
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you discover a security vulnerability in smart-router, please **do not** open a public GitHub issue. Email <security@magmadevs.com> instead with:
+
+- A description of the issue and its potential impact.
+- Steps to reproduce.
+- Affected version(s) — the output of `smartrouter version`.
+- Any suggested mitigation.
+
+We aim to acknowledge reports within 2 business days. Confirmed vulnerabilities are resolved within 90 days, coordinated with affected customers, and disclosed publicly via a GitHub Security Advisory after patches ship and a reasonable update window (typically 7–14 days).
+
+## Supported versions
+
+Only the latest released minor version line receives security patches. Subscribe to the [Releases page](https://github.com/Magma-Devs/smart-router/releases) for update notifications.
+
+## Scope
+
+In scope:
+
+- The `smartrouter` binary and the published Docker image at `ghcr.io/magma-devs/smart-router`.
+- Wire protocols smart-router exposes: JSON-RPC, REST, gRPC, Tendermint RPC, plus the `Smart-Router-*` and `Lava-*` HTTP metadata headers.
+- The release pipeline configuration (`.goreleaser.yaml`, `Dockerfile.release`, `.github/workflows/release.yml`).
+
+Out of scope:
+
+- Vulnerabilities in upstream RPC providers — smart-router is a relay, not the origin of trust.
+- Configuration mistakes that expose the router to the public internet without authentication; smart-router is intended to run behind your edge.


### PR DESCRIPTION
**Stacked on top of [#40](https://github.com/Magma-Devs/smart-router/pull/40)** — base branch is \`docs/release-readme-polish\`. Merge #40 first; GitHub will then retarget this PR's base to \`main\`.

## Summary

Takes the README from \"how to build/run\" to \"what the system actually does + where it sits in the stack\" so a customer-evaluator can calibrate in 60 seconds without reading code. Plus a SECURITY.md so we have a documented vulnerability-reporting path before v1 ships.

## What's new in the README

1. **Three badges in the header**: CI status (auto-resolves for authenticated repo viewers), \`pre-v1\` status, Go version. Static shields.io badges where the repo's privacy would otherwise block image rendering.
2. **Status callout block** under the tagline: calls out pre-v1, the pin-to-version recommendation, and points at SECURITY.md.
3. **\`## How it works\` section** with:
   - ASCII data-flow diagram (clients → router → upstream).
   - Five-step hot-path walkthrough, each step labelled with the actual code package it lives in (\`chainlib\`, \`ecosystem/cache\`, \`provideroptimizer\`, \`relaycore\`, \`metrics\`).
   - \`### What it's not\` subsection pre-empting the recurring \"why not HAProxy?\" / \"is this a chain node?\" / \"do I put this on the internet?\" questions.
4. **\`## Security\` section** linking SECURITY.md and reiterating \"don't open public issues for security concerns.\"

## New SECURITY.md

- Vulnerability reporting via \`security@magmadevs.com\` (**placeholder — confirm or replace before publish**).
- 2-business-day acknowledgement, 90-day-max patch, 7-14 day disclosure window after fix ships.
- Latest released minor line is the only supported line.
- Scope: binary + Docker image + wire protocols + release config. Out of scope: upstream-provider vulns, misconfiguration exposing the router to the public internet.

## What I deliberately did NOT add (from the original menu)

- **Coverage / quality badges** (CodeFactor / Codacy / etc.) — third-party noise.
- **License badge** — proprietary/customer-NDA setup, deferred until licensing is decided.
- **Star / fork / issue-count vanity badges** — meaningless on a private repo.
- **\"Used by\" / customer logos** — wait until customers publicly attribute.
- **Latest-release auto-updating badge** — shields.io can't read private repos; static \"pre-v1\" badge is more accurate today.

## Test plan

- [ ] Render the README on GitHub, scan that the ASCII diagram doesn't get mangled by markdown.
- [ ] Verify the CI badge renders correctly for a logged-in repo viewer (it'll 404 for anonymous, which is expected on a private repo).
- [ ] **Verify or replace \`security@magmadevs.com\`** with the actual address you want reports going to.
- [ ] Decide whether the scope section in SECURITY.md is right for your audit / compliance posture.

## Out of scope (follow-up if you want)

- Performance benchmarks section — only meaningful once real numbers exist from a customer deployment or load test.
- CONTRIBUTING.md / CODE_OF_CONDUCT.md — internal project, not OSS yet.
- Roadmap section — would commit us to promises that may shift.