### PR TITLE
feat(websocket): add support for send request as json format to websocket

### DIFF
--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -159,12 +160,24 @@ type HTTPDirectRPCConnection struct {
 // Subscriptions/streaming are NOT served here — those use the dedicated
 // UpstreamWSPool layer.
 type WebSocketDirectRPCConnection struct {
-	nodeUrl   common.NodeUrl
-	protocol  DirectRPCProtocol
-	isJsonRPC bool // true → EVM JSON-RPC framing; false → Tendermint RPC framing
+	nodeUrl  common.NodeUrl
+	protocol DirectRPCProtocol
+	// isJsonRPC carries the EVM-vs-Tendermint distinction for parity with the
+	// HTTP/Tendermint call sites and is forwarded to CallContext. NOTE: rpcclient
+	// only consumes this flag on its HTTP path (non-2xx HTTP-status handling);
+	// over a WebSocket frame it is currently ignored. Kept for forward-correctness.
+	isJsonRPC bool
 
 	mu     sync.Mutex
 	client *rpcclient.Client // lazily dialed on first SendRequest, then cached
+	closed bool              // set by Close(); prevents re-dialing a closed connection
+
+	// wireID issues a connection-unique JSON-RPC id per request. rpcclient.Client
+	// multiplexes concurrent requests on one socket and routes replies by id
+	// (handler.respWait is a plain id→op map), so reusing a caller-supplied id
+	// across concurrent calls would misroute responses. We send a unique wire id
+	// and restore the caller's original id on the reply before returning.
+	wireID atomic.Uint64
 }
 
 // GRPCDirectRPCConnection implements DirectRPCConnection for gRPC.
@@ -534,17 +547,24 @@ func (w *WebSocketDirectRPCConnection) SendRequest(
 	if err := json.Unmarshal(data, &reqMsg); err != nil {
 		return nil, fmt.Errorf("failed to parse JSON-RPC request for WebSocket %s: %w", w.nodeUrl.Url, err)
 	}
-	id := reqMsg.ID
-	if len(id) == 0 {
-		id = json.RawMessage("1")
-	}
 
-	reply, err := client.CallContext(ctx, id, reqMsg.Method, reqMsg.Params, w.isJsonRPC, false)
+	// Send a connection-unique wire id so concurrent requests can't collide in
+	// the client's id→response map, then restore the caller's id on the reply.
+	wireID := json.RawMessage(strconv.FormatUint(w.wireID.Add(1), 10))
+
+	reply, err := client.CallContext(ctx, wireID, reqMsg.Method, reqMsg.Params, w.isJsonRPC, false)
 	if err != nil {
 		return nil, err
 	}
 
-	respBytes, err := json.Marshal(reply)
+	// Restore the caller's id on a COPY of the reply. The rpcclient dispatch
+	// goroutine may still read the returned reply concurrently, so mutating it
+	// in place is a data race — we only read it (to copy) and write the id on
+	// our own value.
+	out := *reply
+	out.ID = reqMsg.ID // caller's id (omitted/empty for notifications)
+
+	respBytes, err := json.Marshal(&out)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal WebSocket response for %s: %w", w.nodeUrl.Url, err)
 	}
@@ -565,6 +585,9 @@ func (w *WebSocketDirectRPCConnection) SendRequest(
 func (w *WebSocketDirectRPCConnection) ensureClient(ctx context.Context) (*rpcclient.Client, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if w.closed {
+		return nil, fmt.Errorf("WebSocket connection is closed for endpoint %s", w.nodeUrl.Url)
+	}
 	if w.client != nil {
 		return w.client, nil
 	}
@@ -590,6 +613,7 @@ func (w *WebSocketDirectRPCConnection) GetProtocol() DirectRPCProtocol {
 func (w *WebSocketDirectRPCConnection) Close() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	w.closed = true
 	if w.client != nil {
 		w.client.Close()
 		w.client = nil

--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jhump/protoreflect/grpcreflect"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcInterfaceMessages"
+	rpcclient "github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcclient"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/grpcproxy/dyncodec"
 	"github.com/magma-Devs/smart-router/protocol/common"
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
@@ -147,10 +148,23 @@ type HTTPDirectRPCConnection struct {
 	healthy atomic.Bool
 }
 
-// WebSocketDirectRPCConnection implements DirectRPCConnection for WebSocket/WSS
+// WebSocketDirectRPCConnection implements DirectRPCConnection for WebSocket/WSS.
+//
+// Request/response is served over a persistent JSON-RPC-over-WebSocket client
+// (rpcclient.Client), dialed lazily on first SendRequest and cached. The client
+// multiplexes concurrent requests by JSON-RPC id and transparently reconnects a
+// dropped socket, so callers (chain-tracker polls, direct relays) get the same
+// raw-bytes contract as HTTP with no WebSocket-specific handling.
+//
+// Subscriptions/streaming are NOT served here — those use the dedicated
+// UpstreamWSPool layer.
 type WebSocketDirectRPCConnection struct {
-	nodeUrl  common.NodeUrl
-	protocol DirectRPCProtocol
+	nodeUrl   common.NodeUrl
+	protocol  DirectRPCProtocol
+	isJsonRPC bool // true → EVM JSON-RPC framing; false → Tendermint RPC framing
+
+	mu     sync.Mutex
+	client *rpcclient.Client // lazily dialed on first SendRequest, then cached
 }
 
 // GRPCDirectRPCConnection implements DirectRPCConnection for gRPC.
@@ -239,11 +253,13 @@ func NewDirectRPCConnection(
 		return conn, nil
 
 	case DirectRPCProtocolWS, DirectRPCProtocolWSS:
-		// WebSocket support is handled via a dedicated subscription/streaming layer.
-		// See WEBSOCKET_SUPPORT.md for the design (connection lifecycle differs from request/response).
+		// Request/response over WebSocket uses the shared go-ethereum-derived
+		// JSON-RPC client (rpcclient), dialed lazily on first SendRequest.
+		// Subscriptions/streaming continue to use the dedicated UpstreamWSPool layer.
 		return &WebSocketDirectRPCConnection{
-			nodeUrl:  nodeUrl,
-			protocol: protocol,
+			nodeUrl:   nodeUrl,
+			protocol:  protocol,
+			isJsonRPC: !strings.EqualFold(apiInterface, "tendermintrpc"),
 		}, nil
 
 	case DirectRPCProtocolGRPC:
@@ -493,13 +509,78 @@ func (h *HTTPDirectRPCConnection) DoHTTPRequest(
 	}, nil
 }
 
-// SendRequest implements DirectRPCConnection for WebSocket/WSS
+// SendRequest implements DirectRPCConnection for WebSocket/WSS.
+//
+// It ships the already-built request body as a single JSON-RPC frame over a
+// persistent WebSocket connection and waits for the id-correlated response
+// frame, presenting the same raw-bytes-in / raw-bytes-out contract as the HTTP
+// transport. This is request/response only — subscriptions/streaming use the
+// dedicated UpstreamWSPool layer.
 func (w *WebSocketDirectRPCConnection) SendRequest(
 	ctx context.Context,
 	data []byte,
 	headers map[string]string,
 ) (*DirectRPCResponse, error) {
-	return nil, fmt.Errorf("WebSocket SendRequest not implemented; use subscription/streaming flow")
+	client, err := w.ensureClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial WebSocket %s: %w", w.nodeUrl.Url, err)
+	}
+
+	// Decode the already-built request body to recover id/method/params for the
+	// typed client API. Params is interface{}, so a JSON array decodes to
+	// []interface{} and an object to map[string]interface{} — exactly the shapes
+	// CallContext accepts.
+	var reqMsg rpcInterfaceMessages.JsonrpcMessage
+	if err := json.Unmarshal(data, &reqMsg); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON-RPC request for WebSocket %s: %w", w.nodeUrl.Url, err)
+	}
+	id := reqMsg.ID
+	if len(id) == 0 {
+		id = json.RawMessage("1")
+	}
+
+	reply, err := client.CallContext(ctx, id, reqMsg.Method, reqMsg.Params, w.isJsonRPC, false)
+	if err != nil {
+		return nil, err
+	}
+
+	respBytes, err := json.Marshal(reply)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal WebSocket response for %s: %w", w.nodeUrl.Url, err)
+	}
+	utils.LavaFormatTrace("WebSocket SendRequest succeeded",
+		utils.LogAttr("endpoint", w.nodeUrl.Url),
+		utils.LogAttr("method", reqMsg.Method),
+		utils.LogAttr("responseBytes", len(respBytes)),
+	)
+	return &DirectRPCResponse{Data: respBytes, StatusCode: http.StatusOK}, nil
+}
+
+// ensureClient lazily dials the WebSocket on first use and caches the resulting
+// rpcclient.Client. The client owns reconnection internally (Client.write ->
+// reconnect, using each call's context), so a single successful dial survives
+// transient socket drops; only a failed initial dial leaves client nil, and the
+// next call retries the dial. The dial context is used only to establish the
+// connection — it does not bound the connection's lifetime.
+func (w *WebSocketDirectRPCConnection) ensureClient(ctx context.Context) (*rpcclient.Client, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.client != nil {
+		return w.client, nil
+	}
+
+	headers := make(map[string]string)
+	for k, v := range w.nodeUrl.GetAuthHeaders() {
+		headers[k] = v
+	}
+	endpoint := w.nodeUrl.AuthConfig.AddAuthPath(w.nodeUrl.Url)
+
+	client, err := rpcclient.DialWebsocket(ctx, endpoint, headers)
+	if err != nil {
+		return nil, err
+	}
+	w.client = client
+	return client, nil
 }
 
 func (w *WebSocketDirectRPCConnection) GetProtocol() DirectRPCProtocol {
@@ -507,6 +588,12 @@ func (w *WebSocketDirectRPCConnection) GetProtocol() DirectRPCProtocol {
 }
 
 func (w *WebSocketDirectRPCConnection) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.client != nil {
+		w.client.Close()
+		w.client = nil
+	}
 	return nil
 }
 

--- a/protocol/lavasession/direct_rpc_connection_test.go
+++ b/protocol/lavasession/direct_rpc_connection_test.go
@@ -272,11 +272,111 @@ func TestWebSocketSendRequest_RoundTrip(t *testing.T) {
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Contains(t, string(resp.Data), `"result":"0x10"`)
+	assert.Contains(t, string(resp.Data), `"id":1`, "caller's id must be restored on the reply")
 
-	// Second call reuses the cached client (no re-dial).
+	// Second call reuses the cached client (no re-dial) and carries its own id.
 	resp2, err := conn.SendRequest(ctx, []byte(`{"jsonrpc":"2.0","id":2,"method":"eth_blockNumber","params":[]}`), nil)
 	require.NoError(t, err)
 	assert.Contains(t, string(resp2.Data), `"result":"0x10"`)
+	assert.Contains(t, string(resp2.Data), `"id":2`)
+}
+
+// TestWebSocketSendRequest_ConcurrentSameID fires many concurrent requests that
+// all reuse caller id "1". Because rpcclient multiplexes them on one socket and
+// routes replies by id, the connection must issue unique wire ids internally —
+// otherwise replies misroute. The server echoes each request's first param back
+// as the result, so each goroutine can verify it got its own response.
+func TestWebSocketSendRequest_ConcurrentSameID(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		var writeMu sync.Mutex // gorilla/websocket forbids concurrent writers
+		for {
+			_, msg, err := c.ReadMessage()
+			if err != nil {
+				return
+			}
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Params []string        `json:"params"`
+			}
+			if err := json.Unmarshal(msg, &req); err != nil {
+				return
+			}
+			go func(id json.RawMessage, params []string) {
+				time.Sleep(20 * time.Millisecond) // keep many requests in-flight at once
+				val := ""
+				if len(params) > 0 {
+					val = params[0]
+				}
+				resp := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":%q}`, string(id), val)
+				writeMu.Lock()
+				_ = c.WriteMessage(websocket.TextMessage, []byte(resp))
+				writeMu.Unlock()
+			}(req.ID, req.Params)
+		}
+	}))
+	defer srv.Close()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	conn, err := NewDirectRPCConnection(ctx, common.NodeUrl{Url: wsURL}, 5, "")
+	require.NoError(t, err)
+	defer conn.Close()
+
+	const n = 25
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	got := make([]string, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			want := fmt.Sprintf("v%d", i)
+			// Every request deliberately reuses caller id "1".
+			body := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"echo","params":[%q]}`, want)
+			resp, err := conn.SendRequest(ctx, []byte(body), nil)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			got[i] = string(resp.Data)
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < n; i++ {
+		require.NoErrorf(t, errs[i], "request %d failed", i)
+		assert.Containsf(t, got[i], fmt.Sprintf(`"result":"v%d"`, i),
+			"request %d got a misrouted response: %s", i, got[i])
+		assert.Containsf(t, got[i], `"id":1`, "request %d should carry caller id 1", i)
+	}
+}
+
+// TestWebSocketSendRequest_AfterClose verifies Close() is terminal: a closed
+// connection must not silently re-dial on a subsequent SendRequest.
+func TestWebSocketSendRequest_AfterClose(t *testing.T) {
+	wsURL, cleanup := newTestWSJSONRPCServer(t, `"0x10"`)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := NewDirectRPCConnection(ctx, common.NodeUrl{Url: wsURL}, 5, "")
+	require.NoError(t, err)
+
+	_, err = conn.SendRequest(ctx, []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}`), nil)
+	require.NoError(t, err)
+
+	require.NoError(t, conn.Close())
+
+	_, err = conn.SendRequest(ctx, []byte(`{"jsonrpc":"2.0","id":2,"method":"eth_blockNumber","params":[]}`), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "closed")
 }
 
 // TestWebSocketSendRequest_DialFailure verifies that an unreachable WebSocket

--- a/protocol/lavasession/direct_rpc_connection_test.go
+++ b/protocol/lavasession/direct_rpc_connection_test.go
@@ -2,12 +2,16 @@ package lavasession
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -214,17 +218,80 @@ func TestHTTPConnectionInterface(t *testing.T) {
 	assert.NoError(t, conn.Close())
 }
 
-func TestWebSocketSendRequestNotImplemented(t *testing.T) {
-	ctx := context.Background()
-	nodeUrl := common.NodeUrl{Url: "wss://test.example.com"}
+// newTestWSJSONRPCServer starts a minimal JSON-RPC-over-WebSocket server that
+// answers eth_blockNumber with a fixed block and echoes the request id. It
+// returns the ws:// URL and a cleanup func.
+func newTestWSJSONRPCServer(t *testing.T, result string) (string, func()) {
+	t.Helper()
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		for {
+			_, msg, err := c.ReadMessage()
+			if err != nil {
+				return
+			}
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(msg, &req); err != nil {
+				return
+			}
+			resp := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":%s}`, string(req.ID), result)
+			if err := c.WriteMessage(websocket.TextMessage, []byte(resp)); err != nil {
+				return
+			}
+		}
+	}))
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") // http://host -> ws://host
+	return wsURL, srv.Close
+}
 
-	conn, err := NewDirectRPCConnection(ctx, nodeUrl, 5, "")
+// TestWebSocketSendRequest_RoundTrip verifies request/response works over a real
+// WebSocket connection: SendRequest ships the JSON-RPC frame, the id-correlated
+// reply comes back, and the cached client is reused on the second call.
+func TestWebSocketSendRequest_RoundTrip(t *testing.T) {
+	wsURL, cleanup := newTestWSJSONRPCServer(t, `"0x10"`)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := NewDirectRPCConnection(ctx, common.NodeUrl{Url: wsURL}, 5, "")
+	require.NoError(t, err)
+	defer conn.Close()
+	require.Equal(t, DirectRPCProtocolWS, conn.GetProtocol())
+
+	resp, err := conn.SendRequest(ctx, []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}`), nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, string(resp.Data), `"result":"0x10"`)
+
+	// Second call reuses the cached client (no re-dial).
+	resp2, err := conn.SendRequest(ctx, []byte(`{"jsonrpc":"2.0","id":2,"method":"eth_blockNumber","params":[]}`), nil)
+	require.NoError(t, err)
+	assert.Contains(t, string(resp2.Data), `"result":"0x10"`)
+}
+
+// TestWebSocketSendRequest_DialFailure verifies that an unreachable WebSocket
+// endpoint surfaces a dial error (which the chain-tracker retries) rather than
+// the old "not implemented" stub.
+func TestWebSocketSendRequest_DialFailure(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	conn, err := NewDirectRPCConnection(ctx, common.NodeUrl{Url: "ws://127.0.0.1:1"}, 5, "")
 	require.NoError(t, err)
 
-	// WebSocket SendRequest should return not implemented error
-	_, err = conn.SendRequest(ctx, []byte("test"), nil)
+	_, err = conn.SendRequest(ctx, []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}`), nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "WebSocket SendRequest not implemented")
+	assert.Contains(t, err.Error(), "failed to dial WebSocket")
 }
 
 func TestGRPCConnectionURLValidation(t *testing.T) {


### PR DESCRIPTION
# Description

Implements request/response over WebSocket for `DirectRPCConnection`.

Previously `WebSocketDirectRPCConnection.SendRequest` was a hard stub
(`"WebSocket SendRequest not implemented"`). Because the per-endpoint chain
tracker polls every endpoint through `SendRequest`, any `ws://`/`wss://`
endpoint failed that call permanently and the tracker retried its startup
forever — an indefinite error/retry storm (observed on `eth-router` and
`eth-sim-router`, which declare WS endpoints). WebSocket JSON-RPC supports
plain request/response (not just subscriptions), so the fix is to make the
call actually work rather than skip WS endpoints.

## What changed

`protocol/lavasession/direct_rpc_connection.go`:
- `WebSocketDirectRPCConnection` now lazily dials a persistent JSON-RPC-over-WS
  client (`rpcclient.Client`, the same go-ethereum–derived client used by the
  subscription pool) on first `SendRequest`, and caches it. The client
  multiplexes requests by id and reconnects dropped sockets internally, so
  callers get the same raw-bytes-in/raw-bytes-out contract as HTTP.
- `SendRequest` decodes the request body, sends a **connection-unique wire id**
  (so concurrent requests multiplexed on the shared client can't collide in the
  client's id→response map), and restores the caller's original id on a copy of
  the reply before returning.
- `Close()` is now terminal (a `closed` guard prevents a closed connection from
  silently re-dialing).
- Subscriptions/streaming are unchanged — they still use the dedicated
  `UpstreamWSPool` layer.

## Notes for reviewers

- `isJsonRPC` is forwarded to `CallContext` for parity with the HTTP/Tendermint
  call sites, but `rpcclient` only consumes it on its HTTP path; it is inert over
  a WebSocket frame (documented in the field comment).
- Credentials embedded in node URLs are still logged raw by **pre-existing**
  code paths (chain tracker, connection setup). Sanitizing those is a broader,
  separate logging-hygiene change and is intentionally out of scope here.

## Testing

- Unit tests against an in-process WS JSON-RPC server: round-trip + cached
  client reuse, caller-id restoration, **concurrent same-id requests** (verifies
  no id-collision/misrouting; runs clean under `-race`), dial failure, and
  after-`Close()` behavior.
- Verified live end-to-end against real nodes (`wss://ethereum-rpc.publicnode.com`
  and the `wss://g.w.lavanet.xyz` gateway): the chain tracker now fetches latest
  block and block history over WebSocket; the previous retry storm is gone.

Closes: <!-- link the WS chain-tracker retry-storm issue -->
