### PR TITLE
feat(rpcsmartrouter): /debug/reset-scores resets chain-tracker + conn-health

### DIFF
--- a/protocol/chaintracker/chain_tracker.go
+++ b/protocol/chaintracker/chain_tracker.go
@@ -40,6 +40,12 @@ type IChainTracker interface {
 	// GetAtomicLatestBlockNum returns the current latest block number atomically
 	GetAtomicLatestBlockNum() int64
 
+	// ResetLatestBlock zeroes the cached latest block so the next consistency
+	// pre-validation skips the lag check (validation_consistency.go treats
+	// endpointLatestBlock <= 0 as "unknown, do not gate"). The poll loop
+	// repopulates the value on its next successful fetch.
+	ResetLatestBlock()
+
 	// StartAndServe starts the chain tracker and serves gRPC if configured
 	StartAndServe(ctx context.Context) error
 
@@ -206,6 +212,36 @@ func (cs *ChainTracker) GetServerBlockMemory() uint64 {
 
 func (cs *ChainTracker) setLatestBlockNum(value int64) {
 	atomic.StoreInt64(&cs.latestBlockNum, value)
+}
+
+// ResetLatestBlock zeroes the cached latest block under blockQueueMu. After
+// reset, consistency pre-validation skips the lag check until the next poll
+// repopulates the value (validation_consistency.go treats endpointLatestBlock
+// <= 0 as "unknown, do not gate"). May be invoked concurrently with the poll
+// goroutine, so accesses outside this method's own locked region must go
+// through the locked helpers below.
+func (cs *ChainTracker) ResetLatestBlock() {
+	cs.blockQueueMu.Lock()
+	defer cs.blockQueueMu.Unlock()
+	atomic.StoreInt64(&cs.latestBlockNum, 0)
+	cs.latestChangeTime = time.Time{}
+}
+
+// getLatestChangeTime/setLatestChangeTime serialize access to latestChangeTime.
+// The field used to be touched only by the poll goroutine, but ResetLatestBlock
+// and the locked readers in GetLatestBlockData/GetLatestBlockNum make it a
+// concurrent field. All paths outside an already-held blockQueueMu must go
+// through these helpers.
+func (cs *ChainTracker) getLatestChangeTime() time.Time {
+	cs.blockQueueMu.RLock()
+	defer cs.blockQueueMu.RUnlock()
+	return cs.latestChangeTime
+}
+
+func (cs *ChainTracker) setLatestChangeTime(t time.Time) {
+	cs.blockQueueMu.Lock()
+	defer cs.blockQueueMu.Unlock()
+	cs.latestChangeTime = t
 }
 
 // this function fetches all previous blocks from the node starting at the latest provided going backwards blocksToSave blocks
@@ -377,10 +413,11 @@ func (cs *ChainTracker) fetchAllPreviousBlocksIfNecessary(ctx context.Context) (
 			}
 			blocksUpdated := uint64(newLatestBlock - prev_latest)
 			// update our timer resolution
-			if !cs.latestChangeTime.IsZero() {
-				cs.AddBlockGap(time.Since(cs.latestChangeTime), blocksUpdated)
+			prevChangeTime := cs.getLatestChangeTime()
+			if !prevChangeTime.IsZero() {
+				cs.AddBlockGap(time.Since(prevChangeTime), blocksUpdated)
 			}
-			cs.latestChangeTime = time.Now()
+			cs.setLatestChangeTime(time.Now())
 		}
 		if forked {
 			if cs.forkCallback != nil {
@@ -400,8 +437,8 @@ func (cs *ChainTracker) fetchAllPreviousBlocksIfNecessary(ctx context.Context) (
 }
 
 func (cs *ChainTracker) notUpdated() {
-	latestBlockTime := cs.latestChangeTime
-	if cs.latestChangeTime.IsZero() {
+	latestBlockTime := cs.getLatestChangeTime()
+	if latestBlockTime.IsZero() {
 		latestBlockTime = cs.startupTime
 	}
 	cs.oldBlockCallback(latestBlockTime)
@@ -464,7 +501,7 @@ func (cs *ChainTracker) start(ctx context.Context, pollingTime time.Duration) er
 
 func (cs *ChainTracker) updateTimer(tickerBaseTime time.Duration, fetchFails uint64) {
 	blockGap := cs.smallestBlockGap()
-	timeSinceLastUpdate := time.Since(cs.latestChangeTime)
+	timeSinceLastUpdate := time.Since(cs.getLatestChangeTime())
 	var newPollingTime time.Duration
 	if timeSinceLastUpdate <= tickerBaseTime/2 && blockGap > tickerBaseTime/4 {
 		newPollingTime = tickerBaseTime / (cs.pollingTimeMultiplier / 4)

--- a/protocol/chaintracker/chain_tracker_test.go
+++ b/protocol/chaintracker/chain_tracker_test.go
@@ -750,3 +750,53 @@ func TestChainTrackerMultipleInstancesNoLeaks(t *testing.T) {
 	// All instances should have cleaned up their resources (tickers, timers, goroutines)
 	// If there were leaks, this test would accumulate resources with each iteration
 }
+
+// TestChainTrackerResetLatestBlock verifies ResetLatestBlock zeroes both the
+// atomic latestBlockNum and the latestChangeTime so consistency pre-validation
+// treats the tracker as "unknown, do not gate" (validation_consistency.go:80).
+//
+// The poll loop is cancelled before Reset: after Reset prev_latest=0 and the
+// next tick would take the gotNewBlock branch in
+// fetchAllPreviousBlocksIfNecessary, rewriting latestBlockNum from the mock.
+// With TimeForPollingMock=2ms that's a tight flake window if we don't cancel.
+func TestChainTrackerResetLatestBlock(t *testing.T) {
+	mockBlocks := int64(20)
+	fetcherBlocks := int64(5)
+
+	mockChainFetcher := NewMockChainFetcher(1000, mockBlocks, nil)
+	mockChainFetcher.AdvanceBlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	chainTrackerConfig := chaintracker.ChainTrackerConfig{
+		BlocksToSave:          uint64(fetcherBlocks),
+		AverageBlockTime:      TimeForPollingMock,
+		ServerBlockMemory:     uint64(mockBlocks),
+		ParseDirectiveEnabled: true,
+	}
+
+	chainTracker, err := chaintracker.NewChainTracker(ctx, mockChainFetcher, chainTrackerConfig)
+	require.NoError(t, err)
+	require.NoError(t, chainTracker.StartAndServe(ctx))
+
+	for i := 0; i < 3; i++ {
+		mockChainFetcher.AdvanceBlock()
+	}
+	require.Eventually(t, func() bool {
+		return chainTracker.GetAtomicLatestBlockNum() > 1000
+	}, time.Second, TimeForPollingMock, "tracker should have polled a non-zero latest block")
+
+	// Stop the poll loop and give the goroutine time to exit before Reset so
+	// no subsequent tick can rewrite latestBlockNum.
+	cancel()
+	time.Sleep(TimeForPollingMock * 5)
+
+	chainTracker.ResetLatestBlock()
+
+	require.Equal(t, int64(0), chainTracker.GetAtomicLatestBlockNum())
+
+	latestBlock, changeTime := chainTracker.GetLatestBlockNum()
+	require.Equal(t, int64(0), latestBlock)
+	require.True(t, changeTime.IsZero(), "latestChangeTime should be zero after reset, got %v", changeTime)
+}

--- a/protocol/chaintracker/dummy_chain_tracker.go
+++ b/protocol/chaintracker/dummy_chain_tracker.go
@@ -28,6 +28,9 @@ func (dct *DummyChainTracker) GetAtomicLatestBlockNum() int64 {
 	return DummyChainTrackerLatestBlock
 }
 
+// ResetLatestBlock is a no-op for the dummy tracker; it has no cached state to clear.
+func (dct *DummyChainTracker) ResetLatestBlock() {}
+
 // StartAndServe starts the chain tracker and serves gRPC if configured
 func (dct *DummyChainTracker) StartAndServe(ctx context.Context) error {
 	return nil

--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -76,6 +76,19 @@ type DirectRPCConnection interface {
 	// IsHealthy returns true if the connection is healthy
 	IsHealthy() bool
 
+	// MarkHealthy forcibly sets the connection's healthy flag back to true.
+	// Intended only for the /debug/reset-scores recovery path so a stuck-false
+	// flag from a transient earlier failure (network blip, brief read error)
+	// does not permanently exclude an endpoint from CV fan-out or pairing
+	// selection. Production code paths must rely on the natural
+	// healthy→false (SendRequest error) and healthy→true (SendRequest
+	// success) transitions; this only shortcuts the recovery when the next
+	// IsHealthy() gate would otherwise block the very request that would
+	// re-establish health. Side effect: the probe path that consults
+	// IsHealthy() at epoch transitions will also see true after a reset
+	// until the next SendRequest outcome resettles it.
+	MarkHealthy()
+
 	// GetURL returns the endpoint URL
 	GetURL() string
 
@@ -393,6 +406,14 @@ func (h *HTTPDirectRPCConnection) IsHealthy() bool {
 	return h.healthy.Load()
 }
 
+// MarkHealthy forcibly resets healthy to true. See the interface docstring;
+// this is the recovery-only escape for stuck-false caused by a one-off
+// transient that the natural SendRequest-success transition can never reach
+// because IsHealthy gates the request itself.
+func (h *HTTPDirectRPCConnection) MarkHealthy() {
+	h.healthy.Store(true)
+}
+
 func (h *HTTPDirectRPCConnection) GetURL() string {
 	return h.nodeUrl.Url
 }
@@ -492,6 +513,11 @@ func (w *WebSocketDirectRPCConnection) Close() error {
 func (w *WebSocketDirectRPCConnection) IsHealthy() bool {
 	return true // health tracking is done at the endpoint/QoS layer
 }
+
+// MarkHealthy is a no-op for WebSocket: this type has no internal healthy
+// flag (IsHealthy already always returns true). The interface method exists
+// so /debug/reset-scores can call it uniformly across transport types.
+func (w *WebSocketDirectRPCConnection) MarkHealthy() {}
 
 func (w *WebSocketDirectRPCConnection) GetURL() string {
 	return w.nodeUrl.Url
@@ -913,6 +939,14 @@ func (g *GRPCDirectRPCConnection) Close() error {
 
 func (g *GRPCDirectRPCConnection) IsHealthy() bool {
 	return g.healthy.Load()
+}
+
+// MarkHealthy forcibly resets healthy to true. See the interface docstring;
+// this is the recovery-only escape for stuck-false caused by a one-off
+// transient that the natural SendRequest-success transition can never reach
+// because IsHealthy gates the request itself.
+func (g *GRPCDirectRPCConnection) MarkHealthy() {
+	g.healthy.Store(true)
 }
 
 func (g *GRPCDirectRPCConnection) GetURL() string {

--- a/protocol/lavasession/direct_rpc_connection_test.go
+++ b/protocol/lavasession/direct_rpc_connection_test.go
@@ -396,6 +396,47 @@ func TestHTTPDirectRPCConnection_IsHealthy_Stays4xxHealthy(t *testing.T) {
 		"a 4xx/5xx response is an application error; transport reached the upstream and health must remain true")
 }
 
+// TestDirectRPCConnection_MarkHealthy_FlipsHTTPHealthyToTrue verifies the
+// recovery-only escape: after a transient failure leaves healthy=false (a
+// state the natural SendRequest-success path cannot reach because
+// IsHealthy() gates the request itself), MarkHealthy must unstick it without
+// requiring a successful exchange. Same idea for the gRPC variant — both
+// have an internal atomic.Bool we expect to flip. WebSocket has no internal
+// flag so MarkHealthy is a no-op there (covered in
+// TestDirectRPCConnection_MarkHealthy_WebSocketIsNoOp).
+func TestDirectRPCConnection_MarkHealthy_FlipsHTTPHealthyToTrue(t *testing.T) {
+	httpConn := &HTTPDirectRPCConnection{}
+	httpConn.healthy.Store(false)
+	require.False(t, httpConn.IsHealthy(), "precondition: healthy starts false")
+
+	httpConn.MarkHealthy()
+
+	require.True(t, httpConn.IsHealthy(), "MarkHealthy must flip the atomic back to true")
+}
+
+func TestDirectRPCConnection_MarkHealthy_FlipsGRPCHealthyToTrue(t *testing.T) {
+	grpcConn := &GRPCDirectRPCConnection{}
+	grpcConn.healthy.Store(false)
+	require.False(t, grpcConn.IsHealthy(), "precondition: healthy starts false")
+
+	grpcConn.MarkHealthy()
+
+	require.True(t, grpcConn.IsHealthy(), "MarkHealthy must flip the atomic back to true")
+}
+
+// TestDirectRPCConnection_MarkHealthy_WebSocketIsNoOp documents that
+// WebSocketDirectRPCConnection has no internal healthy flag (IsHealthy is a
+// constant true). MarkHealthy must still satisfy the interface without
+// panicking; the call is intentionally a no-op.
+func TestDirectRPCConnection_MarkHealthy_WebSocketIsNoOp(t *testing.T) {
+	wsConn := &WebSocketDirectRPCConnection{}
+	require.True(t, wsConn.IsHealthy(), "precondition: WebSocket IsHealthy is constant true")
+
+	wsConn.MarkHealthy() // must not panic
+
+	require.True(t, wsConn.IsHealthy())
+}
+
 // TestHTTPDirectRPCConnection_IsHealthy_RecoversAfterFailure verifies the full
 // unhealthy → healthy transition: once a connection has observed a transport
 // failure, a subsequent successful exchange must flip IsHealthy back to true.

--- a/protocol/rpcsmartrouter/debug_server_test.go
+++ b/protocol/rpcsmartrouter/debug_server_test.go
@@ -5,12 +5,15 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/magma-Devs/smart-router/protocol/chaintracker"
 	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
 	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
 	"github.com/magma-Devs/smart-router/protocol/relaycore"
 	"github.com/stretchr/testify/require"
@@ -114,6 +117,12 @@ func TestDebugResetScores_SmartRouter_ReturnsJSON(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 	require.Contains(t, rr.Body.String(), `"reset":true`)
 	require.Contains(t, rr.Body.String(), `"chains_reset":0`)
+	// trackers_reset and connections_reset are the chain-tracker / direct-
+	// connection contributions; with no router wired (deps.router == nil)
+	// both return 0 — but the fields must still appear so callers can rely
+	// on the shape regardless of fixture wiring.
+	require.Contains(t, rr.Body.String(), `"trackers_reset":0`)
+	require.Contains(t, rr.Body.String(), `"connections_reset":0`)
 }
 
 func TestDebugResetScores_SmartRouter_MethodNotAllowed(t *testing.T) {
@@ -143,6 +152,185 @@ func TestDebugResetScores_SmartRouter_DoesNotChangeOffset(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, getRR.Code)
 	require.Contains(t, getRR.Body.String(), `"offset_seconds":3600`)
+}
+
+// recordingChainTracker is a fake IChainTracker that records ResetLatestBlock
+// calls. We embed *chaintracker.DummyChainTracker for all the methods we don't
+// care about and shadow ResetLatestBlock with our own counter. The atomic
+// counter is required because EndpointChainTrackerManager.ResetAllLatestBlocks
+// only takes RLock while iterating — multiple tracker resets could race in
+// principle (in practice they run sequentially in the loop, but make the test
+// fixture safe regardless).
+type recordingChainTracker struct {
+	*chaintracker.DummyChainTracker
+	resetCalls atomic.Int32
+}
+
+func (r *recordingChainTracker) ResetLatestBlock() {
+	r.resetCalls.Add(1)
+}
+
+// newRouterWithChainTrackers builds a minimal *RPCSmartRouter wired with
+// rpcServers, each holding an EndpointChainTrackerManager whose trackers map
+// is pre-populated with the supplied fakes. The router itself has no real
+// session managers or other state — just enough scaffolding for
+// resetAllChainTrackers to walk router→servers→manager and reach the fakes.
+func newRouterWithChainTrackers(t *testing.T, byServer map[string][]*recordingChainTracker) *RPCSmartRouter {
+	t.Helper()
+	router := &RPCSmartRouter{
+		rpcServers: make(map[string]*RPCSmartRouterServer),
+	}
+	for serverKey, fakes := range byServer {
+		manager := &EndpointChainTrackerManager{
+			trackers:          make(map[string]chaintracker.IChainTracker),
+			fetchers:          make(map[string]*EndpointChainFetcher),
+			cancelFuncs:       make(map[string]context.CancelFunc),
+			trackerStates:     make(map[string]EndpointChainTrackerState),
+			trackerLastErrors: make(map[string]string),
+		}
+		for i, f := range fakes {
+			endpointURL := serverKey + "-endpoint-" + strconv.Itoa(i)
+			manager.trackers[endpointURL] = f
+		}
+		router.rpcServers[serverKey] = &RPCSmartRouterServer{
+			endpointChainTrackerManager: manager,
+		}
+	}
+	return router
+}
+
+// TestDebugResetScores_SmartRouter_ResetsChainTrackers verifies the
+// chain-tracker reset branch added for BTC pollution recovery: every per-
+// endpoint ChainTracker across all rpcServers must have ResetLatestBlock
+// invoked, and the response body must report the total count via
+// trackers_reset so the test framework can assert it from the outside.
+func TestDebugResetScores_SmartRouter_ResetsChainTrackers(t *testing.T) {
+	var offsetNano atomic.Int64
+
+	// Two servers (e.g. eth/jsonrpc and btc/rest), one with 3 providers and
+	// one with 2 — total of 5 trackers across the router.
+	serverA := []*recordingChainTracker{{}, {}, {}}
+	serverB := []*recordingChainTracker{{}, {}}
+	router := newRouterWithChainTrackers(t, map[string][]*recordingChainTracker{
+		"chainA-jsonrpc": serverA,
+		"chainB-rest":    serverB,
+	})
+
+	mux := buildDebugMux(debugMuxDeps{
+		optimizers: newEmptyOptimizersRouter(),
+		offsetNano: &offsetNano,
+		router:     router,
+	})
+
+	rr := postResetScoresRouter(mux)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"reset":true`)
+	require.Contains(t, rr.Body.String(), `"trackers_reset":5`)
+
+	for _, fakes := range [][]*recordingChainTracker{serverA, serverB} {
+		for i, f := range fakes {
+			require.Equal(t, int32(1), f.resetCalls.Load(),
+				"tracker %d should have had ResetLatestBlock called exactly once", i)
+		}
+	}
+}
+
+// recordingDirectRPCConnection is a minimal lavasession.DirectRPCConnection
+// fake that records MarkHealthy invocations. Only the methods the manager
+// touches (IsHealthy/MarkHealthy) carry real behavior; the rest return zero
+// values so the test doesn't pull in chainParser / Endpoint scaffolding it
+// doesn't need.
+type recordingDirectRPCConnection struct {
+	healthy          atomic.Bool
+	markHealthyCalls atomic.Int32
+}
+
+func (r *recordingDirectRPCConnection) SendRequest(context.Context, []byte, map[string]string) (*lavasession.DirectRPCResponse, error) {
+	return nil, errors.New("recordingDirectRPCConnection: SendRequest not implemented")
+}
+
+func (r *recordingDirectRPCConnection) GetProtocol() lavasession.DirectRPCProtocol {
+	return lavasession.DirectRPCProtocolHTTP
+}
+func (r *recordingDirectRPCConnection) Close() error              { return nil }
+func (r *recordingDirectRPCConnection) IsHealthy() bool           { return r.healthy.Load() }
+func (r *recordingDirectRPCConnection) GetURL() string            { return "" }
+func (r *recordingDirectRPCConnection) GetNodeUrl() *common.NodeUrl { return nil }
+
+func (r *recordingDirectRPCConnection) MarkHealthy() {
+	r.markHealthyCalls.Add(1)
+	r.healthy.Store(true)
+}
+
+// newRouterWithConnectionFetchers builds a minimal *RPCSmartRouter wired so
+// resetAllConnectionHealth can walk router→servers→manager.fetchers→connection.
+// Pre-populates each manager's fetchers map (not trackers) with the supplied
+// recording connection fakes, since ResetAllConnectionHealth iterates
+// fetchers — keeping the two reset paths' fixtures decoupled so one test
+// can fail without dragging the other.
+func newRouterWithConnectionFetchers(t *testing.T, byServer map[string][]*recordingDirectRPCConnection) *RPCSmartRouter {
+	t.Helper()
+	router := &RPCSmartRouter{
+		rpcServers: make(map[string]*RPCSmartRouterServer),
+	}
+	for serverKey, conns := range byServer {
+		manager := &EndpointChainTrackerManager{
+			trackers:          make(map[string]chaintracker.IChainTracker),
+			fetchers:          make(map[string]*EndpointChainFetcher),
+			cancelFuncs:       make(map[string]context.CancelFunc),
+			trackerStates:     make(map[string]EndpointChainTrackerState),
+			trackerLastErrors: make(map[string]string),
+		}
+		for i, c := range conns {
+			endpointURL := serverKey + "-endpoint-" + strconv.Itoa(i)
+			manager.fetchers[endpointURL] = &EndpointChainFetcher{directConnection: c}
+		}
+		router.rpcServers[serverKey] = &RPCSmartRouterServer{
+			endpointChainTrackerManager: manager,
+		}
+	}
+	return router
+}
+
+// TestDebugResetScores_SmartRouter_ResetsConnectionHealth verifies the
+// direct-connection health reset branch: every per-endpoint
+// DirectRPCConnection across all rpcServers must have MarkHealthy invoked
+// (to unstick the healthy atomic when CV's IsHealthy() gate is preventing
+// the very SendRequest that would naturally re-establish health), and the
+// response body must report the total count via connections_reset.
+func TestDebugResetScores_SmartRouter_ResetsConnectionHealth(t *testing.T) {
+	var offsetNano atomic.Int64
+
+	serverA := []*recordingDirectRPCConnection{{}, {}, {}}
+	serverB := []*recordingDirectRPCConnection{{}, {}}
+	for _, c := range append(append([]*recordingDirectRPCConnection{}, serverA...), serverB...) {
+		c.healthy.Store(false) // stuck-false precondition
+	}
+
+	router := newRouterWithConnectionFetchers(t, map[string][]*recordingDirectRPCConnection{
+		"chainA-jsonrpc": serverA,
+		"chainB-rest":    serverB,
+	})
+
+	mux := buildDebugMux(debugMuxDeps{
+		optimizers: newEmptyOptimizersRouter(),
+		offsetNano: &offsetNano,
+		router:     router,
+	})
+
+	rr := postResetScoresRouter(mux)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"reset":true`)
+	require.Contains(t, rr.Body.String(), `"connections_reset":5`)
+
+	for _, conns := range [][]*recordingDirectRPCConnection{serverA, serverB} {
+		for i, c := range conns {
+			require.Equal(t, int32(1), c.markHealthyCalls.Load(),
+				"connection %d should have had MarkHealthy called exactly once", i)
+			require.True(t, c.IsHealthy(),
+				"connection %d healthy atomic should be true after MarkHealthy", i)
+		}
+	}
 }
 
 func postResetAllRouter(mux http.Handler) *httptest.ResponseRecorder {

--- a/protocol/rpcsmartrouter/endpoint_chain_fetcher.go
+++ b/protocol/rpcsmartrouter/endpoint_chain_fetcher.go
@@ -47,6 +47,15 @@ func NewEndpointChainFetcher(
 	}
 }
 
+// GetDirectConnection returns the underlying DirectRPCConnection. The same
+// pointer is stored in endpoint.DirectConnections[0] at construction time
+// (see ConsumerSessionManager.GetAllDirectRPCEndpoints), so a MarkHealthy()
+// call through this getter affects the exact atomic the cross-validation
+// path's IsHealthy() reads.
+func (ecf *EndpointChainFetcher) GetDirectConnection() lavasession.DirectRPCConnection {
+	return ecf.directConnection
+}
+
 // FetchLatestBlockNum fetches the latest block number from the endpoint.
 // Uses spec-driven parsing to support any chain type (EVM, Tendermint, REST, etc.).
 func (ecf *EndpointChainFetcher) FetchLatestBlockNum(ctx context.Context) (int64, error) {

--- a/protocol/rpcsmartrouter/endpoint_chain_tracker_manager.go
+++ b/protocol/rpcsmartrouter/endpoint_chain_tracker_manager.go
@@ -401,6 +401,49 @@ func (m *EndpointChainTrackerManager) GetLatestBlockData(endpointURL string) (la
 	return latestBlock, changeTime, true
 }
 
+// ResetAllLatestBlocks calls ResetLatestBlock on every registered tracker so the
+// next consistency pre-validation skips the lag check until the poll loop
+// repopulates the cached value. Used by /debug/reset-scores to clear per-
+// endpoint chain-tracker pollution without restarting the tracker goroutines.
+// Returns the number of trackers that were reset.
+func (m *EndpointChainTrackerManager) ResetAllLatestBlocks() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	count := 0
+	for _, t := range m.trackers {
+		t.ResetLatestBlock()
+		count++
+	}
+	return count
+}
+
+// ResetAllConnectionHealth calls MarkHealthy on every per-endpoint
+// DirectRPCConnection. The same connection pointer is held in
+// endpoint.DirectConnections, which is what the cross-validation IsHealthy()
+// gate reads — so flipping the atomic here unblocks CV fan-out for endpoints
+// whose flag got stuck false from a long-ago transient failure. Returns the
+// number of connections visited (WebSocket connections are counted even
+// though their MarkHealthy is a no-op; the count is "invocations", not
+// "state transitions", so the caller can predict the number from the
+// endpoint count).
+func (m *EndpointChainTrackerManager) ResetAllConnectionHealth() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	count := 0
+	for _, fetcher := range m.fetchers {
+		if fetcher == nil {
+			continue
+		}
+		conn := fetcher.GetDirectConnection()
+		if conn == nil {
+			continue
+		}
+		conn.MarkHealthy()
+		count++
+	}
+	return count
+}
+
 // RemoveTracker removes and stops a ChainTracker for an endpoint.
 // It cancels the tracker's context first, which signals the goroutine to exit cleanly.
 func (m *EndpointChainTrackerManager) RemoveTracker(endpointURL string) {

--- a/protocol/rpcsmartrouter/endpoint_chain_tracker_test.go
+++ b/protocol/rpcsmartrouter/endpoint_chain_tracker_test.go
@@ -48,6 +48,10 @@ func (m *mockDirectRPCConnection) IsHealthy() bool {
 	return m.healthy
 }
 
+func (m *mockDirectRPCConnection) MarkHealthy() {
+	m.healthy = true
+}
+
 func (m *mockDirectRPCConnection) GetURL() string {
 	return m.url
 }

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -442,6 +442,51 @@ type consistencyResetter interface {
 	ResetState()
 }
 
+// resetAllChainTrackers walks the router's per-server EndpointChainTrackerManagers
+// and zeroes every cached latest-block, so consistency pre-validation skips the
+// lag check until the next poll repopulates the value. Returns the total number
+// of trackers reset across all servers. Nil-safe at every level so test fixtures
+// without a fully-wired router still get a useful no-op (count == 0).
+func resetAllChainTrackers(deps debugMuxDeps) int {
+	if deps.router == nil {
+		return 0
+	}
+	deps.router.mu.Lock()
+	defer deps.router.mu.Unlock()
+	count := 0
+	for _, server := range deps.router.rpcServers {
+		if server == nil || server.endpointChainTrackerManager == nil {
+			continue
+		}
+		count += server.endpointChainTrackerManager.ResetAllLatestBlocks()
+	}
+	return count
+}
+
+// resetAllConnectionHealth walks the router's per-server
+// EndpointChainTrackerManagers and forcibly flips every direct connection's
+// healthy flag back to true. Recovery escape for the case where a transient
+// upstream failure stuck the flag false and the IsHealthy() gate (in CV
+// fan-out and elsewhere) prevents the very SendRequest that would naturally
+// re-establish health. Intentionally scoped to /debug/reset-scores only —
+// /debug/reset-all still has a separate session-manager regression we don't
+// want to entangle with this safe path.
+func resetAllConnectionHealth(deps debugMuxDeps) int {
+	if deps.router == nil {
+		return 0
+	}
+	deps.router.mu.Lock()
+	defer deps.router.mu.Unlock()
+	count := 0
+	for _, server := range deps.router.rpcServers {
+		if server == nil || server.endpointChainTrackerManager == nil {
+			continue
+		}
+		count += server.endpointChainTrackerManager.ResetAllConnectionHealth()
+	}
+	return count
+}
+
 // resetAllConsistencies flushes every per-chain seen-block cache that
 // implements consistencyResetter. Why this is necessary: SetSeenBlockFromKey
 // only writes monotonically (consistency.go: `block >= blockSeen → return`),
@@ -556,9 +601,14 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 	})
 
 	// POST /debug/reset-scores — clears optimizer score state without changing
-	// current time offset or NowFunc. Also flushes per-chain seen-block caches
-	// so a corrupted seenBlock (e.g. a ms-timestamp accidentally passed as a
-	// block number) can be scrubbed without restarting the process.
+	// current time offset or NowFunc. Also flushes per-chain seen-block caches,
+	// zeroes per-endpoint chain-tracker latest-block values, and forces every
+	// per-endpoint direct connection back to healthy=true. The connection-
+	// health reset unblocks CV fan-out for endpoints whose healthy atomic got
+	// stuck false from a long-ago transient (IsHealthy() gates the very
+	// SendRequest that would naturally re-establish health). Together these
+	// give a recovery path that does not touch session-manager state — which
+	// trips a separate BTC-router regression on /debug/reset-all.
 	mux.HandleFunc("/debug/reset-scores", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "POST only", http.StatusMethodNotAllowed)
@@ -571,8 +621,11 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 			return true
 		})
 		resetAllConsistencies(deps.consistencies)
+		trackersReset := resetAllChainTrackers(deps)
+		connectionsReset := resetAllConnectionHealth(deps)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"reset":true,"chains_reset":%d}`, count)
+		fmt.Fprintf(w, `{"reset":true,"chains_reset":%d,"trackers_reset":%d,"connections_reset":%d}`,
+			count, trackersReset, connectionsReset)
 	})
 
 	// POST /debug/reset-all — flush every state store the test framework


### PR DESCRIPTION
## Summary

Extends `POST /debug/reset-scores` to also reset two pieces of per-endpoint state that previously could only be cleared by restarting the pod, giving the black-box test framework a safe recovery escape for chain-tracker pollution and stuck-false connection health.

- **ChainTracker `latestBlockNum` / `latestChangeTime`** → zeroed. The next consistency pre-validation skips the lag gate (validation treats `endpointLatestBlock <= 0` as "unknown, do not gate"); the poll loop repopulates on the next successful fetch.
- **`DirectRPCConnection.healthy` atomic** → forced back to `true` for HTTP and gRPC connections (WebSocket: no-op, no internal flag). Unblocks CV fan-out for endpoints whose flag got stuck `false` from a transient failure — `IsHealthy()` gates the very `SendRequest` that would naturally re-establish health, so without an external nudge the endpoint is permanently excluded.

Response shape: `{"reset":true,"chains_reset":N,"trackers_reset":M,"connections_reset":K}`.

## Why not extend `/debug/reset-all`

`/debug/reset-all` also touches session-manager state and trips a separate BTC-router regression. This change is intentionally scoped to chain-tracker + connection-health only — the session-manager-free path keeps the recovery available to BTC tests without entangling with that regression.

## Surface area

- **`chaintracker.IChainTracker.ResetLatestBlock()`** — under `blockQueueMu`, zeros `latestBlockNum` (atomic store) and `latestChangeTime`.
- **`lavasession.DirectRPCConnection.MarkHealthy()`** — HTTP/gRPC: `healthy.Store(true)`; WebSocket: no-op (interface uniformity).
- **`EndpointChainFetcher.GetDirectConnection()`** — returns the same pointer held in `endpoint.DirectConnections[0]`, so `MarkHealthy()` reaches the exact atomic the CV `IsHealthy()` gate reads.
- **`EndpointChainTrackerManager.ResetAllLatestBlocks()` / `ResetAllConnectionHealth()`** — iterate trackers/fetchers under `RLock`, return counts.
- **Handler glue** in `rpcsmartrouter.go` — `resetAllChainTrackers` / `resetAllConnectionHealth` walk `router.rpcServers` under `router.mu` (mirrors `/debug/reset-all`'s pattern), sum per-server counts. Nil-safe at every level.
- **`dummy_chain_tracker.go`** — picks up the new interface method.

## Side fix: pre-existing race on `latestChangeTime`

The field was written/read in the poll goroutine without locking while `GetLatestBlockNum` was reading it under `blockQueueMu`. The race shipped on main; the new `ResetLatestBlock` caller inherently triggers it under `-race`. Three sites (`fetchAllPreviousBlocksIfNecessary`, `notUpdated`, `updateTimer`) now go through new `getLatestChangeTime` / `setLatestChangeTime` helpers.

Note: `go test -race ./protocol/chaintracker/` still surfaces other race reports beyond `latestChangeTime` — those appear to be additional pre-existing races not addressed by this change.

## Test plan

- [x] `go build ./protocol/{chaintracker,lavasession,rpcsmartrouter}/...` — passes.
- [x] `go test ./protocol/rpcsmartrouter/ -run "TestDebugResetScores_SmartRouter_(ReturnsJSON|ResetsChainTrackers|ResetsConnectionHealth)"` — all pass.
- [x] `go test ./protocol/{chaintracker,rpcsmartrouter}/` — pass.
- [x] `go test ./protocol/lavasession/` — passes (one flake on `MaximumNumberOfSelectionLockAttempts`, pre-existing timing flake unrelated to this branch, passed on retry).
- [ ] Manual: hit `POST /debug/reset-scores` against a dev cluster, confirm response includes `trackers_reset` and `connections_reset` counts and that a previously stuck CV endpoint resumes participating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)