### PR TITLE
fix(cache): give explicit lava-extension directives their own cache lane

### DIFF
--- a/protocol/chainlib/base_chain_parser_addon_extension_test.go
+++ b/protocol/chainlib/base_chain_parser_addon_extension_test.go
@@ -1,0 +1,26 @@
+package chainlib
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSeparateAddonsExtensionsArchiveIsExtension documents the classification the
+// lava-extension: archive directive relies on. "archive" is registered only in the extension set
+// (no shipped spec puts it in allowedAddons), so SeparateAddonsExtensions classifies it as an
+// extension instead of swallowing it as an addon — which is why the directive header is honored
+// and resolves to an archive extension rather than being dropped.
+func TestSeparateAddonsExtensionsArchiveIsExtension(t *testing.T) {
+	bcp := BaseChainParser{
+		// Mirrors the ethereum spec: archive lives in the extension set; addons are debug/trace/bundler.
+		allowedAddons:     map[string]bool{"": true, "debug": true, "trace": true, "bundler": true},
+		allowedExtensions: map[string]struct{}{"archive": {}},
+	}
+
+	addons, extensions, err := bcp.SeparateAddonsExtensions(context.Background(), []string{"archive"})
+	require.NoError(t, err)
+	require.Empty(t, addons, "archive must not be classified as an addon")
+	require.Equal(t, []string{"archive"}, extensions, "archive must be classified as an extension so the directive is honored")
+}

--- a/protocol/chainlib/cache_hash_directive_test.go
+++ b/protocol/chainlib/cache_hash_directive_test.go
@@ -1,0 +1,88 @@
+package chainlib
+
+import (
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHashCacheRequestExplicitExtensionDirectiveSeparatesLane is the regression guard for the
+// archive-header cache collision: two requests can resolve to the SAME Extensions=["archive"]
+// (one because the client sent lava-extension: archive, the other because the router auto-promoted
+// an old-block request), yet the explicitly-directed request must land in its own cache lane so it
+// does not get served the auto-promoted request's cached response.
+func TestHashCacheRequestExplicitExtensionDirectiveSeparatesLane(t *testing.T) {
+	const chainId = "ETH1"
+
+	newRelayData := func() *pairingtypes.RelayPrivateData {
+		return &pairingtypes.RelayPrivateData{
+			ConnectionType: "POST",
+			Data:           []byte(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x1224567",false],"id":1}`),
+			RequestBlock:   19017063,
+			ApiInterface:   spectypes.APIInterfaceJsonRPC,
+			Salt:           []byte{1, 2, 3},
+			Extensions:     []string{"archive"}, // identical resolved extensions for both requests
+		}
+	}
+
+	hashWith := func(directiveHeaders map[string]string) []byte {
+		pm := &BaseProtocolMessage{
+			relayRequestData: newRelayData(),
+			directiveHeaders: directiveHeaders,
+		}
+		hash, _, err := pm.HashCacheRequest(chainId)
+		require.NoError(t, err)
+		return hash
+	}
+
+	// Bare request (auto-promoted to archive): no directive header.
+	autoPromoted := hashWith(nil)
+	// Explicit request: client sent lava-extension: archive.
+	explicitArchive := hashWith(map[string]string{common.EXTENSION_OVERRIDE_HEADER_NAME: "archive"})
+
+	// The fix: explicit archive must NOT collide with the auto-promoted lane despite identical Extensions.
+	require.NotEqual(t, autoPromoted, explicitArchive,
+		"explicit lava-extension:archive must produce a different cache key than an auto-promoted request with identical Extensions")
+
+	// Backward compatibility: the no-directive path must reproduce the legacy package-level hash byte-for-byte,
+	// so existing cache entries and all non-directive traffic are unaffected.
+	legacy, _, err := HashCacheRequest(newRelayData(), chainId)
+	require.NoError(t, err)
+	require.Equal(t, legacy, autoPromoted, "absent directive must reproduce the historical cache key")
+
+	// Deterministic lane: repeated explicit-archive requests share a lane (so the second one can hit the first).
+	require.Equal(t, explicitArchive, hashWith(map[string]string{common.EXTENSION_OVERRIDE_HEADER_NAME: "archive"}))
+
+	// Distinct directives get distinct lanes.
+	require.NotEqual(t, explicitArchive, hashWith(map[string]string{common.EXTENSION_OVERRIDE_HEADER_NAME: "debug"}))
+
+	// Normalization: case/whitespace variants collapse onto the same lane as "archive".
+	require.Equal(t, explicitArchive, hashWith(map[string]string{common.EXTENSION_OVERRIDE_HEADER_NAME: "  ARCHIVE "}))
+}
+
+func TestNormalizeExtensionDirective(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+		{"plain", "archive", "archive"},
+		{"uppercase", "Archive", "archive"},
+		{"padded", "  archive  ", "archive"},
+		{"sorted already", "archive,debug", "archive,debug"},
+		{"unsorted", "debug,archive", "archive,debug"},
+		{"mixed case and space", "DEBUG, Archive", "archive,debug"},
+		{"empty segments", ",archive,,", "archive"},
+		{"none", "none", "none"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, normalizeExtensionDirective(tc.in))
+		})
+	}
+}

--- a/protocol/chainlib/chain_fetcher.go
+++ b/protocol/chainlib/chain_fetcher.go
@@ -632,6 +632,15 @@ func NewVerificationsOnlyChainFetcher(ctx context.Context, chainRouter ChainRout
 // this method will calculate the request hash by changing the original object, and returning the data back to it after calculating the hash
 // couldn't be used in parallel
 func HashCacheRequest(relayData *pairingtypes.RelayPrivateData, chainId string) ([]byte, func([]byte) []byte, error) {
+	return hashCacheRequest(relayData, chainId, "")
+}
+
+// hashCacheRequest derives the cache key for a relay. explicitExtensionDirective carries the
+// normalized value of the client's lava-extension directive header (empty when absent). When
+// present it is folded into the hash so an explicitly requested extension (e.g. "archive") lands
+// in its own cache lane and cannot collide with a request that was only auto-promoted to the same
+// resolved Extensions. Passing "" reproduces the historical hash, keeping existing entries valid.
+func hashCacheRequest(relayData *pairingtypes.RelayPrivateData, chainId, explicitExtensionDirective string) ([]byte, func([]byte) []byte, error) {
 	originalData := relayData.Data
 	originalSalt := relayData.Salt
 	originalRequestedBlock := relayData.RequestBlock
@@ -673,6 +682,12 @@ func HashCacheRequest(relayData *pairingtypes.RelayPrivateData, chainId string) 
 	cashHashBytes, err := json.Marshal(cashHash)
 	if err != nil {
 		return nil, outputFormatter, utils.LavaFormatError("Failed marshalling cash hash in HashCacheRequest", err)
+	}
+
+	// Fold an explicit lava-extension directive into the key so explicitly-requested extensions
+	// get a dedicated cache lane, separate from requests auto-promoted to the same Extensions.
+	if explicitExtensionDirective != "" {
+		cashHashBytes = append(cashHashBytes, []byte("\x00lava-extension="+explicitExtensionDirective)...)
 	}
 
 	// return the value

--- a/protocol/chainlib/protocol_message.go
+++ b/protocol/chainlib/protocol_message.go
@@ -2,14 +2,15 @@ package chainlib
 
 import (
 	"errors"
+	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/magma-Devs/smart-router/protocol/chainlib/extensionslib"
 	"github.com/magma-Devs/smart-router/protocol/common"
-	"github.com/magma-Devs/smart-router/utils"
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
 	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/magma-Devs/smart-router/utils"
 )
 
 type UserData struct {
@@ -42,7 +43,31 @@ func (bpm *BaseProtocolMessage) RelayPrivateData() *pairingtypes.RelayPrivateDat
 }
 
 func (bpm *BaseProtocolMessage) HashCacheRequest(chainId string) ([]byte, func([]byte) []byte, error) {
-	return HashCacheRequest(bpm.relayRequestData, chainId)
+	return hashCacheRequest(bpm.relayRequestData, chainId, bpm.explicitExtensionDirective())
+}
+
+// explicitExtensionDirective returns the normalized value of the client's lava-extension directive
+// header, or "" when absent. Normalization makes equivalent directives such as "Archive",
+// " archive " and "archive,debug"/"debug,archive" collapse to the same cache lane.
+func (bpm *BaseProtocolMessage) explicitExtensionDirective() string {
+	if bpm.directiveHeaders == nil {
+		return ""
+	}
+	return normalizeExtensionDirective(bpm.directiveHeaders[common.EXTENSION_OVERRIDE_HEADER_NAME])
+}
+
+func normalizeExtensionDirective(raw string) string {
+	cleaned := make([]string, 0)
+	for _, part := range strings.Split(strings.ToLower(raw), ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			cleaned = append(cleaned, part)
+		}
+	}
+	if len(cleaned) == 0 {
+		return ""
+	}
+	sort.Strings(cleaned)
+	return strings.Join(cleaned, ",")
 }
 
 // addMissingExtensions adds any extensions from updatedProtocolExtensions that are not in currentPrivateDataExtensions

--- a/protocol/rpcsmartrouter/directive_metadata_roundtrip_test.go
+++ b/protocol/rpcsmartrouter/directive_metadata_roundtrip_test.go
@@ -1,0 +1,33 @@
+package rpcsmartrouter
+
+import (
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMetadataFromDirectiveHeadersRoundTrip guards the earliest-block re-parse fix in
+// updateProtocolMessageIfNeededWithNewEarliestData: directive headers rebuilt into metadata must
+// survive being re-split by LavaDirectiveHeaders (the same path ParseRelay uses), so a re-parsed
+// protocol message keeps the client's lava-extension (and other) directives. Without this, the
+// rebuilt message's cache key would disagree with the original message's key on the archive path,
+// undermining the per-directive cache lane.
+func TestMetadataFromDirectiveHeadersRoundTrip(t *testing.T) {
+	rpcss := &RPCSmartRouterServer{}
+
+	t.Run("directives survive the round-trip", func(t *testing.T) {
+		original := map[string]string{
+			common.EXTENSION_OVERRIDE_HEADER_NAME:  "archive",
+			common.FORCE_CACHE_REFRESH_HEADER_NAME: "true",
+		}
+		forwarded, directives := rpcss.LavaDirectiveHeaders(metadataFromDirectiveHeaders(original))
+		require.Empty(t, forwarded, "directive headers must not leak into forwarded metadata")
+		require.Equal(t, original, directives, "directives must survive the metadata round-trip")
+	})
+
+	t.Run("empty maps to nil metadata", func(t *testing.T) {
+		require.Nil(t, metadataFromDirectiveHeaders(nil))
+		require.Nil(t, metadataFromDirectiveHeaders(map[string]string{}))
+	})
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -1449,9 +1449,10 @@ func (rpcss *RPCSmartRouterServer) tryCacheWrite(
 		return
 	}
 
-	// Compute cache key
+	// Compute cache key via the protocol message so the SET key matches the GET key,
+	// including any explicit lava-extension directive folded in by HashCacheRequest.
 	chainId := rpcss.listenEndpoint.ChainID
-	hashKey, _, hashErr := chainlib.HashCacheRequest(relayData, chainId)
+	hashKey, _, hashErr := protocolMessage.HashCacheRequest(chainId)
 	if hashErr != nil {
 		utils.LavaFormatDebug("cache write skipped: hash computation failed",
 			utils.LogAttr("error", hashErr),
@@ -2621,7 +2622,12 @@ func (rpcss *RPCSmartRouterServer) updateProtocolMessageIfNeededWithNewEarliestD
 		relayState.SetIsEarliestUsed()
 		relayRequestData := protocolMessage.RelayPrivateData()
 		userData := protocolMessage.GetUserData()
-		newProtocolMessage, err := rpcss.ParseRelay(ctx, relayRequestData.ApiUrl, string(relayRequestData.Data), relayRequestData.ConnectionType, userData.DappId, userData.ConsumerIp, nil)
+		// Preserve the client's directive headers (e.g. lava-extension, force-cache-refresh) across
+		// the re-parse. Passing nil drops them, which on the archive/earliest-block path would make
+		// the rebuilt message's cache key disagree with the original message's key (and silently
+		// discards the directive the client sent).
+		directiveMetadata := metadataFromDirectiveHeaders(protocolMessage.GetDirectiveHeaders())
+		newProtocolMessage, err := rpcss.ParseRelay(ctx, relayRequestData.ApiUrl, string(relayRequestData.Data), relayRequestData.ConnectionType, userData.DappId, userData.ConsumerIp, directiveMetadata)
 		if err != nil {
 			utils.LavaFormatError("failed copying protocol message in sendRelayToEndpoint", err)
 			return protocolMessage
@@ -2635,6 +2641,20 @@ func (rpcss *RPCSmartRouterServer) updateProtocolMessageIfNeededWithNewEarliestD
 		return newProtocolMessage
 	}
 	return protocolMessage
+}
+
+// metadataFromDirectiveHeaders rebuilds relay metadata entries from already-parsed directive
+// headers, so they can be re-fed through ParseRelay (which re-splits metadata into directives).
+// Used to carry directives across a re-parse without losing them.
+func metadataFromDirectiveHeaders(directiveHeaders map[string]string) []pairingtypes.Metadata {
+	if len(directiveHeaders) == 0 {
+		return nil
+	}
+	metadata := make([]pairingtypes.Metadata, 0, len(directiveHeaders))
+	for name, value := range directiveHeaders {
+		metadata = append(metadata, pairingtypes.Metadata{Name: name, Value: value})
+	}
+	return metadata
 }
 
 // classifyHTTPStatus classifies an HTTP status code for endpoint health decisions.


### PR DESCRIPTION
## What & why

An explicit `lava-extension: archive` request could be served a response that
was cached for a **non-archive** request to the same method+params. On a block
old enough to trigger archive auto-promotion, the bare request and the
explicit-archive request both resolve to `Extensions=["archive"]`, so
`HashCacheRequest` produced an identical key and the archive request hit the
bare request's entry. A client asking for archive routing "for safety" had no
way to get a distinct response.

### Root cause (differs from the ticket)

MAG-1736 attributed this to the header being dropped in
`getExtensionsFromDirectiveHeaders` because `SeparateAddonsExtensions`
classifies `archive` as an addon. In this codebase `archive` is registered as
an **extension**, not an addon, so the header is honored and already yields
`AdditionalExtensions: ["archive"]`. The real cause is **auto-promotion**: the
cache key reflects only the *resolved* extensions, not whether the client
explicitly asked, so the two requests collapse onto one key. (The ticket's own
control — a recent-block archive request *misses* the cache — proves the header
is not dropped.)

## The fix

- **Directive-aware cache key.** Fold the normalized `lava-extension` value into
  `HashCacheRequest`, so an explicitly requested extension lands in its own
  cache lane, distinct from an auto-promoted request with identical resolved
  extensions. Provider routing is unchanged (both still go to archive providers);
  the no-directive path reproduces the historical hash, so existing entries and
  all non-directive traffic are unaffected.
- **GET/SET consistency.** `tryCacheWrite` now derives the key via
  `protocolMessage.HashCacheRequest` (same path as the lookup) so SET matches GET.
- **Re-parse directive preservation.** `updateProtocolMessageIfNeededWithNewEarliestData`
  re-parsed with `nil` metadata, dropping *all* directive headers
  (`lava-extension`, `force-cache-refresh`, …) on the earliest-block/archive path
  — which would have defeated the lane on exactly the old-block case. Fixed via
  `metadataFromDirectiveHeaders`.

## Files

- `protocol/chainlib/chain_fetcher.go` — public `HashCacheRequest` delegates to a directive-aware helper
- `protocol/chainlib/protocol_message.go` — pass the normalized directive; `normalizeExtensionDirective`
- `protocol/rpcsmartrouter/rpcsmartrouter_server.go` — SET via `protocolMessage.HashCacheRequest`; preserve directives across re-parse
- tests: cache-key divergence/backward-compat/normalization, `archive` classification, directive metadata round-trip

## Verification

- `go build ./...` + full `chainlib` and `rpcsmartrouter` suites green; new unit tests pass.
- Deployed to the simulator tenant and ran the MAG-1736 repro (old block, cache reset):

  | req | header | result |
  |-----|--------|--------|
  | r1 | none | `simprovider1` (seeds) |
  | r2 | `archive` | `simprovider3` — **not `Cached`** ✅ |
  | r1b | none | `Cached` (caching active) |
  | r2b | `archive` | `Cached` (separate archive lane) |

## Follow-ups (not in this PR)

- The product/simulator test `test_archive_extension_bypasses_cache` (MAG-1736 case 5) can drop its `xfail`.
- The `smart-router-helm-chart` still injects flags `main` removed (`--optimizer-qos-listen`, `--show-provider-address-in-metrics`, `--enable-grpc-compression`); it needs updating so standard deploys of `main` don't crash-loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
