### PR TITLE
fix(relaycore): canonicalize response before cross-validation hashing (MAG-2062)

### DIFF
--- a/protocol/relaycore/relay_processor.go
+++ b/protocol/relaycore/relay_processor.go
@@ -1,8 +1,10 @@
 package relaycore
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -373,6 +375,37 @@ func (rp *RelayProcessor) HasRequiredNodeResults(tries int) (bool, int) {
 	return false, nodeErrors
 }
 
+// canonicalResponseHash returns a hash of a provider response that is invariant
+// to JSON object key ordering and insignificant whitespace. Cross-validation
+// must place two providers that return the same semantic answer in the same
+// quorum bucket even when their JSON envelope keys are serialized in a different
+// order — e.g. {"jsonrpc","id","result"} from one provider vs
+// {"id","jsonrpc","result"} from another. Hashing the raw bytes would split
+// these into separate buckets and falsely fail agreement (see MAG-2062).
+//
+// It decodes into an interface{} and re-marshals; Go's encoding/json sorts map
+// keys alphabetically on marshal, yielding a deterministic canonical byte form.
+// json.Number (via UseNumber) preserves the literal numeric token rather than
+// coercing through float64 — without this, two distinct large integers could
+// round to the same float64 and produce a *false agreement*, which is worse
+// than the false negative this fixes.
+//
+// If the data is not valid JSON (e.g. binary gRPC payloads) it falls back to
+// hashing the raw bytes, preserving prior behavior for non-JSON interfaces.
+func canonicalResponseHash(data []byte) [32]byte {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	var v interface{}
+	if err := dec.Decode(&v); err != nil {
+		return sha256.Sum256(data)
+	}
+	canonical, err := json.Marshal(v)
+	if err != nil {
+		return sha256.Sum256(data)
+	}
+	return sha256.Sum256(canonical)
+}
+
 func (rp *RelayProcessor) handleResponse(response *RelayResponse) {
 	nodeError := rp.ResultsManager.SetResponse(response, rp.RelayStateMachine.GetProtocolMessage())
 
@@ -386,8 +419,10 @@ func (rp *RelayProcessor) handleResponse(response *RelayResponse) {
 	// Only hash successful responses (not errors) for cross-validation tracking
 	// This prevents error responses from being counted toward cross-validation
 	if response != nil && nodeError == nil && response.Err == nil {
-		// Hash the response data once and cache it in the RelayResult
-		hash := sha256.Sum256(response.RelayResult.GetReply().GetData())
+		// Hash the response data once and cache it in the RelayResult.
+		// Canonicalize first so semantically-identical responses that differ only
+		// in JSON key order land in the same quorum bucket (MAG-2062).
+		hash := canonicalResponseHash(response.RelayResult.GetReply().GetData())
 		response.RelayResult.ResponseHash = hash // Cache the hash for later reuse
 		rp.quorumMap[hash]++
 		if rp.quorumMap[hash] > rp.currentQuorumEqualResults {
@@ -484,8 +519,10 @@ func (rp *RelayProcessor) responsesCrossValidation(results []common.RelayResult,
 			// This eliminates redundant SHA256 computation for responses already hashed
 			hash := result.ResponseHash
 			if hash == [32]byte{} {
-				// Fallback: hash not cached (e.g., for old code paths or error cases)
-				hash = sha256.Sum256(result.Reply.Data)
+				// Fallback: hash not cached (e.g., for old code paths or error
+				// cases). Must use the same canonicalization as handleResponse so
+				// the cached and recomputed hashes agree (MAG-2062).
+				hash = canonicalResponseHash(result.Reply.Data)
 			}
 
 			if count, exists := countMap[hash]; exists {

--- a/protocol/relaycore/relay_processor.go
+++ b/protocol/relaycore/relay_processor.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -390,13 +391,27 @@ func (rp *RelayProcessor) HasRequiredNodeResults(tries int) (bool, int) {
 // round to the same float64 and produce a *false agreement*, which is worse
 // than the false negative this fixes.
 //
-// If the data is not valid JSON (e.g. binary gRPC payloads) it falls back to
-// hashing the raw bytes, preserving prior behavior for non-JSON interfaces.
+// Canonicalization normalizes structure only (key order, whitespace), never
+// values: json.Number keeps numeric literals distinct, so the same value sent
+// as 1.0 vs 1, or 100 vs 1e2, still hashes differently. That is intentional —
+// the alternative (collapsing numerics) would risk a false agreement.
+//
+// If the data is not valid JSON (e.g. binary gRPC payloads), is not exactly one
+// JSON value (trailing bytes or multiple concatenated documents), or fails to
+// re-marshal, it falls back to hashing the raw bytes. The single-value check
+// matters for safety: json.Decoder.Decode reads only the first value and
+// silently ignores any trailing data, so without it two byte-different payloads
+// (e.g. "{...}A" vs "{...}B") would collapse into one bucket — a false agreement
+// that the raw-byte hash would otherwise have caught.
 func canonicalResponseHash(data []byte) [32]byte {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.UseNumber()
 	var v interface{}
 	if err := dec.Decode(&v); err != nil {
+		return sha256.Sum256(data)
+	}
+	// Reject trailing data: a canonical response must be exactly one JSON value.
+	if _, err := dec.Token(); err != io.EOF {
 		return sha256.Sum256(data)
 	}
 	canonical, err := json.Marshal(v)
@@ -417,8 +432,12 @@ func (rp *RelayProcessor) handleResponse(response *RelayResponse) {
 	}
 
 	// Only hash successful responses (not errors) for cross-validation tracking
-	// This prevents error responses from being counted toward cross-validation
-	if response != nil && nodeError == nil && response.Err == nil {
+	// This prevents error responses from being counted toward cross-validation.
+	// The hash and quorumMap are only consumed in CrossValidation mode (see
+	// checkEndProcessing / HasRequiredNodeResults), so skip the canonicalization
+	// work entirely for Stateless/Stateful traffic — it would otherwise decode
+	// and re-marshal every response body (potentially large) for a map nothing reads.
+	if rp.selection == CrossValidation && response != nil && nodeError == nil && response.Err == nil {
 		// Hash the response data once and cache it in the RelayResult.
 		// Canonicalize first so semantically-identical responses that differ only
 		// in JSON key order land in the same quorum bucket (MAG-2062).

--- a/protocol/relaycore/relay_processor_test.go
+++ b/protocol/relaycore/relay_processor_test.go
@@ -2315,4 +2315,37 @@ func TestCanonicalResponseHash(t *testing.T) {
 		require.NotEqual(t, canonicalResponseHash(a), canonicalResponseHash(b),
 			"differing trailing documents must hash differently")
 	})
+
+	t.Run("nested object keys are sorted recursively", func(t *testing.T) {
+		// Decoding into interface{} yields map[string]interface{} at every depth,
+		// and json.Marshal sorts keys recursively — so reordering keys inside a
+		// nested object must not change the hash.
+		a := []byte(`{"jsonrpc":"2.0","id":1,"result":{"hash":"0xabc","number":"0x10","gasUsed":"0x5"}}`)
+		b := []byte(`{"id":1,"jsonrpc":"2.0","result":{"number":"0x10","gasUsed":"0x5","hash":"0xabc"}}`)
+		require.Equal(t, canonicalResponseHash(a), canonicalResponseHash(b),
+			"reordered keys in a nested object must hash equally")
+	})
+
+	t.Run("top-level array is normalized and order-sensitive", func(t *testing.T) {
+		// Top-level JSON arrays (e.g. eth_getLogs []) decode and re-marshal
+		// correctly. Object keys inside elements are sorted, but array element
+		// order is significant and must be preserved.
+		a := []byte(`[{"a":1,"b":2},{"c":3}]`)
+		reorderedObjKeys := []byte(`[{"b":2,"a":1},{"c":3}]`)
+		require.Equal(t, canonicalResponseHash(a), canonicalResponseHash(reorderedObjKeys),
+			"reordered object keys inside array elements must hash equally")
+
+		reorderedElems := []byte(`[{"c":3},{"a":1,"b":2}]`)
+		require.NotEqual(t, canonicalResponseHash(a), canonicalResponseHash(reorderedElems),
+			"array element order is significant and must change the hash")
+	})
+
+	t.Run("empty array canonicalizes", func(t *testing.T) {
+		// Empty result arrays (e.g. eth_getLogs with no matches) are valid JSON
+		// and must hash consistently rather than fall back to raw bytes.
+		a := []byte(`[]`)
+		b := []byte(`[ ]`)
+		require.Equal(t, canonicalResponseHash(a), canonicalResponseHash(b),
+			"empty arrays differing only in whitespace must hash equally")
+	})
 }

--- a/protocol/relaycore/relay_processor_test.go
+++ b/protocol/relaycore/relay_processor_test.go
@@ -2296,4 +2296,23 @@ func TestCanonicalResponseHash(t *testing.T) {
 		require.Equal(t, sha256.Sum256(raw), canonicalResponseHash(raw),
 			"invalid JSON must fall back to hashing the raw bytes")
 	})
+
+	t.Run("trailing bytes after a JSON value do not falsely agree", func(t *testing.T) {
+		// json.Decoder.Decode reads only the first value and ignores the rest;
+		// without the single-value guard these byte-different payloads would
+		// collapse into one quorum bucket (a false agreement).
+		a := []byte(`{"id":1,"result":"abc"}TRAILING-A`)
+		b := []byte(`{"id":1,"result":"abc"}TRAILING-B`)
+		require.NotEqual(t, canonicalResponseHash(a), canonicalResponseHash(b),
+			"trailing bytes must keep payloads in distinct buckets")
+	})
+
+	t.Run("multi-document bodies do not falsely agree", func(t *testing.T) {
+		// NDJSON / concatenated documents: only the first is canonicalized, so a
+		// differing later document must still produce a distinct hash.
+		a := []byte("{\"a\":1}\n{\"b\":2}")
+		b := []byte("{\"a\":1}\n{\"b\":999}")
+		require.NotEqual(t, canonicalResponseHash(a), canonicalResponseHash(b),
+			"differing trailing documents must hash differently")
+	})
 }

--- a/protocol/relaycore/relay_processor_test.go
+++ b/protocol/relaycore/relay_processor_test.go
@@ -3,6 +3,7 @@ package relaycore
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"net/http"
 	"sync"
@@ -2190,4 +2191,109 @@ func TestHasRequiredNodeResults_RelayRetryLimitMixed(t *testing.T) {
 			require.Equal(t, tc.expectedNodeErrors, nodeErrors, "nodeErrors count mismatch")
 		})
 	}
+}
+
+// TestCrossValidationAgreesOnDifferentKeyOrder is the MAG-2062 regression test.
+// Two providers return the same semantic Solana getGenesisHash result but with
+// their JSON envelope keys in a different order. Before the canonical-form fix,
+// raw-byte hashing placed them in separate quorum buckets (maxMatchingResults:1)
+// and cross-validation failed with HTTP 500. They must now agree.
+//
+// The payloads are copied verbatim from the ticket's wire proof.
+func TestCrossValidationAgreesOnDifferentKeyOrder(t *testing.T) {
+	ctx := context.Background()
+	serverHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	specId := "LAVA"
+	chainParser, _, _, closeServer, _, err := chainlib.CreateChainLibMocks(ctx, specId, spectypes.APIInterfaceRest, serverHandler, nil, "../../", nil)
+	if closeServer != nil {
+		defer closeServer()
+	}
+	require.NoError(t, err)
+
+	chainMsg, err := chainParser.ParseMsg("/cosmos/base/tendermint/v1beta1/blocks/17", nil, http.MethodGet, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+	require.NoError(t, err)
+	protocolMessage := chainlib.NewProtocolMessage(chainMsg, nil, nil, "", "")
+
+	usedProviders := lavasession.NewUsedProviders(nil)
+	cvParams := &common.CrossValidationParams{
+		AgreementThreshold: 2,
+		MaxParticipants:    2,
+	}
+	relayProcessor := NewRelayProcessor(
+		ctx,
+		cvParams,
+		nil,
+		RelayProcessorMetrics,
+		RelayProcessorMetrics,
+		RelayRetriesManagerInstance,
+		newMockRelayStateMachineWithSelection(protocolMessage, usedProviders, CrossValidation),
+	)
+
+	usedProviders.AddUsed(lavasession.ConsumerSessionsMap{
+		"lavagateway": &lavasession.SessionInfo{},
+		"tatum1":      &lavasession.SessionInfo{},
+	}, nil)
+
+	// Same result value, byte-different envelopes (key order differs).
+	lavaGatewayData := []byte(`{"jsonrpc":"2.0","id":1,"result":"5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d"}`)
+	tatumData := []byte(`{"id":1,"jsonrpc":"2.0","result":"5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d"}`)
+	// Guard the premise: the two envelopes really are byte-different.
+	require.NotEqual(t, lavaGatewayData, tatumData, "test payloads must differ at the byte level")
+
+	relayProcessor.SetResponse(createMockRelayResponseWithData("lavagateway", lavaGatewayData, nil))
+	relayProcessor.SetResponse(createMockRelayResponseWithData("tatum1", tatumData, nil))
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+	defer cancel()
+	relayProcessor.WaitForResults(waitCtx)
+
+	result, err := relayProcessor.ProcessingResult()
+	require.NoError(t, err, "Cross-validation should succeed for semantically-identical responses with different key order")
+	require.NotNil(t, result)
+	require.GreaterOrEqual(t, result.CrossValidation, 2, "CrossValidation count should meet the agreement threshold")
+	// The returned bytes must be one of the verbatim provider envelopes — the
+	// fix changes only the bucket key, never the body returned to the client.
+	returned := result.Reply.Data
+	require.True(t, bytes.Equal(returned, lavaGatewayData) || bytes.Equal(returned, tatumData),
+		"returned body must be a verbatim provider envelope, got: %s", string(returned))
+}
+
+func TestCanonicalResponseHash(t *testing.T) {
+	t.Run("key order invariance", func(t *testing.T) {
+		a := []byte(`{"jsonrpc":"2.0","id":1,"result":"abc"}`)
+		b := []byte(`{"id":1,"result":"abc","jsonrpc":"2.0"}`)
+		require.Equal(t, canonicalResponseHash(a), canonicalResponseHash(b),
+			"same object with reordered keys must hash equally")
+	})
+
+	t.Run("whitespace invariance", func(t *testing.T) {
+		a := []byte(`{"id":1,"result":"abc"}`)
+		b := []byte("{ \"id\": 1, \n \"result\": \"abc\" }")
+		require.Equal(t, canonicalResponseHash(a), canonicalResponseHash(b),
+			"insignificant whitespace must not affect the hash")
+	})
+
+	t.Run("distinct large integers do not falsely agree", func(t *testing.T) {
+		// 9007199254740993 and 9007199254740992 both round to 2^53 as float64;
+		// UseNumber must keep them distinct so CV never reports false agreement.
+		a := []byte(`{"id":1,"result":9007199254740993}`)
+		b := []byte(`{"id":1,"result":9007199254740992}`)
+		require.NotEqual(t, canonicalResponseHash(a), canonicalResponseHash(b),
+			"distinct large integers must hash differently")
+	})
+
+	t.Run("genuinely different results disagree", func(t *testing.T) {
+		a := []byte(`{"jsonrpc":"2.0","id":1,"result":"hashA"}`)
+		b := []byte(`{"jsonrpc":"2.0","id":1,"result":"hashB"}`)
+		require.NotEqual(t, canonicalResponseHash(a), canonicalResponseHash(b),
+			"different result values must hash differently")
+	})
+
+	t.Run("non-JSON falls back to raw-byte hash", func(t *testing.T) {
+		raw := []byte{0x00, 0x01, 0x02, 0xff} // e.g. binary gRPC payload
+		require.Equal(t, sha256.Sum256(raw), canonicalResponseHash(raw),
+			"invalid JSON must fall back to hashing the raw bytes")
+	})
 }

--- a/scripts/test_mag2062_e2e.sh
+++ b/scripts/test_mag2062_e2e.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+#
+# test_mag2062_e2e.sh — end-to-end check for the MAG-2062 cross-validation fix.
+#
+# MAG-2062: two providers returning the SAME semantic result but with their JSON
+# envelope keys in a different order (e.g. {jsonrpc,id,result} vs {id,jsonrpc,result})
+# were placed in separate quorum buckets, so cross-validation failed with HTTP 500
+# even though the responses were semantically identical. The fix hashes a canonical
+# form (sorted keys) so reordered envelopes land in the same bucket.
+#
+# This script reproduces that exact condition against a LIVE router + the sibling
+# provider_simulator:
+#   1. (optionally) launches the provider_simulator
+#   2. pins two providers to the same result with DIFFERENT key order via /scenario
+#   3. sends a request through the router and asserts CV SUCCEEDS  (the fix)
+#   4. NEGATIVE CONTROL: pins a genuinely different result and asserts CV FAILS,
+#      proving the header reflects real agreement and not a constant "success".
+#
+# It deliberately does NOT build or launch the router: the router config is
+# environment-specific and the cross-validation config wiring may live on a
+# different branch. Point it at a running, cross-validation-enabled router.
+#
+# Usage:
+#   ROUTER_URL=http://127.0.0.1:3340 bash scripts/test_mag2062_e2e.sh --start-sim
+#   ROUTER_URL=https://eth-sim.example.com bash scripts/test_mag2062_e2e.sh
+#
+# Environment variables:
+#   ROUTER_URL    (required) base URL the router listens on for RPC requests.
+#   CONTROL_URL   simulator control endpoint for /scenario. Default http://127.0.0.1:19000
+#   SIM_DIR       path to the provider_simulator checkout (for --start-sim).
+#                 Default: ../provider_simulator relative to this repo.
+#   METHOD        JSON-RPC method to exercise. Default eth_chainId.
+#                 IMPORTANT: must be a BLOCK-INDEPENDENT method. Block-height
+#                 methods like eth_blockNumber feed the router's consistency
+#                 tracker, so overriding them makes providers look stale and the
+#                 consistency filter drops them before cross-validation runs
+#                 ("insufficient sessions"). eth_chainId mirrors the ticket's
+#                 own block-independent method (Solana getGenesisHash).
+#   RESULT        the shared "result" value both providers return. Default "0x1"
+#   ALT_RESULT    the divergent value for the negative control. Default "0x89"
+#   CV_HEADER     response header carrying CV status. Default lava-cross-validation-status
+#   ROUTER_PORT   port the --start-router router listens on. Default 3340
+#   SPEC_DIR      spec directory for --use-static-spec. Default <repo>/specs
+#
+# Flags:
+#   --start-sim      launch provider_simulator (python run.py) and tear it down on exit.
+#   --start-router   build a router from THIS branch + a 2-provider sim config and
+#                    launch it on ROUTER_PORT (sets ROUTER_URL automatically), torn
+#                    down on exit. Use this to verify the fix without a prebuilt router.
+#
+# Exit status: 0 if both the positive and negative assertions pass, 1 otherwise.
+
+set -euo pipefail
+
+# ── configuration ─────────────────────────────────────────────────────────────
+ROUTER_URL="${ROUTER_URL:-}"
+CONTROL_URL="${CONTROL_URL:-http://127.0.0.1:19000}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SIM_DIR="${SIM_DIR:-$SCRIPT_DIR/../../provider_simulator}"
+SPEC_DIR="${SPEC_DIR:-$REPO_ROOT/specs}"
+ROUTER_PORT="${ROUTER_PORT:-3340}"
+METHOD="${METHOD:-eth_chainId}"
+RESULT="${RESULT:-0x1}"
+ALT_RESULT="${ALT_RESULT:-0x89}"
+CV_HEADER="${CV_HEADER:-lava-cross-validation-status}"
+# Request directive headers that ACTIVATE cross-validation (both required).
+MAX_PARTICIPANTS_HEADER="${MAX_PARTICIPANTS_HEADER:-lava-cross-validation-max-participants}"
+AGREEMENT_THRESHOLD_HEADER="${AGREEMENT_THRESHOLD_HEADER:-lava-cross-validation-agreement-threshold}"
+MAX_PARTICIPANTS="${MAX_PARTICIPANTS:-2}"
+AGREEMENT_THRESHOLD="${AGREEMENT_THRESHOLD:-2}"
+START_SIM=false
+START_ROUTER=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --start-sim)    START_SIM=true ;;
+        --start-router) START_ROUTER=true ;;
+        -h|--help)      sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "unknown argument: $arg" >&2; exit 2 ;;
+    esac
+done
+
+# --start-router owns the router URL; otherwise the caller must supply one.
+if [[ "$START_ROUTER" == true ]]; then
+    ROUTER_URL="http://127.0.0.1:$ROUTER_PORT"
+fi
+
+if [[ -z "$ROUTER_URL" ]]; then
+    echo "ERROR: ROUTER_URL is required (the router's RPC listen address)," >&2
+    echo "       or pass --start-router to build & launch one from this branch." >&2
+    echo "       e.g. ROUTER_URL=http://127.0.0.1:3340 bash $0" >&2
+    echo "       e.g. bash $0 --start-sim --start-router" >&2
+    exit 2
+fi
+
+# ── pretty output ─────────────────────────────────────────────────────────────
+if [[ -t 1 ]]; then GREEN=$'\e[32m'; RED=$'\e[31m'; BOLD=$'\e[1m'; DIM=$'\e[2m'; RST=$'\e[0m'
+else GREEN=; RED=; BOLD=; DIM=; RST=; fi
+
+header() { printf '\n%s══ %s ══%s\n' "$BOLD" "$1" "$RST"; }
+info()   { printf '%s   %s%s\n' "$DIM" "$1" "$RST"; }
+pass()   { printf '%s ✓ PASS%s  %s\n' "$GREEN" "$RST" "$1"; }
+fail()   { printf '%s ✗ FAIL%s  %s\n' "$RED" "$RST" "$1"; }
+
+# ── process lifecycle (optional) ──────────────────────────────────────────────
+SIM_PID=""
+ROUTER_PID=""
+ROUTER_CFG=""
+ROUTER_BIN=""
+ROUTER_LOG=""
+# shellcheck disable=SC2329  # invoked indirectly via `trap cleanup EXIT`
+cleanup() {
+    if [[ -n "$ROUTER_PID" ]] && kill -0 "$ROUTER_PID" 2>/dev/null; then
+        info "stopping router (pid $ROUTER_PID)"
+        kill "$ROUTER_PID" 2>/dev/null || true
+        wait "$ROUTER_PID" 2>/dev/null || true
+    fi
+    [[ -n "$ROUTER_CFG" ]] && rm -f "$ROUTER_CFG"
+    [[ -n "$ROUTER_BIN" ]] && rm -f "$ROUTER_BIN"
+    if [[ -n "$SIM_PID" ]] && kill -0 "$SIM_PID" 2>/dev/null; then
+        info "stopping provider_simulator (pid $SIM_PID)"
+        kill "$SIM_PID" 2>/dev/null || true
+        wait "$SIM_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+wait_for_control() {
+    info "waiting for simulator control plane at $CONTROL_URL ..."
+    for _ in $(seq 1 30); do
+        if curl -fsS "$CONTROL_URL/scenario" >/dev/null 2>&1; then
+            info "control plane is up"
+            return 0
+        fi
+        sleep 0.5
+    done
+    fail "simulator control plane never became reachable at $CONTROL_URL"
+    exit 1
+}
+
+if [[ "$START_SIM" == true ]]; then
+    header "Launching provider_simulator"
+    # Reuse an already-running simulator rather than spawning one that would
+    # crash on EADDRINUSE (the simulator binds fixed ports 18545+/19000) and
+    # leave us asserting against the wrong process.
+    if curl -fsS "$CONTROL_URL/scenario" >/dev/null 2>&1; then
+        info "a simulator is already listening on $CONTROL_URL — reusing it (not launching another)"
+    else
+        if [[ ! -f "$SIM_DIR/run.py" ]]; then
+            fail "provider_simulator not found at $SIM_DIR (set SIM_DIR=...)"
+            exit 1
+        fi
+        info "starting: python run.py  (cwd: $SIM_DIR)"
+        ( cd "$SIM_DIR" && exec python3 run.py ) &
+        SIM_PID=$!
+        # If the freshly-spawned process dies immediately (e.g. port clash), fail loudly.
+        sleep 1
+        if ! kill -0 "$SIM_PID" 2>/dev/null; then
+            SIM_PID=""
+            fail "provider_simulator exited immediately after launch (port already in use?)"
+            exit 1
+        fi
+        wait_for_control
+    fi
+else
+    info "assuming provider_simulator is already running; control: $CONTROL_URL"
+fi
+
+# ── router lifecycle (optional) ───────────────────────────────────────────────
+# Builds a router from the CURRENT branch (so it contains the fix) and launches
+# it with a minimal 2-provider direct-rpc config wired to the simulator's
+# JSON-RPC listeners (18545/18546). Two providers + threshold 2 keeps the test
+# deterministic: both are always queried, so divergence can't be masked by the
+# optimizer picking an unconfigured third provider.
+if [[ "$START_ROUTER" == true ]]; then
+    header "Building & launching router from this branch"
+
+    ROUTER_BIN="$(mktemp -t smartrouter_mag2062.XXXXXX)"
+    info "go build ./cmd/smartrouter  ->  $ROUTER_BIN"
+    ( cd "$REPO_ROOT" && go build -o "$ROUTER_BIN" ./cmd/smartrouter ) \
+        || { fail "router build failed"; exit 1; }
+
+    # The router resolves its config arg as a viper config NAME searched in
+    # [cwd, cwd/config, ~/.lava] — not an arbitrary path. Write it into the repo
+    # root (a search path) and pass the basename; remove it on exit.
+    ROUTER_CFG="$REPO_ROOT/.mag2062_sim_cv.yml"
+    cat > "$ROUTER_CFG" <<YAML
+endpoints:
+  - chain-id: ETH1
+    api-interface: jsonrpc
+    network-address: 127.0.0.1:$ROUTER_PORT
+
+direct-rpc:
+  - name: sim1
+    chain-id: ETH1
+    api-interface: jsonrpc
+    node-urls:
+      - url: http://127.0.0.1:18545
+        skip-verifications: [chain-id, pruning]
+  - name: sim2
+    chain-id: ETH1
+    api-interface: jsonrpc
+    node-urls:
+      - url: http://127.0.0.1:18546
+        skip-verifications: [chain-id, pruning]
+YAML
+
+    ROUTER_LOG="$(mktemp -t smartrouter_mag2062_log.XXXXXX)"
+    info "starting router on :$ROUTER_PORT (log: $ROUTER_LOG)"
+    ( cd "$REPO_ROOT" && exec "$ROUTER_BIN" "$(basename "$ROUTER_CFG")" \
+        --geolocation 1 --use-static-spec "$SPEC_DIR" \
+        --skip-websocket-verification --log-level warn ) > "$ROUTER_LOG" 2>&1 &
+    ROUTER_PID=$!
+
+    info "waiting for router at $ROUTER_URL ..."
+    router_up=false
+    for _ in $(seq 1 60); do
+        if ! kill -0 "$ROUTER_PID" 2>/dev/null; then
+            fail "router exited during startup — last log lines:"; tail -15 "$ROUTER_LOG" >&2
+            ROUTER_PID=""; exit 1
+        fi
+        if curl -fsS -o /dev/null -X POST "$ROUTER_URL" \
+            -H 'Content-Type: application/json' \
+            -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$METHOD\",\"params\":[]}" 2>/dev/null; then
+            router_up=true; break
+        fi
+        sleep 0.5
+    done
+    if [[ "$router_up" != true ]]; then
+        fail "router did not become reachable at $ROUTER_URL — last log lines:"; tail -15 "$ROUTER_LOG" >&2
+        exit 1
+    fi
+    info "router is up"
+fi
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+# Configure providers 1 & 2 via the simulator's /scenario body-override.
+# json.dumps in the simulator preserves the key order we send here, which is
+# exactly what lets us reproduce the byte-different-but-semantically-equal case.
+configure() {
+    local body_p1="$1" body_p2="$2"
+    curl -fsS "$CONTROL_URL/scenario" -H 'Content-Type: application/json' -d @- >/dev/null <<JSON
+{
+  "providers": {
+    "1": {"mode": "success", "responses": {"$METHOD": {"body": $body_p1}}},
+    "2": {"mode": "success", "responses": {"$METHOD": {"body": $body_p2}}}
+  }
+}
+JSON
+}
+
+# Send one request through the router; echo "<http_status> <cv_status>".
+# cv_status is the value of the CV header, or "<absent>" if the router didn't emit it.
+#
+# Cross-validation only activates when BOTH directive headers are present on the
+# request (see GetCrossValidationParameters in chainlib/protocol_message.go):
+# max-participants and agreement-threshold, each >= 1, with threshold <= participants.
+# Without them the router runs an ordinary relay and emits no CV status header —
+# which presents identically to "CV disabled". Send both here.
+probe() {
+    local resp http_status cv_status
+    resp="$(curl -sS -D - -o /dev/null \
+        -X POST "$ROUTER_URL" \
+        -H 'Content-Type: application/json' \
+        -H "$MAX_PARTICIPANTS_HEADER: $MAX_PARTICIPANTS" \
+        -H "$AGREEMENT_THRESHOLD_HEADER: $AGREEMENT_THRESHOLD" \
+        -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$METHOD\",\"params\":[]}")"
+    http_status="$(printf '%s' "$resp" | awk 'NR==1{print $2}')"
+    cv_status="$(printf '%s' "$resp" \
+        | tr -d '\r' \
+        | awk -F': ' -v h="$CV_HEADER" 'tolower($1)==tolower(h){print $2}')"
+    printf '%s %s' "${http_status:-000}" "${cv_status:-<absent>}"
+}
+
+FAILURES=0
+
+# ── 1. POSITIVE: same result, different key order → CV must SUCCEED ────────────
+header "Test 1 — reordered envelopes must AGREE (the MAG-2062 fix)"
+configure \
+    "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"$RESULT\"}" \
+    "{\"id\":1,\"jsonrpc\":\"2.0\",\"result\":\"$RESULT\"}"
+info "provider 1: {jsonrpc,id,result} = $RESULT"
+info "provider 2: {id,jsonrpc,result} = $RESULT   (same value, reordered keys)"
+read -r http cv <<<"$(probe)"
+info "router responded: HTTP $http   $CV_HEADER=$cv"
+if [[ "$cv" == "<absent>" ]]; then
+    fail "router did not emit '$CV_HEADER' — is cross-validation enabled on this router/config?"
+    FAILURES=$((FAILURES + 1))
+elif [[ "$http" == "200" && "$cv" == "success" ]]; then
+    pass "semantically-identical responses agreed despite different key order"
+else
+    fail "expected HTTP 200 + $CV_HEADER=success, got HTTP $http + $cv (pre-fix symptom: 500/failed)"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ── 2. NEGATIVE CONTROL: different result → CV must FAIL ───────────────────────
+header "Test 2 — genuinely different results must DISAGREE (negative control)"
+configure \
+    "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"$RESULT\"}" \
+    "{\"id\":1,\"jsonrpc\":\"2.0\",\"result\":\"$ALT_RESULT\"}"
+info "provider 1: result = $RESULT"
+info "provider 2: result = $ALT_RESULT   (genuinely divergent)"
+read -r http cv <<<"$(probe)"
+info "router responded: HTTP $http   $CV_HEADER=$cv"
+if [[ "$cv" == "<absent>" ]]; then
+    fail "router did not emit '$CV_HEADER' — is cross-validation enabled on this router/config?"
+    FAILURES=$((FAILURES + 1))
+elif [[ "$cv" == "failed" ]]; then
+    pass "divergent responses correctly failed agreement (header is not a constant)"
+else
+    fail "expected $CV_HEADER=failed for divergent results, got HTTP $http + $cv"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ── verdict ───────────────────────────────────────────────────────────────────
+header "Result"
+if [[ "$FAILURES" -eq 0 ]]; then
+    pass "MAG-2062 verified end-to-end (agreement on reorder, failure on divergence)"
+    exit 0
+else
+    fail "$FAILURES check(s) failed"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Cross-validation bucketed providers by `sha256.Sum256` of the **raw** response bytes, so two providers returning the same semantic result with their JSON envelope keys in a different order (e.g. `{jsonrpc,id,result}` from LavaGateway vs `{id,jsonrpc,result}` from Tatum1) landed in separate hash buckets. Agreement then failed with `maxMatchingResults:1` and the request returned **HTTP 500** with `lava-cross-validation-status: failed`, even though both responses were byte-for-byte identical in their `result` field (**MAG-2062**).

## Root cause

A prior change (memory optimization) replaced canonical-form hashing with raw-byte `sha256.Sum256(Reply.Data)`, silently dropping the key-order invariance that the old `json.Unmarshal`→`json.Marshal` round-trip provided (Go's `encoding/json` sorts map keys on marshal). The bug is latent: it only manifests when **different provider implementations** return the same answer with different envelope serialization — common on multi-implementation chains (Solana: LavaGateway vs Tatum; ETH: Infura vs Alchemy vs QuickNode).

## Fix

Hash a **canonical form** instead — decode and re-marshal so object keys are sorted before hashing. Applied at **both** hash sites (the counting-site hash in `handleResponse` and the `responsesCrossValidation` fallback) so the cached and recomputed hashes always agree.

Design choices:
- **`json.Number` via `UseNumber()`** — plain unmarshal coerces numbers through `float64`, where two distinct large integers can collapse to one value and cause a **false agreement** (CV claiming agreement on different data — worse than the bug being fixed). `UseNumber` preserves the literal token, so it can only ever err toward the safe direction.
- **Decode into `interface{}`** (not `map[string]interface{}`) — correctly normalizes top-level arrays (e.g. `[]` from `eth_getLogs`) and recursively sorts nested objects.
- **Non-JSON fallback** — binary gRPC payloads that fail to parse fall back to raw-byte hashing, preserving prior behavior for non-JSON interfaces.

`Reply.Data` is untouched — canonicalization affects only the internal quorum bucket key; the bytes returned to the client stay verbatim.

## Tests

- `TestCrossValidationAgreesOnDifferentKeyOrder` — the ticket's **exact wire payloads**. Proven to catch the regression: reverting the hash to raw bytes reproduces the literal `maxMatchingResults:1,agreementThreshold:2` failure; with the fix it passes.
- `TestCanonicalResponseHash` — key-order invariance, whitespace invariance, the large-integer false-agreement guard, genuine-divergence disagreement, and non-JSON fallback.

## Verification

- `go build ./...` clean
- Full `relaycore` suite green
- `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)