### PR TITLE
fix(rpcsmartrouter): treat REST 501 as a non-retryable NodeError (MAG-1576)

### DIFF
--- a/protocol/common/error_classifier.go
+++ b/protocol/common/error_classifier.go
@@ -296,6 +296,9 @@ func httpStatusCodeMappings() []errorMapping {
 		{CodeEquals(413), LavaErrorUserRequestTooLarge},
 		{CodeEquals(429), LavaErrorNodeRateLimited},
 		{CodeEquals(500), LavaErrorNodeInternalError},
+		// 501 Not Implemented: node lacks this method/endpoint (e.g. Cosmos REST
+		// gRPC-gateway). Non-retryable node error, not a transient server failure.
+		{CodeEquals(501), LavaErrorNodeUnimplemented},
 		{CodeEquals(502), LavaErrorNodeBadGateway},
 		{CodeEquals(503), LavaErrorNodeServiceUnavailable},
 		{CodeEquals(504), LavaErrorNodeGatewayTimeout},
@@ -322,6 +325,8 @@ func httpStatusMessageMappings() []errorMapping {
 		{HTTPStatusContains(413), LavaErrorUserRequestTooLarge},
 		{HTTPStatusContains(429), LavaErrorNodeRateLimited},
 		{HTTPStatusContains(500), LavaErrorNodeInternalError},
+		// 501 Not Implemented: node lacks this method/endpoint. Non-retryable.
+		{HTTPStatusContains(501), LavaErrorNodeUnimplemented},
 		{HTTPStatusContains(502), LavaErrorNodeBadGateway},
 		{HTTPStatusContains(503), LavaErrorNodeServiceUnavailable},
 		{HTTPStatusContains(504), LavaErrorNodeGatewayTimeout},

--- a/protocol/common/error_registry_test.go
+++ b/protocol/common/error_registry_test.go
@@ -1012,6 +1012,7 @@ func TestClassifyError_GenericRESTMappings(t *testing.T) {
 		{"413 too large", "HTTP 413: Request Entity Too Large", LavaErrorUserRequestTooLarge},
 		{"429 rate limit", "HTTP 429: Too Many Requests", LavaErrorNodeRateLimited},
 		{"500 internal", "HTTP 500: Internal Server Error", LavaErrorNodeInternalError},
+		{"501 not implemented", "HTTP 501: Not Implemented", LavaErrorNodeUnimplemented},
 		{"502 bad gateway", "HTTP 502: Bad Gateway", LavaErrorNodeBadGateway},
 		{"503 unavailable", "HTTP 503: Service Unavailable", LavaErrorNodeServiceUnavailable},
 		{"504 timeout", "HTTP 504: Gateway Timeout", LavaErrorNodeGatewayTimeout},
@@ -1022,6 +1023,24 @@ func TestClassifyError_GenericRESTMappings(t *testing.T) {
 			assert.Equal(t, tt.expected, result, "expected %s but got %s", tt.expected.Name, result.Name)
 		})
 	}
+}
+
+// TestClassifyError_REST501NotImplemented pins the classifier half of the MAG-1576
+// "REST not implemented" fix. The REST relay path classifies on the HTTP status code
+// itself (errorCode = StatusCode), so a Cosmos node's 501 must map to
+// NODE_UNIMPLEMENTED and be non-retryable — otherwise the router would retry an
+// unsupported method as if it were a transient server error.
+func TestClassifyError_REST501NotImplemented(t *testing.T) {
+	// Code-based path: the REST relay forwards errorCode = HTTP status (501).
+	result := ClassifyError(nil, ChainFamilyCosmosSDK, TransportREST, 501, "Not Implemented")
+	assert.Equal(t, LavaErrorNodeUnimplemented, result,
+		"REST 501 must classify as NODE_UNIMPLEMENTED, got %s", result.Name)
+	assert.False(t, result.Retryable, "NODE_UNIMPLEMENTED must be non-retryable")
+
+	// The umbrella retry verdict the relay path actually consults.
+	assert.True(t,
+		IsNonRetryableNodeErrorWithContext(ChainFamilyCosmosSDK, TransportREST, 501, "Not Implemented"),
+		"REST 501 must be non-retryable")
 }
 
 // TestClassifyError_GenericJsonRPCHTTPStatusMappings is the JSON-RPC analogue
@@ -1051,6 +1070,7 @@ func TestClassifyError_GenericJsonRPCHTTPStatusMappings(t *testing.T) {
 		{"413 too large", "HTTP 413: Request Entity Too Large", LavaErrorUserRequestTooLarge},
 		{"429 rate limit", "HTTP 429: Too Many Requests", LavaErrorNodeRateLimited},
 		{"500 internal", "HTTP 500: Internal Server Error", LavaErrorNodeInternalError},
+		{"501 not implemented", "HTTP 501: Not Implemented", LavaErrorNodeUnimplemented},
 		{"502 bad gateway", "HTTP 502: Bad Gateway", LavaErrorNodeBadGateway},
 		{"503 unavailable", "HTTP 503: Service Unavailable", LavaErrorNodeServiceUnavailable},
 		{"504 timeout", "HTTP 504: Gateway Timeout", LavaErrorNodeGatewayTimeout},

--- a/protocol/rpcsmartrouter/rest_integration_test.go
+++ b/protocol/rpcsmartrouter/rest_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/magma-Devs/smart-router/protocol/chainlib"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/extensionslib"
+	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
 	spectypes "github.com/magma-Devs/smart-router/types/spec"
 	"github.com/stretchr/testify/assert"
@@ -351,4 +352,91 @@ func TestRESTRelay_ResponseHeaders(t *testing.T) {
 		}
 	}
 	assert.True(t, found, fmt.Sprintf("expected X-Custom-Header in metadata, got: %+v", result.Reply.Metadata))
+}
+
+// TestRESTRelay_501_NotImplemented_relayInnerDirect reproduces MAG-1576: a
+// Cosmos-based node returns HTTP 501 ("not implemented"), and relayInnerDirect()
+// mis-routes it to the PROTOCOL-error path instead of treating it as a NodeError.
+//
+// Why the bug lives in relayInnerDirect (not the REST sender): sendRESTRelay
+// already classifies 5xx as IsNodeError=true and returns a NIL Go error — see
+// TestRESTRelay_503_ServiceUnavailable. But relayInnerDirect's blanket
+//
+//	if statusCode >= 500 || statusCode == 429 { ... return fmt.Errorf("HTTP %d", statusCode) }
+//
+// converts that node-error result into a synthetic transport error, which the
+// caller files via setErrorResponse on the protocol-error path. For 501 this is
+// wrong: 501 should be NODE_UNIMPLEMENTED (Retryable:false), so as a protocol
+// error it gets RETRIED instead of failing fast and the node's body is lost.
+//
+// Regression guard: asserts that relayInnerDirect does NOT convert a REST 501
+// into a transport error. Before the fix this failed with fmt.Errorf("HTTP 501");
+// the fix excludes 501 from the `statusCode >= 500` transport-error branch so the
+// NodeError the sender produced is preserved and returned to the client.
+func TestRESTRelay_501_NotImplemented_relayInnerDirect(t *testing.T) {
+	ctx := context.Background()
+	chainParser, _, _, closeServer, endpoint, err := chainlib.CreateChainLibMocks(
+		ctx,
+		"LAVA",
+		spectypes.APIInterfaceRest,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Cosmos gRPC-gateway "not implemented" surfaces as HTTP 501.
+			w.WriteHeader(http.StatusNotImplemented)
+			_, _ = w.Write([]byte(`{"code":12,"message":"Not Implemented"}`))
+		}),
+		nil,
+		"../../",
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, chainParser)
+	require.NotNil(t, endpoint)
+	defer closeServer()
+
+	chainMessage, err := chainParser.ParseMsg(
+		"/cosmos/base/tendermint/v1beta1/blocks/latest",
+		nil,
+		http.MethodGet,
+		nil,
+		extensionslib.ExtensionInfo{LatestBlock: 0},
+	)
+	require.NoError(t, err)
+
+	nodeUrl := endpoint.NodeUrls[0]
+	directConn, err := lavasession.NewDirectRPCConnection(ctx, nodeUrl, 5, "")
+	require.NoError(t, err)
+
+	// Minimal smart-router direct session. Endpoint is deliberately left nil so
+	// relayInnerDirect's MarkUnhealthy/metrics blocks (guarded by
+	// `targetEndpoint != nil`) are skipped — smartRouterEndpointMetrics is never
+	// dereferenced, keeping the harness self-contained.
+	cswp := &lavasession.ConsumerSessionsWithProvider{PublicLavaAddress: "test-cosmos-lcd"}
+	session := &lavasession.SingleConsumerSession{
+		Parent: cswp,
+		Connection: &lavasession.DirectRPCSessionConnection{
+			DirectConnection: directConn,
+			EndpointAddress:  nodeUrl.Url,
+		},
+	}
+
+	rpcss := &RPCSmartRouterServer{
+		listenEndpoint: &lavasession.RPCEndpoint{ChainID: "LAVA", ApiInterface: "rest"},
+	}
+
+	relayResult := &common.RelayResult{}
+	_, relayErr, _ := rpcss.relayInnerDirect(ctx, session, relayResult, 5*time.Second, chainMessage, nil, nil)
+
+	// DESIRED (post-fix): a REST 501 "not implemented" is a NodeError, so
+	// relayInnerDirect must NOT convert it into a Go error (which routes it to
+	// setErrorResponse / the protocol-error path). This fails today with
+	// relayErr = "HTTP 501" — that failure IS the reproduction.
+	require.NoError(t, relayErr,
+		"BUG: relayInnerDirect converts a REST 501 (which sendRESTRelay tagged IsNodeError=true) into a transport error, routing it to the protocol-error path instead of treating it as a NodeError")
+	assert.Equal(t, http.StatusNotImplemented, relayResult.StatusCode)
+	assert.True(t, relayResult.IsNodeError, "REST 501 should be classified as a node error")
+	// End-to-end: with the classifier mapping 501→NODE_UNIMPLEMENTED, the node
+	// error must be non-retryable so the policy stops instead of retrying an
+	// unsupported method. This ties the routing fix (Part 1) to the classifier
+	// fix (Part 2).
+	assert.True(t, relayResult.IsNonRetryable, "REST 501 should be a non-retryable node error")
 }

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2052,9 +2052,18 @@ func (rpcss *RPCSmartRouterServer) relayInnerDirect(
 		return relayLatency, err, needsBackoff
 	}
 
-	// Check status code even when err == nil (for REST 5xx/429)
+	// Check status code even when err == nil (for REST 5xx/429).
+	//
+	// HTTP 501 (Not Implemented) is deliberately excluded: a Cosmos REST node
+	// returns it to mean "I don't implement this method" — a node-capability
+	// error, not a server/transport failure. Routing it through this branch
+	// would convert it into a synthetic transport error (triggering retry +
+	// backoff) and discard the node's response. Excluding it lets the result
+	// flow through as the NodeError the REST sender already produced
+	// (IsNodeError=true), where it classifies as NODE_UNIMPLEMENTED
+	// (non-retryable) and is returned to the client.
 	statusCode := result.StatusCode
-	if statusCode >= 500 || statusCode == 429 {
+	if (statusCode >= 500 && statusCode != http.StatusNotImplemented) || statusCode == 429 {
 		shouldMarkUnhealthy, needsBackoffHTTP := classifyHTTPStatus(statusCode)
 		needsBackoff = needsBackoffHTTP
 


### PR DESCRIPTION
## What

Cosmos REST nodes return HTTP **501 "Not Implemented"** for methods/endpoints they don't support. The router classified that as a **protocol (transport) error** instead of a **node error** — so a deterministic "not implemented" response got **retried across providers** (added latency, wasted provider calls) and the node's own response body was discarded.

## Root cause

`relayInnerDirect()` routed **all** REST 5xx through a transport-error branch:

```go
if statusCode >= 500 || statusCode == 429 {
    ...
    return relayLatency, fmt.Errorf("HTTP %d", statusCode), needsBackoff
}
```

That synthetic error lands on the `setErrorResponse` (protocol-error) path. But `sendRESTRelay` had **already** tagged the 501 as `IsNodeError=true` with a `nil` error — `relayInnerDirect` was overriding that intent. For 500/502/503/504 this is harmless (they're retryable anyway); 501 is the one with teeth — it should be `NODE_UNIMPLEMENTED` (non-retryable), so it was retried instead of failing fast.

## Fix (two parts)

1. **Routing** (`rpcsmartrouter_server.go`): exclude `501` from the `statusCode >= 500` transport-error branch, so it flows through as the `NodeError` the REST sender already produced (and stops wrongly marking the endpoint unhealthy).
2. **Classification** (`error_classifier.go`): map `501 → NODE_UNIMPLEMENTED` (non-retryable) for REST (`CodeEquals(501)`) and the shared HTTP-status message matchers. Without this, a correctly-routed 501 would classify as `Unknown` (retryable).

This is intentionally **501-only** — 500/502/503/504 remain retryable transport errors. JSON-RPC behavior is unchanged (its sender already errors on 5xx; part 2 only relabels the existing protocol error).

## Tests

- `TestRESTRelay_501_NotImplemented_relayInnerDirect` — drives the real `relayInnerDirect` against a mock 501 and asserts it stays a **non-retryable `NodeError`** (no transport error). Written red (failed with `HTTP 501` before the fix), green after.
- `TestClassifyError_REST501NotImplemented` + `501` rows added to the REST and JSON-RPC HTTP-status classifier tables.
- Full `protocol/common` and `protocol/rpcsmartrouter` suites pass — no regressions.

Jira: MAG-1576

🤖 Generated with [Claude Code](https://claude.com/claude-code)
