### PR TITLE
fix(release): drop changelog.disable so --release-notes body lands

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -99,13 +99,19 @@ checksum:
   name_template: "sha256sum.txt"
   algorithm: sha256
 
-# Auto-changelog is disabled — CHANGELOG.md is the source of truth and the
-# release body comes from `release.header_file` below. The conventional-
-# commit grouping logic that used to live here now lives in
-# scripts/changelog-bump.sh and runs at `make changelog` time, not at
-# release time. See RELEASING.md.
-changelog:
-  disable: true
+# No `changelog:` block. The release workflow passes
+# `--release-notes .release-notes/body.md` to goreleaser, which:
+#   1. Uses that file as the entire release body, AND
+#   2. Skips goreleaser's own changelog generation (per the flag's docs).
+#
+# We previously had `changelog: { disable: true }` here, but combining
+# it with `--release-notes` caused goreleaser to silently ship a release
+# with an empty body — the file content was never loaded. Dropping
+# `disable: true` and trusting the flag's own skip-changelog behavior
+# fixes that.
+#
+# The conventional-commit grouping logic that used to live here is now
+# in scripts/changelog-bump.sh — see RELEASING.md.
 
 # Cosign keyless signing of the checksum file. Requires `id-token: write`
 # in the release workflow and cosign installed on the runner (added by


### PR DESCRIPTION
## Summary

The v1.0.0-rc1 draft release was published with an empty body (just a single newline character) despite:

- The bumper writing a populated `## v1.0.0-rc1` section to `CHANGELOG.md`
- The extract step writing the section to `.release-notes/body.md` with the right content (verified in workflow logs)
- The workflow passing `--release-notes .release-notes/body.md` to goreleaser

The `--release-notes` CLI flag's own docs say it loads the file as the release body AND skips goreleaser's changelog generation. But `.goreleaser.yaml` also had `changelog: { disable: true }`. With both set, goreleaser appears to silently skip the entire release-notes loading and ship an empty body.

## Fix

Remove the `changelog:` block entirely. Trust the `--release-notes` flag to do both jobs (load file + skip changelog generation).

## Verification

`goreleaser check` passes. End-to-end verification requires retagging rc1 after merge.

## Test plan

- [x] `goreleaser check` passes
- [ ] After merge: retag `v1.0.0-rc1` (delete + recreate at new main HEAD), watch workflow, confirm draft release body contains the populated `## v1.0.0-rc1` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)