### PR TITLE
fix(release): use RELEASE_BOT_PAT for CHANGELOG push to protected main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,17 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.release_tag != '' && github.event.inputs.release_tag || github.ref_name }}
+          # Use a fine-grained PAT (RELEASE_BOT_PAT secret) for the
+          # CHANGELOG-back-to-main push later in this job. The default
+          # GITHUB_TOKEN gets rejected by `main`'s PR-required branch
+          # protection. The PAT owner must be in `main`'s bypass list
+          # (Settings → Branches → main → "Allow specified actors to
+          # bypass required pull requests"). See RELEASING.md.
+          #
+          # Setting `token:` here configures git credentials for every
+          # subsequent step in this job, so `git push origin HEAD:main`
+          # uses the PAT automatically.
+          token: ${{ secrets.RELEASE_BOT_PAT }}
 
       - name: Fetch all tags
         run: git fetch --force --tags

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -63,23 +63,37 @@ Highlights` placeholder and the workflow still publishes — but the
 draft release will have a visible TODO that you'll need to edit before
 publishing.
 
-### Branch protection on `main`
+### `RELEASE_BOT_PAT` (fine-grained PAT)
 
-The workflow pushes the `CHANGELOG.md` commit to `main` using the
-default `GITHUB_TOKEN`. If `main` is branch-protected with "require PR
-review" or "require status checks", that push will be rejected.
+The workflow pushes the auto-generated `CHANGELOG.md` commit to `main`.
+The default `GITHUB_TOKEN` is rejected by `main`'s "require PR review"
+branch protection, so we use a fine-grained PAT instead.
 
-Two ways to fix:
+**Create the PAT** at <https://github.com/settings/personal-access-tokens>:
 
-- **Allow bypass for `github-actions[bot]`** in the `main` branch
-  protection rules (cleanest, no extra credentials).
-- **Use a fine-grained PAT** with `contents: write` on this repo, store
-  it as `secrets.RELEASE_TOKEN`, and swap `GITHUB_TOKEN` for it in the
-  commit step.
+- **Name:** `smart-router-release-bot`
+- **Resource owner:** `Magma-Devs`
+- **Repository access:** Only select repositories → `smart-router`
+- **Repository permissions:** Contents: Read and write (Metadata: Read
+  is added automatically; everything else: No access)
+- **Expiration:** pick something you'll remember to rotate (e.g. 1 year).
 
-If neither is set up, the release still publishes — but `CHANGELOG.md`
-in `main` won't be updated, and you'll need to commit it manually
-afterwards.
+Then add as a repo secret:
+
+```
+gh secret set RELEASE_BOT_PAT --repo Magma-Devs/smart-router
+# paste the token when prompted
+```
+
+**Add the PAT owner to `main`'s bypass list:** Settings → Branches → edit
+the `main` rule → "Allow specified actors to bypass required pull
+requests" → add the user account that owns the PAT → Save. (If the PAT
+owner is already an admin and the rule allows admins, this is a no-op.)
+
+If `RELEASE_BOT_PAT` is missing or expired, the commit-CHANGELOG-to-main
+step will fail and stop the workflow before goreleaser runs — the
+release won't be published. Rotate the PAT and re-run the workflow via
+`gh workflow run release.yml -f release_tag=vX.Y.Z`.
 
 ## Manually previewing a changelog locally
 


### PR DESCRIPTION
## Summary

The release workflow needs to push the auto-generated `CHANGELOG.md` commit back to `main`. The default `GITHUB_TOKEN` is rejected by `main`'s PR-required branch protection, so use a fine-grained PAT (`RELEASE_BOT_PAT`) wired through `actions/checkout`'s `token:` input.

## Before merging — one-time setup

1. **Create a fine-grained PAT** at <https://github.com/settings/personal-access-tokens>
   - Name: `smart-router-release-bot`
   - Resource owner: `Magma-Devs`
   - Repository access: Only select repositories → `smart-router`
   - Permissions: Contents: Read and write (Metadata auto-included, everything else No access)
   - Expiration: pick a duration you'll rotate
2. **Add as repo secret:**
   ```
   gh secret set RELEASE_BOT_PAT --repo Magma-Devs/smart-router
   ```
3. **Add the PAT owner to `main`'s bypass list:** Settings → Branches → `main` rule → "Allow specified actors to bypass required pull requests" → add user → Save

## Failure mode

If `RELEASE_BOT_PAT` is missing or expired, the "Commit CHANGELOG.md update to main" step fails and the workflow stops before goreleaser runs (no draft release published). Rotate the PAT and re-run via `gh workflow run release.yml -f release_tag=vX.Y.Z`.

## Test plan

- [x] Workflow YAML parses
- [ ] After merge: `RELEASE_BOT_PAT` set + bypass configured, then re-tag `v1.0.0-rc1`, verify the workflow runs end-to-end and the chore(changelog) commit lands on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)