### PR TITLE
fix(lavasession): renew provider second chance after proven recovery

### DIFF
--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -1612,6 +1612,16 @@ func (csm *ConsumerSessionManager) blockProvider(ctx context.Context, address st
 			} else {
 				// first time reported, allowing a second chance.
 				csm.secondChanceGivenToAddresses[address] = struct{}{}
+				// Mark the provider as on probation: it has now consumed its single
+				// second chance. A later successful relay (OnSessionDone) clears both
+				// this flag and the secondChanceGivenToAddresses entry, so genuine
+				// recovery renews eligibility. Without this, in direct-rpc mode (no
+				// epoch transitions to clear the map) any provider that trips a block
+				// twice — even with full health in between — is hard-blocked for the
+				// rest of the process lifetime.
+				if provider, ok := csm.pairing[address]; ok {
+					provider.atomicMarkSecondChanceProbation()
+				}
 				// address was removed from valid addresses, we can still return it after a duration for second chance.
 				runSecondChance = true
 			}
@@ -1752,6 +1762,16 @@ func (csm *ConsumerSessionManager) validateAndReturnBlockedProviderToValidAddres
 	// if we didn't find it, we might had two sessions in parallel and thats ok. the first one dealt with it we can just return
 }
 
+// forgetSecondChanceGiven removes a provider from the second-chance memory after
+// it has proven recovery with a successful relay (see OnSessionDone). This lets a
+// future isolated failure be treated as a first offense again instead of an
+// immediate hard block. Must NOT be called while holding csm.lock.
+func (csm *ConsumerSessionManager) forgetSecondChanceGiven(providerAddress string) {
+	csm.lock.Lock()
+	defer csm.lock.Unlock()
+	delete(csm.secondChanceGivenToAddresses, providerAddress)
+}
+
 // On a successful session this function will update all necessary fields in the consumerSession. and unlock it when it finishes
 func (csm *ConsumerSessionManager) OnSessionDone(
 	consumerSession *SingleConsumerSession,
@@ -1778,6 +1798,16 @@ func (csm *ConsumerSessionManager) OnSessionDone(
 		// we want this method to run last after we unlock the consumer session
 		// golang defer operates in a Last-In-First-Out (LIFO) order, meaning this defer will run last.
 		defer func() { go csm.validateAndReturnBlockedProviderToValidAddressesList(providerAddress) }()
+	}
+
+	// A successful relay proves the provider has recovered. If it was on
+	// second-chance probation, forget that it ever used its second chance so a
+	// future isolated failure is treated as a first offense again (gets a fresh
+	// 3-minute second chance) instead of an immediate, lifetime-long hard block.
+	// The atomic CAS ensures exactly one cleanup is scheduled across concurrent relays.
+	if consumerSession.Parent.atomicTryClearSecondChanceProbation() {
+		recoveredProviderAddress := consumerSession.Parent.PublicLavaAddress
+		defer func() { go csm.forgetSecondChanceGiven(recoveredProviderAddress) }()
 	}
 
 	defer consumerSession.Free(nil)                        // we need to be locked here, if we didn't get it locked we try lock anyway

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -417,6 +417,80 @@ func TestSecondChanceRecoveryFlow(t *testing.T) {
 	require.True(t, csm.reportedProviders.IsReported(pairingList[0].PublicLavaAddress))
 }
 
+// TestSecondChanceRenewedAfterProvenRecovery verifies that a provider which has
+// consumed its single second chance earns it back once it proves recovery with a
+// successful relay. Without this, in direct-rpc mode (no epoch transitions to
+// clear secondChanceGivenToAddresses) a provider that tripped a block twice over
+// its lifetime — even with full health in between — would stay hard-blocked for
+// the rest of the process lifetime. See MAG-1860.
+func TestSecondChanceRenewedAfterProvenRecovery(t *testing.T) {
+	retrySecondChanceAfter = time.Second * 2
+	ctx := context.Background()
+	csm := CreateConsumerSessionManager()
+	pairingList := createPairingList("", true)
+	err := csm.UpdateAllProviders(firstEpochHeight, map[uint64]*ConsumerSessionsWithProvider{0: pairingList[0], 1: pairingList[1]}, nil)
+	require.NoError(t, err)
+	provider0 := pairingList[0].PublicLavaAddress
+	timeLimit := time.Second * 30
+
+	// Phase 1: fail provider0 (provider1 directive-blocked) until it consumes its single second chance.
+	loopStartTime := time.Now()
+	for {
+		directiveHeaders := DirectiveHeaders{map[string]string{"lava-providers-block": pairingList[1].PublicLavaAddress}}
+		usedProviders := NewUsedProviders(directiveHeaders)
+		css, err := csm.GetSessions(ctx, 1, cuForFirstRequest, usedProviders, servicedBlockNumber, "", nil, common.NO_STATE, 0, "", "")
+		require.NoError(t, err)
+		_, gotProvider0 := css[provider0]
+		require.True(t, gotProvider0)
+		for _, sessionInfo := range css {
+			csm.OnSessionFailure(sessionInfo.Session, fmt.Errorf("testError"))
+		}
+		if _, ok := csm.secondChanceGivenToAddresses[provider0]; ok {
+			break
+		}
+		require.True(t, time.Since(loopStartTime) < timeLimit)
+	}
+	// Precondition: provider0 has used its single second chance and is on probation.
+	require.Equal(t, uint32(1), csm.pairing[provider0].onSecondChanceProbation)
+
+	// Phase 2: wait for the second-chance timer to return provider0 to the valid pool.
+	loopStartTime = time.Now()
+	for !func() bool {
+		csm.lock.RLock()
+		defer csm.lock.RUnlock()
+		return lavaslices.Contains(csm.validAddresses, provider0)
+	}() {
+		time.Sleep(100 * time.Millisecond)
+		require.True(t, time.Since(loopStartTime) < timeLimit)
+	}
+	require.False(t, csm.reportedProviders.IsReported(provider0))
+
+	// Phase 3: a successful relay proves recovery — it must clear the probation
+	// marker (synchronously) and the second-chance memory (via deferred goroutine).
+	directiveHeaders := DirectiveHeaders{map[string]string{"lava-providers-block": pairingList[1].PublicLavaAddress}}
+	usedProviders := NewUsedProviders(directiveHeaders)
+	css, err := csm.GetSessions(ctx, 1, cuForFirstRequest, usedProviders, servicedBlockNumber, "", nil, common.NO_STATE, 0, "", "")
+	require.NoError(t, err)
+	_, gotProvider0 := css[provider0]
+	require.True(t, gotProvider0)
+	for _, sessionInfo := range css {
+		doneErr := csm.OnSessionDone(sessionInfo.Session, servicedBlockNumber, cuForFirstRequest, time.Millisecond, sessionInfo.Session.CalculateExpectedLatency(2*time.Millisecond), 1, numberOfProviders, numberOfProviders, false, nil)
+		require.NoError(t, doneErr)
+	}
+	require.Equal(t, uint32(0), csm.pairing[provider0].onSecondChanceProbation, "probation must clear on a successful relay")
+
+	loopStartTime = time.Now()
+	for func() bool {
+		csm.lock.RLock()
+		defer csm.lock.RUnlock()
+		_, ok := csm.secondChanceGivenToAddresses[provider0]
+		return ok
+	}() {
+		time.Sleep(50 * time.Millisecond)
+		require.True(t, time.Since(loopStartTime) < timeLimit, "second-chance memory must be forgotten after proven recovery")
+	}
+}
+
 func runOnSessionDoneForConsumerSessionMap(t *testing.T, css ConsumerSessionsMap, csm *ConsumerSessionManager) {
 	for _, cs := range css {
 		require.NotNil(t, cs)

--- a/protocol/lavasession/consumer_types.go
+++ b/protocol/lavasession/consumer_types.go
@@ -317,7 +317,12 @@ type ConsumerSessionsWithProvider struct {
 	// blocked provider recovery status if 0 currently not used, if 1 a session has tried resume communication with this provider
 	// if the provider is not blocked at all this field is irrelevant
 	blockedAndUsedWithChanceForRecoveryStatus uint32
-	StaticProvider                            bool
+	// onSecondChanceProbation is 1 once this provider has consumed its single
+	// second chance (see ConsumerSessionManager.secondChanceGivenToAddresses). A
+	// successful relay clears it so a future isolated failure is treated as a
+	// first offense again instead of an immediate hard block. 0 == not on probation.
+	onSecondChanceProbation uint32
+	StaticProvider          bool
 }
 
 func NewConsumerSessionWithProvider(publicLavaAddress string, pairingEndpoints []*Endpoint, maxCu uint64, epoch uint64, stakeSize int64) *ConsumerSessionsWithProvider {
@@ -337,6 +342,19 @@ func (cswp *ConsumerSessionsWithProvider) atomicReadBlockedStatus() uint32 {
 
 func (cswp *ConsumerSessionsWithProvider) atomicWriteBlockedStatus(status uint32) {
 	atomic.StoreUint32(&cswp.blockedAndUsedWithChanceForRecoveryStatus, status) // we can only set conflict to "reported".
+}
+
+// atomicMarkSecondChanceProbation records that the provider has used its single
+// second chance. Called under ConsumerSessionManager.lock from blockProvider.
+func (cswp *ConsumerSessionsWithProvider) atomicMarkSecondChanceProbation() {
+	atomic.StoreUint32(&cswp.onSecondChanceProbation, 1)
+}
+
+// atomicTryClearSecondChanceProbation transitions the probation flag 1->0 and
+// reports whether this call performed the transition. Only the first caller
+// after a successful relay returns true, so exactly one cleanup is scheduled.
+func (cswp *ConsumerSessionsWithProvider) atomicTryClearSecondChanceProbation() bool {
+	return atomic.CompareAndSwapUint32(&cswp.onSecondChanceProbation, 1, 0)
 }
 
 func (cswp *ConsumerSessionsWithProvider) atomicReadConflictReported() bool {


### PR DESCRIPTION
## Problem

Refs [MAG-1860](https://magmadevs.atlassian.net/browse/MAG-1860).

A provider that consumed its single second chance is recorded in `secondChanceGivenToAddresses` (`consumer_session_manager.go:1614`) and **never removed during normal operation**. The two clearing sites — `UpdateAllProviders` (epoch transition) and `ResetTransientFailureState` (`/debug/reset-all`) — do not fire in **direct-rpc mode**, which has no epoch transitions (see the note at `rpcsmartrouter.go:680-685`).

Net effect: a provider that trips a block **twice over its lifetime — even with full health in between — is hard-blocked until process restart.** This is the genuine "permanently quarantines a recovered provider" behavior reported in MAG-1860 (the ticket's stated root cause, the optimizer, was misattributed — see the comment on the ticket for the full analysis).

## Fix

Make the second chance **renewable on proven recovery**:

- `blockProvider` marks the provider on probation (`atomicMarkSecondChanceProbation`) when it consumes its single second chance.
- On a successful relay, `OnSessionDone` clears the probation flag via an atomic CAS (hot-path safe, fires the cleanup exactly once under concurrent relays) and a deferred goroutine deletes the `secondChanceGivenToAddresses` entry (off the session lock, consistent with the existing redemption defer).

Semantics:
- `flap → return → fail again` ⇒ hard block (**unchanged**)
- `outage → return → succeed` ⇒ probation cleared; a future isolated failure gets a fresh second chance

## Tests

- Existing `TestSecondChanceRecoveryFlow` still passes (backward-compatible — it fails again *without* a success in between, so it still hard-blocks).
- New `TestSecondChanceRenewedAfterProvenRecovery` covers the renewal path.
- Full `lavasession` suite green under `make test` (the standard gate; no `-race`).

## Notes / out of scope

- Under `-race`, both the new and the **pre-existing** `TestSecondChanceRecoveryFlow` trip the detector on `SetUsageForSession`/`GetSessions` — a pre-existing harness concurrency issue, not introduced here.
- The `test_10_2_recovery_point` repro frames recovery in *request count*, but block-list redemption is *wall-clock* based (`retrySecondChanceAfter = 3m`); the test bound likely needs to be time-based or force a deterministic block. Connection-failure blocks (`:515`/`:915`, `allowSecondChance=false`) and the non-clearing `currentlyBlockedProviderAddresses` in direct mode are adjacent paths not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MAG-1860]: https://magmadevs.atlassian.net/browse/MAG-1860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ