### PR TITLE
fix(chainlib): reply to eth_unsubscribe instead of hanging the client

### DIFF
--- a/protocol/chainlib/consumer_websocket_manager.go
+++ b/protocol/chainlib/consumer_websocket_manager.go
@@ -303,7 +303,21 @@ func (cwm *ConsumerWebsocketManager) ListenToMessages(ctx context.Context) {
 							sendWS(webSocketMsgWithType{messageType: messageType, msg: formatterMsg})
 						}
 					}
-				} else if responseData != nil {
+				} else {
+					if responseData == nil {
+						// Legacy provider-relay path: Unsubscribe returns (nil, nil) on
+						// success because the provider's relay stream has no synchronous
+						// ack frame to forward. Synthesize a §4.2-compliant reply so
+						// clients don't hang on recv() until they time out (~15s). The
+						// JSON-RPC envelope is safe here: ConsumerWebsocketManager is
+						// only constructed by jsonRPC.go and tendermintRPC.go, both
+						// JSON-RPC-shaped. Mirrors lavanet/lava#2296.
+						responseData = buildUnsubscribeSuccessReply(msg)
+						utils.LavaFormatTrace("synthesized unsubscribe ack",
+							utils.LogAttr("GUID", webSocketCtx),
+							utils.LogAttr("dappID", dappID),
+						)
+					}
 					// Forward the node's response directly to the end user - no transformation or wrapping.
 					sendWS(webSocketMsgWithType{messageType: messageType, msg: responseData})
 				}
@@ -401,4 +415,21 @@ func (cwm *ConsumerWebsocketManager) ListenToMessages(ctx context.Context) {
 			logger.LogRequestAndResponse("jsonrpc ws msg", false, "ws", websocketConn.LocalAddr().String(), string(msg), string(reply.Data), msgSeed, time.Since(startTime), nil)
 		}
 	}
+}
+
+// buildUnsubscribeSuccessReply synthesizes a JSON-RPC 2.0 success response for an
+// eth_unsubscribe / unsubscribe that the consumer satisfied locally — provider
+// relays do not surface an unsubscribe acknowledgement frame, so we fabricate
+// one here rather than letting clients hang. id is substituted as raw JSON to
+// preserve the caller's exact type (§4.2).
+//
+// result is hard-coded to `true`, matching EVM upstream conventions. Tendermint
+// upstreams typically return `{}` here; we optimize for "client unblocks"
+// rather than exact upstream parity.
+func buildUnsubscribeSuccessReply(requestBytes []byte) []byte {
+	idRaw := "null"
+	if r := gjson.GetBytes(requestBytes, "id"); r.Exists() {
+		idRaw = r.Raw
+	}
+	return []byte(`{"jsonrpc":"2.0","id":` + idRaw + `,"result":true}`)
 }

--- a/protocol/chainlib/consumer_websocket_manager_test.go
+++ b/protocol/chainlib/consumer_websocket_manager_test.go
@@ -7,7 +7,61 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// TestBuildUnsubscribeSuccessReply verifies that the synthesized reply for a
+// successful eth_unsubscribe / unsubscribe echoes the caller's JSON-RPC id
+// verbatim (per spec §4.2) and returns result:true. Without the synthesized
+// reply, clients hang on recv() until they time out (~15s) because provider
+// relays do not surface an unsubscribe ack frame. Mirrors lavanet/lava#2296.
+func TestBuildUnsubscribeSuccessReply(t *testing.T) {
+	cases := []struct {
+		name string
+		req  string
+		want string
+	}{
+		{
+			name: "string id",
+			req:  `{"jsonrpc":"2.0","id":"sub-1","method":"eth_unsubscribe","params":["0xabc"]}`,
+			want: `{"jsonrpc":"2.0","id":"sub-1","result":true}`,
+		},
+		{
+			name: "numeric id",
+			req:  `{"jsonrpc":"2.0","id":42,"method":"eth_unsubscribe","params":["0xabc"]}`,
+			want: `{"jsonrpc":"2.0","id":42,"result":true}`,
+		},
+		{
+			name: "null id",
+			req:  `{"jsonrpc":"2.0","id":null,"method":"eth_unsubscribe","params":["0xabc"]}`,
+			want: `{"jsonrpc":"2.0","id":null,"result":true}`,
+		},
+		{
+			name: "missing id falls back to null",
+			req:  `{"jsonrpc":"2.0","method":"eth_unsubscribe","params":["0xabc"]}`,
+			want: `{"jsonrpc":"2.0","id":null,"result":true}`,
+		},
+		{
+			name: "string id containing escaped quote round-trips",
+			req:  `{"jsonrpc":"2.0","id":"a\"b","method":"eth_unsubscribe","params":["0xabc"]}`,
+			want: `{"jsonrpc":"2.0","id":"a\"b","result":true}`,
+		},
+		{
+			// JSON-RPC 2.0 §4.2 recommends scalar ids but does not forbid structured
+			// ones. Lock in that we pass an object id through verbatim rather than
+			// silently corrupting it.
+			name: "object id passes through verbatim",
+			req:  `{"jsonrpc":"2.0","id":{"foo":1},"method":"eth_unsubscribe","params":["0xabc"]}`,
+			want: `{"jsonrpc":"2.0","id":{"foo":1},"result":true}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildUnsubscribeSuccessReply([]byte(tc.req))
+			require.Equal(t, tc.want, string(got))
+		})
+	}
+}
 
 func TestWebsocketConnectionLimiter(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- Synthesize a JSON-RPC 2.0 success reply when the WS-subscription manager's `Unsubscribe` returns `(nil, nil)` — previously left clients hanging until their own timeout (~15s).
- Echo caller's `id` verbatim via `gjson.Raw` so string / number / null / object id types all round-trip per JSON-RPC 2.0 §4.2.
- Ported from [`lavanet/lava#2296`](https://github.com/lavanet/lava/pull/2296); the single fix from this week's lava→smart-router audit that wasn't already in our tree.

### Background

The smart-router was audited against `lavanet/lava` `main` for bug fixes worth pulling forward (audit covered 9 candidate commits across `chainlib`, `chaintracker`, `lavasession`, `common`, `rpcsmartrouter`). Eight had already landed in our tree via parallel development. This PR is the ninth — the `eth_unsubscribe` reply synthesis was missing because the bug is silent (no panic, no log, no metric — just a slow client) and only surfaces when an operator notices unsubscribe latency.

### Code shape

Two edits in `protocol/chainlib/consumer_websocket_manager.go`:
1. Change `else if responseData != nil` to `else { ... }` with a `responseData == nil` synthesis branch.
2. New helper `buildUnsubscribeSuccessReply(requestBytes []byte) []byte` at file bottom.

`gjson` was already imported; no go.mod change.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./protocol/chainlib/...` clean
- [x] New test `TestBuildUnsubscribeSuccessReply` — 6 subtests cover string / numeric / null / missing / escaped-quote-string / object id shapes — all pass
- [x] Full `protocol/chainlib/...` suite passes (`12.4s`)
- [x] `make test-short` passes (`78.7s`)
- [ ] CI verification — `Edition gates and binary verification` + `Unit tests (community)` + `Unit tests (enterprise)` should remain green; the change touches only chainlib and adds no new exported symbol
- [ ] Optional manual smoke: run smart router against `ws://localhost:3360/ws`, issue `eth_subscribe newHeads` then `eth_unsubscribe <sub-id>` — expect reply in ~2ms, not 15s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)