### PR TITLE
fix: drop the per-socket isHealthy selection gate

### DIFF
--- a/protocol/lavasession/common.go
+++ b/protocol/lavasession/common.go
@@ -33,6 +33,14 @@ func GetMaxAllowedBlockListedSessionPerProvider() int {
 }
 
 const (
+	// MaxConsecutiveConnectionAttempts is the number of consecutive connection
+	// failures after which an endpoint is backed off (endpoint.Enabled = false).
+	// Raised from 5 to 50 alongside removing the per-socket health gate: with that
+	// gate gone the (often sole) direct endpoint must not be disabled too eagerly on
+	// a transient blip, since disabling the only endpoint reproduces the "No pairings"
+	// symptom until an epoch/successful relay re-enables it. A successful relay resets
+	// the counter (see Endpoint.ResetHealth), so this is a consecutive-failure budget.
+	// Shared by the provider-relay path and blockProvider — this threshold gates both.
 	MaxConsecutiveConnectionAttempts                 = 50
 	TimeoutForEstablishingAConnection                = 1500 * time.Millisecond // 1.5 seconds
 	MaximumNumberOfFailuresAllowedPerConsumerSession = 15

--- a/protocol/lavasession/common.go
+++ b/protocol/lavasession/common.go
@@ -33,7 +33,7 @@ func GetMaxAllowedBlockListedSessionPerProvider() int {
 }
 
 const (
-	MaxConsecutiveConnectionAttempts                 = 5
+	MaxConsecutiveConnectionAttempts                 = 50
 	TimeoutForEstablishingAConnection                = 1500 * time.Millisecond // 1.5 seconds
 	MaximumNumberOfFailuresAllowedPerConsumerSession = 15
 	RelayNumberIncrement                             = 1

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -599,9 +599,8 @@ func (csm *ConsumerSessionManager) probeDirectRPCEndpoints(
 	consumerSessionsWithProvider.Lock.RLock()
 	defer consumerSessionsWithProvider.Lock.RUnlock()
 
-	var healthyEndpoints int
+	var usableEndpoints int
 	var totalEndpoints int
-	minLatency := time.Hour // Start with a large value
 
 	for _, endpoint := range consumerSessionsWithProvider.Endpoints {
 		if !endpoint.IsDirectRPC() {
@@ -610,12 +609,13 @@ func (csm *ConsumerSessionManager) probeDirectRPCEndpoints(
 
 		totalEndpoints++
 
-		// Belt-and-suspenders with conn.IsHealthy(): the endpoint struct tracks
-		// cumulative relay-path failures via MarkUnhealthy → ConnectionRefusals,
-		// while IsHealthy() tracks the last transport attempt. A disabled endpoint
-		// must never be considered healthy at probe time — otherwise a backup with
-		// 5+ consecutive refusals could be unblocked at epoch transition despite
-		// the relay path having already confirmed it's down.
+		// The relay path no longer gates on a per-socket health bit (a dead socket
+		// fails the real relay, which feeds QoS via OnSessionFailure and trips the
+		// endpoint.Enabled consecutive-failure backoff — both self-healing). So the
+		// probe no longer reads connection health either. We still honour
+		// endpoint.Enabled: a backup with 5+ consecutive refusals stays backed off
+		// and must not be optimistically unblocked at epoch transition. Active
+		// per-endpoint probing/recovery is handled by the chain tracker (Step 3).
 		if !endpoint.Enabled {
 			utils.LavaFormatDebug("Direct RPC endpoint is disabled, skipping probe",
 				utils.LogAttr("provider", providerAddress),
@@ -629,28 +629,10 @@ func (csm *ConsumerSessionManager) probeDirectRPCEndpoints(
 				continue
 			}
 
-			// Check connection health - this is a cheap operation
-			// that checks the internal health state without making a network call
-			startTime := time.Now()
-			healthy := conn.IsHealthy()
-			checkLatency := time.Since(startTime)
+			usableEndpoints++
 
-			if healthy {
-				healthyEndpoints++
-				// Track minimum latency (for consistent API with provider probe)
-				if checkLatency < minLatency {
-					minLatency = checkLatency
-				}
-
-				if DebugProbes {
-					utils.LavaFormatDebug("Direct RPC endpoint probe succeeded",
-						utils.LogAttr("provider", providerAddress),
-						utils.LogAttr("url", conn.GetURL()),
-						utils.LogAttr("protocol", conn.GetProtocol()),
-					)
-				}
-			} else {
-				utils.LavaFormatDebug("Direct RPC endpoint is unhealthy",
+			if DebugProbes {
+				utils.LavaFormatDebug("Direct RPC endpoint probe (no health gate)",
 					utils.LogAttr("provider", providerAddress),
 					utils.LogAttr("url", conn.GetURL()),
 					utils.LogAttr("protocol", conn.GetProtocol()),
@@ -663,18 +645,18 @@ func (csm *ConsumerSessionManager) probeDirectRPCEndpoints(
 		return 0, providerAddress, fmt.Errorf("no direct RPC endpoints found for provider %s", providerAddress)
 	}
 
-	if healthyEndpoints == 0 {
-		return 0, providerAddress, fmt.Errorf("all direct RPC endpoints unhealthy for provider %s", providerAddress)
+	if usableEndpoints == 0 {
+		return 0, providerAddress, fmt.Errorf("no enabled direct RPC endpoints for provider %s", providerAddress)
 	}
 
-	// Reset latency to a reasonable default if we didn't measure any
-	if minLatency == time.Hour {
-		minLatency = time.Millisecond // Default minimal latency for healthy direct connections
-	}
+	// No per-connection latency is measured anymore (the old "latency" was just the
+	// time to read an atomic bool). Report a nominal minimal latency for parity with
+	// the provider-relay probe API.
+	minLatency := time.Millisecond
 
 	utils.LavaFormatTrace("Direct RPC endpoints probe completed",
 		utils.LogAttr("provider", providerAddress),
-		utils.LogAttr("healthyEndpoints", healthyEndpoints),
+		utils.LogAttr("usableEndpoints", usableEndpoints),
 		utils.LogAttr("totalEndpoints", totalEndpoints),
 		utils.LogAttr("latency", minLatency),
 	)

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -613,8 +613,9 @@ func (csm *ConsumerSessionManager) probeDirectRPCEndpoints(
 		// fails the real relay, which feeds QoS via OnSessionFailure and trips the
 		// endpoint.Enabled consecutive-failure backoff — both self-healing). So the
 		// probe no longer reads connection health either. We still honour
-		// endpoint.Enabled: a backup with 5+ consecutive refusals stays backed off
-		// and must not be optimistically unblocked at epoch transition. Active
+		// endpoint.Enabled: a backup that hit MaxConsecutiveConnectionAttempts
+		// consecutive refusals stays backed off and must not be optimistically
+		// unblocked at epoch transition. Active
 		// per-endpoint probing/recovery is handled by the chain tracker (Step 3).
 		if !endpoint.Enabled {
 			utils.LavaFormatDebug("Direct RPC endpoint is disabled, skipping probe",

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -2307,10 +2307,11 @@ func TestGetAllDirectRPCEndpoints_IncludesBackupProviders(t *testing.T) {
 }
 
 // TestProbeDirectRPCEndpoints_RespectsDisabledEndpoint guards the endpoint.Enabled
-// gate added to probeDirectRPCEndpoints. A disabled endpoint (ConnectionRefusals
-// hit the MarkUnhealthy threshold in the relay hot path) must not be counted as
-// healthy at probe time — otherwise checkAndUnblockHealthyReBlockedProviders
-// could unblock a backup that the relay path has already confirmed is down.
+// gate in probeDirectRPCEndpoints. A disabled endpoint (ConnectionRefusals hit the
+// MarkUnhealthy threshold in the relay hot path) must not be counted as usable at
+// probe time — otherwise checkAndUnblockHealthyReBlockedProviders could unblock a
+// backup that the relay path has already confirmed is down. This is the only
+// remaining health signal the probe honours now that the per-socket bool is gone.
 func TestProbeDirectRPCEndpoints_RespectsDisabledEndpoint(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -2336,7 +2337,7 @@ func TestProbeDirectRPCEndpoints_RespectsDisabledEndpoint(t *testing.T) {
 	csm := CreateConsumerSessionManager()
 	_, _, probeErr := csm.probeDirectRPCEndpoints(ctx, cswp, cswp.PublicLavaAddress)
 	require.Error(t, probeErr,
-		"a disabled endpoint must cause the direct RPC probe to fail, even though HTTPDirectRPCConnection.IsHealthy starts optimistically true")
+		"a disabled endpoint must cause the direct RPC probe to fail (no usable enabled endpoints)")
 }
 
 // stateSizeRecorder is a minimal ConsumerMetricsManagerInf used to observe

--- a/protocol/lavasession/consumer_types.go
+++ b/protocol/lavasession/consumer_types.go
@@ -707,6 +707,12 @@ func (cswp *ConsumerSessionsWithProvider) fetchEndpointConnectionFromConsumerSes
 					// QoS via OnSessionFailure, and (after MaxConsecutiveConnectionAttempts) is
 					// backed off via endpoint.Enabled, both of which self-heal. This mirrors how
 					// WebSocket connections have always behaved (IsHealthy hardcoded true).
+					//
+					// The != nil check is defensive: construction (rpcsmartrouter.go, via the
+					// error-checked `continue` in convertProvidersToSessions) already guarantees a
+					// non-nil element, so this guards a future construction regression — not a live
+					// case — and lets a nil element fall through to the (nil, false) skip below
+					// instead of panicking the relay goroutine.
 					if len(endpoint.DirectConnections) > 0 && endpoint.DirectConnections[0] != nil {
 						utils.LavaFormatTrace("using direct RPC connection",
 							utils.LogAttr("url", endpoint.DirectConnections[0].GetURL()),

--- a/protocol/lavasession/consumer_types.go
+++ b/protocol/lavasession/consumer_types.go
@@ -707,7 +707,7 @@ func (cswp *ConsumerSessionsWithProvider) fetchEndpointConnectionFromConsumerSes
 					// QoS via OnSessionFailure, and (after MaxConsecutiveConnectionAttempts) is
 					// backed off via endpoint.Enabled, both of which self-heal. This mirrors how
 					// WebSocket connections have always behaved (IsHealthy hardcoded true).
-					if len(endpoint.DirectConnections) > 0 {
+					if len(endpoint.DirectConnections) > 0 && endpoint.DirectConnections[0] != nil {
 						utils.LavaFormatTrace("using direct RPC connection",
 							utils.LogAttr("url", endpoint.DirectConnections[0].GetURL()),
 							utils.LogAttr("protocol", endpoint.DirectConnections[0].GetProtocol()),

--- a/protocol/lavasession/consumer_types.go
+++ b/protocol/lavasession/consumer_types.go
@@ -43,7 +43,6 @@ func (list EndpointInfoList) Swap(i, j int) {
 // SessionConnection is the base interface for RPC connections with QoS management.
 type SessionConnection interface {
 	GetQoSManager() *qos.QoSManager
-	IsHealthy() bool
 	GetEndpointAddress() string
 }
 
@@ -56,10 +55,6 @@ type ProviderRelayConnection struct {
 
 func (prc *ProviderRelayConnection) GetQoSManager() *qos.QoSManager {
 	return prc.QoSManager
-}
-
-func (prc *ProviderRelayConnection) IsHealthy() bool {
-	return prc.EndpointConnection != nil
 }
 
 func (prc *ProviderRelayConnection) GetEndpointAddress() string {
@@ -76,10 +71,6 @@ type DirectRPCSessionConnection struct {
 
 func (drsc *DirectRPCSessionConnection) GetQoSManager() *qos.QoSManager {
 	return drsc.QoSManager
-}
-
-func (drsc *DirectRPCSessionConnection) IsHealthy() bool {
-	return drsc.DirectConnection != nil && drsc.DirectConnection.IsHealthy()
 }
 
 func (drsc *DirectRPCSessionConnection) GetEndpointAddress() string {

--- a/protocol/lavasession/consumer_types.go
+++ b/protocol/lavasession/consumer_types.go
@@ -704,9 +704,15 @@ func (cswp *ConsumerSessionsWithProvider) fetchEndpointConnectionFromConsumerSes
 					// silently dropping the endpoint here and never sending the request that
 					// would heal it (the deadlock behind the `No pairings` bug class). Instead
 					// the relay is always attempted — a genuinely dead socket fails fast, feeds
-					// QoS via OnSessionFailure, and (after MaxConsecutiveConnectionAttempts) is
-					// backed off via endpoint.Enabled, both of which self-heal. This mirrors how
-					// WebSocket connections have always behaved (IsHealthy hardcoded true).
+					// QoS via OnSessionFailure, and (after MaxConsecutiveConnectionAttempts
+					// consecutive failures, currently 50) is backed off via endpoint.Enabled,
+					// both of which self-heal. With the bit gone endpoint.Enabled is now the
+					// *sole* automatic disable, so in a multi-endpoint pool a dead endpoint
+					// stays in selection rotation for up to that many dial-and-fail cycles
+					// before backoff (the threshold was raised 5→50 — see
+					// MaxConsecutiveConnectionAttempts in common.go for why and the tradeoff).
+					// This mirrors how WebSocket connections have always behaved (IsHealthy
+					// hardcoded true).
 					//
 					// The != nil check is defensive: construction (rpcsmartrouter.go, via the
 					// error-checked `continue` in convertProvidersToSessions) already guarantees a

--- a/protocol/lavasession/consumer_types.go
+++ b/protocol/lavasession/consumer_types.go
@@ -707,9 +707,16 @@ func (cswp *ConsumerSessionsWithProvider) fetchEndpointConnectionFromConsumerSes
 			connectEndpoint := func(cswp *ConsumerSessionsWithProvider, ctx context.Context, endpoint *Endpoint) (endpointConnection_ *EndpointConnection, connected_ bool) {
 				// Check if this is a direct RPC endpoint (smart router mode)
 				if endpoint.IsDirectRPC() {
-					// Direct RPC connections are already established in convertProvidersToSessions
-					// Just verify they're healthy and return success
-					if len(endpoint.DirectConnections) > 0 && endpoint.DirectConnections[0].IsHealthy() {
+					// Direct RPC connections are already established in convertProvidersToSessions.
+					// We no longer gate selection on a per-socket health bit: a transient
+					// transport blip used to latch that bit false with no automatic recovery,
+					// silently dropping the endpoint here and never sending the request that
+					// would heal it (the deadlock behind the `No pairings` bug class). Instead
+					// the relay is always attempted — a genuinely dead socket fails fast, feeds
+					// QoS via OnSessionFailure, and (after MaxConsecutiveConnectionAttempts) is
+					// backed off via endpoint.Enabled, both of which self-heal. This mirrors how
+					// WebSocket connections have always behaved (IsHealthy hardcoded true).
+					if len(endpoint.DirectConnections) > 0 {
 						utils.LavaFormatTrace("using direct RPC connection",
 							utils.LogAttr("url", endpoint.DirectConnections[0].GetURL()),
 							utils.LogAttr("protocol", endpoint.DirectConnections[0].GetProtocol()),
@@ -717,7 +724,7 @@ func (cswp *ConsumerSessionsWithProvider) fetchEndpointConnectionFromConsumerSes
 						)
 						return nil, true
 					}
-					utils.LavaFormatWarning("direct RPC connection is unhealthy", nil,
+					utils.LavaFormatWarning("direct RPC endpoint has no connection object", nil,
 						utils.LogAttr("endpoint", endpoint.NetworkAddress),
 						utils.LogAttr("GUID", ctx),
 					)

--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -73,22 +73,6 @@ type DirectRPCConnection interface {
 	// Close closes the connection and cleans up resources
 	Close() error
 
-	// IsHealthy returns true if the connection is healthy
-	IsHealthy() bool
-
-	// MarkHealthy forcibly sets the connection's healthy flag back to true.
-	// Intended only for the /debug/reset-scores recovery path so a stuck-false
-	// flag from a transient earlier failure (network blip, brief read error)
-	// does not permanently exclude an endpoint from CV fan-out or pairing
-	// selection. Production code paths must rely on the natural
-	// healthy→false (SendRequest error) and healthy→true (SendRequest
-	// success) transitions; this only shortcuts the recovery when the next
-	// IsHealthy() gate would otherwise block the very request that would
-	// re-establish health. Side effect: the probe path that consults
-	// IsHealthy() at epoch transitions will also see true after a reset
-	// until the next SendRequest outcome resettles it.
-	MarkHealthy()
-
 	// GetURL returns the endpoint URL
 	GetURL() string
 
@@ -137,14 +121,6 @@ type HTTPDirectRPCConnection struct {
 	nodeUrl  common.NodeUrl
 	protocol DirectRPCProtocol
 	client   *http.Client
-
-	// healthy reflects the last observed transport outcome (dial / TLS / read).
-	// It is updated by every SendRequest / DoHTTPRequest call: any transport-level
-	// error flips it to false; a successful exchange (including HTTP 4xx / 5xx,
-	// which are application-level errors, not transport failures) flips it back
-	// to true. The comprehensive probe path reads this via IsHealthy to decide
-	// whether to unblock a backup provider at epoch transition.
-	healthy atomic.Bool
 }
 
 // WebSocketDirectRPCConnection implements DirectRPCConnection for WebSocket/WSS
@@ -170,9 +146,6 @@ type GRPCDirectRPCConnection struct {
 	registry         *dyncodec.Registry
 	codec            *dyncodec.Codec
 	descriptorsCache *common.SafeSyncMap[string, *desc.MethodDescriptor]
-
-	// Health tracking
-	healthy atomic.Bool
 
 	// Initialization state
 	initialized atomic.Bool
@@ -235,7 +208,6 @@ func NewDirectRPCConnection(
 			protocol: protocol,
 			client:   common.OptimizedHttpClient(),
 		}
-		conn.healthy.Store(true) // Start as healthy until proven otherwise
 		return conn, nil
 
 	case DirectRPCProtocolWS, DirectRPCProtocolWSS:
@@ -251,7 +223,6 @@ func NewDirectRPCConnection(
 			nodeUrl:          nodeUrl,
 			descriptorsCache: &common.SafeSyncMap[string, *desc.MethodDescriptor]{},
 		}
-		conn.healthy.Store(true) // Start as healthy until proven otherwise
 		return conn, nil
 
 	default:
@@ -310,9 +281,8 @@ func (h *HTTPDirectRPCConnection) SendRequest(
 	// (GET/POST/etc.). This transport layer sends bytes and returns bytes; method selection is driven by chain spec.
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.nodeUrl.AuthConfig.AddAuthPath(h.nodeUrl.Url), bytes.NewReader(data))
 	if err != nil {
-		// NewRequestWithContext only fails on malformed URL / method; not a transport
-		// failure, so leave `healthy` alone — flipping it here would give false negatives
-		// on programmer error while leaving genuine upstream outages unreported.
+		// NewRequestWithContext only fails on malformed URL / method — a programmer
+		// error, not a transport failure or upstream outage.
 		return nil, fmt.Errorf("failed to build request: %w", err)
 	}
 
@@ -335,19 +305,14 @@ func (h *HTTPDirectRPCConnection) SendRequest(
 
 	resp, err := h.client.Do(req)
 	if err != nil {
-		h.healthy.Store(false)
 		return nil, fmt.Errorf("http request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		h.healthy.Store(false)
 		return nil, fmt.Errorf("failed reading response body: %w", err)
 	}
-
-	// Got a response (even 4xx/5xx) — transport is reachable.
-	h.healthy.Store(true)
 
 	// Build response with metadata (HTTP headers)
 	response := &DirectRPCResponse{
@@ -388,30 +353,6 @@ func (h *HTTPDirectRPCConnection) GetProtocol() DirectRPCProtocol {
 
 func (h *HTTPDirectRPCConnection) Close() error {
 	return nil
-}
-
-// IsHealthy returns whether the last transport attempt through this connection
-// reached the upstream. Used by probeDirectRPCEndpoints to decide whether a
-// static HTTP backup is safe to unblock at epoch transition.
-//
-// Note: a brand-new connection that has never been exercised returns true
-// (initialized state). That means the first comprehensive probe after startup
-// may optimistically trust an unreachable upstream — the relay hot path and
-// MarkUnhealthy → endpoint.Enabled gate in probeDirectRPCEndpoints catches the
-// typical cases (connection failed at least once; or 5+ relay failures), but a
-// never-hit backup with an unreachable upstream can still be optimistically
-// unblocked on the first epoch. Closing that cold-start gap requires an active
-// probe request (chain-specific no-op), which is a separate follow-up.
-func (h *HTTPDirectRPCConnection) IsHealthy() bool {
-	return h.healthy.Load()
-}
-
-// MarkHealthy forcibly resets healthy to true. See the interface docstring;
-// this is the recovery-only escape for stuck-false caused by a one-off
-// transient that the natural SendRequest-success transition can never reach
-// because IsHealthy gates the request itself.
-func (h *HTTPDirectRPCConnection) MarkHealthy() {
-	h.healthy.Store(true)
 }
 
 func (h *HTTPDirectRPCConnection) GetURL() string {
@@ -469,7 +410,6 @@ func (h *HTTPDirectRPCConnection) DoHTTPRequest(
 	// Send request
 	resp, err := h.client.Do(req)
 	if err != nil {
-		h.healthy.Store(false)
 		return nil, fmt.Errorf("http request failed: %w", err)
 	}
 	defer resp.Body.Close()
@@ -477,12 +417,8 @@ func (h *HTTPDirectRPCConnection) DoHTTPRequest(
 	// Read response body
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		h.healthy.Store(false)
 		return nil, fmt.Errorf("failed reading response: %w", err)
 	}
-
-	// Got a response (even 4xx/5xx) — transport is reachable.
-	h.healthy.Store(true)
 
 	// Return complete response (status + headers + body)
 	// Don't return error for 4xx/5xx - client needs the response
@@ -509,15 +445,6 @@ func (w *WebSocketDirectRPCConnection) GetProtocol() DirectRPCProtocol {
 func (w *WebSocketDirectRPCConnection) Close() error {
 	return nil
 }
-
-func (w *WebSocketDirectRPCConnection) IsHealthy() bool {
-	return true // health tracking is done at the endpoint/QoS layer
-}
-
-// MarkHealthy is a no-op for WebSocket: this type has no internal healthy
-// flag (IsHealthy already always returns true). The interface method exists
-// so /debug/reset-scores can call it uniformly across transport types.
-func (w *WebSocketDirectRPCConnection) MarkHealthy() {}
 
 func (w *WebSocketDirectRPCConnection) GetURL() string {
 	return w.nodeUrl.Url
@@ -550,7 +477,6 @@ func (g *GRPCDirectRPCConnection) SendRequest(
 	// Get gRPC connection from pool
 	conn, err := g.connector.GetRpc(ctx, true)
 	if err != nil {
-		g.healthy.Store(false)
 		return nil, utils.LavaFormatError("gRPC get connection failed", err,
 			utils.LogAttr("url", g.nodeUrl.Url))
 	}
@@ -613,8 +539,6 @@ func (g *GRPCDirectRPCConnection) SendRequest(
 		return nil, utils.LavaFormatError("failed to marshal gRPC response", err,
 			utils.LogAttr("method", methodPath))
 	}
-
-	g.healthy.Store(true)
 
 	// Return response with metadata from gRPC headers
 	return &DirectRPCResponse{
@@ -688,7 +612,6 @@ func (g *GRPCDirectRPCConnection) initialize(ctx context.Context) error {
 			utils.LogAttr("url", g.nodeUrl.Url))
 	}
 
-	g.healthy.Store(true)
 	utils.LavaFormatInfo("gRPC direct connection initialized",
 		utils.LogAttr("url", g.nodeUrl.Url),
 		utils.LogAttr("tls", parsedURL.Scheme == "grpcs"))
@@ -870,17 +793,8 @@ func (g *GRPCDirectRPCConnection) handleGRPCError(ctx context.Context, err error
 	if statusErr, ok := status.FromError(err); ok {
 		errorCode = uint32(statusErr.Code())
 		errorMessage = statusErr.Message()
-
-		// Mark as unhealthy for certain error codes
-		switch statusErr.Code() {
-		case 14: // UNAVAILABLE
-			g.healthy.Store(false)
-		case 13: // INTERNAL
-			g.healthy.Store(false)
-		}
 	} else {
 		errorMessage = err.Error()
-		g.healthy.Store(false)
 	}
 
 	// Return error as JSON response
@@ -935,18 +849,6 @@ func (g *GRPCDirectRPCConnection) Close() error {
 	}
 
 	return nil
-}
-
-func (g *GRPCDirectRPCConnection) IsHealthy() bool {
-	return g.healthy.Load()
-}
-
-// MarkHealthy forcibly resets healthy to true. See the interface docstring;
-// this is the recovery-only escape for stuck-false caused by a one-off
-// transient that the natural SendRequest-success transition can never reach
-// because IsHealthy gates the request itself.
-func (g *GRPCDirectRPCConnection) MarkHealthy() {
-	g.healthy.Store(true)
 }
 
 func (g *GRPCDirectRPCConnection) GetURL() string {

--- a/protocol/lavasession/direct_rpc_connection_test.go
+++ b/protocol/lavasession/direct_rpc_connection_test.go
@@ -100,7 +100,6 @@ func TestHTTPConnectionCreation(t *testing.T) {
 	require.NotNil(t, conn)
 
 	assert.Equal(t, DirectRPCProtocolHTTP, conn.GetProtocol())
-	assert.True(t, conn.IsHealthy())
 	assert.Equal(t, "http://localhost:8545", conn.GetURL())
 
 	err = conn.Close()
@@ -116,7 +115,6 @@ func TestHTTPSConnectionCreation(t *testing.T) {
 	require.NotNil(t, conn)
 
 	assert.Equal(t, DirectRPCProtocolHTTPS, conn.GetProtocol())
-	assert.True(t, conn.IsHealthy())
 	assert.Equal(t, "https://eth-mainnet.g.alchemy.com/v2/test", conn.GetURL())
 
 	err = conn.Close()
@@ -132,7 +130,6 @@ func TestWebSocketConnectionCreation(t *testing.T) {
 	require.NotNil(t, conn)
 
 	assert.Equal(t, DirectRPCProtocolWSS, conn.GetProtocol())
-	assert.True(t, conn.IsHealthy())
 	assert.Equal(t, "wss://eth-mainnet.g.alchemy.com/v2/test", conn.GetURL())
 
 	err = conn.Close()
@@ -149,7 +146,6 @@ func TestGRPCConnectionCreation(t *testing.T) {
 	require.NotNil(t, conn)
 
 	assert.Equal(t, DirectRPCProtocolGRPC, conn.GetProtocol())
-	assert.True(t, conn.IsHealthy())
 	assert.Equal(t, "grpcs://localhost:9090", conn.GetURL())
 
 	err = conn.Close()
@@ -171,7 +167,6 @@ func TestGRPCConnectionCreationInsecure(t *testing.T) {
 	require.NotNil(t, conn)
 
 	assert.Equal(t, DirectRPCProtocolGRPC, conn.GetProtocol())
-	assert.True(t, conn.IsHealthy())
 
 	err = conn.Close()
 	assert.NoError(t, err)
@@ -209,7 +204,6 @@ func TestHTTPConnectionInterface(t *testing.T) {
 
 	// Test interface methods
 	assert.Equal(t, DirectRPCProtocolHTTPS, conn.GetProtocol())
-	assert.True(t, conn.IsHealthy())
 	assert.Equal(t, "https://test.example.com", conn.GetURL())
 	assert.NoError(t, conn.Close())
 }
@@ -275,7 +269,6 @@ func TestGRPCConnectionURLValidation(t *testing.T) {
 				grpcConn, ok := conn.(*GRPCDirectRPCConnection)
 				require.True(t, ok, "expected GRPCDirectRPCConnection type")
 				assert.Equal(t, DirectRPCProtocolGRPC, grpcConn.GetProtocol())
-				assert.True(t, grpcConn.IsHealthy())
 
 				err = conn.Close()
 				assert.NoError(t, err)
@@ -328,26 +321,13 @@ func TestGRPCConnectionWithGrpcConfig(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestHTTPDirectRPCConnection_IsHealthy_StartsTrue documents the
-// initialize-as-healthy behavior. A fresh connection is optimistically healthy
-// until proven otherwise — the first failed SendRequest flips it, after which
-// IsHealthy reflects real transport outcomes.
-func TestHTTPDirectRPCConnection_IsHealthy_StartsTrue(t *testing.T) {
-	ctx := context.Background()
-	nodeUrl := common.NodeUrl{Url: "http://127.0.0.1:1"} // port 1 is not accepting
-	conn, err := NewDirectRPCConnection(ctx, nodeUrl, 5, "")
-	require.NoError(t, err)
-
-	require.True(t, conn.IsHealthy(),
-		"a brand-new HTTP connection must start healthy (optimistic init); the first probe or request flips it")
-}
-
-// TestHTTPDirectRPCConnection_IsHealthy_FlipsOnDialFailure is the core fix: a
+// TestHTTPDirectRPCConnection_SendRequest_SurfacesTransportError verifies a
 // transport-level failure (connection refused, DNS miss, TLS handshake failure,
-// timeout) must drop IsHealthy to false so the comprehensive probe path in
-// checkAndUnblockHealthyReBlockedProviders won't optimistically unblock a
-// backup whose upstream is actually unreachable.
-func TestHTTPDirectRPCConnection_IsHealthy_FlipsOnDialFailure(t *testing.T) {
+// timeout) is surfaced to the caller as an error rather than swallowed. The
+// relay path turns this error into an OnSessionFailure → QoS availability
+// penalty, which is what lets the optimizer route away from a dead upstream now
+// that selection no longer consults a per-socket health bit.
+func TestHTTPDirectRPCConnection_SendRequest_SurfacesTransportError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -357,22 +337,16 @@ func TestHTTPDirectRPCConnection_IsHealthy_FlipsOnDialFailure(t *testing.T) {
 	conn, err := NewDirectRPCConnection(ctx, nodeUrl, 5, "")
 	require.NoError(t, err)
 
-	httpConn, ok := conn.(*HTTPDirectRPCConnection)
-	require.True(t, ok)
-
-	_, sendErr := httpConn.SendRequest(ctx, []byte(`{"jsonrpc":"2.0","method":"probe","id":1}`), nil)
-	require.Error(t, sendErr, "SendRequest must surface the transport failure")
-	require.False(t, httpConn.IsHealthy(),
-		"a transport-layer failure must flip IsHealthy to false so the comprehensive probe skips this backup")
+	_, sendErr := conn.SendRequest(ctx, []byte(`{"jsonrpc":"2.0","method":"probe","id":1}`), nil)
+	require.Error(t, sendErr, "SendRequest must surface the transport failure to the caller")
 }
 
-// TestHTTPDirectRPCConnection_IsHealthy_Stays4xxHealthy ensures the fix doesn't
-// overreach: a 4xx/5xx HTTP response is an *application* error (rate limit,
-// forbidden, server-side bug) — transport is still fine. A connection must not
-// be marked unhealthy just because the upstream RPC server returned a non-2xx.
-// Without this nuance, dashboards would flap any time an endpoint hit a rate
-// limit and the probe would wrongly refuse to unblock otherwise-healthy providers.
-func TestHTTPDirectRPCConnection_IsHealthy_Stays4xxHealthy(t *testing.T) {
+// TestHTTPDirectRPCConnection_SendRequest_4xxReturnsResponseAndError ensures a
+// 4xx/5xx HTTP response is treated as an *application* error: the transport
+// reached the upstream, so the response body is returned alongside an
+// HTTPStatusError. This is why a 429 alone must not take an endpoint out of
+// rotation — it stays a candidate, and QoS (not transport) decides its fate.
+func TestHTTPDirectRPCConnection_SendRequest_4xxReturnsResponseAndError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusTooManyRequests) // 429 — application error, transport is fine
 		_, _ = w.Write([]byte(`{"error":"rate limited"}`))
@@ -386,84 +360,10 @@ func TestHTTPDirectRPCConnection_IsHealthy_Stays4xxHealthy(t *testing.T) {
 	conn, err := NewDirectRPCConnection(ctx, nodeUrl, 5, "")
 	require.NoError(t, err)
 
-	httpConn, ok := conn.(*HTTPDirectRPCConnection)
-	require.True(t, ok)
-
-	// 429 returns an HTTPStatusError but the transport succeeded.
-	_, sendErr := httpConn.SendRequest(ctx, []byte(`{"jsonrpc":"2.0"}`), nil)
+	resp, sendErr := conn.SendRequest(ctx, []byte(`{"jsonrpc":"2.0"}`), nil)
 	require.Error(t, sendErr, "4xx/5xx still returns an HTTPStatusError to the caller")
-	require.True(t, httpConn.IsHealthy(),
-		"a 4xx/5xx response is an application error; transport reached the upstream and health must remain true")
-}
-
-// TestDirectRPCConnection_MarkHealthy_FlipsHTTPHealthyToTrue verifies the
-// recovery-only escape: after a transient failure leaves healthy=false (a
-// state the natural SendRequest-success path cannot reach because
-// IsHealthy() gates the request itself), MarkHealthy must unstick it without
-// requiring a successful exchange. Same idea for the gRPC variant — both
-// have an internal atomic.Bool we expect to flip. WebSocket has no internal
-// flag so MarkHealthy is a no-op there (covered in
-// TestDirectRPCConnection_MarkHealthy_WebSocketIsNoOp).
-func TestDirectRPCConnection_MarkHealthy_FlipsHTTPHealthyToTrue(t *testing.T) {
-	httpConn := &HTTPDirectRPCConnection{}
-	httpConn.healthy.Store(false)
-	require.False(t, httpConn.IsHealthy(), "precondition: healthy starts false")
-
-	httpConn.MarkHealthy()
-
-	require.True(t, httpConn.IsHealthy(), "MarkHealthy must flip the atomic back to true")
-}
-
-func TestDirectRPCConnection_MarkHealthy_FlipsGRPCHealthyToTrue(t *testing.T) {
-	grpcConn := &GRPCDirectRPCConnection{}
-	grpcConn.healthy.Store(false)
-	require.False(t, grpcConn.IsHealthy(), "precondition: healthy starts false")
-
-	grpcConn.MarkHealthy()
-
-	require.True(t, grpcConn.IsHealthy(), "MarkHealthy must flip the atomic back to true")
-}
-
-// TestDirectRPCConnection_MarkHealthy_WebSocketIsNoOp documents that
-// WebSocketDirectRPCConnection has no internal healthy flag (IsHealthy is a
-// constant true). MarkHealthy must still satisfy the interface without
-// panicking; the call is intentionally a no-op.
-func TestDirectRPCConnection_MarkHealthy_WebSocketIsNoOp(t *testing.T) {
-	wsConn := &WebSocketDirectRPCConnection{}
-	require.True(t, wsConn.IsHealthy(), "precondition: WebSocket IsHealthy is constant true")
-
-	wsConn.MarkHealthy() // must not panic
-
-	require.True(t, wsConn.IsHealthy())
-}
-
-// TestHTTPDirectRPCConnection_IsHealthy_RecoversAfterFailure verifies the full
-// unhealthy → healthy transition: once a connection has observed a transport
-// failure, a subsequent successful exchange must flip IsHealthy back to true.
-// Without this, a single glitch would leave a backup permanently flagged as
-// unhealthy even after upstream recovery.
-func TestHTTPDirectRPCConnection_IsHealthy_RecoversAfterFailure(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","result":"ok","id":1}`))
-	}))
-	defer server.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	nodeUrl := common.NodeUrl{Url: server.URL}
-	conn, err := NewDirectRPCConnection(ctx, nodeUrl, 5, "")
-	require.NoError(t, err)
-
-	httpConn, ok := conn.(*HTTPDirectRPCConnection)
-	require.True(t, ok)
-
-	httpConn.healthy.Store(false) // simulate a prior failure
-
-	_, sendErr := httpConn.SendRequest(ctx, []byte(`{"jsonrpc":"2.0"}`), nil)
-	require.NoError(t, sendErr)
-	require.True(t, httpConn.IsHealthy(),
-		"a successful transport exchange must restore IsHealthy=true after a prior failure")
+	require.NotNil(t, resp, "the response body must still be returned for a 4xx/5xx")
+	require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 }
 
 // TestHTTPDirectRPCConnection_UsesSharedOptimizedTransport locks in the

--- a/protocol/lavasession/direct_rpc_session_selection_test.go
+++ b/protocol/lavasession/direct_rpc_session_selection_test.go
@@ -182,3 +182,75 @@ func TestFetchEndpointConnection_DirectRPC(t *testing.T) {
 	assert.NotNil(t, endpoints[0].endpoint, "Should have endpoint reference")
 	assert.True(t, endpoints[0].endpoint.IsDirectRPC(), "Endpoint should be direct RPC")
 }
+
+// TestFetchEndpointConnection_DirectRPC_BackoffAndSelfHeal is the regression guard
+// for PR #100 (drop the per-socket isHealthy selection gate). It locks in the three
+// properties the fix depends on:
+//
+//  1. Selection ignores transport state. The endpoint points at an unreachable
+//     upstream (port 1), yet it is still offered for relay — connecting is the relay
+//     path's job, not selection's. Before the fix a single transport blip latched a
+//     per-socket health bit false with no auto-recovery, silently dropping the
+//     endpoint here forever (the "No pairings available" deadlock).
+//  2. Backoff is the only disable signal, and only after MaxConsecutiveConnectionAttempts
+//     consecutive failures: one short of the threshold the endpoint stays selectable;
+//     crossing it disables the endpoint, after which selection skips it and reports
+//     all-endpoints-disabled.
+//  3. Self-heal: a single ResetHealth (what a successful relay performs) puts the
+//     endpoint straight back into rotation — recovery is automatic, not restart-only.
+func TestFetchEndpointConnection_DirectRPC_BackoffAndSelfHeal(t *testing.T) {
+	rand.InitRandomSeed()
+	ctx := context.Background()
+	// Unreachable upstream (port 1 never accepts): a "dead socket" that under the old
+	// gate would have latched unhealthy and been dropped by selection.
+	nodeUrl := common.NodeUrl{Url: "http://127.0.0.1:1"}
+
+	directConn, err := NewDirectRPCConnection(ctx, nodeUrl, 5, "")
+	require.NoError(t, err)
+
+	endpoint := &Endpoint{
+		NetworkAddress:    nodeUrl.Url,
+		Enabled:           true,
+		DirectConnections: []DirectRPCConnection{directConn},
+	}
+	cswp := &ConsumerSessionsWithProvider{
+		Sessions:          make(map[int64]*SingleConsumerSession),
+		PairingEpoch:      100,
+		StaticProvider:    true,
+		PublicLavaAddress: "direct-rpc-provider",
+		Endpoints:         []*Endpoint{endpoint},
+	}
+
+	fetch := func() (bool, []*EndpointAndChosenConnection, error) {
+		connected, endpoints, _, err := cswp.fetchEndpointConnectionFromConsumerSessionWithProvider(ctx, false, false, "", nil)
+		return connected, endpoints, err
+	}
+
+	// (1) + (2a): one short of the threshold the endpoint is still enabled and is
+	// offered for relay despite the unreachable upstream.
+	for i := 0; i < MaxConsecutiveConnectionAttempts-1; i++ {
+		endpoint.MarkUnhealthy()
+	}
+	require.True(t, endpoint.Enabled, "endpoint must stay enabled below the consecutive-failure threshold")
+	connected, endpoints, err := fetch()
+	require.NoError(t, err)
+	require.True(t, connected, "an enabled direct RPC endpoint must be selectable regardless of transport state")
+	require.Len(t, endpoints, 1)
+
+	// (2b): crossing the threshold disables the endpoint; selection now skips it and
+	// reports the provider as fully disabled.
+	endpoint.MarkUnhealthy()
+	require.False(t, endpoint.Enabled, "endpoint must back off after MaxConsecutiveConnectionAttempts consecutive failures")
+	connected, _, err = fetch()
+	require.ErrorIs(t, err, AllProviderEndpointsDisabledError)
+	require.False(t, connected, "a disabled endpoint must not be selected")
+
+	// (3): a successful relay's ResetHealth re-enables the endpoint and it is
+	// immediately selectable again — the self-heal that replaces restart-only recovery.
+	require.True(t, endpoint.ResetHealth(), "ResetHealth must report it re-enabled a disabled endpoint")
+	require.True(t, endpoint.Enabled)
+	connected, endpoints, err = fetch()
+	require.NoError(t, err)
+	require.True(t, connected, "the endpoint must be selectable again after self-heal")
+	require.Len(t, endpoints, 1)
+}

--- a/protocol/lavasession/session_connection_test.go
+++ b/protocol/lavasession/session_connection_test.go
@@ -26,39 +26,7 @@ func TestProviderRelayConnection_InterfaceCompliance(t *testing.T) {
 
 	// Test interface methods
 	assert.Equal(t, qosManager, prc.GetQoSManager())
-	assert.True(t, prc.IsHealthy())
 	assert.Equal(t, "provider.example.com:443", prc.GetEndpointAddress())
-}
-
-func TestProviderRelayConnection_IsHealthy(t *testing.T) {
-	tests := []struct {
-		name     string
-		conn     *ProviderRelayConnection
-		expected bool
-	}{
-		{
-			name: "healthy with endpoint connection",
-			conn: &ProviderRelayConnection{
-				EndpointConnection: &EndpointConnection{},
-				QoSManager:         &qos.QoSManager{},
-			},
-			expected: true,
-		},
-		{
-			name: "unhealthy with nil endpoint connection",
-			conn: &ProviderRelayConnection{
-				EndpointConnection: nil,
-				QoSManager:         &qos.QoSManager{},
-			},
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.conn.IsHealthy())
-		})
-	}
 }
 
 func TestDirectRPCSessionConnection_InterfaceCompliance(t *testing.T) {
@@ -81,45 +49,7 @@ func TestDirectRPCSessionConnection_InterfaceCompliance(t *testing.T) {
 
 	// Test interface methods
 	assert.Equal(t, qosManager, drsc.GetQoSManager())
-	assert.True(t, drsc.IsHealthy())
 	assert.Equal(t, "eth-mainnet.g.alchemy.com", drsc.GetEndpointAddress())
-}
-
-func TestDirectRPCSessionConnection_IsHealthy(t *testing.T) {
-	ctx := context.Background()
-	nodeUrl := common.NodeUrl{Url: "https://test.example.com"}
-
-	directConn, err := NewDirectRPCConnection(ctx, nodeUrl, 5, "")
-	require.NoError(t, err)
-
-	tests := []struct {
-		name     string
-		conn     *DirectRPCSessionConnection
-		expected bool
-	}{
-		{
-			name: "healthy with direct connection",
-			conn: &DirectRPCSessionConnection{
-				DirectConnection: directConn,
-				QoSManager:       &qos.QoSManager{},
-			},
-			expected: true,
-		},
-		{
-			name: "unhealthy with nil direct connection",
-			conn: &DirectRPCSessionConnection{
-				DirectConnection: nil,
-				QoSManager:       &qos.QoSManager{},
-			},
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.conn.IsHealthy())
-		})
-	}
 }
 
 func TestSingleConsumerSession_GetDirectConnection(t *testing.T) {

--- a/protocol/rpcsmartrouter/debug_server_test.go
+++ b/protocol/rpcsmartrouter/debug_server_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/magma-Devs/smart-router/protocol/chaintracker"
 	"github.com/magma-Devs/smart-router/protocol/common"
-	"github.com/magma-Devs/smart-router/protocol/lavasession"
 	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
 	"github.com/magma-Devs/smart-router/protocol/relaycore"
 	"github.com/magma-Devs/smart-router/utils"
@@ -119,12 +118,10 @@ func TestDebugResetScores_SmartRouter_ReturnsJSON(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 	require.Contains(t, rr.Body.String(), `"reset":true`)
 	require.Contains(t, rr.Body.String(), `"chains_reset":0`)
-	// trackers_reset and connections_reset are the chain-tracker / direct-
-	// connection contributions; with no router wired (deps.router == nil)
-	// both return 0 — but the fields must still appear so callers can rely
-	// on the shape regardless of fixture wiring.
+	// trackers_reset is the chain-tracker contribution; with no router wired
+	// (deps.router == nil) it returns 0 — but the field must still appear so
+	// callers can rely on the shape regardless of fixture wiring.
 	require.Contains(t, rr.Body.String(), `"trackers_reset":0`)
-	require.Contains(t, rr.Body.String(), `"connections_reset":0`)
 }
 
 func TestDebugResetScores_SmartRouter_MethodNotAllowed(t *testing.T) {
@@ -233,104 +230,6 @@ func TestDebugResetScores_SmartRouter_ResetsChainTrackers(t *testing.T) {
 		for i, f := range fakes {
 			require.Equal(t, int32(1), f.resetCalls.Load(),
 				"tracker %d should have had ResetLatestBlock called exactly once", i)
-		}
-	}
-}
-
-// recordingDirectRPCConnection is a minimal lavasession.DirectRPCConnection
-// fake that records MarkHealthy invocations. Only the methods the manager
-// touches (IsHealthy/MarkHealthy) carry real behavior; the rest return zero
-// values so the test doesn't pull in chainParser / Endpoint scaffolding it
-// doesn't need.
-type recordingDirectRPCConnection struct {
-	healthy          atomic.Bool
-	markHealthyCalls atomic.Int32
-}
-
-func (r *recordingDirectRPCConnection) SendRequest(context.Context, []byte, map[string]string) (*lavasession.DirectRPCResponse, error) {
-	return nil, errors.New("recordingDirectRPCConnection: SendRequest not implemented")
-}
-
-func (r *recordingDirectRPCConnection) GetProtocol() lavasession.DirectRPCProtocol {
-	return lavasession.DirectRPCProtocolHTTP
-}
-func (r *recordingDirectRPCConnection) Close() error                { return nil }
-func (r *recordingDirectRPCConnection) IsHealthy() bool             { return r.healthy.Load() }
-func (r *recordingDirectRPCConnection) GetURL() string              { return "" }
-func (r *recordingDirectRPCConnection) GetNodeUrl() *common.NodeUrl { return nil }
-
-func (r *recordingDirectRPCConnection) MarkHealthy() {
-	r.markHealthyCalls.Add(1)
-	r.healthy.Store(true)
-}
-
-// newRouterWithConnectionFetchers builds a minimal *RPCSmartRouter wired so
-// resetAllConnectionHealth can walk router→servers→manager.fetchers→connection.
-// Pre-populates each manager's fetchers map (not trackers) with the supplied
-// recording connection fakes, since ResetAllConnectionHealth iterates
-// fetchers — keeping the two reset paths' fixtures decoupled so one test
-// can fail without dragging the other.
-func newRouterWithConnectionFetchers(t *testing.T, byServer map[string][]*recordingDirectRPCConnection) *RPCSmartRouter {
-	t.Helper()
-	router := &RPCSmartRouter{
-		rpcServers: make(map[string]*RPCSmartRouterServer),
-	}
-	for serverKey, conns := range byServer {
-		manager := &EndpointChainTrackerManager{
-			trackers:          make(map[string]chaintracker.IChainTracker),
-			fetchers:          make(map[string]*EndpointChainFetcher),
-			cancelFuncs:       make(map[string]context.CancelFunc),
-			trackerStates:     make(map[string]EndpointChainTrackerState),
-			trackerLastErrors: make(map[string]string),
-		}
-		for i, c := range conns {
-			endpointURL := serverKey + "-endpoint-" + strconv.Itoa(i)
-			manager.fetchers[endpointURL] = &EndpointChainFetcher{directConnection: c}
-		}
-		router.rpcServers[serverKey] = &RPCSmartRouterServer{
-			endpointChainTrackerManager: manager,
-		}
-	}
-	return router
-}
-
-// TestDebugResetScores_SmartRouter_ResetsConnectionHealth verifies the
-// direct-connection health reset branch: every per-endpoint
-// DirectRPCConnection across all rpcServers must have MarkHealthy invoked
-// (to unstick the healthy atomic when CV's IsHealthy() gate is preventing
-// the very SendRequest that would naturally re-establish health), and the
-// response body must report the total count via connections_reset.
-func TestDebugResetScores_SmartRouter_ResetsConnectionHealth(t *testing.T) {
-	var offsetNano atomic.Int64
-
-	serverA := []*recordingDirectRPCConnection{{}, {}, {}}
-	serverB := []*recordingDirectRPCConnection{{}, {}}
-	for _, c := range append(append([]*recordingDirectRPCConnection{}, serverA...), serverB...) {
-		c.healthy.Store(false) // stuck-false precondition
-	}
-
-	router := newRouterWithConnectionFetchers(t, map[string][]*recordingDirectRPCConnection{
-		"chainA-jsonrpc": serverA,
-		"chainB-rest":    serverB,
-	})
-
-	mux := buildDebugMux(debugMuxDeps{
-		optimizers: newEmptyOptimizersRouter(),
-		offsetNano: &offsetNano,
-		router:     router,
-	})
-
-	rr := postResetScoresRouter(mux)
-	require.Equal(t, http.StatusOK, rr.Code)
-	require.Contains(t, rr.Body.String(), `"reset":true`)
-	require.Contains(t, rr.Body.String(), `"connections_reset":5`)
-
-	for _, conns := range [][]*recordingDirectRPCConnection{serverA, serverB} {
-		for i, c := range conns {
-			require.Equal(t, int32(1), c.markHealthyCalls.Load(),
-				"connection %d should have had MarkHealthy called exactly once", i)
-			require.True(t, c.IsHealthy(),
-				"connection %d healthy atomic should be true after MarkHealthy", i)
 		}
 	}
 }

--- a/protocol/rpcsmartrouter/endpoint_chain_fetcher.go
+++ b/protocol/rpcsmartrouter/endpoint_chain_fetcher.go
@@ -49,9 +49,8 @@ func NewEndpointChainFetcher(
 
 // GetDirectConnection returns the underlying DirectRPCConnection. The same
 // pointer is stored in endpoint.DirectConnections[0] at construction time
-// (see ConsumerSessionManager.GetAllDirectRPCEndpoints), so a MarkHealthy()
-// call through this getter affects the exact atomic the cross-validation
-// path's IsHealthy() reads.
+// (see ConsumerSessionManager.GetAllDirectRPCEndpoints), so the tracker and the
+// relay path share one connection object.
 func (ecf *EndpointChainFetcher) GetDirectConnection() lavasession.DirectRPCConnection {
 	return ecf.directConnection
 }
@@ -285,8 +284,8 @@ func (ecf *EndpointChainFetcher) CustomMessage(ctx context.Context, path string,
 // For REST/GET requests, requestData is a URL path that must be appended to the base URL.
 // For JSON-RPC/POST requests, requestData is the JSON body.
 func (ecf *EndpointChainFetcher) sendRawRequest(ctx context.Context, requestData []byte, connectionType string, apiName string) ([]byte, error) {
-	if ecf.directConnection == nil || !ecf.directConnection.IsHealthy() {
-		return nil, fmt.Errorf("direct connection is not healthy for endpoint %s", ecf.endpointURL)
+	if ecf.directConnection == nil {
+		return nil, fmt.Errorf("no direct connection for endpoint %s", ecf.endpointURL)
 	}
 
 	// REST GET: requestData is a URL path (e.g. "/cosmos/base/tendermint/v1beta1/blocks/latest")

--- a/protocol/rpcsmartrouter/endpoint_chain_fetcher.go
+++ b/protocol/rpcsmartrouter/endpoint_chain_fetcher.go
@@ -47,14 +47,6 @@ func NewEndpointChainFetcher(
 	}
 }
 
-// GetDirectConnection returns the underlying DirectRPCConnection. The same
-// pointer is stored in endpoint.DirectConnections[0] at construction time
-// (see ConsumerSessionManager.GetAllDirectRPCEndpoints), so the tracker and the
-// relay path share one connection object.
-func (ecf *EndpointChainFetcher) GetDirectConnection() lavasession.DirectRPCConnection {
-	return ecf.directConnection
-}
-
 // FetchLatestBlockNum fetches the latest block number from the endpoint.
 // Uses spec-driven parsing to support any chain type (EVM, Tendermint, REST, etc.).
 func (ecf *EndpointChainFetcher) FetchLatestBlockNum(ctx context.Context) (int64, error) {

--- a/protocol/rpcsmartrouter/endpoint_chain_fetcher_test.go
+++ b/protocol/rpcsmartrouter/endpoint_chain_fetcher_test.go
@@ -23,8 +23,7 @@ func TestEndpointChainFetcher_CustomMessage_POSTDelegatesToConnection(t *testing
 	)
 
 	conn := &mockDirectRPCConnection{
-		url:     url,
-		healthy: true,
+		url: url,
 		responses: map[string][]byte{
 			svmRequest: []byte(svmResp),
 		},
@@ -77,23 +76,21 @@ func TestEndpointChainTrackerManager_ForcesBlocksToSave1ForSolana(t *testing.T) 
 	}
 }
 
-// TestEndpointChainFetcher_CustomMessage_PropagatesUnhealthyConnection guards against
-// silently swallowing upstream failures: when the direct connection is unhealthy,
-// CustomMessage should surface an error so the SVM tracker's retry logic kicks in
-// instead of treating an empty body as a successful fetch.
-func TestEndpointChainFetcher_CustomMessage_PropagatesUnhealthyConnection(t *testing.T) {
-	conn := &mockDirectRPCConnection{
-		url:     "https://solana.lava.build:443/",
-		healthy: false, // the whole point of the check
-	}
+// TestEndpointChainFetcher_CustomMessage_PropagatesMissingConnection guards the
+// remaining nil-connection check in sendRawRequest: with no direct connection the
+// fetcher must surface an error rather than treat an empty body as a successful
+// fetch. (The old per-socket health gate is gone — a live-but-failing socket now
+// surfaces its failure through SendRequest itself, which the relay path turns into
+// a QoS penalty, instead of being pre-empted by a latched health bit.)
+func TestEndpointChainFetcher_CustomMessage_PropagatesMissingConnection(t *testing.T) {
 	fetcher := NewEndpointChainFetcher(
-		&lavasession.Endpoint{NetworkAddress: conn.url, Enabled: true},
-		conn,
+		&lavasession.Endpoint{NetworkAddress: "https://solana.lava.build:443/", Enabled: true},
+		nil, // no direct connection
 		nil,
 		"SOLANA",
 		"jsonrpc",
 	)
 
 	_, err := fetcher.CustomMessage(context.Background(), "", []byte(`{}`), "POST", "getLatestBlockhash")
-	require.Error(t, err, "CustomMessage must fail when the direct connection is not healthy")
+	require.Error(t, err, "CustomMessage must fail when there is no direct connection")
 }

--- a/protocol/rpcsmartrouter/endpoint_chain_tracker_manager.go
+++ b/protocol/rpcsmartrouter/endpoint_chain_tracker_manager.go
@@ -412,33 +412,6 @@ func (m *EndpointChainTrackerManager) ResetAllLatestBlocks() int {
 	return count
 }
 
-// ResetAllConnectionHealth calls MarkHealthy on every per-endpoint
-// DirectRPCConnection. The same connection pointer is held in
-// endpoint.DirectConnections, which is what the cross-validation IsHealthy()
-// gate reads — so flipping the atomic here unblocks CV fan-out for endpoints
-// whose flag got stuck false from a long-ago transient failure. Returns the
-// number of connections visited (WebSocket connections are counted even
-// though their MarkHealthy is a no-op; the count is "invocations", not
-// "state transitions", so the caller can predict the number from the
-// endpoint count).
-func (m *EndpointChainTrackerManager) ResetAllConnectionHealth() int {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	count := 0
-	for _, fetcher := range m.fetchers {
-		if fetcher == nil {
-			continue
-		}
-		conn := fetcher.GetDirectConnection()
-		if conn == nil {
-			continue
-		}
-		conn.MarkHealthy()
-		count++
-	}
-	return count
-}
-
 // RemoveTracker removes and stops a ChainTracker for an endpoint.
 // It cancels the tracker's context first, which signals the goroutine to exit cleanly.
 func (m *EndpointChainTrackerManager) RemoveTracker(endpointURL string) {

--- a/protocol/rpcsmartrouter/endpoint_chain_tracker_test.go
+++ b/protocol/rpcsmartrouter/endpoint_chain_tracker_test.go
@@ -17,7 +17,6 @@ import (
 // mockDirectRPCConnection implements lavasession.DirectRPCConnection for testing
 type mockDirectRPCConnection struct {
 	url       string
-	healthy   bool
 	responses map[string][]byte // request -> response
 }
 
@@ -42,14 +41,6 @@ func (m *mockDirectRPCConnection) GetProtocol() lavasession.DirectRPCProtocol {
 
 func (m *mockDirectRPCConnection) Close() error {
 	return nil
-}
-
-func (m *mockDirectRPCConnection) IsHealthy() bool {
-	return m.healthy
-}
-
-func (m *mockDirectRPCConnection) MarkHealthy() {
-	m.healthy = true
 }
 
 func (m *mockDirectRPCConnection) GetURL() string {

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -509,30 +509,6 @@ func resetAllChainTrackers(deps debugMuxDeps) int {
 	return count
 }
 
-// resetAllConnectionHealth walks the router's per-server
-// EndpointChainTrackerManagers and forcibly flips every direct connection's
-// healthy flag back to true. Recovery escape for the case where a transient
-// upstream failure stuck the flag false and the IsHealthy() gate (in CV
-// fan-out and elsewhere) prevents the very SendRequest that would naturally
-// re-establish health. Intentionally scoped to /debug/reset-scores only —
-// /debug/reset-all still has a separate session-manager regression we don't
-// want to entangle with this safe path.
-func resetAllConnectionHealth(deps debugMuxDeps) int {
-	if deps.router == nil {
-		return 0
-	}
-	deps.router.mu.Lock()
-	defer deps.router.mu.Unlock()
-	count := 0
-	for _, server := range deps.router.rpcServers {
-		if server == nil || server.endpointChainTrackerManager == nil {
-			continue
-		}
-		count += server.endpointChainTrackerManager.ResetAllConnectionHealth()
-	}
-	return count
-}
-
 // resetAllConsistencies flushes every per-chain seen-block cache that
 // implements consistencyResetter. Why this is necessary: SetSeenBlockFromKey
 // only writes monotonically (consistency.go: `block >= blockSeen → return`),
@@ -647,14 +623,10 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 	})
 
 	// POST /debug/reset-scores — clears optimizer score state without changing
-	// current time offset or NowFunc. Also flushes per-chain seen-block caches,
-	// zeroes per-endpoint chain-tracker latest-block values, and forces every
-	// per-endpoint direct connection back to healthy=true. The connection-
-	// health reset unblocks CV fan-out for endpoints whose healthy atomic got
-	// stuck false from a long-ago transient (IsHealthy() gates the very
-	// SendRequest that would naturally re-establish health). Together these
-	// give a recovery path that does not touch session-manager state — which
-	// trips a separate BTC-router regression on /debug/reset-all.
+	// current time offset or NowFunc. Also flushes per-chain seen-block caches and
+	// zeroes per-endpoint chain-tracker latest-block values. Gives a recovery path
+	// that does not touch session-manager state — which trips a separate BTC-router
+	// regression on /debug/reset-all.
 	mux.HandleFunc("/debug/reset-scores", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "POST only", http.StatusMethodNotAllowed)
@@ -668,10 +640,9 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 		})
 		resetAllConsistencies(deps.consistencies)
 		trackersReset := resetAllChainTrackers(deps)
-		connectionsReset := resetAllConnectionHealth(deps)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"reset":true,"chains_reset":%d,"trackers_reset":%d,"connections_reset":%d}`,
-			count, trackersReset, connectionsReset)
+		fmt.Fprintf(w, `{"reset":true,"chains_reset":%d,"trackers_reset":%d}`,
+			count, trackersReset)
 	})
 
 	// POST /debug/reset-all — flush every state store the test framework

--- a/protocol/rpcsmartrouter/rpcsmartrouter_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_test.go
@@ -175,7 +175,7 @@ func TestUpdateEpoch_ResetsDisabledEndpoints(t *testing.T) {
 	sessionManager := lavasession.NewConsumerSessionManager(rpcEndpoint, optimizer, nil, "test-router", lavasession.NewActiveSubscriptionProvidersStorage())
 	rpsr.sessionManagers[chainKey] = sessionManager
 
-	// Create endpoints that are disabled — simulating 5 consecutive failures.
+	// Create endpoints that are disabled — simulating MaxConsecutiveConnectionAttempts consecutive failures.
 	disabledEndpoint := &lavasession.Endpoint{
 		NetworkAddress:     "http://provider1:8080",
 		Enabled:            false,

--- a/scripts/pre_setups/init_smartrouter_sol.sh
+++ b/scripts/pre_setups/init_smartrouter_sol.sh
@@ -1,0 +1,267 @@
+#!/bin/bash
+# Smart Router — Solana DIRECT RPC test setup.
+#
+# Purpose: reproduce / verify the Solana consistency bug fixed in PR #21
+# (fix: solana slot unit mismatch). On Solana, `context.slot` and
+# `value.lastValidBlockHeight` diverge by the skip rate (~21-22M on mainnet).
+# The old SVMChainTracker stored lastValidBlockHeight into `seenBlock` while
+# provider spec parsing (GET_BLOCKNUM -> context.slot) used the slot, so the
+# consistency engine compared two different units and produced
+#   "Consistency Error code 3368 ... Requested a block that is too new".
+# The fix tracks context.slot on both sides. With a fixed binary, the requests
+# below should succeed with NO 3368 / "block too new" / "No pairings" errors.
+__dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "$__dir"/../useful_commands.sh
+# Optional vars file (not present in all checkouts) — source only if it exists.
+[ -f "${__dir}/../vars/variables.sh" ] && . "${__dir}/../vars/variables.sh"
+
+# Use absolute paths for logs
+LOGS_DIR=${__dir}/../../debugging/logs
+mkdir -p $LOGS_DIR
+LOGS_DIR=$(cd "$LOGS_DIR" && pwd)
+rm $LOGS_DIR/*.log 2>/dev/null || true
+
+# Save project root for later use
+PROJECT_ROOT=$(cd ${__dir}/../.. && pwd)
+CONFIG_FILE="$PROJECT_ROOT/config/smartrouter_examples/smartrouter_sol.yml"
+
+# Resolve the smartrouter binary by absolute path so the screen session does not
+# depend on the user's shell profile putting $(go env GOPATH)/bin on PATH.
+SMARTROUTER_BIN="$(go env GOPATH)/bin/smartrouter"
+
+# Only remove config when explicitly regenerating (keeps manual edits for e.g. timeout testing)
+if [[ "$REGENERATE_CONFIG" == "1" ]]; then
+    echo "REGENERATE_CONFIG=1: removing existing smart router config..."
+    rm -f "$CONFIG_FILE" 2>/dev/null || true
+fi
+
+# Kill any running smartrouter / lavap processes
+killall smartrouter lavap 2>/dev/null || true
+sleep 1
+
+# Kill all screen sessions
+killall screen 2>/dev/null || true
+sleep 1
+screen -wipe
+sleep 1  # Give processes time to fully shut down before starting new ones
+
+echo "============================================"
+echo "Smart Router Solana Direct RPC Test Setup"
+echo "============================================"
+echo "Chain: SOLANA (jsonrpc)"
+echo "Mode: DIRECT RPC (no providers!)"
+echo "Goal: verify PR #21 slot/blockHeight consistency fix"
+echo "============================================"
+echo ""
+
+echo "[Test Setup] installing smartrouter binary"
+make -C "$PROJECT_ROOT" install
+
+# Start cache service (the consistency / shared-state path used by the bug
+# flows through the cache, so we run it to mirror production).
+echo "[Test Setup] starting smart router cache service"
+screen -d -m -S cache bash -c "source ~/.bashrc; \"$SMARTROUTER_BIN\" cache \
+127.0.0.1:20100 --metrics_address 0.0.0.0:20200 --log_level debug 2>&1 | tee $LOGS_DIR/CACHE.log" && sleep 0.25
+
+sleep 2
+
+echo "Verifying cache service..."
+if screen -list | grep -q "cache"; then
+    echo "  Cache screen session: RUNNING"
+    sleep 1
+    if nc -z 127.0.0.1 20100 2>/dev/null; then
+        echo "  Cache port 20100: LISTENING"
+    else
+        echo "  WARNING: Cache port 20100 not yet listening (may still be starting)"
+    fi
+else
+    echo "  ERROR: Cache screen failed to start! Check $LOGS_DIR/CACHE.log"
+fi
+echo ""
+
+# Static Solana spec (SOLANA index). Copied from lava specs/mainnet-1/specs/solana.json.
+SPECS_DIR="$PROJECT_ROOT/specs/solana.json"
+echo "Using static specs: $SPECS_DIR"
+if [ ! -f "$SPECS_DIR" ]; then
+    echo "ERROR: Solana spec not found at $SPECS_DIR"
+    exit 1
+fi
+
+# Solana HTTP RPC endpoints.
+#   export SOL_RPC_URL_1="https://your-solana-rpc/..."
+# At least one is required; 2-3 enable cross-validation / consistency testing.
+export SOL_RPC_URL_1="${SOL_RPC_URL_1:-https://g.w.lavanet.xyz:443/gateway/solana/rpc-http/YOUR_LAVA_GATEWAY_KEY}"
+export SOL_RPC_URL_2="${SOL_RPC_URL_2:-}"
+export SOL_RPC_URL_3="${SOL_RPC_URL_3:-}"
+
+if [[ -z "$SOL_RPC_URL_1" ]]; then
+    echo "ERROR: SOL_RPC_URL_1 must be set to a Solana JSON-RPC endpoint."
+    exit 1
+fi
+
+# Generate config only if missing or REGENERATE_CONFIG=1 (keeps manual edits otherwise)
+if [[ -f "$CONFIG_FILE" && "$REGENERATE_CONFIG" != "1" ]]; then
+    echo "Using existing config: $CONFIG_FILE"
+    echo "  (Set REGENERATE_CONFIG=1 to regenerate from env vars)"
+    echo ""
+else
+echo "Generating smart router config: $CONFIG_FILE"
+echo "  HTTP Endpoint 1: ${SOL_RPC_URL_1:0:60}..."
+[[ -n "$SOL_RPC_URL_2" ]] && echo "  HTTP Endpoint 2: ${SOL_RPC_URL_2:0:60}..."
+[[ -n "$SOL_RPC_URL_3" ]] && echo "  HTTP Endpoint 3: ${SOL_RPC_URL_3:0:60}..."
+echo ""
+
+cat > $CONFIG_FILE <<EOF
+# Smart Router Direct RPC Configuration — Solana (SOLANA)
+# Mode: Direct connections to Solana JSON-RPC endpoints (no Lava providers!)
+
+endpoints:
+  - listen-address: "0.0.0.0:3360"
+    chain-id: "SOLANA"
+    api-interface: "jsonrpc"
+    network-address: "0.0.0.0:3360"
+
+direct-rpc:
+  # HTTP Endpoint 1
+  - name: "sol-rpc-1"
+    chain-id: "SOLANA"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "$SOL_RPC_URL_1"
+        skip-verifications:
+          - chain-id
+          - pruning
+EOF
+
+if [[ -n "$SOL_RPC_URL_2" ]]; then
+cat >> $CONFIG_FILE <<EOF
+
+  # HTTP Endpoint 2
+  - name: "sol-rpc-2"
+    chain-id: "SOLANA"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "$SOL_RPC_URL_2"
+        skip-verifications:
+          - chain-id
+          - pruning
+EOF
+fi
+
+if [[ -n "$SOL_RPC_URL_3" ]]; then
+cat >> $CONFIG_FILE <<EOF
+
+  # HTTP Endpoint 3
+  - name: "sol-rpc-3"
+    chain-id: "SOLANA"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "$SOL_RPC_URL_3"
+        skip-verifications:
+          - chain-id
+          - pruning
+EOF
+fi
+
+echo ""
+echo "Verifying generated config file..."
+if [ -f "$CONFIG_FILE" ]; then
+    echo "Smart router config exists: $CONFIG_FILE (size: $(wc -c < "$CONFIG_FILE") bytes)"
+    echo ""
+    echo "Config:"
+    sed 's/^/  /' "$CONFIG_FILE"
+else
+    echo "ERROR: Smart router config NOT found: $CONFIG_FILE"
+    exit 1
+fi
+echo ""
+fi  # end: regenerate config or use existing
+
+# Start Smart Router with DIRECT RPC (no providers!)
+echo "[Test Setup] starting Smart Router (DIRECT RPC mode, standalone)"
+echo "   - Chain: SOLANA   Listen: 0.0.0.0:3360   Cache: 127.0.0.1:20100"
+echo ""
+
+screen -d -m -S smartrouter bash -c "cd $PROJECT_ROOT && source ~/.bashrc; \"$SMARTROUTER_BIN\" \
+config/smartrouter_examples/smartrouter_sol.yml \
+--geolocation 1 \
+--log-level debug \
+--cache-be \"127.0.0.1:20100\" \
+--use-static-spec $SPECS_DIR \
+--skip-websocket-verification \
+--metrics-listen-address ':7779' 2>&1 | tee $LOGS_DIR/SMARTROUTER.log" && sleep 0.25
+
+sleep 3
+
+echo "Verifying smart router screen session..."
+if screen -list | grep -q "smartrouter"; then
+    echo "Smart router screen is running"
+else
+    echo "ERROR: Smart router screen failed to start! Check $LOGS_DIR/SMARTROUTER.log"
+    exit 1
+fi
+echo ""
+
+echo "--- setting up screens done ---"
+screen -ls
+
+echo ""
+echo "============================================"
+echo "Smart Router Solana Setup Complete!"
+echo "============================================"
+echo "Cache:         127.0.0.1:20100 (metrics: 20200)"
+echo "Smart Router:  0.0.0.0:3360 (metrics: 7779)"
+echo ""
+echo "Test Commands (HTTP / JSON-RPC):"
+echo ""
+echo "  # getSlot — should return the current slot (~425M range)"
+echo "  curl -s -X POST http://127.0.0.1:3360 \\"
+echo "    -H 'Content-Type: application/json' \\"
+echo "    -d '{\"jsonrpc\":\"2.0\",\"method\":\"getSlot\",\"params\":[],\"id\":1}'"
+echo ""
+echo "  # getLatestBlockhash — slot (context.slot) vs lastValidBlockHeight differ by ~21M"
+echo "  curl -s -X POST http://127.0.0.1:3360 \\"
+echo "    -H 'Content-Type: application/json' \\"
+echo "    -d '{\"jsonrpc\":\"2.0\",\"method\":\"getLatestBlockhash\",\"params\":[{\"commitment\":\"finalized\"}],\"id\":1}'"
+echo ""
+echo "  # getBlockHeight"
+echo "  curl -s -X POST http://127.0.0.1:3360 \\"
+echo "    -H 'Content-Type: application/json' \\"
+echo "    -d '{\"jsonrpc\":\"2.0\",\"method\":\"getBlockHeight\",\"params\":[],\"id\":1}'"
+echo ""
+echo "  # getAccountInfo (consistency-sensitive read)"
+echo "  curl -s -X POST http://127.0.0.1:3360 \\"
+echo "    -H 'Content-Type: application/json' \\"
+echo "    -d '{\"jsonrpc\":\"2.0\",\"method\":\"getAccountInfo\",\"params\":[\"11111111111111111111111111111111\",{\"encoding\":\"base64\"}],\"id\":1}'"
+echo ""
+echo "============================================"
+echo "VERIFYING THE PR #21 CONSISTENCY FIX"
+echo "============================================"
+echo ""
+echo "Hammer the router so the SVMChainTracker polls latest repeatedly and the"
+echo "shared-state seen-block path is exercised (this is what tripped the bug):"
+echo ""
+echo "  for i in \$(seq 1 20); do"
+echo "    curl -s -o /dev/null -w '%{http_code}\\n' -X POST http://127.0.0.1:3360 \\"
+echo "      -H 'Content-Type: application/json' \\"
+echo "      -d '{\"jsonrpc\":\"2.0\",\"method\":\"getSlot\",\"params\":[],\"id\":1}'"
+echo "    sleep 0.5"
+echo "  done"
+echo ""
+echo "PASS  (fix working): all requests return slot/height values, and the grep"
+echo "      below finds NOTHING."
+echo "FAIL  (bug present): responses carry 'No pairings available' and the log"
+echo "      shows 3368 / 'block that is too new' with blockGap ~21-22M."
+echo ""
+echo "  # This MUST be empty on a fixed binary:"
+echo "  grep -Ei 'consistency error|too new|No pairings|blockGap' $LOGS_DIR/SMARTROUTER.log"
+echo ""
+echo "  # Confirm the tracker reports a SLOT (~425M), not block height (~403M):"
+echo "  grep -i 'SVMChainTracker' $LOGS_DIR/SMARTROUTER.log | tail"
+echo ""
+echo "Monitor logs:"
+echo "  tail -f $LOGS_DIR/SMARTROUTER.log | grep -Ei 'slot|consistency|relay|pairings'"
+echo ""
+echo "To Stop All Services:"
+echo "  killall smartrouter; screen -wipe"
+echo "============================================"

--- a/specs/solana.json
+++ b/specs/solana.json
@@ -1,0 +1,1494 @@
+{
+    "proposal": {
+        "title": "Add Specs: Solana",
+        "description": "Adding new specification support for relaying Solana data on Lava",
+        "specs": [
+            {
+                "index": "SOLANA",
+                "name": "solana mainnet",
+                "enabled": true,
+                "reliability_threshold": 268435455,
+                "data_reliability_enabled": true,
+                "block_distance_for_finalized_data": 0,
+                "blocks_in_finalization_proof": 1,
+                "average_block_time": 400,
+                "allowed_block_lag_for_qos_sync": 25,
+                "shares": 1,
+                "min_stake_provider": {
+                    "denom": "ulava",
+                    "amount": "5000000000"
+                },
+                "api_collections": [
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "jsonrpc",
+                            "internal_path": "",
+                            "type": "POST",
+                            "add_on": ""
+                        },
+                        "inheritance_apis": [
+                            {
+                                "api_interface": "jsonrpc",
+                                "internal_path": "WS-ONLY",
+                                "type": "POST",
+                                "add_on": ""
+                            }
+                        ],
+                        "apis": [
+                            {
+                                "name": "getAccountInfo",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getBalance",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getBlock",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "0"
+                                    ],
+                                    "parser_func": "PARSE_BY_ARG"
+                                },
+                                "compute_units": 30,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getBlockHeight",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getBlockProduction",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getBlockCommitment",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "0"
+                                    ],
+                                    "parser_func": "PARSE_BY_ARG"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getBlocks",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "1"
+                                    ],
+                                    "parser_func": "PARSE_BY_ARG"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getBlocksWithLimit",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getBlockTime",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "0"
+                                    ],
+                                    "parser_func": "PARSE_BY_ARG"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getClusterNodes",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getEpochInfo",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getEpochSchedule",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getFeeForMessage",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getFirstAvailableBlock",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getGenesisHash",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getHealth",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getHighestSnapshotSlot",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getIdentity",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getInflationGovernor",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getInflationRate",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getInflationReward",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getLargestAccounts",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getLatestBlockhash",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getLeaderSchedule",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getMaxRetransmitSlot",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getMaxShredInsertSlot",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getMinimumBalanceForRentExemption",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getMultipleAccounts",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getProgramAccounts",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getRecentPerformanceSamples",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getRecentPrioritizationFees",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getSignaturesForAddress",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getSignatureStatuses",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getSlot",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getSlotLeader",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getSlotLeaders",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getStakeMinimumDelegation",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getSupply",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getTokenAccountBalance",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getTokenAccountsByDelegate",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getTokenAccountsByOwner",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getTokenLargestAccounts",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getTokenSupply",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getTransaction",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getTransactionCount",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getVersion",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "getVoteAccounts",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "isBlockhashValid",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "minimumLedgerSlot",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "requestAirdrop",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "sendTransaction",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging_api": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "simulateTransaction",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            }
+                        ],
+                        "headers": [],
+                        "parse_directives": [
+                            {
+                                "function_template": "{\"jsonrpc\":\"2.0\",\"method\":\"getLatestBlockhash\",\"params\":[{\"commitment\":\"finalized\"}],\"id\":1}",
+                                "function_tag": "GET_BLOCKNUM",
+                                "result_parsing": {
+                                    "parser_arg": [
+                                        "0",
+                                        "context",
+                                        "slot"
+                                    ],
+                                    "parser_func": "PARSE_CANONICAL"
+                                },
+                                "api_name": "getLatestBlockhash"
+                            },
+                            {
+                                "function_tag": "GET_BLOCK_BY_NUM",
+                                "function_template": "{\"jsonrpc\":\"2.0\",\"method\":\"getBlock\",\"params\":[%d,{\"transactionDetails\":\"none\",\"rewards\":false,\"maxSupportedTransactionVersion\":0}],\"id\":1}",
+                                "result_parsing": {
+                                    "parser_arg": [
+                                        "0",
+                                        "blockhash"
+                                    ],
+                                    "parser_func": "PARSE_CANONICAL",
+                                    "encoding": "base64"
+                                },
+                                "api_name": "getBlock"
+                            }
+                        ],
+                        "verifications": [
+                            {
+                                "name": "version",
+                                "parse_directive": {
+                                    "function_template": "{\"jsonrpc\":\"2.0\",\"method\":\"getVersion\",\"params\":[],\"id\":1}",
+                                    "function_tag": "VERIFICATION",
+                                    "result_parsing": {
+                                        "parser_arg": [
+                                            "0",
+                                            "solana-core"
+                                        ],
+                                        "parser_func": "PARSE_CANONICAL"
+                                    },
+                                    "api_name": "getVersion"
+                                },
+                                "values": [
+                                    {
+                                        "expected_value": "*"
+                                    }
+                                ]
+                            },
+                            {
+                                "name": "tokens-owner-indexed",
+                                "parse_directive": {
+                                    "function_template": "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getTokenAccountsByOwner\",\"params\":[\"4Qkev8aNZcqFNSRhQzwyLMFSsi94jHqE8WNVTJzTP99F\",{\"programId\":\"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA\"},{\"encoding\":\"jsonParsed\"}]}",
+                                    "function_tag": "VERIFICATION",
+                                    "result_parsing": {
+                                        "parser_arg": [
+                                            "0",
+                                            "value"
+                                        ],
+                                        "parser_func": "PARSE_CANONICAL"
+                                    },
+                                    "api_name": "getTokenAccountsByOwner"
+                                },
+                                "values": [
+                                    {
+                                        "expected_value": "*",
+                                        "severity": "Warning"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "enabled": false,
+                        "collection_data": {
+                            "api_interface": "jsonrpc",
+                            "internal_path": "WS-ONLY",
+                            "type": "POST",
+                            "add_on": ""
+                        },
+                        "apis": [
+                            {
+                                "name": "accountSubscribe",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 1000,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": true,
+                                    "subscription": true,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "accountUnsubscribe",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 1000,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": true,
+                                    "subscription": true,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "blockSubscribe",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 1000,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": true,
+                                    "subscription": true,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "blockUnsubscribe",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 1000,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": true,
+                                    "subscription": true,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "logsSubscribe",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 1000,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": true,
+                                    "subscription": true,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "logsUnsubscribe",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 1000,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": true,
+                                    "subscription": true,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "programSubscribe",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 1000,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": true,
+                                    "subscription": true,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "programUnsubscribe",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 1000,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": true,
+                                    "subscription": true,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "rootSubscribe",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 1000,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": true,
+                                    "subscription": true,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "rootUnsubscribe",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 1000,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": true,
+                                    "subscription": true,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "signatureSubscribe",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 1000,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": true,
+                                    "subscription": true,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "signatureUnsubscribe",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 1000,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": true,
+                                    "subscription": true,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "slotSubscribe",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 1000,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": true,
+                                    "subscription": true,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "slotUnsubscribe",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 1000,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": true,
+                                    "subscription": true,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "slotsUpdatesSubscribe",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 1000,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": true,
+                                    "subscription": true,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "slotsUpdatesUnsubscribe",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 1000,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": true,
+                                    "subscription": true,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "voteSubscribe",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 1000,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": true,
+                                    "subscription": true,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "voteUnsubscribe",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 1000,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": true,
+                                    "subscription": true,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            }
+                        ],
+                        "headers": [],
+                        "parse_directives": [
+                            {
+                                "function_tag": "SUBSCRIBE",
+                                "api_name": "accountSubscribe"
+                            },
+                            {
+                                "function_template": "{\"jsonrpc\":\"2.0\",\"method\":\"accountUnsubscribe\",\"params\":[%d],\"id\":1}",
+                                "function_tag": "UNSUBSCRIBE",
+                                "api_name": "accountUnsubscribe"
+                            },
+                            {
+                                "function_tag": "SUBSCRIBE",
+                                "api_name": "blockSubscribe"
+                            },
+                            {
+                                "function_template": "{\"jsonrpc\":\"2.0\",\"method\":\"blockUnsubscribe\",\"params\":[%d],\"id\":1}",
+                                "function_tag": "UNSUBSCRIBE",
+                                "api_name": "blockUnsubscribe"
+                            },
+                            {
+                                "function_tag": "SUBSCRIBE",
+                                "api_name": "logsSubscribe"
+                            },
+                            {
+                                "function_template": "{\"jsonrpc\":\"2.0\",\"method\":\"logsUnsubscribe\",\"params\":[%d],\"id\":1}",
+                                "function_tag": "UNSUBSCRIBE",
+                                "api_name": "logsUnsubscribe"
+                            },
+                            {
+                                "function_tag": "SUBSCRIBE",
+                                "api_name": "programSubscribe"
+                            },
+                            {
+                                "function_template": "{\"jsonrpc\":\"2.0\",\"method\":\"programUnsubscribe\",\"params\":[%d],\"id\":1}",
+                                "function_tag": "UNSUBSCRIBE",
+                                "api_name": "programUnsubscribe"
+                            },
+                            {
+                                "function_tag": "SUBSCRIBE",
+                                "api_name": "rootSubscribe"
+                            },
+                            {
+                                "function_template": "{\"jsonrpc\":\"2.0\",\"method\":\"rootUnsubscribe\",\"params\":[%d],\"id\":1}",
+                                "function_tag": "UNSUBSCRIBE",
+                                "api_name": "rootUnsubscribe"
+                            },
+                            {
+                                "function_tag": "SUBSCRIBE",
+                                "api_name": "signatureSubscribe"
+                            },
+                            {
+                                "function_template": "{\"jsonrpc\":\"2.0\",\"method\":\"signatureUnsubscribe\",\"params\":[%d],\"id\":1}",
+                                "function_tag": "UNSUBSCRIBE",
+                                "api_name": "signatureUnsubscribe"
+                            },
+                            {
+                                "function_tag": "SUBSCRIBE",
+                                "api_name": "slotSubscribe"
+                            },
+                            {
+                                "function_template": "{\"jsonrpc\":\"2.0\",\"method\":\"slotUnsubscribe\",\"params\":[%d],\"id\":1}",
+                                "function_tag": "UNSUBSCRIBE",
+                                "api_name": "slotUnsubscribe"
+                            },
+                            {
+                                "function_tag": "SUBSCRIBE",
+                                "api_name": "slotsUpdatesSubscribe"
+                            },
+                            {
+                                "function_template": "{\"jsonrpc\":\"2.0\",\"method\":\"slotsUpdatesUnsubscribe\",\"params\":[%d],\"id\":1}",
+                                "function_tag": "UNSUBSCRIBE",
+                                "api_name": "slotsUpdatesUnsubscribe"
+                            },
+                            {
+                                "function_tag": "SUBSCRIBE",
+                                "api_name": "voteSubscribe"
+                            },
+                            {
+                                "function_template": "{\"jsonrpc\":\"2.0\",\"method\":\"voteUnsubscribe\",\"params\":[%d],\"id\":1}",
+                                "function_tag": "UNSUBSCRIBE",
+                                "api_name": "voteUnsubscribe"
+                            }
+                        ],
+                        "verifications": []
+                    }
+                ]
+            },
+            {
+                "index": "SOLANAT",
+                "name": "solana test net",
+                "enabled": true,
+                "imports": [
+                    "SOLANA"
+                ],
+                "reliability_threshold": 268435455,
+                "data_reliability_enabled": true,
+                "block_distance_for_finalized_data": 0,
+                "blocks_in_finalization_proof": 1,
+                "average_block_time": 400,
+                "allowed_block_lag_for_qos_sync": 25,
+                "shares": 1,
+                "min_stake_provider": {
+                    "denom": "ulava",
+                    "amount": "5000000000"
+                }
+            }
+        ]
+    },
+    "deposit": "10000000ulava"
+}


### PR DESCRIPTION
# Description

Removes the per-socket `DirectRPCConnection.healthy` bit (`isHealthy`) and the gates that read it, fixing the `No pairings available` connection-health **deadlock** (Hypernative/monad + gk8solana incidents). Selection is now driven by QoS + the self-healing `endpoint.Enabled` backoff — the way WebSocket connections already behaved.

## The bug

Each direct-RPC socket carried a `healthy atomic.Bool`. **Any** transport blip (dial refused / reset / EOF / read error) latched it `false`, and **both** the relay path *and* the chain-tracker fetcher refused to send over an `unhealthy` socket. Since the only thing that set it back to `true` was a *successful send over that same socket*, once it latched `false` the curing send could never happen → **permanent `No pairings available` until process restart**.

The relay path and the chain tracker **share one `DirectRPCConnection` per endpoint**, so a failed *background tracker poll* poisons the *user relay path* too (this is the gk8solana mechanism).

## What changed

- Remove the three read-gates on the bit: relay path (`consumer_types.go`), chain-tracker fetcher (`endpoint_chain_fetcher.go`), epoch-transition probe (`consumer_session_manager.go`).
- Delete the now-dead plumbing: `IsHealthy`/`MarkHealthy` (interface + HTTP/gRPC/WS impls), `SessionConnection.IsHealthy()`, the `/debug/reset-scores` connection-health reset (`ResetAllConnectionHealth` + the `connections_reset` response field), and the orphaned `EndpointChainFetcher.GetDirectConnection`.
- Add a nil-element guard on `DirectConnections[0]` in the relay path (latent pre-existing panic risk surfaced during review).
- **Raise `MaxConsecutiveConnectionAttempts` 5 → 50** (`common.go`, commit `25dc90f`). With the health gate gone, `endpoint.Enabled` becomes the *sole* automatic disable mechanism — see the two-latch note below for why 50 and exactly what it trades off.
- Update/repoint tests; net code change ≈ **+45 / −497**.

**Two-latch note (why this is safe, and what the threshold change trades off):** there are two automatic disable mechanisms — the `healthy` bool (single-blip latch, **no** auto-recovery → the deadlock, removed here) and `endpoint.Enabled` (a consecutive-failure backoff that **already self-heals** on a successful relay — `ResetHealth` zeroes the refusal counter — and at every epoch). Today the bool gate fires *first* and starves the `Enabled` resets, making them futile; removing the bool is what makes the `Enabled` backoff effective.

This PR **also raises that backoff threshold from 5 → 50** (`MaxConsecutiveConnectionAttempts`, commit `25dc90f`), and that deserves to be called out plainly: with the gate gone `endpoint.Enabled` is the *only* automatic disable, so the net behavioral change here is bigger than "drop the gate" — it is **"drop the gate *and* make the remaining backoff 10× more lenient."** Concretely, a dead endpoint in a multi-endpoint pool now stays in selection rotation for up to **50** dial-and-fail cycles (each bounded by the relay timeout) instead of 5 before it is backed off — which directly **amplifies the outage-time-dialing tradeoff** noted below. Why 50 and not 5: in the single-endpoint shape (the actual incident shape), disabling the *sole* endpoint merely re-creates `No pairings` until the next epoch re-enables it (see the on-call note), so a higher threshold keeps the lone endpoint fast-failing (consistent `500`s) through brief outages instead of flapping into `No pairings`. The threshold is **shared with the provider-relay path and `blockProvider`**, so this leniency applies there too. (If preferred, `25dc90f` can be split out so the gate removal is reviewed against the original 5-strike backoff — but the value was chosen deliberately for the single-endpoint case.)

## QA / verification (live A/B)

Harness: single-endpoint Solana **direct-RPC** router with a toggleable reverse proxy between the router and the real upstream, so we can cut/restore the upstream (a true transport failure — connection refused, *not* an HTTP error) without touching the router process. Same harness, config, and outage sequence run against both binaries.

| Observation | **`main` @ `7957d91b7` (pre-fix)** | **this branch (fixed)** |
|---|---|---|
| Baseline | `200 200 200` | `200 200 200` |
| While upstream down | `500` (fast-fail ~25 ms) | `500` (fast-fail ~25 ms) |
| **After upstream restored** | `500 ×8` — **never recovers** | `200 ×5` — **immediate** |
| `direct connection is not healthy` (fetcher gate) | **24** | **0** |
| `direct RPC connection is unhealthy` (relay gate) | **20** | **0** |
| `Pairing list empty` / `No pairings` after restore | present (repeating) | absent |
| Cure | **process restart only** | none needed* |

\* For the **tested outage duration**. See the on-call note below for the single-endpoint long-outage edge.

**`main` — the deadlock** (upstream is provably healthy the whole time):
```
ERR failed to fetch all previous blocks and was necessary
  error="[SVMChainTracker] ... direct connection is not healthy for endpoint http://127.0.0.1:8899 ..." fetchFails=13
WRN direct RPC connection is unhealthy endpoint=http://127.0.0.1:8899
DBG Pairing list empty IgnoredProviderList=map[sol-rpc-1:{}] Provider list=sol-rpc-1
DBG SOLANA could not get a provider addresses error="No pairings available."
```

**This branch — self-heals** (same trigger, the tracker hits the dead shared socket, but nothing latches):
```
ERR provider node error error="...connect: connection refused" error_name=PROTOCOL_CONNECTION_REFUSED retryable=true
... upstream restored, no router restart ...
DBG direct RPC relay succeeded in goroutine endpoint=sol-rpc-1 latency=780ms
```
Gate strings over the window: **0**. A reproducible harness (toggleable upstream proxy), raw evidence logs, and a QA suite design are maintained in the team's internal QA notes for this incident (not in-repo).

## On-call note (single-endpoint long outages)

The QA table's *"Cure: none needed"* holds for the **tested outage duration**, not unconditionally. In a **single-endpoint** deployment, if the sole endpoint accrues `MaxConsecutiveConnectionAttempts` (50) consecutive failures — a long, uninterrupted outage — `endpoint.Enabled` flips `false` → there are zero usable endpoints → `probeDirectRPCEndpoints` returns *"no enabled direct RPC endpoints"* and selection again yields `No pairings available`, until `checkAndUnblockHealthyReBlockedProviders` re-enables it at the next epoch (`rpcsmartrouter.go`).

This is **strictly milder than the original deadlock** — it self-heals at the epoch boundary instead of requiring a process restart — and the 5→50 bump makes it far less likely to trip. **On-call should treat a between-epoch `No pairings` under a long single-endpoint outage as expected, self-healing behavior — not a regression.** The proper long-term fixes live in the roadmap: the hard `0.8` availability floor (**Step 2**) and active per-endpoint probing/recovery (**Step 3**).

## Tests

- Unit: bool/`MarkHealthy` tests removed; the meaningful behavior re-expressed as `SendRequest`-level tests (`…_SurfacesTransportError`, `…_4xxReturnsResponseAndError`); the probe's `endpoint.Enabled` guard test kept; the chain-fetcher guard test repointed at the surviving nil check.
- Added `TestFetchEndpointConnection_DirectRPC_BackoffAndSelfHeal` — a regression guard that drives the real selection path against an unreachable upstream and locks in the three properties the fix relies on: selection **ignores transport state**, an endpoint is backed off **only after `MaxConsecutiveConnectionAttempts` consecutive failures**, and a single `ResetHealth` (the successful-relay self-heal) returns it to rotation.
- `go build ./...` + the full `lavasession` and `rpcsmartrouter` suites pass locally.
- ⚠️ CI note: the `Build and Test` workflow currently only runs `go build` (no `go test`), so these test changes aren't gated by CI — verified locally + by the live A/B above.

## Out of scope / follow-ups

- **Outage-time dialing** (intended tradeoff, amplified by the 5→50 bump above): with the gate gone the tracker/relay now actually dial a dead endpoint each attempt instead of short-circuiting. Bounded by the relay timeout + the `Enabled` **50**-strike backoff (raised from 5 in this PR — see the two-latch note); the proactive-probe backoff / node-quota work is **Step 3** of the roadmap.
- Hard `0.8` availability floor (**Step 2**) and a permanent operator block-list (**Step 4**) are separate.
- The `endpoint.Enabled` recovery-before-epoch design is tracked as a future investigation.

---

## Author Checklist

* [x] included the correct type prefix in the PR title (`fix:`)
* [x] targeted the `main` branch
* [x] included the necessary unit tests (note CI `go test` gap above)
* [x] updated relevant documentation / Go comments
