### PR TITLE
feat(chaintracker): polling-relief flags to slow polling + widen consistency gate

### DIFF
--- a/protocol/chaintracker/chain_tracker.go
+++ b/protocol/chaintracker/chain_tracker.go
@@ -56,17 +56,44 @@ type IChainTracker interface {
 }
 
 const (
-	initRetriesCount               = 4
-	BACKOFF_MAX_TIME               = 10 * time.Minute
-	maxFails                       = 10
-	GoodStabilityThreshold         = 0.3
-	PollingUpdateLength            = 10
-	MostFrequentPollingMultiplier  = 16
-	LavaPollingMultiplierFrequency = 4
-	PollingMultiplierFlagName      = "polling-multiplier"
+	initRetriesCount                      = 4
+	BACKOFF_MAX_TIME                      = 10 * time.Minute
+	maxFails                              = 10
+	GoodStabilityThreshold                = 0.3
+	PollingUpdateLength                   = 10
+	MostFrequentPollingMultiplier         = 16
+	MinPollingTimeMultiplier              = 4 // adaptive tiers compute base/(multiplier/4); below this divides by zero
+	ChainTrackerPollingMultiplierFlagName = "chain-tracker-polling-multiplier"
 )
 
-var PollingMultiplier = uint64(1)
+// PollingTimeMultiplierOverride is the polling-relief process-wide override of
+// MostFrequentPollingMultiplier (default 16). 0 = no relief (current behavior).
+// A smaller value = slower polling = fewer upstream calls. Set once at startup from
+// the --chain-tracker-polling-multiplier flag and honored in newCustomChainTracker,
+// so it applies to every tracker (the global one and all per-endpoint ones).
+var PollingTimeMultiplierOverride = 0
+
+// EffectivePollingMultiplier returns the multiplier actually in force: the
+// polling-relief override when set, otherwise the built-in MostFrequentPollingMultiplier.
+func EffectivePollingMultiplier() int {
+	if PollingTimeMultiplierOverride != 0 {
+		return PollingTimeMultiplierOverride
+	}
+	return MostFrequentPollingMultiplier
+}
+
+// clampPollingMultiplier enforces the divide-by-zero floor: updateTimer's adaptive
+// tiers compute base/(multiplier/4), so a multiplier below 4 divides by zero. Warns
+// when it has to clamp — the flag path is already range-validated, so this only fires
+// if a per-tracker config sets PollingTimeMultiplier below the floor.
+func clampPollingMultiplier(m int) int {
+	if m < MinPollingTimeMultiplier {
+		utils.LavaFormatWarning("chain-tracker polling multiplier below safe floor; clamping", nil,
+			utils.LogAttr("provided", m), utils.LogAttr("floor", MinPollingTimeMultiplier))
+		return MinPollingTimeMultiplier
+	}
+	return m
+}
 
 type ChainFetcher interface {
 	FetchLatestBlockNum(ctx context.Context) (int64, error)
@@ -505,9 +532,6 @@ func (cs *ChainTracker) updateTimer(tickerBaseTime time.Duration, fetchFails uin
 		newPollingTime = tickerBaseTime / cs.pollingTimeMultiplier
 	}
 	newTickerDuration := exponentialBackoff(newPollingTime, fetchFails)
-	if PollingMultiplier > 1 {
-		newTickerDuration /= time.Duration(PollingMultiplier)
-	}
 
 	cs.timer = time.NewTimer(newTickerDuration)
 }
@@ -670,10 +694,16 @@ func newCustomChainTracker(chainFetcher ChainFetcher, config ChainTrackerConfig)
 		return &DummyChainTracker{}
 	}
 
+	// polling-relief: apply the process-wide override (flag) first, then any per-tracker
+	// config override, then clamp to the divide-by-zero floor.
 	pollingTime := MostFrequentPollingMultiplier
+	if PollingTimeMultiplierOverride != 0 {
+		pollingTime = PollingTimeMultiplierOverride
+	}
 	if config.PollingTimeMultiplier != 0 {
 		pollingTime = config.PollingTimeMultiplier
 	}
+	pollingTime = clampPollingMultiplier(pollingTime)
 	if chainFetcher == nil {
 		utils.LavaFormatFatal("can't start chainTracker with nil chainFetcher argument", nil)
 	}

--- a/protocol/chaintracker/polling_relief_test.go
+++ b/protocol/chaintracker/polling_relief_test.go
@@ -1,0 +1,30 @@
+package chaintracker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestClampPollingMultiplier guards the divide-by-zero floor: updateTimer's adaptive
+// tiers compute base/(multiplier/4), so any resolved multiplier below 4 must be
+// clamped up to 4 (3/4 == 0 -> panic). Tested at 2 and 3, not just at the boundary.
+func TestClampPollingMultiplier(t *testing.T) {
+	require.Equal(t, MinPollingTimeMultiplier, clampPollingMultiplier(2), "2 is below the floor, clamps to 4")
+	require.Equal(t, MinPollingTimeMultiplier, clampPollingMultiplier(3), "3 is below the floor, clamps to 4")
+	require.Equal(t, 4, clampPollingMultiplier(4), "4 is the floor, unchanged")
+	require.Equal(t, 8, clampPollingMultiplier(8), "mid-range unchanged")
+	require.Equal(t, MostFrequentPollingMultiplier, clampPollingMultiplier(16), "16 unchanged")
+}
+
+// TestEffectivePollingMultiplier verifies the relief override takes effect and falls
+// back to the built-in multiplier when unset.
+func TestEffectivePollingMultiplier(t *testing.T) {
+	defer func(orig int) { PollingTimeMultiplierOverride = orig }(PollingTimeMultiplierOverride)
+
+	PollingTimeMultiplierOverride = 0
+	require.Equal(t, MostFrequentPollingMultiplier, EffectivePollingMultiplier(), "unset -> built-in default 16")
+
+	PollingTimeMultiplierOverride = 4
+	require.Equal(t, 4, EffectivePollingMultiplier(), "override in force")
+}

--- a/protocol/relaycore/consistency_config.go
+++ b/protocol/relaycore/consistency_config.go
@@ -6,6 +6,16 @@ import (
 	"github.com/magma-Devs/smart-router/utils"
 )
 
+// ConsistencyBlockGapFactorFlagName is the polling-relief flag that widens the
+// endpoint-lag consistency gate (the blockLagForQosSync multiplier; default 2).
+const ConsistencyBlockGapFactorFlagName = "consistency-block-gap-factor"
+
+// ConsistencyBlockGapFactorOverride is the polling-relief process-wide override of
+// the blockLagForQosSync multiplier inside EndpointLagThreshold (default 2). 0 = no
+// relief. A larger value tolerates staler endpoints — the companion to slower polling.
+// Set once at startup from the flag and passed into NewConsistencyValidationConfig.
+var ConsistencyBlockGapFactorOverride int64 = 0
+
 // ConsistencyValidationConfig holds configuration for consistency validation
 // with chain-specific thresholds derived from chain spec values.
 // Only pre-request validation is used (post-response validation removed).
@@ -42,18 +52,24 @@ func DefaultConsistencyValidationConfig() *ConsistencyValidationConfig {
 //   - blockLagForQosSync: The block lag threshold used for QoS sync calculations
 //   - blockDistanceToFinalization: The number of blocks until finalization
 //   - averageBlockTime: The average time between blocks for this chain
+//   - blockGapFactor: polling-relief multiplier on blockLagForQosSync (0 = default 2)
 //
 // Derivation logic:
-//   - EndpointLagThreshold: max(blockLagForQosSync*2, blockDistanceToFinalization), minimum 10
+//   - EndpointLagThreshold: max(blockLagForQosSync*blockGapFactor, blockDistanceToFinalization), minimum 10
 //   - MaxWaitTime: averageBlockTime * 2 - wait up to 2 average block times
 func NewConsistencyValidationConfig(
 	blockLagForQosSync int64,
 	blockDistanceToFinalization uint32,
 	averageBlockTime time.Duration,
+	blockGapFactor int64,
 ) *ConsistencyValidationConfig {
 	// Calculate endpoint lag threshold: use the larger of double QoS sync lag
 	// or the finalization distance, to ensure endpoints can serve finalized blocks.
-	endpointLagThreshold := blockLagForQosSync * 2
+	gapFactor := int64(2)
+	if blockGapFactor != 0 {
+		gapFactor = blockGapFactor
+	}
+	endpointLagThreshold := blockLagForQosSync * gapFactor
 	if finalizationThreshold := int64(blockDistanceToFinalization); finalizationThreshold > endpointLagThreshold {
 		endpointLagThreshold = finalizationThreshold
 	}

--- a/protocol/relaycore/consistency_validation_test.go
+++ b/protocol/relaycore/consistency_validation_test.go
@@ -234,7 +234,7 @@ func TestConsistencyValidationConfig_Creation(t *testing.T) {
 
 	t.Run("config from chain spec - typical EVM", func(t *testing.T) {
 		// Typical EVM: blockLagForQosSync=3, finalization=64, avgBlockTime=12s
-		config := NewConsistencyValidationConfig(3, 64, 12*time.Second)
+		config := NewConsistencyValidationConfig(3, 64, 12*time.Second, 0)
 		require.NotNil(t, config)
 		// EndpointLagThreshold = max(3*2=6, 64) = 64, but min 10, so 64
 		require.Equal(t, int64(64), config.EndpointLagThreshold)
@@ -244,7 +244,7 @@ func TestConsistencyValidationConfig_Creation(t *testing.T) {
 
 	t.Run("config from chain spec - fast chain", func(t *testing.T) {
 		// Fast chain: blockLagForQosSync=10, finalization=32, avgBlockTime=2s
-		config := NewConsistencyValidationConfig(10, 32, 2*time.Second)
+		config := NewConsistencyValidationConfig(10, 32, 2*time.Second, 0)
 		require.NotNil(t, config)
 		// EndpointLagThreshold = max(10*2=20, 32) = 32
 		require.Equal(t, int64(32), config.EndpointLagThreshold)
@@ -254,7 +254,7 @@ func TestConsistencyValidationConfig_Creation(t *testing.T) {
 
 	t.Run("config from chain spec - slow chain", func(t *testing.T) {
 		// Slow chain: blockLagForQosSync=1, finalization=6, avgBlockTime=60s
-		config := NewConsistencyValidationConfig(1, 6, 60*time.Second)
+		config := NewConsistencyValidationConfig(1, 6, 60*time.Second, 0)
 		require.NotNil(t, config)
 		// EndpointLagThreshold = max(1*2=2, 6) = 10 (minimum)
 		require.Equal(t, int64(10), config.EndpointLagThreshold)
@@ -264,12 +264,23 @@ func TestConsistencyValidationConfig_Creation(t *testing.T) {
 
 	t.Run("config from chain spec - very fast block time", func(t *testing.T) {
 		// Very fast: blockLagForQosSync=20, finalization=100, avgBlockTime=100ms
-		config := NewConsistencyValidationConfig(20, 100, 100*time.Millisecond)
+		config := NewConsistencyValidationConfig(20, 100, 100*time.Millisecond, 0)
 		require.NotNil(t, config)
 		// EndpointLagThreshold = max(20*2=40, 100) = 100
 		require.Equal(t, int64(100), config.EndpointLagThreshold)
 		// MaxWaitTime = max(100ms*2=200ms, 500ms floor) = 500ms
 		require.Equal(t, 500*time.Millisecond, config.MaxWaitTime)
+	})
+
+	t.Run("block-gap-factor widens the threshold when QoS-lag dominates (polling-relief)", func(t *testing.T) {
+		// Solana-like: blockLagForQosSync=25 with a small finalization distance, so the
+		// QoS-lag term dominates the max() and the factor actually moves the threshold.
+		// (On finalization-dominated chains like EVM the factor is inert until it exceeds
+		// the finalization distance.)
+		require.Equal(t, int64(50), NewConsistencyValidationConfig(25, 5, 400*time.Millisecond, 0).EndpointLagThreshold)  // 0 -> default x2
+		require.Equal(t, int64(50), NewConsistencyValidationConfig(25, 5, 400*time.Millisecond, 2).EndpointLagThreshold)  // explicit 2 == default
+		require.Equal(t, int64(100), NewConsistencyValidationConfig(25, 5, 400*time.Millisecond, 4).EndpointLagThreshold) // x4
+		require.Equal(t, int64(200), NewConsistencyValidationConfig(25, 5, 400*time.Millisecond, 8).EndpointLagThreshold) // x8
 	})
 }
 

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -1657,8 +1657,30 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 				utils.LavaFormatWarning("AllowInsecureConnectionToProviders is set to true, this should be used only in development", nil, utils.Attribute{Key: lavasession.AllowInsecureConnectionToProvidersFlag, Value: lavasession.AllowInsecureConnectionToProviders})
 			}
 
-			// polling-relief: set the process-wide cadence/consistency overrides from flags
-			// BEFORE any chain tracker or consistency config is built. Zero = no relief;
+			var rpcEndpoints []*lavasession.RPCEndpoint
+			var viper_endpoints *viper.Viper
+			if len(args) > 1 {
+				viper_endpoints, err = common.ParseEndpointArgs(args, Yaml_config_properties, common.EndpointsConfigName)
+				if err != nil {
+					return utils.LavaFormatError("invalid endpoints arguments", err, utils.Attribute{Key: "endpoint_strings", Value: strings.Join(args, "")})
+				}
+				viper.MergeConfigMap(viper_endpoints.AllSettings())
+				err := viper.SafeWriteConfigAs(DefaultRPCSmartRouterFileName)
+				if err != nil {
+					utils.LavaFormatInfo("did not create new config file, if it's desired remove the config file", utils.Attribute{Key: "file_name", Value: viper.ConfigFileUsed()})
+				} else {
+					utils.LavaFormatInfo("created new config file", utils.Attribute{Key: "file_name", Value: DefaultRPCSmartRouterFileName})
+				}
+			} else if err = viper.ReadInConfig(); err != nil {
+				utils.LavaFormatFatal("could not load config file", err, utils.Attribute{Key: "expected_config_name", Value: viper.ConfigFileUsed()})
+			} else {
+				utils.LavaFormatInfo("read config file successfully", utils.Attribute{Key: "expected_config_name", Value: viper.ConfigFileUsed()})
+			}
+
+			// polling-relief: set the process-wide cadence/consistency overrides AFTER the
+			// config file is merged into viper (above), so the flags resolve from CLI *or*
+			// config.yml (viper precedence: CLI-if-passed > config file > default). Still set
+			// before any chain tracker or consistency config is built. Zero = no relief;
 			// out-of-range values warn-and-revert to the built-in default (not silent clamp).
 			if m := viper.GetInt(chaintracker.ChainTrackerPollingMultiplierFlagName); m != 0 {
 				if m < chaintracker.MinPollingTimeMultiplier || m > chaintracker.MostFrequentPollingMultiplier {
@@ -1680,25 +1702,6 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 					utils.LogAttr("consistencyBlockGapFactor", relaycore.ConsistencyBlockGapFactorOverride))
 			}
 
-			var rpcEndpoints []*lavasession.RPCEndpoint
-			var viper_endpoints *viper.Viper
-			if len(args) > 1 {
-				viper_endpoints, err = common.ParseEndpointArgs(args, Yaml_config_properties, common.EndpointsConfigName)
-				if err != nil {
-					return utils.LavaFormatError("invalid endpoints arguments", err, utils.Attribute{Key: "endpoint_strings", Value: strings.Join(args, "")})
-				}
-				viper.MergeConfigMap(viper_endpoints.AllSettings())
-				err := viper.SafeWriteConfigAs(DefaultRPCSmartRouterFileName)
-				if err != nil {
-					utils.LavaFormatInfo("did not create new config file, if it's desired remove the config file", utils.Attribute{Key: "file_name", Value: viper.ConfigFileUsed()})
-				} else {
-					utils.LavaFormatInfo("created new config file", utils.Attribute{Key: "file_name", Value: DefaultRPCSmartRouterFileName})
-				}
-			} else if err = viper.ReadInConfig(); err != nil {
-				utils.LavaFormatFatal("could not load config file", err, utils.Attribute{Key: "expected_config_name", Value: viper.ConfigFileUsed()})
-			} else {
-				utils.LavaFormatInfo("read config file successfully", utils.Attribute{Key: "expected_config_name", Value: viper.ConfigFileUsed()})
-			}
 			geolocation, err := cmd.Flags().GetUint64(lavasession.GeolocationFlag)
 			if err != nil {
 				utils.LavaFormatFatal("failed to read geolocation flag, required flag", err)

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -1542,7 +1542,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 
 				utils.LavaFormatInfo("Chain tracker started",
 					utils.LogAttr("chain", rpcEndpoint.ChainID),
-					utils.LogAttr("pollingInterval", averageBlockTime/time.Duration(chaintracker.MostFrequentPollingMultiplier)),
+					utils.LogAttr("pollingInterval", averageBlockTime/time.Duration(chaintracker.EffectivePollingMultiplier())),
 					utils.LogAttr("blocksToSave", blocksToSaveChainTracker),
 				)
 			}
@@ -1655,6 +1655,29 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 			lavasession.AllowInsecureConnectionToProviders = viper.GetBool(lavasession.AllowInsecureConnectionToProvidersFlag)
 			if lavasession.AllowInsecureConnectionToProviders {
 				utils.LavaFormatWarning("AllowInsecureConnectionToProviders is set to true, this should be used only in development", nil, utils.Attribute{Key: lavasession.AllowInsecureConnectionToProvidersFlag, Value: lavasession.AllowInsecureConnectionToProviders})
+			}
+
+			// polling-relief: set the process-wide cadence/consistency overrides from flags
+			// BEFORE any chain tracker or consistency config is built. Zero = no relief;
+			// out-of-range values warn-and-revert to the built-in default (not silent clamp).
+			if m := viper.GetInt(chaintracker.ChainTrackerPollingMultiplierFlagName); m != 0 {
+				if m < chaintracker.MinPollingTimeMultiplier || m > chaintracker.MostFrequentPollingMultiplier {
+					utils.LavaFormatWarning("--"+chaintracker.ChainTrackerPollingMultiplierFlagName+" out of allowed range [4,16]; reverting to default", nil, utils.LogAttr("provided", m))
+				} else {
+					chaintracker.PollingTimeMultiplierOverride = m
+				}
+			}
+			if f := viper.GetInt(relaycore.ConsistencyBlockGapFactorFlagName); f != 0 {
+				if f < 2 || f > 8 {
+					utils.LavaFormatWarning("--"+relaycore.ConsistencyBlockGapFactorFlagName+" out of allowed range [2,8]; reverting to default", nil, utils.LogAttr("provided", f))
+				} else {
+					relaycore.ConsistencyBlockGapFactorOverride = int64(f)
+				}
+			}
+			if chaintracker.PollingTimeMultiplierOverride != 0 || relaycore.ConsistencyBlockGapFactorOverride != 0 {
+				utils.LavaFormatInfo("polling-relief active",
+					utils.LogAttr("chainTrackerPollingMultiplier", chaintracker.EffectivePollingMultiplier()),
+					utils.LogAttr("consistencyBlockGapFactor", relaycore.ConsistencyBlockGapFactorOverride))
 			}
 
 			var rpcEndpoints []*lavasession.RPCEndpoint
@@ -1949,6 +1972,8 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	cmdRPCSmartRouter.Flags().Int(performance.PyroscopeBlockProfileRateFlagName, performance.DefaultBlockProfileRate, "block profile rate in nanoseconds (1 records all blocking events)")
 	cmdRPCSmartRouter.Flags().String(performance.PyroscopeTagsFlagName, "", "comma-separated list of tags in key=value format (e.g., instance=router-1,region=us-east)")
 	cmdRPCSmartRouter.Flags().String(performance.CacheFlagName, "", "address for a cache server to improve performance")
+	cmdRPCSmartRouter.Flags().Int(chaintracker.ChainTrackerPollingMultiplierFlagName, 0, "polling-relief: override the chain-tracker polling multiplier (default 16). Allowed [4,16]; out-of-range reverts to default. Smaller = slower polling = fewer upstream calls.")
+	cmdRPCSmartRouter.Flags().Int(relaycore.ConsistencyBlockGapFactorFlagName, 0, "polling-relief: widen the consistency endpoint-lag gate (blockLagForQosSync x factor; default 2). Allowed [2,8]; out-of-range reverts to default. Companion to the polling multiplier.")
 	cmdRPCSmartRouter.Flags().Var(&strategyFlag, "strategy", fmt.Sprintf("the strategy to use to pick providers (%s)", strings.Join(strategyNames, "|")))
 	defaultWeightedConfig := provideroptimizer.DefaultWeightedSelectorConfig()
 	cmdRPCSmartRouter.Flags().Float64(common.ProviderOptimizerAvailabilityWeight, defaultWeightedConfig.AvailabilityWeight, "weight assigned to provider availability when computing selection scores")

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -116,6 +116,7 @@ func (rpcss *RPCSmartRouterServer) ServeRPCRequests(
 		blockLagForQosSync,
 		blockDistanceForFinalizedData,
 		averageBlockTime,
+		relaycore.ConsistencyBlockGapFactorOverride, // polling-relief: 0 = default x2
 	)
 
 	// Assign before creating the manager so that goroutines spawned by


### PR DESCRIPTION
## What & why

Proactive chain-tracker polling is billed against the customer's own upstream node
quota, and the cadence (`averageBlockTime / 16`, no floor) is pathological on fast
chains — Solana's 400ms blocks drive polls as fast as ~25ms (~40/s per endpoint).
Add two **opt-in, zero-default** process-wide relief flags, modeled on
**lavanet/lava [#2276](https://github.com/lavanet/lava/pull/2276)** (adapted to the
smart-router's architecture).

| Flag | Effect | Default | Range |
|---|---|---|---|
| `--chain-tracker-polling-multiplier` | overrides the polling divisor; **smaller = slower polling = fewer upstream calls** | 16 | [4,16] |
| `--consistency-block-gap-factor` | widens the endpoint-lag consistency gate (`blockLagForQosSync × factor`) | 2 | [2,8] |

These are a **coupled pair**: slower polling makes each endpoint's cached "latest
block" staler → the consistency gate rejects more endpoints ("no pairings") unless
the gate is widened in step.

## Implementation

- **Multiplier** — a process-wide override (`chaintracker.PollingTimeMultiplierOverride`)
  honored in `newCustomChainTracker`, so it applies to the global tracker *and* every
  per-endpoint tracker with no per-call threading. The resolved value is clamped to a
  floor of **4** (the adaptive tiers compute `base/(m/4)`; `m<4` divides by zero) with
  a warn.
- **Gap-factor** — a `blockGapFactor` parameter on `NewConsistencyValidationConfig`
  (`× 2` → `× factor`). Note `EndpointLagThreshold = max(blockLagForQosSync × factor,
  finalizationDistance, 10)`.
- **Validation** — out-of-range values **warn-and-revert** to the default. Zero = no
  relief. Overrides are set in `RunE` before any tracker/config is built.
- **Logging** — startup log reports the *effective* interval; a "polling-relief active"
  line logs when either override is set.
- **`--consistency-probability-gate` is intentionally NOT ported** — the smart-router
  consistency gate is deterministic (`lag > threshold`) with no Poisson term; that
  model lives in the optimizer, not the consistency path.
- **Dead-code reconcile** — removed the never-wired `PollingMultiplier` /
  `PollingMultiplierFlagName` / `LavaPollingMultiplierFrequency`.

## Coupling math — why the gap-factor need not change at multiplier 4 (but ships anyway)

Slower polling makes an endpoint's cached latest block staler, which feeds the gate's
`lag = seenBlock − endpointLatestBlock`, so in principle the gate should widen in
step. But the *magnitude* of 16→4 is far below the gate's budget:

- **Added staleness is < 1 block, and chain-independent.** Poll interval ≈ `base/m`, so
  the extra staleness from 16→4 is `base/4 − base/16 = (3/16)·base ≈ 0.19 block` — the
  `averageBlockTime` cancels, so it's ~0.19 block on *any* chain (≤ ~1 block even in the
  slowest adaptive tier).
- **The budget is ≥ 10 blocks.** `EndpointLagThreshold = max(blockLagForQosSync ×
  factor, finalizationDistance, 10)` — never below the floor of 10, and ~50 slots on
  Solana (`blockLagForQosSync = 25`, factor 2).

So 16→4 adds a fraction of a block against a ≥10-block (Solana ~50) budget — a
**~50–250× margin**. The multiplier change alone cannot push endpoints over the gate,
so **`--consistency-block-gap-factor` can stay at the default 2 when running multiplier
4** — and since 4 is the floor (you can't go more aggressive), this holds across the
whole `[4,16]` range. Confirmed by the runtime A/B below: it ran with the gap-factor
**unset** and saw no rejections.

### So why add the second flag at all

1. **Coupled companion (lava's lesson).** lava #2276 ships them together because
   slowing polling without widening the gate backfires into rejections under more
   aggressive conditions — the principle holds even where 16→4 doesn't trigger it.
2. **Load-bearing on other chains.** The danger case is a chain pinned at the floor-10
   threshold (small `blockLagForQosSync`, small finalization), where even small added
   staleness eats a larger fraction of the budget — there the operator needs the knob.
3. **Non-polling lag sources.** `lag` also grows from a genuinely slow endpoint or
   network jitter, independent of the multiplier; the gap-factor is a general tolerance
   lever for those.
4. **Free + reversible.** Zero-default = no effect; it's there to answer the
   "all endpoints failed consistency pre-validation" / "no pairings" canary without
   another deploy.

In short: **not required for 16→4** (the math has huge margin), but shipped as the
defensive, chain-portable companion and canary-response knob.

## Verification

- `go build ./...` green; `relaycore` + `rpcsmartrouter` suites green.
- New unit tests: clamp floor at 2/3, effective-multiplier override, and the gap-factor
  widening the threshold on QoS-lag-dominated values.
- **Flag wiring confirmed**: both flags appear in `rpcsmartrouter --help`.
- `chaintracker`: 5/6 runs clean; the one failure was a pre-existing **real-timer**
  timing test (`TestChainTrackerFetchSpreadAcrossPollingTime` / `...PollingTimeUpdate`),
  inert on this change's path — timing flakiness, not a regression.

### ✅ Runtime-measured on the deployed server

Deployed to the **eth-sim** router on the `anna` tenant and counted the actual
chain-tracker polls at the simulator (`GET /history?method=eth_blockNumber`,
per-endpoint, 60s windows):

| config | startup log | polls / 60s (per endpoint) | measured interval | expected |
|--------|-------------|----------------------------|-------------------|----------|
| multiplier **16** (default) | `pollingInterval 812.5ms` | 73 | **822 ms** | base/16 = 812 ms |
| multiplier **4** | `pollingInterval 3.25s` + `polling-relief active` | 19 | **3158 ms** | base/4 = 3250 ms |

→ **73 → 19 polls = 3.84× fewer**; the probe fires at the base/4 cadence. Honored
end-to-end: parsed → `polling-relief active chainTrackerPollingMultiplier=4` →
`pollingInterval 3.25s` → actual polls at ~3.16 s. (eth-sim `averageBlockTime ≈ 13 s`.)

The ~74% reduction here is consistent with the handoff doc's fast-node figure (~84%);
the magnitude is **upstream-latency-dependent** — largest on fast/co-located nodes, and
only ~23% on a high-latency gateway where the synchronous fetch already throttles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
