### PR TITLE
feat: debug-mode-only /debug/logs ring-buffer endpoint

### DIFF
--- a/protocol/rpcsmartrouter/debug_server_test.go
+++ b/protocol/rpcsmartrouter/debug_server_test.go
@@ -2,6 +2,7 @@ package rpcsmartrouter
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,7 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
 	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
 	"github.com/magma-Devs/smart-router/protocol/relaycore"
+	"github.com/magma-Devs/smart-router/utils"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -252,9 +254,9 @@ func (r *recordingDirectRPCConnection) SendRequest(context.Context, []byte, map[
 func (r *recordingDirectRPCConnection) GetProtocol() lavasession.DirectRPCProtocol {
 	return lavasession.DirectRPCProtocolHTTP
 }
-func (r *recordingDirectRPCConnection) Close() error              { return nil }
-func (r *recordingDirectRPCConnection) IsHealthy() bool           { return r.healthy.Load() }
-func (r *recordingDirectRPCConnection) GetURL() string            { return "" }
+func (r *recordingDirectRPCConnection) Close() error                { return nil }
+func (r *recordingDirectRPCConnection) IsHealthy() bool             { return r.healthy.Load() }
+func (r *recordingDirectRPCConnection) GetURL() string              { return "" }
 func (r *recordingDirectRPCConnection) GetNodeUrl() *common.NodeUrl { return nil }
 
 func (r *recordingDirectRPCConnection) MarkHealthy() {
@@ -677,4 +679,107 @@ func TestDebugResetAll_SmartRouter_CacheBeUnimplemented_DegradesGracefully(t *te
 	require.Equal(t, http.StatusOK, rr.Code)
 	require.Equal(t, 1, flusher.flushCalls)
 	require.NotContains(t, rr.Body.String(), `"cache-be"`)
+}
+
+// --- /debug/logs ---
+
+// TestDebugLogs_SmartRouter_ReturnsJSON verifies the GET /debug/logs contract:
+// 200 + a JSON body carrying "count" and "lines". We enable the in-memory
+// buffer and emit a log line so there is something to return; ClearDebugLogBuffer
+// keeps the package-level ring from leaking across tests.
+func TestDebugLogs_SmartRouter_ReturnsJSON(t *testing.T) {
+	utils.EnableDebugLogBuffer(100)
+	defer utils.ClearDebugLogBuffer()
+	utils.ClearDebugLogBuffer()
+	utils.LavaFormatInfo("debug-logs test line", utils.LogAttr(utils.KEY_REQUEST_ID, "req-logs-1"))
+
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano})
+
+	req := httptest.NewRequest(http.MethodGet, "/debug/logs", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	body := rr.Body.String()
+	require.Contains(t, body, `"count":`)
+	require.Contains(t, body, `"lines":[`)
+	require.Contains(t, body, "debug-logs test line")
+	// The assembled body must be valid JSON.
+	var parsed struct {
+		Count int               `json:"count"`
+		Lines []json.RawMessage `json:"lines"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &parsed))
+	require.Equal(t, parsed.Count, len(parsed.Lines))
+	require.GreaterOrEqual(t, parsed.Count, 1)
+}
+
+// TestDebugLogs_SmartRouter_RequestIDFilter verifies the request_id query
+// param scopes results to a single request.
+func TestDebugLogs_SmartRouter_RequestIDFilter(t *testing.T) {
+	utils.EnableDebugLogBuffer(100)
+	defer utils.ClearDebugLogBuffer()
+	utils.ClearDebugLogBuffer()
+	utils.LavaFormatInfo("line a", utils.LogAttr(utils.KEY_REQUEST_ID, "req-A"))
+	utils.LavaFormatInfo("line b", utils.LogAttr(utils.KEY_REQUEST_ID, "req-B"))
+
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano})
+
+	req := httptest.NewRequest(http.MethodGet, "/debug/logs?request_id=req-A", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	require.Contains(t, body, "line a")
+	require.NotContains(t, body, "line b")
+}
+
+func TestDebugLogs_SmartRouter_MethodNotAllowed(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano})
+
+	req := httptest.NewRequest(http.MethodPost, "/debug/logs", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}
+
+func TestDebugLogsClear_SmartRouter_ReturnsJSON(t *testing.T) {
+	utils.EnableDebugLogBuffer(100)
+	defer utils.ClearDebugLogBuffer()
+	utils.LavaFormatInfo("to be cleared")
+
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano})
+
+	req := httptest.NewRequest(http.MethodPost, "/debug/logs/clear", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	require.Contains(t, rr.Body.String(), `"cleared":true`)
+
+	// After clearing, GET /debug/logs reports an empty set.
+	getReq := httptest.NewRequest(http.MethodGet, "/debug/logs", nil)
+	getRR := httptest.NewRecorder()
+	mux.ServeHTTP(getRR, getReq)
+	require.Equal(t, http.StatusOK, getRR.Code)
+	require.Contains(t, getRR.Body.String(), `"count":0`)
+}
+
+func TestDebugLogsClear_SmartRouter_MethodNotAllowed(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano})
+
+	req := httptest.NewRequest(http.MethodGet, "/debug/logs/clear", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
 }

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -329,6 +329,9 @@ func (rpsr *RPCSmartRouter) Start(ctx context.Context, options *rpcSmartRouterSt
 	// Start optional debug HTTP server for integration tests.
 	// Only starts when --debug-address flag is provided. Off by default.
 	if options.cmdFlags.DebugAddress != "" {
+		// Debug-mode-only: enable the in-memory ring-buffer log sink so the
+		// /debug/logs endpoint can serve recent logs to the test harness.
+		utils.EnableDebugLogBuffer(50000)
 		var currentOffsetNano atomic.Int64
 		debugMux := buildDebugMux(debugMuxDeps{
 			optimizers:    optimizers,
@@ -772,6 +775,72 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 			return
 		}
 		w.Write(body)
+	})
+
+	// GET /debug/logs — return recent in-memory log records, optionally scoped
+	// by request_id and/or a [from,to] time window, so an external test harness
+	// can attach the router's logs to failing tests. The ring buffer is enabled
+	// only in debug mode (see EnableDebugLogBuffer in Start); when it was never
+	// enabled this returns an empty set. Each line is an already-valid JSON
+	// object (zerolog JSON record); we assemble the array by joining the raw
+	// bytes with commas rather than re-marshalling.
+	mux.HandleFunc("/debug/logs", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "GET only", http.StatusMethodNotAllowed)
+			return
+		}
+		q := r.URL.Query()
+		requestID := q.Get("request_id")
+
+		// from/to are RFC3339; empty or unparseable → zero time (ignored).
+		var from, to time.Time
+		if v := q.Get("from"); v != "" {
+			if parsed, err := time.Parse(time.RFC3339, v); err == nil {
+				from = parsed
+			}
+		}
+		if v := q.Get("to"); v != "" {
+			if parsed, err := time.Parse(time.RFC3339, v); err == nil {
+				to = parsed
+			}
+		}
+
+		// limit defaults to 5000, capped at the ring capacity (50000).
+		limit := 5000
+		if v := q.Get("limit"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				limit = n
+			}
+		}
+		if limit > 50000 {
+			limit = 50000
+		}
+
+		lines := utils.ReadDebugLogBuffer(requestID, from, to, limit)
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"count":%d,"lines":[`, len(lines))
+		for i, line := range lines {
+			if i > 0 {
+				w.Write([]byte{','})
+			}
+			// Strip a trailing newline zerolog appends to each record so the
+			// assembled array stays compact and valid.
+			w.Write([]byte(strings.TrimRight(string(line), "\n")))
+		}
+		fmt.Fprint(w, "]}")
+	})
+
+	// POST /debug/logs/clear — drop every buffered log record so a test can
+	// start from a clean slate before exercising a scenario.
+	mux.HandleFunc("/debug/logs/clear", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST only", http.StatusMethodNotAllowed)
+			return
+		}
+		utils.ClearDebugLogBuffer()
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"cleared":true}`)
 	})
 
 	return mux

--- a/utils/lavalog.go
+++ b/utils/lavalog.go
@@ -2,11 +2,14 @@ package utils
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	zerolog "github.com/rs/zerolog"
@@ -54,6 +57,177 @@ var (
 	rollingLogLogger      = zerolog.New(os.Stderr).Level(zerolog.Disabled) // this is the singleton rolling logger.
 	defaultGlobalLogLevel = zerolog.DebugLevel
 )
+
+// debugRingWriter is a mutex-guarded fixed-capacity circular buffer of raw log
+// records. It implements io.Writer so a zerolog sink can write JSON records into
+// it. Used only in debug mode (--debug-address) as a forensic in-memory log
+// buffer fetched via /debug/logs.
+type debugRingWriter struct {
+	mu  sync.Mutex
+	buf [][]byte
+	cap int
+}
+
+func newDebugRingWriter(capacity int) *debugRingWriter {
+	if capacity <= 0 {
+		capacity = 1
+	}
+	return &debugRingWriter{
+		buf: make([][]byte, 0, capacity),
+		cap: capacity,
+	}
+}
+
+// Write copies p (zerolog reuses its write buffer, so we MUST copy) and appends
+// it to the ring, evicting the oldest record when at capacity.
+func (d *debugRingWriter) Write(p []byte) (int, error) {
+	cp := make([]byte, len(p))
+	copy(cp, p)
+	d.mu.Lock()
+	if len(d.buf) >= d.cap {
+		// evict the oldest record
+		d.buf = d.buf[1:]
+	}
+	d.buf = append(d.buf, cp)
+	d.mu.Unlock()
+	return len(p), nil
+}
+
+// snapshot returns a copy of the current ring contents in oldest-to-newest order.
+func (d *debugRingWriter) snapshot() [][]byte {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make([][]byte, len(d.buf))
+	copy(out, d.buf)
+	return out
+}
+
+// clear empties the ring.
+func (d *debugRingWriter) clear() {
+	d.mu.Lock()
+	d.buf = d.buf[:0]
+	d.mu.Unlock()
+}
+
+var (
+	// debugBufferLogger is the THIRD zerolog sink (alongside the std logger and
+	// rollingLogLogger). Disabled by default; enabled only in debug mode.
+	debugBufferLogger = zerolog.New(io.Discard).Level(zerolog.Disabled)
+	debugRingMu       sync.Mutex
+	debugRing         *debugRingWriter
+)
+
+// EnableDebugLogBuffer turns on the in-memory ring-buffer log sink with the
+// given capacity (number of records). Debug-mode only — called from
+// rpcsmartrouter.Start when --debug-address is set. Captures EVERYTHING
+// (TraceLevel) as machine-parseable JSON; forensics is the point.
+func EnableDebugLogBuffer(maxLines int) {
+	if maxLines <= 0 {
+		maxLines = 5000
+	}
+	debugRingMu.Lock()
+	debugRing = newDebugRingWriter(maxLines)
+	ring := debugRing
+	debugRingMu.Unlock()
+	debugBufferLogger = zerolog.New(ring).Level(zerolog.TraceLevel).With().Timestamp().Logger()
+}
+
+// ClearDebugLogBuffer drops every record currently in the ring. No-op when the
+// buffer was never enabled.
+func ClearDebugLogBuffer() {
+	debugRingMu.Lock()
+	ring := debugRing
+	debugRingMu.Unlock()
+	if ring != nil {
+		ring.clear()
+	}
+}
+
+// ReadDebugLogBuffer returns the buffered log records, filtered by requestID
+// and/or time window, with the most recent `limit` records retained (tail).
+//
+//   - requestID != "": keep only records whose "request_id" field equals it. A
+//     record that fails to JSON-parse is skipped when a requestID filter is
+//     active, and kept when it is not.
+//   - from/to (non-zero): keep records whose "time" field (Unix-nano integer,
+//     since the package sets zerolog.TimeFieldFormat = TimeFormatUnixNano) falls
+//     within [from, to].
+//   - both given → ANDed.
+//   - limit <= 0 defaults to 5000.
+func ReadDebugLogBuffer(requestID string, from, to time.Time, limit int) [][]byte {
+	if limit <= 0 {
+		limit = 5000
+	}
+	debugRingMu.Lock()
+	ring := debugRing
+	debugRingMu.Unlock()
+	if ring == nil {
+		return [][]byte{}
+	}
+	records := ring.snapshot()
+
+	filterRequest := requestID != ""
+	filterFrom := !from.IsZero()
+	filterTo := !to.IsZero()
+	var fromNano, toNano int64
+	if filterFrom {
+		fromNano = from.UnixNano()
+	}
+	if filterTo {
+		toNano = to.UnixNano()
+	}
+
+	out := make([][]byte, 0, len(records))
+	for _, rec := range records {
+		var fields map[string]json.RawMessage
+		parsed := json.Unmarshal(rec, &fields) == nil
+
+		if !parsed {
+			// Unparseable lines: keep only when no requestID filter is active.
+			if filterRequest {
+				continue
+			}
+			out = append(out, rec)
+			continue
+		}
+
+		if filterRequest {
+			raw, ok := fields[KEY_REQUEST_ID]
+			if !ok {
+				continue
+			}
+			var rid string
+			if err := json.Unmarshal(raw, &rid); err != nil || rid != requestID {
+				continue
+			}
+		}
+
+		if filterFrom || filterTo {
+			raw, ok := fields["time"]
+			if !ok {
+				continue
+			}
+			var ts int64
+			if err := json.Unmarshal(raw, &ts); err != nil {
+				continue
+			}
+			if filterFrom && ts < fromNano {
+				continue
+			}
+			if filterTo && ts > toNano {
+				continue
+			}
+		}
+
+		out = append(out, rec)
+	}
+
+	// Apply limit LAST: keep the most recent `limit` records (tail).
+	if len(out) > limit {
+		out = out[len(out)-limit:]
+	}
+	return out
+}
 
 type Attribute struct {
 	Key   string
@@ -326,42 +500,65 @@ func LavaFormatLog(description string, err error, attributes []Attribute, severi
 
 	var logEvent *zerolog.Event
 	var rollingLoggerEvent *zerolog.Event
+	var debugBufferEvent *zerolog.Event
 	rollingLogEnabled := rollingLogLogger.GetLevel() != zerolog.Disabled
+	debugBufferEnabled := debugBufferLogger.GetLevel() != zerolog.Disabled
 	switch severity {
 	case LAVA_LOG_PANIC:
 		logEvent = zerologlog.Panic()
 		if rollingLogEnabled {
 			rollingLoggerEvent = rollingLogLogger.Panic()
 		}
+		if debugBufferEnabled {
+			debugBufferEvent = debugBufferLogger.Error()
+		}
 	case LAVA_LOG_FATAL:
 		logEvent = zerologlog.Fatal()
 		if rollingLogEnabled {
 			rollingLoggerEvent = rollingLogLogger.Fatal()
+		}
+		if debugBufferEnabled {
+			debugBufferEvent = debugBufferLogger.Error()
 		}
 	case LAVA_LOG_ERROR:
 		logEvent = zerologlog.Error()
 		if rollingLogEnabled {
 			rollingLoggerEvent = rollingLogLogger.Error()
 		}
+		if debugBufferEnabled {
+			debugBufferEvent = debugBufferLogger.Error()
+		}
 	case LAVA_LOG_WARN:
 		logEvent = zerologlog.Warn()
 		if rollingLogEnabled {
 			rollingLoggerEvent = rollingLogLogger.Warn()
+		}
+		if debugBufferEnabled {
+			debugBufferEvent = debugBufferLogger.Warn()
 		}
 	case LAVA_LOG_INFO:
 		logEvent = zerologlog.Info()
 		if rollingLogEnabled {
 			rollingLoggerEvent = rollingLogLogger.Info()
 		}
+		if debugBufferEnabled {
+			debugBufferEvent = debugBufferLogger.Info()
+		}
 	case LAVA_LOG_DEBUG:
 		logEvent = zerologlog.Debug()
 		if rollingLogEnabled {
 			rollingLoggerEvent = rollingLogLogger.Debug()
 		}
+		if debugBufferEnabled {
+			debugBufferEvent = debugBufferLogger.Debug()
+		}
 	case LAVA_LOG_TRACE:
 		logEvent = zerologlog.Trace()
 		if rollingLogEnabled {
 			rollingLoggerEvent = rollingLogLogger.Trace()
+		}
+		if debugBufferEnabled {
+			debugBufferEvent = debugBufferLogger.Trace()
 		}
 	}
 	output := description
@@ -370,6 +567,9 @@ func LavaFormatLog(description string, err error, attributes []Attribute, severi
 		logEvent = logEvent.Err(err)
 		if rollingLoggerEvent != nil {
 			rollingLoggerEvent = rollingLoggerEvent.Err(err)
+		}
+		if debugBufferEvent != nil {
+			debugBufferEvent = debugBufferEvent.Err(err)
 		}
 		output = fmt.Sprintf("%s ErrMsg: %s", output, err.Error())
 	}
@@ -382,6 +582,9 @@ func LavaFormatLog(description string, err error, attributes []Attribute, severi
 			if rollingLoggerEvent != nil {
 				rollingLoggerEvent = rollingLoggerEvent.Str(key, st_val)
 			}
+			if debugBufferEvent != nil {
+				debugBufferEvent = debugBufferEvent.Str(key, st_val)
+			}
 			attrStrings = append(attrStrings, fmt.Sprintf("%s:%s", attr.Key, st_val))
 		}
 		attributesStr := "{" + strings.Join(attrStrings, ",") + "}"
@@ -390,6 +593,9 @@ func LavaFormatLog(description string, err error, attributes []Attribute, severi
 	logEvent.Msg(description)
 	if rollingLoggerEvent != nil {
 		rollingLoggerEvent.Msg(description)
+	}
+	if debugBufferEvent != nil {
+		debugBufferEvent.Msg(description)
 	}
 	// Return a wrappedLavaError that supports both Unwrap() (stdlib) and
 	// Cause() (pkg-errors causer interface), preserving error chain

--- a/utils/lavalog.go
+++ b/utils/lavalog.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	zerolog "github.com/rs/zerolog"
@@ -112,10 +113,20 @@ func (d *debugRingWriter) clear() {
 var (
 	// debugBufferLogger is the THIRD zerolog sink (alongside the std logger and
 	// rollingLogLogger). Disabled by default; enabled only in debug mode.
-	debugBufferLogger = zerolog.New(io.Discard).Level(zerolog.Disabled)
+	//
+	// Held in an atomic.Pointer because EnableDebugLogBuffer swaps the logger
+	// at startup while goroutines spawned by Start (epoch timer, monitoring)
+	// may already be logging — a plain assignment would be a data race on the
+	// read sites in LavaFormatLog.
+	debugBufferLogger atomic.Pointer[zerolog.Logger]
 	debugRingMu       sync.Mutex
 	debugRing         *debugRingWriter
 )
+
+func init() {
+	disabled := zerolog.New(io.Discard).Level(zerolog.Disabled)
+	debugBufferLogger.Store(&disabled)
+}
 
 // EnableDebugLogBuffer turns on the in-memory ring-buffer log sink with the
 // given capacity (number of records). Debug-mode only — called from
@@ -129,7 +140,8 @@ func EnableDebugLogBuffer(maxLines int) {
 	debugRing = newDebugRingWriter(maxLines)
 	ring := debugRing
 	debugRingMu.Unlock()
-	debugBufferLogger = zerolog.New(ring).Level(zerolog.TraceLevel).With().Timestamp().Logger()
+	logger := zerolog.New(ring).Level(zerolog.TraceLevel).With().Timestamp().Logger()
+	debugBufferLogger.Store(&logger)
 }
 
 // ClearDebugLogBuffer drops every record currently in the ring. No-op when the
@@ -502,7 +514,8 @@ func LavaFormatLog(description string, err error, attributes []Attribute, severi
 	var rollingLoggerEvent *zerolog.Event
 	var debugBufferEvent *zerolog.Event
 	rollingLogEnabled := rollingLogLogger.GetLevel() != zerolog.Disabled
-	debugBufferEnabled := debugBufferLogger.GetLevel() != zerolog.Disabled
+	dbgLogger := debugBufferLogger.Load()
+	debugBufferEnabled := dbgLogger.GetLevel() != zerolog.Disabled
 	switch severity {
 	case LAVA_LOG_PANIC:
 		logEvent = zerologlog.Panic()
@@ -510,7 +523,7 @@ func LavaFormatLog(description string, err error, attributes []Attribute, severi
 			rollingLoggerEvent = rollingLogLogger.Panic()
 		}
 		if debugBufferEnabled {
-			debugBufferEvent = debugBufferLogger.Error()
+			debugBufferEvent = dbgLogger.Error()
 		}
 	case LAVA_LOG_FATAL:
 		logEvent = zerologlog.Fatal()
@@ -518,7 +531,7 @@ func LavaFormatLog(description string, err error, attributes []Attribute, severi
 			rollingLoggerEvent = rollingLogLogger.Fatal()
 		}
 		if debugBufferEnabled {
-			debugBufferEvent = debugBufferLogger.Error()
+			debugBufferEvent = dbgLogger.Error()
 		}
 	case LAVA_LOG_ERROR:
 		logEvent = zerologlog.Error()
@@ -526,7 +539,7 @@ func LavaFormatLog(description string, err error, attributes []Attribute, severi
 			rollingLoggerEvent = rollingLogLogger.Error()
 		}
 		if debugBufferEnabled {
-			debugBufferEvent = debugBufferLogger.Error()
+			debugBufferEvent = dbgLogger.Error()
 		}
 	case LAVA_LOG_WARN:
 		logEvent = zerologlog.Warn()
@@ -534,7 +547,7 @@ func LavaFormatLog(description string, err error, attributes []Attribute, severi
 			rollingLoggerEvent = rollingLogLogger.Warn()
 		}
 		if debugBufferEnabled {
-			debugBufferEvent = debugBufferLogger.Warn()
+			debugBufferEvent = dbgLogger.Warn()
 		}
 	case LAVA_LOG_INFO:
 		logEvent = zerologlog.Info()
@@ -542,7 +555,7 @@ func LavaFormatLog(description string, err error, attributes []Attribute, severi
 			rollingLoggerEvent = rollingLogLogger.Info()
 		}
 		if debugBufferEnabled {
-			debugBufferEvent = debugBufferLogger.Info()
+			debugBufferEvent = dbgLogger.Info()
 		}
 	case LAVA_LOG_DEBUG:
 		logEvent = zerologlog.Debug()
@@ -550,7 +563,7 @@ func LavaFormatLog(description string, err error, attributes []Attribute, severi
 			rollingLoggerEvent = rollingLogLogger.Debug()
 		}
 		if debugBufferEnabled {
-			debugBufferEvent = debugBufferLogger.Debug()
+			debugBufferEvent = dbgLogger.Debug()
 		}
 	case LAVA_LOG_TRACE:
 		logEvent = zerologlog.Trace()
@@ -558,7 +571,7 @@ func LavaFormatLog(description string, err error, attributes []Attribute, severi
 			rollingLoggerEvent = rollingLogLogger.Trace()
 		}
 		if debugBufferEnabled {
-			debugBufferEvent = debugBufferLogger.Trace()
+			debugBufferEvent = dbgLogger.Trace()
 		}
 	}
 	output := description

--- a/utils/lavalog_buffer_test.go
+++ b/utils/lavalog_buffer_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"encoding/json"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,7 +17,8 @@ func resetDebugBuffer() {
 	debugRingMu.Lock()
 	debugRing = nil
 	debugRingMu.Unlock()
-	debugBufferLogger = zerolog.New(io.Discard).Level(zerolog.Disabled)
+	disabled := zerolog.New(io.Discard).Level(zerolog.Disabled)
+	debugBufferLogger.Store(&disabled)
 }
 
 func TestDebugRingWriter_EvictsOldestAtCapacity(t *testing.T) {
@@ -149,6 +151,43 @@ func TestClearDebugLogBuffer(t *testing.T) {
 	if got := ReadDebugLogBuffer("", time.Time{}, time.Time{}, 0); len(got) != 0 {
 		t.Fatalf("post-clear: %d records, want 0", len(got))
 	}
+}
+
+// TestDebugBuffer_ConcurrentEnableAndLog exercises the data race the
+// atomic.Pointer guards against: EnableDebugLogBuffer swaps the sink logger
+// while other goroutines are calling LavaFormat* (which reads it). Run under
+// `go test -race` to catch a regression to a plain assignment. The assertions
+// are weak on purpose — the point is the race detector, not the contents.
+func TestDebugBuffer_ConcurrentEnableAndLog(t *testing.T) {
+	resetDebugBuffer()
+	defer resetDebugBuffer()
+
+	const writers = 8
+	const iterations = 200
+	done := make(chan struct{})
+
+	// Concurrently swap the buffer in/out under the loggers.
+	go func() {
+		for i := 0; i < iterations; i++ {
+			EnableDebugLogBuffer(100)
+			ClearDebugLogBuffer()
+		}
+		close(done)
+	}()
+
+	var wg sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				LavaFormatInfo("concurrent line", LogAttr(KEY_REQUEST_ID, "race"))
+				_ = ReadDebugLogBuffer("race", time.Time{}, time.Time{}, 0)
+			}
+		}()
+	}
+	wg.Wait()
+	<-done
 }
 
 // --- helpers ---

--- a/utils/lavalog_buffer_test.go
+++ b/utils/lavalog_buffer_test.go
@@ -1,0 +1,186 @@
+package utils
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+	"time"
+
+	zerolog "github.com/rs/zerolog"
+)
+
+// resetDebugBuffer restores the debug-buffer package state to its disabled
+// default. lavalog uses package-level singletons; tests must leave the buffer
+// disabled so they don't leak into one another or other package tests.
+func resetDebugBuffer() {
+	debugRingMu.Lock()
+	debugRing = nil
+	debugRingMu.Unlock()
+	debugBufferLogger = zerolog.New(io.Discard).Level(zerolog.Disabled)
+}
+
+func TestDebugRingWriter_EvictsOldestAtCapacity(t *testing.T) {
+	const cap = 4
+	ring := newDebugRingWriter(cap)
+
+	// Write cap+N records; only the newest `cap` must survive.
+	const extra = 6
+	for i := 0; i < cap+extra; i++ {
+		if _, err := ring.Write([]byte{byte('A' + i)}); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+
+	snap := ring.snapshot()
+	if len(snap) != cap {
+		t.Fatalf("snapshot len = %d, want %d", len(snap), cap)
+	}
+	// Newest cap records are indices [extra, cap+extra) → bytes 'A'+extra ...
+	for idx, rec := range snap {
+		want := byte('A' + extra + idx)
+		if len(rec) != 1 || rec[0] != want {
+			t.Fatalf("snapshot[%d] = %q, want %q", idx, rec, []byte{want})
+		}
+	}
+}
+
+func TestDebugRingWriter_CopiesInput(t *testing.T) {
+	ring := newDebugRingWriter(2)
+	p := []byte("hello")
+	ring.Write(p)
+	// Mutate the caller's slice the way zerolog reuses its buffer.
+	for i := range p {
+		p[i] = 'X'
+	}
+	snap := ring.snapshot()
+	if string(snap[0]) != "hello" {
+		t.Fatalf("ring did not copy input: got %q", snap[0])
+	}
+}
+
+func TestReadDebugLogBuffer_RequestIDFilter(t *testing.T) {
+	resetDebugBuffer()
+	defer resetDebugBuffer()
+
+	EnableDebugLogBuffer(100)
+	// defaultGlobalLogLevel is DebugLevel by default → Info passes the gate.
+	LavaFormatInfo("hello target", LogAttr(KEY_REQUEST_ID, "req-123"))
+	LavaFormatInfo("hello other", LogAttr(KEY_REQUEST_ID, "req-999"))
+
+	got := ReadDebugLogBuffer("req-123", time.Time{}, time.Time{}, 0)
+	if len(got) != 1 {
+		t.Fatalf("request_id=req-123 returned %d records, want 1: %s", len(got), dump(got))
+	}
+	assertRecordHasRequestID(t, got[0], "req-123")
+
+	none := ReadDebugLogBuffer("does-not-exist", time.Time{}, time.Time{}, 0)
+	if len(none) != 0 {
+		t.Fatalf("request_id=does-not-exist returned %d records, want 0", len(none))
+	}
+}
+
+func TestReadDebugLogBuffer_TimeWindowFilter(t *testing.T) {
+	resetDebugBuffer()
+	defer resetDebugBuffer()
+
+	EnableDebugLogBuffer(100)
+	before := time.Now()
+	LavaFormatInfo("within window")
+	after := time.Now()
+
+	// A window that brackets the record keeps it.
+	within := ReadDebugLogBuffer("", before.Add(-time.Second), after.Add(time.Second), 0)
+	if len(within) == 0 {
+		t.Fatalf("expected at least 1 record within [%v,%v]", before, after)
+	}
+
+	// A window entirely in the past excludes it.
+	past := ReadDebugLogBuffer("", before.Add(-2*time.Hour), before.Add(-time.Hour), 0)
+	if len(past) != 0 {
+		t.Fatalf("expected 0 records in past window, got %d", len(past))
+	}
+
+	// A window entirely in the future excludes it.
+	future := ReadDebugLogBuffer("", after.Add(time.Hour), after.Add(2*time.Hour), 0)
+	if len(future) != 0 {
+		t.Fatalf("expected 0 records in future window, got %d", len(future))
+	}
+}
+
+func TestReadDebugLogBuffer_LimitKeepsTail(t *testing.T) {
+	resetDebugBuffer()
+	defer resetDebugBuffer()
+
+	EnableDebugLogBuffer(100)
+	for i := 0; i < 10; i++ {
+		LavaFormatInfo("msg", LogAttr("i", i))
+	}
+	got := ReadDebugLogBuffer("", time.Time{}, time.Time{}, 3)
+	if len(got) != 3 {
+		t.Fatalf("limit=3 returned %d records, want 3", len(got))
+	}
+	// Tail → last record must be i=9.
+	assertRecordField(t, got[2], "i", "9")
+}
+
+func TestReadDebugLogBuffer_DisabledByDefault(t *testing.T) {
+	resetDebugBuffer()
+	defer resetDebugBuffer()
+
+	// No EnableDebugLogBuffer call → buffer is disabled.
+	LavaFormatInfo("should not be buffered", LogAttr(KEY_REQUEST_ID, "req-abc"))
+	got := ReadDebugLogBuffer("", time.Time{}, time.Time{}, 0)
+	if len(got) != 0 {
+		t.Fatalf("buffer disabled by default but returned %d records", len(got))
+	}
+}
+
+func TestClearDebugLogBuffer(t *testing.T) {
+	resetDebugBuffer()
+	defer resetDebugBuffer()
+
+	EnableDebugLogBuffer(100)
+	LavaFormatInfo("one")
+	LavaFormatInfo("two")
+	if got := ReadDebugLogBuffer("", time.Time{}, time.Time{}, 0); len(got) != 2 {
+		t.Fatalf("pre-clear: %d records, want 2", len(got))
+	}
+	ClearDebugLogBuffer()
+	if got := ReadDebugLogBuffer("", time.Time{}, time.Time{}, 0); len(got) != 0 {
+		t.Fatalf("post-clear: %d records, want 0", len(got))
+	}
+}
+
+// --- helpers ---
+
+func assertRecordHasRequestID(t *testing.T, rec []byte, want string) {
+	t.Helper()
+	assertRecordField(t, rec, KEY_REQUEST_ID, want)
+}
+
+func assertRecordField(t *testing.T, rec []byte, key, want string) {
+	t.Helper()
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(rec, &fields); err != nil {
+		t.Fatalf("record is not valid JSON (%v): %s", err, rec)
+	}
+	raw, ok := fields[key]
+	if !ok {
+		t.Fatalf("record missing %q field: %s", key, rec)
+	}
+	var got string
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("field %q not a string (%v): %s", key, err, rec)
+	}
+	if got != want {
+		t.Fatalf("field %q = %q, want %q", key, got, want)
+	}
+}
+
+func dump(recs [][]byte) string {
+	out := ""
+	for _, r := range recs {
+		out += string(r)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- Adds an in-memory **ring buffer** (50k lines, trace level) that captures the router's logs when `--debug-address` is set, and exposes them over the debug mux.
- New `GET /debug/logs?request_id=&from=&to=&limit=` returns the records a specific test produced; `POST /debug/logs/clear` zeroes the buffer.
- Lets the `smart-router-automation` harness fetch and attach a failing test's exact log window to its report (paired PR: Magma-Devs/smart-router-automation `feat/attach-router-logs-on-failure`).

## How it works
- `utils/lavalog.go`: a `debugRingWriter` (`io.Writer` over a mutex-guarded circular buffer; copies zerolog's reused slice) feeds a **third zerolog sink** mirrored inside `LavaFormatLog` exactly like the existing `rollingLogger`. `EnableDebugLogBuffer` / `ReadDebugLogBuffer` (filters by `request_id` and/or time window, AND-ed, `limit` tail) / `ClearDebugLogBuffer`.
- `protocol/rpcsmartrouter/rpcsmartrouter.go`: `EnableDebugLogBuffer(50000)` inside the existing `DebugAddress != ""` block; two new handlers in `buildDebugMux`.

## Contract
`GET /debug/logs` → `{"count": N, "lines": [ {<zerolog json record>}, ... ]}` (each record has numeric Unix-nano `time`, `level`, `message`, and any `request_id`/`task_id` attrs). `POST /debug/logs/clear` → `{"cleared": true}`. Wrong method → 405.

## No deploy change
Activates off the **already-deployed** `--debug-address :9999`. Buffer stays disabled and the mux is unmounted when the flag is absent — same trust boundary as the existing `reset-all` / `time-warp` debug endpoints.

## Security note
Captured log lines may include api-key-bearing request data. This shares the debug-mux gate (off in prod), consistent with the existing debug surface.

## Test plan
- `go build ./utils/... ./protocol/rpcsmartrouter/...` — clean
- `go test ./utils/ -run 'DebugLogBuffer|Ring|Buffer|Clear'` — pass (ring eviction, slice-copy safety, request_id + time-window filters, limit tail, disabled-by-default, clear)
- `go test ./protocol/rpcsmartrouter/ -run 'Debug'` — pass (GET /debug/logs 200+JSON, request_id filter, 405 guards, clear)
- `go vet ./utils/ ./protocol/rpcsmartrouter/` — clean