### PR TITLE
feat(smart-router/debug): add /debug/reset-pairing to rebuild pairing from config

### DIFF
--- a/protocol/rpcsmartrouter/reset_pairing_test.go
+++ b/protocol/rpcsmartrouter/reset_pairing_test.go
@@ -1,0 +1,110 @@
+package rpcsmartrouter
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
+	"github.com/magma-Devs/smart-router/utils/rand"
+	"github.com/stretchr/testify/require"
+)
+
+// stubStaticSessions builds canned ConsumerSessionsWithProvider for the given
+// configured providers without opening real connections — a stand-in for the
+// per-chain convertProvidersToSessions closure (a func field on
+// chainReverifyInputs), which would otherwise dial DirectRPCConnections.
+func stubStaticSessions(list []*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+	out := make(map[uint64]*lavasession.ConsumerSessionsWithProvider, len(list))
+	for i, p := range list {
+		s := lavasession.NewConsumerSessionWithProvider(
+			p.Name,
+			[]*lavasession.Endpoint{{NetworkAddress: p.Name + ":80", Enabled: true}},
+			999999, uint64(1), int64(1),
+		)
+		s.StaticProvider = true
+		out[uint64(i)] = s
+	}
+	return out
+}
+
+// TestRebuildPairingFromConfig_ReadmitsDemotedProvider is the router-level guard
+// for /debug/reset-pairing: a provider absent from the live pairing (the state the
+// per-epoch spec re-verifier leaves after demotion) is re-admitted cold from
+// configuredStatic, with no epoch transition. It asserts the deterministic outputs
+// — the returned restored map and the rebuilt providerSessions — per the design;
+// validAddresses selectability is covered end-to-end by the simulator repro, since
+// UpdateAllProviders' async probe can mutate validAddresses after this returns.
+func TestRebuildPairingFromConfig_ReadmitsDemotedProvider(t *testing.T) {
+	rand.InitRandomSeed()
+
+	const chainID, apiInterface = "ETH1", "jsonrpc"
+	rpcEndpoint := &lavasession.RPCEndpoint{ChainID: chainID, ApiInterface: apiInterface, NetworkAddress: "127.0.0.1:0"}
+	chainKey := rpcEndpoint.Key()
+	optimizer := provideroptimizer.NewProviderOptimizer(provideroptimizer.StrategyBalanced, time.Second, uint(1), nil, chainID)
+
+	mkProvider := func(name string) *lavasession.RPCStaticProviderEndpoint {
+		return &lavasession.RPCStaticProviderEndpoint{Name: name, ChainID: chainID, ApiInterface: apiInterface}
+	}
+	p1, p2, p3 := mkProvider("simprovider1"), mkProvider("simprovider2"), mkProvider("simprovider3")
+
+	rpsr := &RPCSmartRouter{
+		sessionManagers: map[string]*lavasession.ConsumerSessionManager{
+			chainKey: lavasession.NewConsumerSessionManager(
+				rpcEndpoint, optimizer, nil, nil, "test-router", lavasession.NewActiveSubscriptionProvidersStorage()),
+		},
+		providerSessions:       make(map[string]map[uint64]*lavasession.ConsumerSessionsWithProvider),
+		backupProviderSessions: make(map[string]map[uint64]*lavasession.ConsumerSessionsWithProvider),
+		failedStaticProviders:  make(map[string][]*lavasession.RPCStaticProviderEndpoint),
+		reverifyInputs:         make(map[string]*chainReverifyInputs),
+		rpcServers:             make(map[string]*RPCSmartRouterServer),
+		epochTimer:             common.NewEpochTimer(15 * time.Minute),
+	}
+	rpsr.reverifyInputs[chainKey] = &chainReverifyInputs{
+		configuredStatic:           []*lavasession.RPCStaticProviderEndpoint{p1, p2, p3},
+		convertProvidersToSessions: stubStaticSessions,
+	}
+	// Demoted state: the re-verifier dropped simprovider3 from the live pairing.
+	rpsr.providerSessions[chainKey] = stubStaticSessions([]*lavasession.RPCStaticProviderEndpoint{p1, p2})
+
+	restored := rpsr.rebuildPairingFromConfig()
+
+	require.Equal(t, map[string][]string{chainKey: {"simprovider3"}}, restored,
+		"only the demoted provider should be reported restored")
+
+	names := map[string]bool{}
+	for _, s := range rpsr.providerSessions[chainKey] {
+		names[s.PublicLavaAddress] = true
+	}
+	require.Len(t, rpsr.providerSessions[chainKey], 3, "pairing should hold all three configured providers after rebuild")
+	require.True(t, names["simprovider1"] && names["simprovider2"] && names["simprovider3"],
+		"rebuilt pairing must contain all configured providers, got %v", names)
+
+	// Idempotent: a second call finds nothing absent and restores nothing.
+	require.Empty(t, rpsr.rebuildPairingFromConfig(), "second rebuild should be a no-op")
+}
+
+// TestDebugResetPairing_Handler covers the HTTP surface: POST returns 200 with a
+// JSON body, non-POST is rejected, and a nil router degrades to an empty restored
+// map (the test-fixture path) rather than panicking.
+func TestDebugResetPairing_Handler(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano})
+
+	t.Run("POST with nil router returns 200 and empty restored", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/debug/reset-pairing", nil))
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.JSONEq(t, `{"reset":true,"restored":{}}`, rr.Body.String())
+	})
+
+	t.Run("GET is rejected", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/debug/reset-pairing", nil))
+		require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+	})
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -745,6 +745,35 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 		}
 	})
 
+	// POST /debug/reset-pairing — cold-rebuild every chain's pairing table from
+	// the startup provider config, re-admitting providers the per-epoch spec
+	// re-verifier (applyReverification) demoted. Additive companion to
+	// /debug/reset-all, which intentionally leaves pairing intact (see the comment
+	// above): long test runs accumulate demotions faster than the 15m epoch tick
+	// recovers them, and a pod restart is otherwise the only way to readmit a
+	// demoted primary. Cold — no re-probing; the simulator controls provider
+	// behaviour in the tests this serves. No-op 200 (empty restored) when the
+	// router is absent (test fixtures) so callers can probe it unconditionally.
+	mux.HandleFunc("/debug/reset-pairing", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST only", http.StatusMethodNotAllowed)
+			return
+		}
+		restored := map[string][]string{}
+		if deps.router != nil {
+			restored = deps.router.rebuildPairingFromConfig()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		body, err := json.Marshal(map[string]any{"reset": true, "restored": restored})
+		if err != nil {
+			// restored is map[string][]string — Marshal can't realistically fail;
+			// emit a minimal valid body rather than a half-written response.
+			fmt.Fprint(w, `{"reset":true,"restored":{}}`)
+			return
+		}
+		w.Write(body)
+	})
+
 	return mux
 }
 
@@ -2400,6 +2429,155 @@ func (rpsr *RPCSmartRouter) retryFailedStaticProviders(
 			rpsr.mu.Unlock()
 		}
 	}
+}
+
+// rebuildPairingFromConfig restores configured static/backup providers that are
+// currently absent from the live pairing — e.g. ones the per-epoch spec
+// re-verifier (applyReverification) demoted after they returned errors — without
+// waiting for the next 15m epoch tick or a pod restart. It backs the dev/test-only
+// /debug/reset-pairing endpoint.
+//
+// COLD rebuild: absent providers are re-admitted straight from the startup config
+// (reverifyInputs) with no spec re-probing — the simulator drives provider
+// behaviour in the tests this serves, so verification is unnecessary. Only absent
+// providers are converted (which opens fresh DirectRPCConnections); already-active
+// sessions are reused untouched, so healthy providers are not churned. Mirrors
+// retryFailedStaticProviders' copy-on-write merge. Returns the restored provider
+// names per chainKey (chains needing no restore are omitted).
+func (rpsr *RPCSmartRouter) rebuildPairingFromConfig() map[string][]string {
+	restored := make(map[string][]string)
+
+	rpsr.mu.Lock()
+	defer rpsr.mu.Unlock()
+
+	if rpsr.epochTimer == nil { // defensive: production always sets it in CreateSmartRouterEndpoint
+		return restored
+	}
+	currentEpoch := rpsr.epochTimer.GetCurrentEpoch()
+
+	for chainKey, sessionManager := range rpsr.sessionManagers {
+		inputs := rpsr.reverifyInputs[chainKey]
+		if sessionManager == nil || inputs == nil {
+			continue
+		}
+
+		mergedStatic, restoredStatic := mergeAbsentProviders(
+			rpsr.providerSessions[chainKey], inputs.configuredStatic, inputs.convertProvidersToSessions, currentEpoch)
+		mergedBackup, restoredBackup := mergeAbsentProviders(
+			rpsr.backupProviderSessions[chainKey], inputs.configuredBackup, inputs.convertProvidersToSessions, currentEpoch)
+
+		if len(restoredStatic) == 0 && len(restoredBackup) == 0 {
+			continue // pairing already whole — don't churn the session manager
+		}
+
+		rpsr.providerSessions[chainKey] = mergedStatic
+		if len(mergedBackup) > 0 {
+			rpsr.backupProviderSessions[chainKey] = mergedBackup
+		} else {
+			delete(rpsr.backupProviderSessions, chainKey)
+		}
+
+		// A re-admitted provider supersedes any pending failed-init retry: drop it
+		// from failedStaticProviders so retryFailedStaticProviders won't later merge
+		// a duplicate session for the same name (and can self-terminate once empty).
+		if failed := rpsr.failedStaticProviders[chainKey]; len(failed) > 0 {
+			restoredSet := make(map[string]struct{}, len(restoredStatic)+len(restoredBackup))
+			for _, n := range restoredStatic {
+				restoredSet[n] = struct{}{}
+			}
+			for _, n := range restoredBackup {
+				restoredSet[n] = struct{}{}
+			}
+			var kept []*lavasession.RPCStaticProviderEndpoint
+			for _, p := range failed {
+				if _, ok := restoredSet[p.Name]; !ok {
+					kept = append(kept, p)
+				}
+			}
+			if len(kept) > 0 {
+				rpsr.failedStaticProviders[chainKey] = kept
+			} else {
+				delete(rpsr.failedStaticProviders, chainKey)
+			}
+		}
+
+		// UpdateAllProviders stays under rpsr.mu so the (providerSessions write →
+		// csm push) pair is atomic with updateEpoch / retryFailedStaticProviders —
+		// otherwise a concurrent epoch tick can push to the csm in the opposite
+		// order it wrote providerSessions, silently dropping the restored providers.
+		if err := sessionManager.UpdateAllProviders(currentEpoch, mergedStatic, mergedBackup); err != nil {
+			utils.LavaFormatError("reset-pairing: failed to push rebuilt pairing to session manager", err,
+				utils.LogAttr("chainKey", chainKey))
+			continue
+		}
+
+		restored[chainKey] = append(restoredStatic, restoredBackup...)
+		utils.LavaFormatInfo("reset-pairing: restored providers from config",
+			utils.LogAttr("chainKey", chainKey),
+			utils.LogAttr("restored", restored[chainKey]),
+			utils.LogAttr("epoch", currentEpoch),
+		)
+	}
+
+	return restored
+}
+
+// mergeAbsentProviders returns a copy-on-write merge of current plus fresh sessions
+// for every configured provider whose Name is absent from current, and the list of
+// restored names (in config order, deterministic). Absent providers are built via
+// convert, which opens fresh connections — providers whose connections all fail are
+// skipped by convert and so are not reported restored. Present providers are reused
+// untouched. Returns (current, nil) when nothing is absent.
+func mergeAbsentProviders(
+	current map[uint64]*lavasession.ConsumerSessionsWithProvider,
+	configured []*lavasession.RPCStaticProviderEndpoint,
+	convert func([]*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider,
+	epoch uint64,
+) (map[uint64]*lavasession.ConsumerSessionsWithProvider, []string) {
+	active := make(map[string]struct{}, len(current))
+	for _, s := range current {
+		active[s.PublicLavaAddress] = struct{}{}
+	}
+
+	var absent []*lavasession.RPCStaticProviderEndpoint
+	for _, p := range configured {
+		if _, ok := active[p.Name]; !ok {
+			absent = append(absent, p)
+		}
+	}
+	if len(absent) == 0 {
+		return current, nil
+	}
+
+	// Copy-on-write: probeProviders / cleanupStaleTrackers may iterate the old map
+	// without the lock, so never mutate it in place. Re-key appended sessions past
+	// the existing max — convert() keys by its own list index, which would collide.
+	merged := make(map[uint64]*lavasession.ConsumerSessionsWithProvider, len(current)+len(absent))
+	maxIdx := uint64(0)
+	for idx, s := range current {
+		merged[idx] = s
+		if idx >= maxIdx {
+			maxIdx = idx + 1
+		}
+	}
+
+	converted := make(map[string]struct{})
+	for _, session := range convert(absent) {
+		session.Lock.Lock()
+		session.PairingEpoch = epoch
+		session.Lock.Unlock()
+		merged[maxIdx] = session
+		maxIdx++
+		converted[session.PublicLavaAddress] = struct{}{}
+	}
+
+	var restored []string
+	for _, p := range absent { // config order → deterministic output
+		if _, ok := converted[p.Name]; ok {
+			restored = append(restored, p.Name)
+		}
+	}
+	return merged, restored
 }
 
 // cleanupStaleTrackers removes ChainTrackers for endpoints that are no longer in the current provider sessions.


### PR DESCRIPTION
## What & why

The per-epoch spec re-verifier (`applyReverification`) demotes static/backup
providers that fail validation, dropping them from the live pairing. In long test
runs these demotions accumulate faster than the 15m epoch tick recovers them, and
`/debug/reset-all` **intentionally** leaves pairing intact (see its source
comment) — so a pod restart was the only way to readmit a demoted provider
mid-session. (MAG-2005 fixed the per-session block-list symptom but not this
underlying pairing demotion; parent: MAG-756.)

Add **`POST /debug/reset-pairing`** as an additive, opt-in companion that
cold-rebuilds each chain's pairing from the startup provider config.

## Implementation

- **`rebuildPairingFromConfig()`** — for each chain, re-admits every configured
  provider currently absent from the live pairing, straight from
  `reverifyInputs.configuredStatic/Backup`, and pushes the rebuilt pairing via
  `UpdateAllProviders` at the **current** epoch (no epoch transition). Cold — no
  spec re-probing.
- **Copy-on-write merge** (`mergeAbsentProviders`): only *absent* providers are
  converted (fresh connections); active sessions are reused untouched, so healthy
  providers aren't churned. Mirrors `retryFailedStaticProviders`.
- Re-admitted providers are dropped from `failedStaticProviders` so the background
  retry loop won't later merge a duplicate session.
- `UpdateAllProviders` stays under `rpsr.mu`, atomic with `updateEpoch` / retry.
- **`reset-all` is unchanged.** Handler returns 200 + `{"reset":true,"restored":{<chain>:[names]}}`, 405 on non-POST, no-op 200 when the router is absent (test fixtures).

## Verification

- `go build ./...`, the new unit tests, and the full `rpcsmartrouter` package suite — all green.
- Unit coverage: router-level readmission of a demoted provider + idempotency; handler 200 / 405 / empty-restored.

### ✅ Behavioral acceptance — verified on a deployed build (simulator repro)

Deployed to the eth-sim router on the `anna` tenant and ran the ticket's repro
(epoch accelerated to 1m so the re-verifier demotes quickly; debug endpoints
reached via `kubectl port-forward`):

| Step | Result |
|------|--------|
| select `simprovider1` (failing) | **500** — `validProviders:simprovider2,simprovider3` (demoted, absent) |
| `POST /debug/reset-all` | `{"reset":true,"cleared":[…]}` |
| select `simprovider1` *after reset-all* | **500** — **still** missing from `validProviders` → reset-all does **not** recover pairing |
| `POST /debug/reset-pairing` | `{"reset":true,"restored":{"ETH1jsonrpc":["simprovider1"]}}` |
| select `simprovider1` *after reset-pairing* | **200** — request routed to `simprovider1` (its own `-32601` response) → **selectable again** |

So the demoted provider was readmitted to **`validAddresses`** (not just
`pairingAddresses`) with no pod restart and no epoch wait — the acceptance
criterion. The re-block interaction flagged in review did **not** bite: the
provider went straight back to selectable.

## Acceptance mapping

| Acceptance | Status |
|---|---|
| New `POST /debug/reset-pairing` in `buildDebugMux` | ✅ |
| Returns 200 + JSON of restored providers | ✅ |
| No change to `reset-all` | ✅ |
| Readmits demoted provider to `validAddresses` w/o restart/epoch wait | ✅ verified (sim repro above) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
