### PR TITLE
fix(rpcsmartrouter): echo WS subscribe id + fix unsubscribe race (MAG-1824)

### DIFF
--- a/protocol/chainlib/consumer_websocket_manager.go
+++ b/protocol/chainlib/consumer_websocket_manager.go
@@ -289,7 +289,9 @@ func (cwm *ConsumerWebsocketManager) ListenToMessages(ctx context.Context) {
 				if err != nil {
 					utils.LavaFormatWarning("error unsubscribing from subscription", err, utils.LogAttr("GUID", webSocketCtx))
 					if err == common.SubscriptionNotFoundError {
-						msgData, err := json.Marshal(common.JsonRpcSubscriptionNotFoundError)
+						// Echo the caller's id (JSON-RPC 2.0 §4.2) — the template's hardcoded
+						// id is just a fallback for malformed requests with no id field.
+						msgData, err := common.MarshalJsonRPCErrorWithRequestID(common.JsonRpcSubscriptionNotFoundError, msg)
 						if err != nil {
 							continue
 						}

--- a/protocol/common/return_errors.go
+++ b/protocol/common/return_errors.go
@@ -1,9 +1,11 @@
 package common
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/tidwall/gjson"
 )
 
 // #######
@@ -67,6 +69,38 @@ var JsonRpcSubscriptionNotFoundError = JsonRPCErrorMessage{
 		Message: "Internal error",
 		Data:    "subscription not found",
 	},
+}
+
+// MarshalJsonRPCErrorWithRequestID returns the marshaled error response with the JSON-RPC id
+// taken from requestBytes (so the response echoes the caller's id per JSON-RPC 2.0 §4.2).
+// When requestBytes does not contain a parseable id, the template's hardcoded Id is preserved.
+// Supports string ids (e.g. UUIDs), numeric ids, and null.
+func MarshalJsonRPCErrorWithRequestID(template JsonRPCErrorMessage, requestBytes []byte) ([]byte, error) {
+	baseline, err := json.Marshal(template)
+	if err != nil {
+		return nil, err
+	}
+	if len(requestBytes) == 0 {
+		return baseline, nil
+	}
+	idResult := gjson.GetBytes(requestBytes, "id")
+	if !idResult.Exists() {
+		return baseline, nil
+	}
+	// idResult.Raw is the verbatim JSON for the id (e.g. `"client-uuid-1"`, `42`, `null`).
+	// Substituting it as raw JSON preserves the caller's exact type.
+	return setJSONFieldRaw(baseline, "id", []byte(idResult.Raw))
+}
+
+// setJSONFieldRaw replaces a top-level field with raw JSON without going through Go's typed
+// marshaling — needed because string-typed ids must round-trip exactly.
+func setJSONFieldRaw(data []byte, field string, rawValue []byte) ([]byte, error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return data, err
+	}
+	obj[field] = json.RawMessage(rawValue)
+	return json.Marshal(obj)
 }
 
 // #######

--- a/protocol/common/return_errors_test.go
+++ b/protocol/common/return_errors_test.go
@@ -1,0 +1,77 @@
+package common
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMarshalJsonRPCErrorWithRequestID_EchoesAllIDTypes covers MAG-1824: the
+// "subscription not found" response must echo the caller's id verbatim per JSON-RPC 2.0
+// §4.2, including non-numeric ids like string UUIDs (which the legacy hardcoded `Id: 1`
+// path silently dropped).
+func TestMarshalJsonRPCErrorWithRequestID_EchoesAllIDTypes(t *testing.T) {
+	tests := []struct {
+		name      string
+		request   string
+		wantIDRaw string
+	}{
+		{
+			name:      "string UUID id",
+			request:   `{"jsonrpc":"2.0","method":"eth_unsubscribe","params":["0xabc"],"id":"client-uuid-1"}`,
+			wantIDRaw: `"client-uuid-1"`,
+		},
+		{
+			name:      "numeric id",
+			request:   `{"jsonrpc":"2.0","method":"eth_unsubscribe","params":["0xabc"],"id":42}`,
+			wantIDRaw: `42`,
+		},
+		{
+			name:      "null id",
+			request:   `{"jsonrpc":"2.0","method":"eth_unsubscribe","params":["0xabc"],"id":null}`,
+			wantIDRaw: `null`,
+		},
+		{
+			name:      "string with special chars",
+			request:   `{"jsonrpc":"2.0","method":"eth_unsubscribe","params":[],"id":"id with \"quotes\""}`,
+			wantIDRaw: `"id with \"quotes\""`,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := MarshalJsonRPCErrorWithRequestID(JsonRpcSubscriptionNotFoundError, []byte(tc.request))
+			require.NoError(t, err, "tc #%s", tc.name)
+
+			var parsed map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(out, &parsed), "tc #%s", tc.name)
+			assert.JSONEq(t, tc.wantIDRaw, string(parsed["id"]),
+				"tc #%s: id must be echoed verbatim", tc.name)
+
+			// And the error envelope must be preserved.
+			var errObj struct {
+				Code    int    `json:"code"`
+				Message string `json:"message"`
+				Data    string `json:"data"`
+			}
+			require.NoError(t, json.Unmarshal(parsed["error"], &errObj), "tc #%s", tc.name)
+			assert.Equal(t, -32603, errObj.Code, "tc #%s", tc.name)
+			assert.Equal(t, "subscription not found", errObj.Data, "tc #%s", tc.name)
+		})
+	}
+}
+
+// TestMarshalJsonRPCErrorWithRequestID_FallsBackToTemplateID confirms that requests with no
+// parseable id field leave the template's hardcoded id in place — so we don't introduce a
+// regression where the id field disappears entirely.
+func TestMarshalJsonRPCErrorWithRequestID_FallsBackToTemplateID(t *testing.T) {
+	out, err := MarshalJsonRPCErrorWithRequestID(JsonRpcSubscriptionNotFoundError, []byte(`{"not":"a request"}`))
+	require.NoError(t, err)
+
+	var parsed map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(out, &parsed))
+	assert.JSONEq(t, `1`, string(parsed["id"]), "should fall back to template's id when request has no id field")
+}

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
@@ -640,8 +640,11 @@ func (dwsm *DirectWSSubscriptionManager) StartSubscription(
 		originalResult = firstMsg.Result
 	}
 
-	// Create first reply - preserves original format for Tendermint, uses router ID for EVM
-	firstReplyData, err := createSubscriptionReply(routerID, firstMsg, dwsm.apiInterface)
+	// Create first reply - preserves original format for Tendermint, uses router ID for EVM.
+	// requestID is the client's original JSON-RPC id (extracted at the top of this function);
+	// passing it explicitly ensures the response echoes the caller's id verbatim, including
+	// non-numeric ids like string UUIDs (JSON-RPC 2.0 §4.2).
+	firstReplyData, err := createSubscriptionReply(routerID, requestID, firstMsg, dwsm.apiInterface)
 	if err != nil {
 		upstreamSub.Unsubscribe()
 		dwsm.failPendingSubscription(hashedParams)
@@ -752,9 +755,12 @@ func (dwsm *DirectWSSubscriptionManager) Unsubscribe(
 	for hp, sub := range dwsm.activeSubscriptions {
 		if ownedRouterID, exists := sub.clientRouterIDs[clientKey]; exists {
 			// For Tendermint: client unsubscribes using the query (which is also the upstream ID)
-			// For EVM: client unsubscribes using the router ID we gave them
+			// For EVM: client unsubscribes using the router ID we gave them, but accept the
+			// upstream hex id too — some clients echo back the raw `result` they observed,
+			// and (historically) responses leaked the upstream id, so being permissive here
+			// is necessary for correctness. Ownership is already enforced by the outer
+			// `clientRouterIDs[clientKey]` check, so accepting the upstream id is safe.
 			if dwsm.apiInterface == "tendermintrpc" {
-				// Tendermint: match by upstream ID (query string)
 				if sub.upstreamID == subIDFromRequest {
 					activeSub = sub
 					hashedParams = hp
@@ -763,8 +769,7 @@ func (dwsm *DirectWSSubscriptionManager) Unsubscribe(
 					break
 				}
 			} else {
-				// EVM: match by router ID
-				if ownedRouterID == subIDFromRequest {
+				if ownedRouterID == subIDFromRequest || sub.upstreamID == subIDFromRequest {
 					activeSub = sub
 					hashedParams = hp
 					routerSubID = ownedRouterID
@@ -1157,15 +1162,34 @@ func (dwsm *DirectWSSubscriptionManager) createUpstreamSubscription(
 	return sub, firstMsg, msgChan, nil
 }
 
-// listenForUpstreamMessages listens for messages from upstream and routes to clients
+// upstreamErrSource is the minimal slice of *rpcclient.ClientSubscription that
+// listenForUpstreamMessages actually needs. Taking an interface here lets tests drive the
+// error-handling branch with a local fake without exposing test-only constructors from the
+// rpcclient package. *rpcclient.ClientSubscription satisfies it via its Err() method.
+type upstreamErrSource interface {
+	Err() <-chan error
+}
+
+// listenForUpstreamMessages listens for messages from upstream and routes to clients.
+//
+// On an upstream error we hand off to handleUpstreamDisconnect, which either restores the
+// subscription (spawning a fresh listener) or cleans it up. We must NOT run cleanup from this
+// goroutine in that case — handleUpstreamDisconnect mutates activeSub in place to point at the
+// new upstream subscription, and a deferred cleanup here would wipe the just-restored entry
+// from dwsm.activeSubscriptions, leaving notifications flowing through the new listener (which
+// reads activeSub directly) while making the unsubscribe lookup fail with "subscription not
+// found". reconnectInFlight is true when ownership has been handed off to that goroutine.
 func (dwsm *DirectWSSubscriptionManager) listenForUpstreamMessages(
 	ctx context.Context,
 	hashedParams string,
 	activeSub *directActiveSubscription,
-	upstreamSub *rpcclient.ClientSubscription,
+	upstreamSub upstreamErrSource,
 ) {
+	reconnectInFlight := false
 	defer func() {
-		dwsm.cleanupSubscription(hashedParams)
+		if !reconnectInFlight {
+			dwsm.cleanupSubscription(hashedParams)
+		}
 	}()
 
 	for {
@@ -1188,7 +1212,7 @@ func (dwsm *DirectWSSubscriptionManager) listenForUpstreamMessages(
 					err,
 					utils.LogAttr("hashedParams", utils.ToHexString(hashedParams)),
 				)
-				// Attempt reconnection
+				reconnectInFlight = true
 				go dwsm.handleUpstreamDisconnect(ctx, hashedParams, activeSub)
 			}
 			return
@@ -1541,23 +1565,31 @@ func getSubscriptionID(apiInterface string, responseMsg *rpcclient.JsonrpcMessag
 	return extractSubscriptionID(responseMsg)
 }
 
-// createSubscriptionReply creates the first reply with the router subscription ID
-func createSubscriptionReply(routerID string, originalMsg *rpcclient.JsonrpcMessage, apiInterface string) ([]byte, error) {
+// createSubscriptionReply creates the first reply for a brand-new subscription.
+// The response id is taken from the client's request — NOT from originalMsg.ID — because
+// originalMsg.ID is the upstream rpcclient's internal counter, which the client never sent
+// and must not see (JSON-RPC 2.0 §4.2 requires the response id to match the request id
+// exactly, including type: string ids stay strings).
+func createSubscriptionReply(routerID string, requestID json.RawMessage, originalMsg *rpcclient.JsonrpcMessage, apiInterface string) ([]byte, error) {
 	if originalMsg == nil {
 		return nil, fmt.Errorf("original message is nil")
 	}
 
-	// For Tendermint: preserve the original response format {"result":{"query":"..."}}
-	// Tendermint clients expect the query object back, not a router ID
+	// For Tendermint: preserve the original result format ({"query":"..."}) but with the
+	// caller's request id, not the upstream's.
 	if apiInterface == "tendermintrpc" {
-		// Return original message as-is - it already has the correct format
-		return json.Marshal(originalMsg)
+		response := map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      requestID,
+			"result":  originalMsg.Result,
+		}
+		return json.Marshal(response)
 	}
 
-	// For EVM: create response with router ID instead of upstream ID
+	// For EVM: response carries the router ID (not the upstream hex) and the caller's id.
 	response := map[string]interface{}{
 		"jsonrpc": "2.0",
-		"id":      originalMsg.ID,
+		"id":      requestID,
 		"result":  routerID,
 	}
 

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
@@ -1179,6 +1179,11 @@ type upstreamErrSource interface {
 // from dwsm.activeSubscriptions, leaving notifications flowing through the new listener (which
 // reads activeSub directly) while making the unsubscribe lookup fail with "subscription not
 // found". reconnectInFlight is true when ownership has been handed off to that goroutine.
+//
+// Cleanup ownership: once reconnectInFlight is set, handleUpstreamDisconnect is responsible
+// for calling cleanupSubscription on every failure path (reconnect timeout, GetConnection
+// failure post-reconnect, re-subscribe failure) so a failed restoration does not leak the
+// subscription. See handleUpstreamDisconnect for the corresponding cleanup-on-failure calls.
 func (dwsm *DirectWSSubscriptionManager) listenForUpstreamMessages(
 	ctx context.Context,
 	hashedParams string,
@@ -1575,15 +1580,22 @@ func createSubscriptionReply(routerID string, requestID json.RawMessage, origina
 		return nil, fmt.Errorf("original message is nil")
 	}
 
-	// For Tendermint: preserve the original result format ({"query":"..."}) but with the
-	// caller's request id, not the upstream's.
+	// For Tendermint: preserve the upstream message verbatim (custom extensions,
+	// error envelope, anything beyond `result` that a Tendermint client may rely
+	// on) and overwrite only the id field with the caller's request id. A naive
+	// hand-built {jsonrpc,id,result} envelope would drop everything else that
+	// the upstream returned.
 	if apiInterface == "tendermintrpc" {
-		response := map[string]interface{}{
-			"jsonrpc": "2.0",
-			"id":      requestID,
-			"result":  originalMsg.Result,
+		raw, err := json.Marshal(originalMsg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal upstream message: %w", err)
 		}
-		return json.Marshal(response)
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &obj); err != nil {
+			return nil, fmt.Errorf("failed to round-trip upstream message: %w", err)
+		}
+		obj["id"] = requestID
+		return json.Marshal(obj)
 	}
 
 	// For EVM: response carries the router ID (not the upstream hex) and the caller's id.

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
@@ -1477,6 +1477,46 @@ func TestCreateSubscriptionReply_Tendermint(t *testing.T) {
 	assert.Equal(t, "tm.event='NewBlock'", result.Query, "Tendermint response should preserve query object")
 }
 
+// TestCreateSubscriptionReply_Tendermint_PreservesUpstreamFields guards against
+// the Tendermint reply becoming lossy. The pre-PR code returned json.Marshal(originalMsg)
+// verbatim; the post-PR fix must still preserve every top-level field other than id,
+// otherwise a non-nil Error envelope (or any future field a Tendermint client depends on)
+// silently disappears.
+func TestCreateSubscriptionReply_Tendermint_PreservesUpstreamFields(t *testing.T) {
+	originalMsg := &rpcclient.JsonrpcMessage{
+		Version: "2.0",
+		ID:      json.RawMessage(`1`),
+		Result:  json.RawMessage(`{"query":"tm.event='NewBlock'"}`),
+		// Error is the realistic "extra field" most likely to appear on a
+		// subscription reply; if dropped, the client never sees that the
+		// upstream subscribe actually failed.
+		Error: &rpcclient.JsonError{
+			Code:    -32000,
+			Message: "upstream subscription rejected",
+		},
+	}
+
+	replyData, err := createSubscriptionReply("ignored", json.RawMessage(`"abc"`), originalMsg, "tendermintrpc")
+	require.NoError(t, err)
+
+	var resp map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(replyData, &resp))
+
+	// id must be the caller's, not the upstream's.
+	assert.JSONEq(t, `"abc"`, string(resp["id"]))
+	// All other fields the upstream sent must survive — this is the regression guard.
+	require.Contains(t, resp, "result", "result must be preserved")
+	require.Contains(t, resp, "error", "error envelope must be preserved when upstream returned one")
+	assert.JSONEq(t, `{"query":"tm.event='NewBlock'"}`, string(resp["result"]))
+	var errObj struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}
+	require.NoError(t, json.Unmarshal(resp["error"], &errObj))
+	assert.Equal(t, -32000, errObj.Code)
+	assert.Equal(t, "upstream subscription rejected", errObj.Message)
+}
+
 // TestCreateSubscriptionReply_EVM verifies that EVM subscription responses use router IDs
 func TestCreateSubscriptionReply_EVM(t *testing.T) {
 	// Simulated EVM eth_subscribe response from upstream

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
@@ -1455,8 +1455,8 @@ func TestCreateSubscriptionReply_Tendermint(t *testing.T) {
 		Result:  json.RawMessage(`{"query":"tm.event='NewBlock'"}`),
 	}
 
-	// For Tendermint, should return original format (not router ID)
-	replyData, err := createSubscriptionReply("router-id-ignored", originalMsg, "tendermintrpc")
+	// For Tendermint, should return original result format (not router ID)
+	replyData, err := createSubscriptionReply("router-id-ignored", json.RawMessage(`1`), originalMsg, "tendermintrpc")
 	require.NoError(t, err)
 
 	// Parse the response
@@ -1489,7 +1489,7 @@ func TestCreateSubscriptionReply_EVM(t *testing.T) {
 	routerID := "0xrouter456"
 
 	// For EVM, should replace upstream ID with router ID
-	replyData, err := createSubscriptionReply(routerID, originalMsg, "jsonrpc")
+	replyData, err := createSubscriptionReply(routerID, json.RawMessage(`1`), originalMsg, "jsonrpc")
 	require.NoError(t, err)
 
 	// Parse the response
@@ -1575,7 +1575,7 @@ func TestTendermintSubscriptionEndToEnd(t *testing.T) {
 		}
 
 		// Create reply for Tendermint
-		reply, err := createSubscriptionReply("any-router-id", upstreamResponse, "tendermintrpc")
+		reply, err := createSubscriptionReply("any-router-id", json.RawMessage(`1`), upstreamResponse, "tendermintrpc")
 		require.NoError(t, err)
 
 		// Client should see the query format, not a router ID
@@ -1918,4 +1918,460 @@ func TestSelectEndpoint_WS_EndpointsByURL_IncludesBothTiers(t *testing.T) {
 	require.Len(t, manager.endpointsByURL, 2)
 	assert.NotNil(t, manager.endpointsByURL["wss://primary-1.example.com"])
 	assert.NotNil(t, manager.endpointsByURL["wss://backup-1.example.com"])
+}
+
+// ==================== MAG-1824 regression coverage ====================
+
+// mockWSProtocolMessageWithRawData is a ProtocolMessage variant that lets a test inject
+// raw RelayPrivateData bytes, so we can construct unsubscribe requests with non-numeric
+// ids (e.g. string UUIDs) — the scenario the bug targets.
+type mockWSProtocolMessageWithRawData struct {
+	mockWSProtocolMessage
+	rawData []byte
+}
+
+func (m *mockWSProtocolMessageWithRawData) RelayPrivateData() *pairingtypes.RelayPrivateData {
+	return &pairingtypes.RelayPrivateData{Data: m.rawData}
+}
+
+// TestCreateSubscriptionReply_EchoesStringRequestID is the direct regression for MAG-1824's
+// first symptom: the response id must be the caller's verbatim string, not the upstream's
+// internal counter.
+func TestCreateSubscriptionReply_EchoesStringRequestID(t *testing.T) {
+	t.Run("EVM with string UUID id", func(t *testing.T) {
+		// Upstream returned its own id (typically the rpcclient's nextID() = 1) — this
+		// must NOT leak to the response.
+		upstream := &rpcclient.JsonrpcMessage{
+			Version: "2.0",
+			ID:      json.RawMessage(`1`),
+			Result:  json.RawMessage(`"0xabc"`),
+		}
+
+		clientID := json.RawMessage(`"client-uuid-1"`)
+		replyData, err := createSubscriptionReply("rs_abc123_00001", clientID, upstream, "jsonrpc")
+		require.NoError(t, err)
+
+		var resp map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(replyData, &resp))
+
+		assert.JSONEq(t, `"client-uuid-1"`, string(resp["id"]),
+			"id must echo caller's string verbatim")
+		assert.JSONEq(t, `"rs_abc123_00001"`, string(resp["result"]),
+			"result must be router id, not upstream hex")
+	})
+
+	t.Run("EVM with numeric id", func(t *testing.T) {
+		upstream := &rpcclient.JsonrpcMessage{
+			Version: "2.0",
+			ID:      json.RawMessage(`99`), // upstream counter — should not appear
+			Result:  json.RawMessage(`"0xabc"`),
+		}
+
+		replyData, err := createSubscriptionReply("rs_xxx_00001", json.RawMessage(`42`), upstream, "jsonrpc")
+		require.NoError(t, err)
+
+		var resp map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(replyData, &resp))
+
+		assert.JSONEq(t, `42`, string(resp["id"]))
+	})
+
+	t.Run("Tendermint preserves caller id and query result", func(t *testing.T) {
+		upstream := &rpcclient.JsonrpcMessage{
+			Version: "2.0",
+			ID:      json.RawMessage(`7`),
+			Result:  json.RawMessage(`{"query":"tm.event='NewBlock'"}`),
+		}
+
+		replyData, err := createSubscriptionReply("ignored", json.RawMessage(`"abc"`), upstream, "tendermintrpc")
+		require.NoError(t, err)
+
+		var resp map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(replyData, &resp))
+
+		assert.JSONEq(t, `"abc"`, string(resp["id"]),
+			"Tendermint must also echo caller's id, not the upstream's")
+		assert.JSONEq(t, `{"query":"tm.event='NewBlock'"}`, string(resp["result"]),
+			"query format must be preserved")
+	})
+}
+
+// TestUnsubscribe_AcceptsUpstreamIDFallback is the regression for MAG-1824's second symptom:
+// the unsubscribe lookup must succeed even when the client sends back the upstream hex id
+// (rather than the router-issued rs_xxx id). Ownership is still gated on the caller having
+// an entry in clientRouterIDs for that subscription, so this remains safe.
+func TestUnsubscribe_AcceptsUpstreamIDFallback(t *testing.T) {
+	config := &WebsocketConfig{
+		MaxSubscriptionsPerClient:       25,
+		PerClientLimitEnforcement:       "warn",
+		MaxTotalSubscriptions:           5000,
+		TotalLimitEnforcement:           "warn",
+		SubscriptionSharingEnabled:      true,
+		SubscriptionsPerMinutePerClient: 60,
+		UnsubscribesPerMinutePerClient:  60,
+		MaxMessageSize:                  1048576,
+		CleanupInterval:                 time.Minute,
+	}
+
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc", "ETH", "jsonrpc",
+		[]*common.NodeUrl{{Url: "wss://test.example.com"}},
+		nil, nil, config,
+	)
+
+	clientKey := manager.CreateWebSocketConnectionUniqueKey("dapp1", "192.168.1.1", "ws-1")
+	routerID := manager.idMapper.GenerateRouterID(clientKey)
+	upstreamID := "0xupstream-hex-deadbeef"
+	manager.idMapper.RegisterMapping(routerID, upstreamID)
+
+	// Second co-tenant on the same shared subscription — keeps len(connectedClients) > 1
+	// so the unsubscribe stays on the "remove this client only" branch and doesn't try to
+	// tear down the (nil) upstreamSubscription.
+	keeperKey := manager.CreateWebSocketConnectionUniqueKey("dappKeeper", "10.0.0.1", "ws-keeper")
+	keeperRouterID := manager.idMapper.GenerateRouterID(keeperKey)
+	manager.idMapper.RegisterMapping(keeperRouterID, upstreamID)
+
+	subCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	hashedParams := "test-params-hash"
+	activeSub := &directActiveSubscription{
+		upstreamID:       upstreamID,
+		hashedParams:     hashedParams,
+		connectedClients: map[string]*common.SafeChannelSender[*pairingtypes.RelayReply]{},
+		clientRouterIDs:  map[string]string{clientKey: routerID, keeperKey: keeperRouterID},
+		ctx:              subCtx,
+		cancel:           cancel,
+	}
+	replyChan := make(chan *pairingtypes.RelayReply, 1)
+	keeperReplyChan := make(chan *pairingtypes.RelayReply, 1)
+	activeSub.connectedClients[clientKey] = common.NewSafeChannelSender(subCtx, replyChan)
+	activeSub.connectedClients[keeperKey] = common.NewSafeChannelSender(subCtx, keeperReplyChan)
+
+	manager.lock.Lock()
+	manager.activeSubscriptions[hashedParams] = activeSub
+	manager.lock.Unlock()
+
+	// Client sends back the UPSTREAM id, not the router id — historically this would have
+	// produced "subscription not found".
+	body, err := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  "eth_unsubscribe",
+		"params":  []interface{}{upstreamID},
+		"id":      "client-uuid-1",
+	})
+	require.NoError(t, err)
+
+	pm := &mockWSProtocolMessageWithRawData{
+		mockWSProtocolMessage: mockWSProtocolMessage{
+			method: "eth_unsubscribe",
+			params: []interface{}{upstreamID},
+		},
+		rawData: body,
+	}
+
+	_, err = manager.Unsubscribe(context.Background(), pm, "dapp1", "192.168.1.1", "ws-1", nil)
+	assert.NoError(t, err, "unsubscribe should accept the upstream id as a fallback")
+
+	// And confirm the canonical (router-id) path still works for a freshly registered sub.
+	clientKey2 := manager.CreateWebSocketConnectionUniqueKey("dapp2", "192.168.2.2", "ws-2")
+	routerID2 := manager.idMapper.GenerateRouterID(clientKey2)
+	manager.idMapper.RegisterMapping(routerID2, "0xupstream-2")
+	keeperKey2 := manager.CreateWebSocketConnectionUniqueKey("dappKeeper2", "10.0.0.2", "ws-keeper2")
+	keeperRouterID2 := manager.idMapper.GenerateRouterID(keeperKey2)
+	manager.idMapper.RegisterMapping(keeperRouterID2, "0xupstream-2")
+
+	hashedParams2 := "params-2"
+	subCtx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	activeSub2 := &directActiveSubscription{
+		upstreamID:   "0xupstream-2",
+		hashedParams: hashedParams2,
+		connectedClients: map[string]*common.SafeChannelSender[*pairingtypes.RelayReply]{
+			clientKey2: common.NewSafeChannelSender(subCtx2, make(chan *pairingtypes.RelayReply, 1)),
+			keeperKey2: common.NewSafeChannelSender(subCtx2, make(chan *pairingtypes.RelayReply, 1)),
+		},
+		clientRouterIDs: map[string]string{clientKey2: routerID2, keeperKey2: keeperRouterID2},
+		ctx:             subCtx2,
+		cancel:          cancel2,
+	}
+	manager.lock.Lock()
+	manager.activeSubscriptions[hashedParams2] = activeSub2
+	manager.lock.Unlock()
+
+	body2, err := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  "eth_unsubscribe",
+		"params":  []interface{}{routerID2},
+		"id":      2,
+	})
+	require.NoError(t, err)
+	pm2 := &mockWSProtocolMessageWithRawData{
+		mockWSProtocolMessage: mockWSProtocolMessage{method: "eth_unsubscribe", params: []interface{}{routerID2}},
+		rawData:               body2,
+	}
+	_, err = manager.Unsubscribe(context.Background(), pm2, "dapp2", "192.168.2.2", "ws-2", nil)
+	assert.NoError(t, err, "router-id unsubscribe path must still work")
+}
+
+// TestEndToEnd_SubscribeUnsubscribeRoundTrip is the closest in-process analogue of the
+// MAG-1824 smoke test (tests/release_smoke/test_ws_subscribe_smoke.py): drive the manager
+// against a real upstream WebSocket (mockSubscriptionServer) and verify the full lifecycle.
+//
+// Acceptance criteria covered:
+//  1. Subscribe response id echoes the caller's string verbatim (no `id:1` substitution).
+//  2. Unsubscribe of the just-issued subscription succeeds (no SubscriptionNotFoundError).
+//  3. Notifications arrive while the subscription is live (no regression).
+func TestEndToEnd_SubscribeUnsubscribeRoundTrip(t *testing.T) {
+	mockSrv := newMockSubscriptionServer()
+	mockSrv.messageInterval = 20 * time.Millisecond // get a notification quickly
+	defer mockSrv.Close()
+
+	nodeUrl := &common.NodeUrl{Url: mockSrv.URL()}
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc", "ETH", "jsonrpc",
+		[]*common.NodeUrl{nodeUrl},
+		nil, nil, nil,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// 1. Subscribe with a STRING id like the bug report's "client-uuid-1".
+	subscribeBody, err := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  "eth_subscribe",
+		"params":  []interface{}{"newHeads"},
+		"id":      "client-uuid-1",
+	})
+	require.NoError(t, err)
+
+	subscribeMsg := &mockWSProtocolMessageWithRawData{
+		mockWSProtocolMessage: mockWSProtocolMessage{
+			method: "eth_subscribe",
+			params: []interface{}{"newHeads"},
+		},
+		rawData: subscribeBody,
+	}
+
+	const dappID, ip, wsUID = "dapp-e2e", "192.168.99.99", "ws-e2e"
+	reply, repliesChan, err := manager.StartSubscription(ctx, subscribeMsg, dappID, ip, wsUID, nil)
+	require.NoError(t, err, "subscribe must succeed")
+	require.NotNil(t, reply, "subscribe must return a reply")
+	require.NotNil(t, repliesChan, "subscribe must return a notifications channel")
+
+	// Verify id is echoed verbatim — this is Bug #1's regression in the e2e shape.
+	var subResp map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(reply.Data, &subResp))
+	assert.JSONEq(t, `"client-uuid-1"`, string(subResp["id"]),
+		"subscribe response id must be the caller's string, not the upstream's counter")
+
+	// Capture the subscription id the router exposed to the client (router id, NOT upstream).
+	var routerSubID string
+	require.NoError(t, json.Unmarshal(subResp["result"], &routerSubID))
+	assert.NotEmpty(t, routerSubID)
+	assert.True(t, strings.HasPrefix(routerSubID, "rs_"),
+		"router id should be rs_-prefixed (got %q)", routerSubID)
+
+	// 2. At least one notification must arrive on the live subscription.
+	select {
+	case notif := <-repliesChan:
+		require.NotNil(t, notif, "first notification")
+		assert.Contains(t, string(notif.Data), `"eth_subscription"`,
+			"notification should be an eth_subscription event")
+		assert.Contains(t, string(notif.Data), routerSubID,
+			"notification subscription field should be the router id (rewritten from upstream)")
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected at least one notification within 2s")
+	}
+
+	// 3. Unsubscribe using the just-issued router id — the bug's primary symptom is that
+	// this returns SubscriptionNotFoundError. After the fix it must succeed and the node's
+	// response (with the caller's id and result:true) must be returned.
+	unsubBody, err := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  "eth_unsubscribe",
+		"params":  []interface{}{routerSubID},
+		"id":      "client-uuid-2",
+	})
+	require.NoError(t, err)
+
+	unsubMsg := &mockWSProtocolMessageWithRawData{
+		mockWSProtocolMessage: mockWSProtocolMessage{
+			method: "eth_unsubscribe",
+			params: []interface{}{routerSubID},
+		},
+		rawData: unsubBody,
+	}
+
+	nodeResp, err := manager.Unsubscribe(ctx, unsubMsg, dappID, ip, wsUID, nil)
+	require.NoError(t, err, "unsubscribe of just-issued subscription id must NOT return subscription-not-found")
+	require.NotNil(t, nodeResp, "expected node response bytes from upstream")
+
+	// The mock upstream returns {"jsonrpc":"2.0","id":<caller's id>,"result":true}.
+	// Per the ticket's acceptance criteria, the caller's id must round-trip end-to-end.
+	var unsubResp map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(nodeResp, &unsubResp))
+	assert.JSONEq(t, `"client-uuid-2"`, string(unsubResp["id"]),
+		"unsubscribe response id must echo caller's string id")
+	assert.JSONEq(t, `true`, string(unsubResp["result"]),
+		`unsubscribe response result must be "true"`)
+
+	// Belt-and-suspenders: confirm the router translated router-id → upstream-id when
+	// it called the upstream. If the router had forwarded `rs_xxx_NNNNN` to the upstream,
+	// the mock's closeSubscription would not have matched any entry and the map would
+	// still hold the upstream id. This guards against a regression where the router
+	// leaks router ids to upstream nodes.
+	mockSrv.lock.RLock()
+	leftoverSubs := len(mockSrv.subscriptions)
+	mockSrv.lock.RUnlock()
+	assert.Equal(t, 0, leftoverSubs,
+		"mock upstream should see its own subscription id on eth_unsubscribe, not the router id")
+}
+
+// TestListenForUpstreamMessages_ReconnectSkipsCleanup is the regression for the cleanup
+// race in listenForUpstreamMessages. With the bug, when upstreamSub.Err() fires and we
+// hand off to handleUpstreamDisconnect, the deferred dwsm.cleanupSubscription(hashedParams)
+// in the returning goroutine deletes the activeSubscription that the reconnect path is
+// (or will be) restoring. After the fix, the deferred cleanup is skipped when
+// reconnectInFlight is set.
+//
+// We drive the listener directly with a synthetic *ClientSubscription whose Err() is a
+// pre-loaded channel, so we don't need a real WS server. The assertion is on the post-
+// condition: activeSubscriptions[hp] survives the listener's return, AND the client is
+// still present in connectedClients (i.e. cleanupSubscription did NOT close their channel).
+func TestListenForUpstreamMessages_ReconnectSkipsCleanup(t *testing.T) {
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc", "ETH", "jsonrpc",
+		[]*common.NodeUrl{{Url: "wss://test.example.com"}},
+		nil, nil, nil,
+	)
+
+	clientKey := manager.CreateWebSocketConnectionUniqueKey("d", "1.1.1.1", "ws")
+	routerID := manager.idMapper.GenerateRouterID(clientKey)
+	upstreamID := "0xreconnect-survives"
+	manager.idMapper.RegisterMapping(routerID, upstreamID)
+
+	subCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const hp = "hp-reconnect"
+	activeSub := &directActiveSubscription{
+		upstreamID:   upstreamID,
+		hashedParams: hp,
+		connectedClients: map[string]*common.SafeChannelSender[*pairingtypes.RelayReply]{
+			clientKey: common.NewSafeChannelSender(subCtx, make(chan *pairingtypes.RelayReply, 1)),
+		},
+		clientRouterIDs: map[string]string{clientKey: routerID},
+		ctx:             subCtx,
+		cancel:          cancel,
+		closeSubChan:    make(chan struct{}),
+		messagesChan:    make(chan *rpcclient.JsonrpcMessage, 1),
+	}
+	// Pre-set restoring=true so the spawned handleUpstreamDisconnect goroutine no-ops
+	// instead of dereferencing the nil upstreamPool. The thing under test is the OLD
+	// listener's deferred cleanup branch, not the reconnect logic itself.
+	activeSub.restoring.Store(true)
+
+	manager.lock.Lock()
+	manager.activeSubscriptions[hp] = activeSub
+	manager.lock.Unlock()
+
+	// Drive the listener via a local fake satisfying the upstreamErrSource interface.
+	// A pre-loaded, closed channel triggers the Err() branch immediately so the listener
+	// returns deterministically — no need for a real rpcclient.ClientSubscription.
+	errCh := make(chan error, 1)
+	errCh <- fmt.Errorf("simulated upstream error")
+	close(errCh)
+	upstreamSub := fakeUpstreamErrSource{ch: errCh}
+
+	// Run the listener synchronously to observe its return; the listener returns as soon
+	// as it drains the Err() channel and kicks off handleUpstreamDisconnect.
+	done := make(chan struct{})
+	go func() {
+		manager.listenForUpstreamMessages(subCtx, hp, activeSub, upstreamSub)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listenForUpstreamMessages did not return within 2s")
+	}
+
+	// The crucial invariant: the deferred cleanup in the returning listener must NOT have
+	// fired (reconnect handoff suppressed it). Without the fix, this assertion fails:
+	// cleanupSubscription would have deleted activeSubscriptions[hp] and closed every
+	// SafeChannelSender. We rely on the entry being present right after return; the
+	// background handleUpstreamDisconnect goroutine may eventually call cleanup itself,
+	// but only after async reconnect attempts complete.
+	manager.lock.RLock()
+	_, stillPresent := manager.activeSubscriptions[hp]
+	manager.lock.RUnlock()
+	assert.True(t, stillPresent,
+		"deferred cleanup must be skipped when reconnect is in flight (race regression)")
+}
+
+// fakeUpstreamErrSource satisfies the upstreamErrSource interface that
+// listenForUpstreamMessages takes. Defined in the test file so we don't have to expose any
+// test-only constructor from the rpcclient package.
+type fakeUpstreamErrSource struct{ ch chan error }
+
+func (f fakeUpstreamErrSource) Err() <-chan error { return f.ch }
+
+// TestUnsubscribe_StillRejectsForeignSubscription confirms the upstream-id fallback does NOT
+// open a hole that lets one client unsubscribe another client's shared subscription.
+func TestUnsubscribe_StillRejectsForeignSubscription(t *testing.T) {
+	config := &WebsocketConfig{
+		MaxSubscriptionsPerClient:       25,
+		PerClientLimitEnforcement:       "warn",
+		MaxTotalSubscriptions:           5000,
+		TotalLimitEnforcement:           "warn",
+		SubscriptionSharingEnabled:      true,
+		SubscriptionsPerMinutePerClient: 60,
+		UnsubscribesPerMinutePerClient:  60,
+		MaxMessageSize:                  1048576,
+		CleanupInterval:                 time.Minute,
+	}
+
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc", "ETH", "jsonrpc",
+		[]*common.NodeUrl{{Url: "wss://test.example.com"}},
+		nil, nil, config,
+	)
+
+	owner := manager.CreateWebSocketConnectionUniqueKey("dapp1", "192.168.1.1", "ws-owner")
+	ownerRouterID := manager.idMapper.GenerateRouterID(owner)
+	upstreamID := "0xshared-sub"
+	manager.idMapper.RegisterMapping(ownerRouterID, upstreamID)
+
+	subCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	activeSub := &directActiveSubscription{
+		upstreamID:       upstreamID,
+		hashedParams:     "hp",
+		connectedClients: map[string]*common.SafeChannelSender[*pairingtypes.RelayReply]{owner: common.NewSafeChannelSender(subCtx, make(chan *pairingtypes.RelayReply, 1))},
+		clientRouterIDs:  map[string]string{owner: ownerRouterID},
+		ctx:              subCtx,
+		cancel:           cancel,
+	}
+	manager.lock.Lock()
+	manager.activeSubscriptions["hp"] = activeSub
+	manager.lock.Unlock()
+
+	// A second client (different dappID/ip/wsUID) tries to unsubscribe using the upstream id.
+	// The fallback must still require clientRouterIDs[attacker] to exist — which it does not.
+	body, _ := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0", "method": "eth_unsubscribe", "params": []interface{}{upstreamID}, "id": 5,
+	})
+	pm := &mockWSProtocolMessageWithRawData{
+		mockWSProtocolMessage: mockWSProtocolMessage{method: "eth_unsubscribe", params: []interface{}{upstreamID}},
+		rawData:               body,
+	}
+	_, err := manager.Unsubscribe(context.Background(), pm, "evil", "10.0.0.1", "ws-evil", nil)
+	assert.Equal(t, common.SubscriptionNotFoundError, err,
+		"unrelated client must not be able to unsubscribe via upstream-id fallback")
 }


### PR DESCRIPTION
## Summary

Two interlocking bugs in the direct WebSocket subscription path, per [MAG-1824](https://magmadevs.atlassian.net/browse/MAG-1824):

- **JSON-RPC id clobbering on `eth_subscribe`.** `createSubscriptionReply` was writing the upstream rpcclient's internal `nextID()` counter (typically `1`) to the response sent back to the client, so string ids like `"client-uuid-1"` were replaced with `1` — violating JSON-RPC 2.0 §4.2. Fixed by threading the caller's `requestID` through to the reply, and by routing the `subscription-not-found` error response through a new `common.MarshalJsonRPCErrorWithRequestID` helper that echoes string / numeric / null ids verbatim.
- **Subscription "forgotten" after a brief upstream blip.** When `upstreamSub.Err()` fired, `listenForUpstreamMessages` handed off to `handleUpstreamDisconnect` *and* ran its own deferred cleanup. If reconnection succeeded, the new listener picked up notifications (it holds `activeSub` directly) but `dwsm.activeSubscriptions[hp]` had been deleted by the old goroutine's defer — so `eth_unsubscribe` lookup failed with "subscription not found" while notifications kept flowing, matching the bug's reported symptom exactly. Skip the cleanup when reconnect is in flight. Also added a defensive upstream-id fallback in the EVM unsubscribe lookup (ownership still enforced by `clientRouterIDs[clientKey]`).

## Files

- `protocol/rpcsmartrouter/direct_ws_subscription_manager.go` — id-echo, reconnect race, upstream-id fallback. `listenForUpstreamMessages` now takes a consumer-defined `upstreamErrSource` interface (one method, `Err()`) so the race fix is testable without exposing test scaffolding from the rpcclient package.
- `protocol/chainlib/consumer_websocket_manager.go` — unsubscribe-failure response routes through the new id-echoing helper.
- `protocol/common/return_errors.go` — `MarshalJsonRPCErrorWithRequestID` helper.
- Tests: `return_errors_test.go` (new) + 5 new regression tests in `direct_ws_subscription_manager_test.go`.

## Test plan

- [x] `make test-short` — `ok protocol/rpcsmartrouter 78s`
- [x] `make lint` — `go vet ./...` clean
- [x] `go test ./protocol/common ./protocol/chainlib ./protocol/rpcsmartrouter` — all three packages `ok`
- [x] Race-fix test verified to FAIL when the `reconnectInFlight` guard is reverted (then restored)
- [x] End-to-end test `TestEndToEnd_SubscribeUnsubscribeRoundTrip` drives subscribe→notify→unsubscribe against an in-process mock upstream, asserting all three ticket acceptance criteria:
  - Subscribe response id echoes `"client-uuid-1"` verbatim
  - Unsubscribe returns `{"result":true,"id":"client-uuid-2"}`
  - Notifications arrive
  - (Bonus) mock upstream receives the upstream-id on outbound `eth_unsubscribe`, not the router id

Expected outcome on the release-smoke side: `tests/release_smoke/test_ws_subscribe_smoke.py::TestWSSubscribeSmoke::test_unsubscribe_returns_true` flips XFAIL→PASS if the production symptom matches the reconnect race or the upstream-id-echo-back pattern. If it doesn't, capture upstream logs from a reproducing run so we can chase the residual cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MAG-1824]: https://magmadevs.atlassian.net/browse/MAG-1824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ