### PR TITLE
fix(grpc-connector): don't tear down pool on probe ctx cancellation (MAG-1926)

### DIFF
--- a/protocol/chainlib/chainproxy/connector.go
+++ b/protocol/chainlib/chainproxy/connector.go
@@ -353,7 +353,18 @@ func addClientsAsynchronouslyGrpc(ctx context.Context, connector *GRPCConnector,
 		connector.addClient(rpcClient)
 	}
 	if (connector.numberOfFreeClients() + connector.numberOfUsedClients()) == 0 {
-		utils.LavaFormatFatal("Could not create any connections to the node check address", nil, utils.Attribute{Key: "address", Value: nodeUrl.UrlStr()})
+		if ctx.Err() != nil {
+			// Probe-scoped ctx (validateProvider, etc.) was cancelled before
+			// the async fill produced any client. Caller will treat the
+			// returned error as a probe failure; the process must not exit.
+			utils.LavaFormatWarning("gRPC connector aborted before any connection was built", ctx.Err(),
+				utils.LogAttr("address", nodeUrl.UrlStr()),
+			)
+		} else {
+			utils.LavaFormatFatal("Could not create any connections to the node check address", nil,
+				utils.Attribute{Key: "address", Value: nodeUrl.UrlStr()},
+			)
+		}
 	}
 	utils.LavaFormatInfo("Finished adding clients asynchronously", utils.LogAttr("count", len(connector.freeClients)))
 	go connector.connectorLoop(ctx)
@@ -408,7 +419,10 @@ func (connector *GRPCConnector) createConnection(ctx context.Context, nodeUrl co
 			return nil, err
 		}
 		if ctx.Err() != nil {
-			connector.Close()
+			// Don't Close() the connector — that wipes the existing pool.
+			// One probe's cancellation must not destroy connections that
+			// other callers are still using. Just stop dialling more and
+			// return the error.
 			return nil, ctx.Err()
 		}
 		nctx, cancel := connector.nodeUrl.LowerContextTimeoutWithDuration(ctx, common.AverageWorldLatency*2)

--- a/protocol/chainlib/chainproxy/connector_test.go
+++ b/protocol/chainlib/chainproxy/connector_test.go
@@ -268,6 +268,51 @@ func TestHashing(t *testing.T) {
 	require.Equal(t, conn.hashedNodeUrl, HashURL(listenerAddressTcp))
 }
 
+// TestConnectorPoolSurvivesProbeCancellation verifies the H1 fix in
+// connector.createConnection (PR #54, MAG-1926). When a probe-scoped ctx is
+// cancelled while createConnection is mid-loop, the pre-fix code called
+// connector.Close() — which tore down ALL existing free clients in the pool,
+// crashing every other caller that still held a reference to the connector.
+// The fix removes that Close() call; createConnection now just returns ctx.Err()
+// and leaves the pool intact for other callers.
+//
+// Pre-fix (Close on cancellation): pool drops from numberOfClients to 0, and
+// subsequent GetRpc fails / blocks forever waiting for new clients.
+// Post-fix: pool count is unchanged and GetRpc still returns a usable client.
+func TestConnectorPoolSurvivesProbeCancellation(t *testing.T) {
+	server := createGRPCServer(t)
+	defer server.Stop()
+
+	ctx := context.Background()
+	conn, err := NewGRPCConnector(ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
+	require.NoError(t, err)
+	for { // wait for the async fill goroutine to finish populating the pool
+		if conn.numberOfFreeClients() == numberOfClients {
+			break
+		}
+	}
+	require.Equal(t, numberOfClients, conn.numberOfFreeClients(), "pool should be full before cancellation")
+
+	// Simulate a probe-scoped ctx that gets cancelled mid-loop. createConnection
+	// observes ctx.Err() != nil and (pre-fix) calls connector.Close(); (post-fix)
+	// just returns ctx.Err().
+	probeCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	_, err = conn.createConnection(probeCtx, common.NodeUrl{Url: listenerAddressGrpc}, conn.numberOfFreeClients())
+	require.Error(t, err, "createConnection must return the cancellation error")
+	require.ErrorIs(t, err, context.Canceled)
+
+	// The pool that other callers depend on must still be intact.
+	require.Equal(t, numberOfClients, conn.numberOfFreeClients(),
+		"existing pool clients must survive a probe-ctx cancellation; pre-fix Close() wiped them")
+
+	// And the connector is still usable for downstream calls.
+	rpc, err := conn.GetRpc(ctx, false)
+	require.NoError(t, err, "GetRpc should still work after a cancelled probe")
+	require.NotNil(t, rpc)
+	conn.ReturnRpc(rpc)
+}
+
 func createRPCServer() net.Listener {
 	timeserver := new(TimeServer)
 	// Register the timeserver object upon which the GiveServerTime

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -298,7 +298,22 @@ func (rpsr *RPCSmartRouter) Start(ctx context.Context, options *rpcSmartRouterSt
 	// This prevents multiple UpdateAllProviders calls with the same epoch to the same session manager.
 	// Capture ctx in the closure rather than stashing it on rpsr (storing context.Context in a struct is
 	// idiomatically discouraged); the EpochTimer's callback signature is fixed at func(uint64).
+	//
+	// Skip the very first synchronous callback. EpochTimer.Start fires
+	// notifyCallbacks(currentEpoch) inline before returning (see
+	// protocol/common/epoch_timer.go), so without this guard updateEpoch — and
+	// the applyReverification it drives — runs while chain listeners, direct
+	// RPC connection pools, and chain trackers are all still completing their
+	// initial dials against the same upstreams. The contention amplifies the
+	// race window in addClientsAsynchronouslyGrpc; defense-in-depth alongside
+	// the connector fix in chainproxy/connector.go. All subsequent ticks come
+	// from the timer goroutine after the system is steady-state and run
+	// normally.
+	var firstTick atomic.Bool
 	rpsr.epochTimer.RegisterCallback(func(epoch uint64) {
+		if firstTick.CompareAndSwap(false, true) {
+			return
+		}
 		rpsr.updateEpoch(ctx, epoch)
 	})
 

--- a/protocol/rpcsmartrouter/rpcsmartrouter_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1222,4 +1223,64 @@ func TestUpdateEpoch_ReverifyCrossEpochDemoteThenPromote(t *testing.T) {
 		"epoch 3: re-promoted session must be a fresh object, not a resurrected pointer from epoch 1 — applyReverification's toAdmit path goes through convertProvidersToSessions for absent-from-fresh providers")
 	require.Equal(t, uint64(3), epoch3Session.PairingEpoch,
 		"epoch 3: re-promoted session must carry PairingEpoch=3")
+}
+
+// TestEpochTimer_FirstTickIsSwallowed verifies the H2 defense-in-depth gate
+// added in PR #54 (MAG-1926) at rpcsmartrouter.go:312-318. The EpochTimer.Start
+// callback now fires a synchronous boot tick (see protocol/common/epoch_timer.go
+// notifyCallbacks). Before the fix, that boot tick invoked updateEpoch at the
+// exact moment the connector pool was still warming up — amplifying the H1
+// race in addClientsAsynchronouslyGrpc. The fix wraps updateEpoch in an
+// atomic.Bool one-shot gate that swallows the first invocation and lets every
+// subsequent epoch tick through.
+//
+// This test replicates the exact closure pattern shipped at rpcsmartrouter.go
+// :313-318 (atomic.Bool + CompareAndSwap(false, true) + early return) and
+// asserts a spy stand-in for updateEpoch sees zero calls after the first
+// invocation and exactly one call after the second.
+func TestEpochTimer_FirstTickIsSwallowed(t *testing.T) {
+	rpsr := createTestRPCSmartRouter()
+
+	var spyCount atomic.Int64
+	var capturedEpoch atomic.Uint64
+	// Stand-in for rpsr.updateEpoch(ctx, epoch). We can't call the real
+	// updateEpoch here without spinning up endpoints/session managers, so we
+	// observe via a counter the same way the production closure would invoke it.
+	updateEpochSpy := func(epoch uint64) {
+		spyCount.Add(1)
+		capturedEpoch.Store(epoch)
+	}
+
+	// Mirror of the closure registered inside RPCSmartRouter.Start at
+	// protocol/rpcsmartrouter/rpcsmartrouter.go:312-318. The atomic.Bool gate
+	// is local to the closure on purpose so each Start() call gets a fresh
+	// one-shot.
+	var firstTick atomic.Bool
+	cb := func(epoch uint64) {
+		if firstTick.CompareAndSwap(false, true) {
+			return
+		}
+		updateEpochSpy(epoch)
+	}
+	rpsr.epochTimer.RegisterCallback(cb)
+
+	// First invocation = the synchronous boot tick from EpochTimer.Start.
+	// Gate must swallow it.
+	cb(uint64(42))
+	require.Equal(t, int64(0), spyCount.Load(),
+		"first epoch tick must be swallowed by firstTick gate; pre-fix the boot tick called updateEpoch during connector pool warm-up")
+
+	// Second invocation = a normal timer-driven tick. Gate is consumed; this
+	// must call updateEpoch with the supplied epoch.
+	cb(uint64(43))
+	require.Equal(t, int64(1), spyCount.Load(),
+		"second epoch tick must invoke updateEpoch exactly once")
+	require.Equal(t, uint64(43), capturedEpoch.Load(),
+		"updateEpoch must receive the second tick's epoch value, not the boot epoch")
+
+	// Third invocation = another normal tick. Gate stays open.
+	cb(uint64(44))
+	require.Equal(t, int64(2), spyCount.Load(),
+		"subsequent epoch ticks must continue invoking updateEpoch (gate is one-shot, not permanent)")
+	require.Equal(t, uint64(44), capturedEpoch.Load())
 }


### PR DESCRIPTION
## Summary

Two layered fixes for the lava-sim-grpc CrashLoopBackOff regression introduced by a75a283. Either change alone would have closed the boot crash; together they harden against future regressions of the same shape.

**1. `protocol/chainlib/chainproxy/connector.go` — root cause**

`createConnection`'s ctx-cancelled branch no longer calls `connector.Close()`. That call was wiping the **entire connector pool** every time one probe's caller cancelled. The connector is still cleaned up correctly by `connectorLoop` when its own `ctx.Done()` fires; the inline `Close()` was a duplicate that destroyed connections other paths might still be holding. The post-loop check now distinguishes "loop exited because ctx was cancelled" (warn, no exit) from "loop legitimately produced zero connections" (still fatal, preserves original "node unreachable" behavior).

**2. `protocol/rpcsmartrouter/rpcsmartrouter.go` — defense-in-depth**

`EpochTimer.Start` fires `notifyCallbacks(currentEpoch)` synchronously before returning. Pre-a75a283 the callback only ran cheap freshen loops, so that initial fire was harmless. Post-a75a283 it now drives `applyReverification`, which spawns up to `SpecReVerifyConcurrency=5` `validateProvider` goroutines while chain listeners, direct-RPC connection pools, and chain trackers are still completing their *own* initial dials against the same upstream. The contention amplifies the connector race. The guard skips that one synchronous startup fire; every subsequent timer-driven tick runs normally.

## Root cause

On a low-latency upstream (provider-simulator at sub-ms RTT, in-cluster), `validateProvider`'s `Validate(attemptCtx)` returns in ~100ms while the 99-connection async fill loop hasn't finished. `defer attemptCancel()` fires, `createConnection`'s next iteration sees `ctx.Err() != nil`, calls `connector.Close()`, wipes the connections that had been added, then `addClientsAsynchronouslyGrpc`'s post-loop check sees 0 clients and `LavaFormatFatal`s → `os.Exit(1)`. Confirmed end-to-end with a diagnostic build:

```
{"level":"warn","error":"context canceled",
"address":"grpc://provider-simulator…:18548",
"freeClientsBeforeClose":"25","usedClientsBeforeClose":"0","attempt":"2",
"message":"createConnection: ctx cancelled mid-loop, calling connector.Close() (wipes existing pool)"}
{"level":"fatal","ctxErr":"context canceled",
"message":"Could not create any connections to the node check address"}
```


## Why only some gRPC chains were affected

The race is `Validate-RTT` vs. `async-loop-runtime`. For cluster-local provider-simulator both are ~tens of ms and Validate frequently wins. For real LAVA gRPC over WAN+TLS, `Validate` takes seconds and the dial loop finishes comfortably; verified with `lava-grpc-router` running normally through the same code path. The connector change only affects the failing case (cancelled-mid-loop) — the existing "node truly unreachable" path still `LavaFormatFatal`s.

## No resource leak from removing inline `Close()`

`connectorLoop`, spawned at the end of `addClientsAsynchronouslyGrpc`, is the connector's real owner: it blocks on `<-ctx.Done()` and runs `connector.Close()` exactly when the caller's ctx finishes. The inline `Close()` we removed was a duplicate that fired prematurely. FD count in the running pod after ~3 hours of repeated re-verify cycles is flat at 21 (15 sockets) — not climbing.

## Test plan

- [x] Reproduced on denis cluster (`lava-sim-grpc-router`) with v1.0.0 image: CrashLoopBackOff, fatal stack at `connector.go:356`.
- [x] Confirmed mechanism by adding diagnostic logs (Warn before the existing `connector.Close()`, `ctxErr` attribute on the fatal). Both fired with the predicted values immediately before the fatal.
- [x] Applied connector fix, rebuilt, redeployed via `--dev-mode`. `lava-sim-grpc-router` Running 1/1 across multiple natural epoch ticks (15-min interval, ~11+ ticks observed). `lava-grpc-router` (real-LAVA gRPC, never affected) still Running 1/1.
- [x] Applied firstTick guard. New boot: `EpochTimer: Notifying callbacks` fires but no `ConsumerSessionManager: Epoch update triggered` follows — synchronous boot tick suppressed. First natural tick at the 15-min boundary fires normally (`Epoch update triggered` → `starting validation` → `tearing down` → pod stays Running 1/1, `count:36`).
- [x] FD count stable in the running pod (21 total, 15 sockets) — no leak.
- [ ] Verify against a chart deploy with a genuinely unreachable gRPC upstream (wrong host/port) — still expects `LavaFormatFatal`, since `ctx.Err()` would be nil in that case.

#Closes MAG-1926