### PR TITLE
fix(lavasession): bound retry when header-pinned provider fails to co…

### DIFF
--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -1089,6 +1089,22 @@ func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context
 
 	// Handle provider selection via header (smartrouter only)
 	if selectedProvider != "" {
+		// If the pinned provider has already been added to ignoredProvidersList during this
+		// GetSessions call (e.g. a prior fetchEndpointConnectionFromConsumerSessionWithProvider
+		// returned connected=false), the outer loop would otherwise re-call us with the same
+		// selectedProvider and we'd return the same address again — an unbounded spin. Bound
+		// it here by returning an error the caller propagates as a single attempt.
+		if _, ignored := ignoredProvidersList[selectedProvider]; ignored {
+			return nil, utils.LavaFormatWarning(
+				"Selected provider already failed in this request",
+				SelectedProviderUnavailableError,
+				utils.LogAttr("selectedProvider", selectedProvider),
+				utils.LogAttr("addon", addon),
+				utils.LogAttr("extensions", extensions),
+				utils.LogAttr("GUID", ctx),
+			)
+		}
+
 		// Validate that the selected provider is in the valid addresses list
 		providerValid := slices.Contains(validAddresses, selectedProvider)
 		if providerValid {
@@ -1099,18 +1115,18 @@ func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context
 				utils.LogAttr("extensions", extensions),
 				utils.LogAttr("GUID", ctx))
 			return addresses, nil
-		} else {
-			// Return error instead of falling back to random selection
-			return nil, utils.LavaFormatError(
-				"Selected provider not available",
-				nil,
-				utils.LogAttr("selectedProvider", selectedProvider),
-				utils.LogAttr("validProviders", validAddresses),
-				utils.LogAttr("addon", addon),
-				utils.LogAttr("extensions", extensions),
-				utils.LogAttr("GUID", ctx),
-			)
 		}
+
+		// Return error instead of falling back to random selection
+		return nil, utils.LavaFormatError(
+			"Selected provider not available",
+			SelectedProviderUnavailableError,
+			utils.LogAttr("selectedProvider", selectedProvider),
+			utils.LogAttr("validProviders", validAddresses),
+			utils.LogAttr("addon", addon),
+			utils.LogAttr("extensions", extensions),
+			utils.LogAttr("GUID", ctx),
+		)
 	}
 
 	if stickysession, ok := csm.stickySessions.Get(stickiness); ok {

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -1057,6 +1057,37 @@ func TestNoPairingsError(t *testing.T) {
 	require.True(t, errors.Is(err, PairingListEmptyError))
 }
 
+// TestSelectedProviderAlreadyFailedReturnsError verifies the header-pinned path bounds retries.
+// Why: without this guard, GetSessions' outer loop spins forever when the pinned provider's
+// DirectRPC connection is unhealthy — the pinned name keeps being re-selected even after it
+// has been added to the in-request ignored list, producing the unbounded "Provider selected
+// via header" / "direct RPC connection is unhealthy" log pair seen in lava-sim-rest hangs.
+func TestSelectedProviderAlreadyFailedReturnsError(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+	pairingList := createPairingList("", true)
+	err := csm.UpdateAllProviders(firstEpochHeight, pairingList, nil)
+	require.NoError(t, err)
+	time.Sleep(5 * time.Millisecond) // let probes finish
+
+	validAddresses := csm.getValidAddresses("", nil, context.Background())
+	require.NotEmpty(t, validAddresses)
+	pinned := validAddresses[0]
+
+	// Sanity: when not ignored, the pinned address is returned successfully.
+	got, err := csm.getValidProviderAddresses(context.Background(), 1, map[string]struct{}{}, 10, 100, "", nil, common.NO_STATE, "", pinned)
+	require.NoError(t, err)
+	require.Equal(t, []string{pinned}, got)
+
+	// When the pinned address has already been added to ignoredProvidersList
+	// (simulating a prior failed connect attempt in the same GetSessions call),
+	// the helper must return an error instead of re-selecting the same address.
+	ignored := map[string]struct{}{pinned: {}}
+	_, err = csm.getValidProviderAddresses(context.Background(), 1, ignored, 10, 100, "", nil, common.NO_STATE, "", pinned)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, SelectedProviderUnavailableError),
+		"expected SelectedProviderUnavailableError, got: %v", err)
+}
+
 func TestPairingWithStateful(t *testing.T) {
 	ctx := context.Background()
 	t.Run("stateful", func(t *testing.T) {

--- a/protocol/lavasession/errors.go
+++ b/protocol/lavasession/errors.go
@@ -21,6 +21,7 @@ var ( // Consumer Side Errors
 	ContextDoneNoNeedToLockSelectionError   = errors.New("Context deadline exceeded while trying to lock selection")
 	BlockEndpointError                      = errors.New("Block the endpoint")
 	ConsistencyPreValidationError           = errors.New("endpoint failed pre-request consistency validation")
+	SelectedProviderUnavailableError        = errors.New("Header-selected provider has already failed for this request")
 )
 
 


### PR DESCRIPTION
## Summary

Fixes an unbounded retry loop in `lavasession` that hung REST requests indefinitely when the `lava-select-provider` header pinned an unreachable provider. The pinned name was returned every iteration of `GetSessions`' outer loop because the header-pin branch in `getValidProviderAddresses` did not consult `ignoredProvidersList`. Client requests timed out at 12–30s, producing the alternating `Provider selected via header` / `direct RPC connection is unhealthy` log pair under a single GUID.

## Root cause

`protocol/lavasession/consumer_session_manager.go`:

- `getValidProviderAddresses` (L1090-L1114, before fix): when `selectedProvider != ""`, returned the pinned address based solely on `validAddresses` membership. Never checked `ignoredProvidersList`.
- `GetSessions` outer `for { ... }` (L903-L1035): on connect failure, adds the pinned address to `tempIgnoredProviders` and re-fetches sessions via `getSessionWithProviderOrError` while still passing `selectedProvider` unchanged. The header-pin branch returns the same address again. Loop has no attempt counter — runs until the request context expires.

`mode: down` on the provider simulator is what trips this: `HTTPDirectRPCConnection.SendRequest` calls `h.healthy.Store(false)` on dial failure, so subsequent `IsHealthy()` checks fail and `fetchEndpointConnectionFromConsumerSessionWithProvider` returns `connected=false` every iteration.

The ticket's "chainlib retry wrapping" framing is incorrect — neither `jsonRPC.go` nor `rest.go` wraps `SendRelay` in a retry loop; the header parsing site is the shared `rpcsmartrouter_server.go:1808`. The bug lives in shared session-manager code and just happens to manifest first in the REST sim test matrix.

## Fix

`protocol/lavasession/consumer_session_manager.go` — bound the loop at the source: if `selectedProvider` is already in `ignoredProvidersList`, return `SelectedProviderUnavailableError` immediately so the outer `GetSessions` loop exits after one attempt.

`protocol/lavasession/errors.go` — add `SelectedProviderUnavailableError` sentinel. Both header-pin error paths (pinned + already-failed and pinned + not-in-valid-addresses) now wrap this sentinel for uniform `errors.Is` detection.

## Semantics — matches JSON-RPC `lava-select-provider`

`lava-select-provider` is a **hard pin**, not a preference. With the fix, REST now matches the documented JSON-RPC behavior:

| Scenario | JSON-RPC reference test | REST with this fix |
|---|---|---|
| Pinned + healthy | HTTP 200, no retries (test_phase2_8 Case 1) | HTTP 200, no retries |
| Pinned + invalid name | HTTP 500 "Selected provider not available" (test_phase2_8 Case 2) | HTTP 500 "Selected provider not available" |
| Pinned + valid but unreachable | (no published test) hard-pin semantic → HTTP 500 | HTTP 500 "Selected provider not available" (was: hang until context expiry) |

Soft-pin failover is the documented behavior of `lava-stickiness` (test_phase2_8 Case 6), a different header and code path — unchanged by this PR.

## Test plan

- [x] New unit test `TestSelectedProviderAlreadyFailedReturnsError` in `protocol/lavasession/consumer_session_manager_test.go` — verifies (a) baseline pin returns the address, (b) pin + already-ignored returns `SelectedProviderUnavailableError`. Confirmed RED (compile failure on missing sentinel) → GREEN.
- [x] Full `protocol/lavasession` suite passes (`go test ./protocol/lavasession/ -count=1 -timeout 180s` → 27.7s, ok).
- [x] Module builds (`go build ./...` clean).
- [ ] Validate against the 7 failing lava-sim-rest cases in PR #102 / MAG-1740:
  - `test_lava_sim_rest_router_fails_over_when_first_provider_down` — if it asserts HTTP 200 via failover under `lava-select-provider`, the test assertion conflicts with the hard-pin contract documented in JSON-RPC test_phase2_8 Case 2 and should be revised (either switch to `lava-stickiness` or expect HTTP 500).
  - 6× `test_router_classifies_rest_http_status` (400/404/405/429/500/503) — these may exercise the response-classifier path (`HTTPDirectRPCConnection` returns `healthy=true` for any received response), which is separate from this fix. Worth a follow-up investigation in `relaycore`/state-machine.

## Out of scope

- The 6 `test_router_classifies_rest_http_status` failures, if they don't recover with this fix, point at a separate issue in error classification, not the pinning hang.
- The ticket description should be updated to remove the "REST chainlib's missing retry bound" framing — the divergence between the JSON-RPC and REST sim suites is observational, not architectural.

#Closes MAG-1851