### PR TITLE
feat(release): link Changes bullets to PRs; fix dropped-last-commit bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,10 @@ jobs:
         id: generate
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # GH_TOKEN lets the bumper look up the PR associated with each
+          # commit via `GET /commits/{sha}/pulls`. Default GITHUB_TOKEN
+          # has the required read access and isn't rate-limited (5000/hr).
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           v_re=$(printf '%s' "$RELEASE_VERSION" | sed -e 's/[][().*+?^$\|/]/\\&/g')
           if grep -qE "^## ${v_re}( |\$)" CHANGELOG.md 2>/dev/null; then

--- a/scripts/changelog-bump.sh
+++ b/scripts/changelog-bump.sh
@@ -29,6 +29,10 @@ set -euo pipefail
 FORK_BASE="10a450617b7ee6d1aff724030f3a55b60a694533"
 
 REPO_URL="${REPO_URL:-https://github.com/magma-Devs/smart-router}"
+# Owner/repo path derived from REPO_URL — used for GitHub API calls
+# that look up the PR associated with each commit (see PR-link logic
+# in the per-commit loop below).
+REPO_PATH="${REPO_URL#https://github.com/}"
 EDITOR="${EDITOR:-vim}"
 
 : "${VERSION:?VERSION is required, e.g. VERSION=v1.0.0}"
@@ -95,18 +99,54 @@ for i in "${!GROUP_TITLES[@]}"; do : > "$tmp_dir/g$i"; done
 # `git log --reverse` yields oldest-first inside the range; the inline
 # bullet list ends up in chronological order, matching the old goreleaser
 # `sort: asc` behavior.
+#
+# For each commit we resolve a PR number two ways: first by looking for
+# the `(#N)` suffix that GitHub appends to squash-merged commit subjects,
+# and if that's missing, by calling `GET /commits/{sha}/pulls` against
+# the GitHub API (auth via GH_TOKEN). Unauthenticated API calls are rate-
+# limited to 60/hour, so the workflow passes GITHUB_TOKEN as GH_TOKEN.
+# Without a token, we still surface any (#N) baked into the subject.
 while IFS=$'\t' read -r short long subject; do
   if [[ "$subject" =~ $EXCLUDE_REGEX ]]; then
     continue
   fi
+
+  pr_num=""
+  subject_rendered="$subject"
+  if [[ "$subject" =~ \(#([0-9]+)\)[[:space:]]*$ ]]; then
+    pr_num="${BASH_REMATCH[1]}"
+    # Replace the trailing `(#N)` with `([#N])` so it renders as a
+    # markdown reference-style link (definition added to $tmp_dir/refs
+    # below; deduped via sort -u at end of section build).
+    subject_rendered="${subject%\(#${pr_num}\)*}([#${pr_num}])"
+  elif [ -n "${GH_TOKEN:-}" ]; then
+    pr_num="$(curl -sS --max-time 5 \
+      -H "Authorization: token ${GH_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/${REPO_PATH}/commits/${long}/pulls" 2>/dev/null \
+      | jq -r '.[0].number // empty' 2>/dev/null || true)"
+    if [ -n "$pr_num" ]; then
+      subject_rendered="${subject} ([#${pr_num}])"
+    fi
+  fi
+
   for i in "${!GROUP_REGEX[@]}"; do
     if [[ "$subject" =~ ${GROUP_REGEX[$i]} ]]; then
-      printf -- '- %s [`%s`]\n' "$subject" "$short" >> "$tmp_dir/g$i"
+      printf -- '- %s [`%s`]\n' "$subject_rendered" "$short" >> "$tmp_dir/g$i"
       printf '[`%s`]: %s/commit/%s\n' "$short" "$REPO_URL" "$long" >> "$tmp_dir/refs"
+      if [ -n "$pr_num" ]; then
+        printf '[#%s]: %s/pull/%s\n' "$pr_num" "$REPO_URL" "$pr_num" >> "$tmp_dir/refs"
+      fi
       break
     fi
   done
-done < <(git log --reverse --no-merges --pretty=format:'%h%x09%H%x09%s' "${prev_ref}..HEAD")
+done < <(git log --reverse --no-merges --pretty=tformat:'%h%x09%H%x09%s' "${prev_ref}..HEAD")
+# tformat: (terminator) appends a newline after every commit; plain
+# format: only puts newlines BETWEEN commits, so bash `read` drops the
+# last line in the loop above. With tformat: every commit is processed.
+
+# Dedup ref lines: a single PR can be linked from multiple commits.
+sort -u -o "$tmp_dir/refs" "$tmp_dir/refs"
 
 changes_md=""
 for i in "${!GROUP_TITLES[@]}"; do


### PR DESCRIPTION
## Summary

Two changes to the bumper:

### 1. Link each Changes bullet to its source PR

Each bullet in `### Changes` now ends with a clickable `[#N]` reference link to the PR, alongside the existing `[hash]` commit link.

The PR number comes from two sources, in priority order:

- **Squash-merge subject suffix** — GitHub auto-appends `(#13)` to commit messages when squashing PR #13. The bumper rewrites this in-line as `([#13])`.
- **GitHub API lookup** — for commits whose subjects don't carry the suffix (e.g. rebase-merged or directly-pushed), the bumper queries `GET /repos/{owner}/{repo}/commits/{sha}/pulls` and links the first PR returned. The release workflow passes `secrets.GITHUB_TOKEN` as `GH_TOKEN` for this. Local previews without a token still get subject-suffix extraction; only API enrichment is skipped.

PR link definitions go in the same reference-blob at the bottom of each section as commit links (deduped via `sort -u`).

Example output:
```markdown
#### Bug fixes
- fix: solana slot unit mismatch ([#21]) [`705d8be`]
- fix(chain-tracker): filter providers by ApiInterface + refresh example configs ([#3]) [`0ecdf02`]

[#3]: https://github.com/magma-Devs/smart-router/pull/3
[#21]: https://github.com/magma-Devs/smart-router/pull/21
```

### 2. Fix the bumper silently dropping the most recent commit

Pre-existing bug spotted while testing: the git log invocation used `--pretty=format:` which puts newlines BETWEEN commits but not after the last one. Bash `read` in a `while` loop drops the last line in that case. Every prior release was missing one commit from the Changes section.

Switched to `--pretty=tformat:` (terminator) which appends a newline after every commit. All commits in the range get processed now.

## Test plan

- [x] Local: subject-suffix extraction renders `([#N])` and emits the right `[#N]: pull/N` ref (verified against 4 commits from the existing main with `(#N)` suffixes)
- [x] Local: `tformat:` fix processes commits that the previous `format:` was dropping (verified with a single-commit range that was being dropped entirely)
- [x] Local: bumper falls back gracefully without `GH_TOKEN` — no API call, no error
- [ ] CI: confirm the API-lookup path enriches commits that lack `(#N)` subjects (will be exercised on the first release after this merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)