### PR TITLE
ci: add dev-sim-prtests preflight to PR gate workflow

### DIFF
--- a/.github/workflows/pr-gate-build-artifact.yml
+++ b/.github/workflows/pr-gate-build-artifact.yml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: pr-gate-dev-sim-prtests
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build PR artifact
@@ -104,4 +108,110 @@ jobs:
             echo "- Short SHA: \`${SHORT_SHA}\`"
             echo "- Version: \`${VERSION}\`"
             echo "- Artifact name: \`${ARTIFACT_NAME}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Preflight dev-sim-prtests
+        env:
+          SSH_HOST: ${{ secrets.DEV_SIM_PRTESTS_SSH_HOST }}
+          SSH_KEY: ${{ secrets.DEV_SIM_PRTESTS_SSH_KEY }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          ARTIFACT_NAME: ${{ steps.pr.outputs.artifact_name }}
+        run: |
+          set -euo pipefail
+          preflight_result="failed"
+
+          write_summary() {
+            {
+              echo "### dev-sim-prtests preflight"
+              echo ""
+              echo "- Target environment: \`dev-sim-prtests\`"
+              echo "- Artifact name: \`${ARTIFACT_NAME}\`"
+              echo "- PR number: \`${PR_NUMBER}\`"
+              echo "- PR head SHA: \`${HEAD_SHA}\`"
+              echo "- Preflight result: \`${preflight_result}\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          }
+
+          if [ -z "${SSH_HOST:-}" ]; then
+            echo "::error::Missing required repository secret DEV_SIM_PRTESTS_SSH_HOST"
+            exit 1
+          fi
+          if [ -z "${SSH_KEY:-}" ]; then
+            echo "::error::Missing required repository secret DEV_SIM_PRTESTS_SSH_KEY"
+            exit 1
+          fi
+
+          key_file="$(mktemp)"
+          ssh_stdout="$(mktemp)"
+          ssh_stderr="$(mktemp)"
+          trap 'rm -f "$key_file" "$ssh_stdout" "$ssh_stderr"; write_summary' EXIT
+          printf '%s' "$SSH_KEY" > "$key_file"
+          chmod 600 "$key_file"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+
+          if ! ssh \
+            -i "$key_file" \
+            -o StrictHostKeyChecking=accept-new \
+            -o BatchMode=yes \
+            -o RemoteCommand=none \
+            -o RequestTTY=no \
+            "$SSH_HOST" \
+            'set -euo pipefail
+             hostname
+             test -x /root/smart-router-binary
+             kubectl get ns lava-infra
+             kubectl get deploy -n lava-infra
+             kubectl get pods -n lava-infra' >"$ssh_stdout" 2>"$ssh_stderr"; then
+            echo "::error::dev-sim-prtests preflight failed while connecting or running read-only checks"
+            exit 1
+          fi
+
+          preflight_result="passed"
+          echo "dev-sim-prtests preflight passed"
+
+      - name: Plan dev-sim-prtests deployment
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          ARTIFACT_NAME: ${{ steps.pr.outputs.artifact_name }}
+          TARGET_ENVIRONMENT: dev-sim-prtests
+          DRY_RUN: "true"
+          CONCURRENCY_GROUP: pr-gate-dev-sim-prtests
+        run: |
+          set -euo pipefail
+          echo "PR number: ${PR_NUMBER}"
+          echo "PR head SHA: ${HEAD_SHA}"
+          echo "artifact name: ${ARTIFACT_NAME}"
+          echo "target environment: ${TARGET_ENVIRONMENT}"
+          echo "dry-run: ${DRY_RUN}"
+          echo "concurrency group: ${CONCURRENCY_GROUP}"
+          echo "Deployment performed: false"
+          echo "planned actions:"
+          echo "1. wait for exclusive dev-sim-prtests workflow slot"
+          echo "2. download PR artifact"
+          echo "3. copy artifact to dev-sim-prtests"
+          echo "4. reset test environment"
+          echo "5. restart Smart Router with PR artifact"
+          echo "6. wait for Smart Router readiness"
+
+          {
+            echo "### dev-sim-prtests deployment plan"
+            echo ""
+            echo "- PR number: \`${PR_NUMBER}\`"
+            echo "- PR head SHA: \`${HEAD_SHA}\`"
+            echo "- Artifact name: \`${ARTIFACT_NAME}\`"
+            echo "- Target environment: \`${TARGET_ENVIRONMENT}\`"
+            echo "- Dry-run: \`${DRY_RUN}\`"
+            echo "- Concurrency group: \`${CONCURRENCY_GROUP}\`"
+            echo "- Deployment performed: \`false\`"
+            echo ""
+            echo "Planned actions:"
+            echo "1. wait for exclusive dev-sim-prtests workflow slot"
+            echo "2. download PR artifact"
+            echo "3. copy artifact to dev-sim-prtests"
+            echo "4. reset test environment"
+            echo "5. restart Smart Router with PR artifact"
+            echo "6. wait for Smart Router readiness"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr-gate-build-artifact.yml
+++ b/.github/workflows/pr-gate-build-artifact.yml
@@ -1,4 +1,4 @@
-name: PR Gate - Build Artifact
+name: PR Gate - Dev Sim Preflight
 
 on:
   workflow_dispatch:
@@ -138,6 +138,31 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           }
 
+          redact_remote_output() {
+            SSH_HOST_VALUE="$SSH_HOST" perl -0pe '
+              BEGIN {
+                $target = $ENV{"SSH_HOST_VALUE"} // "";
+                @redactions = grep { length } ($target);
+                if ($target =~ /\@([^:@\s]+)(?::\d+)?$/) {
+                  push @redactions, $1;
+                } elsif ($target =~ /^([^:@\s]+)(?::\d+)?$/) {
+                  push @redactions, $1;
+                }
+              }
+              for $value (@redactions) {
+                s/\Q$value\E/[redacted-host]/g;
+              }
+            ' "$1"
+          }
+
+          print_sanitized_remote_output() {
+            echo "dev-sim-prtests preflight failed. Sanitized remote output:"
+            echo "----- ssh stdout -----"
+            redact_remote_output "$ssh_stdout"
+            echo "----- ssh stderr -----"
+            redact_remote_output "$ssh_stderr"
+          }
+
           if [ -z "${SSH_HOST:-}" ]; then
             echo "::error::Missing required repository secret DEV_SIM_PRTESTS_SSH_HOST"
             exit 1
@@ -170,6 +195,7 @@ jobs:
              kubectl get deploy -n lava-infra
              kubectl get pods -n lava-infra' >"$ssh_stdout" 2>"$ssh_stderr"; then
             echo "::error::dev-sim-prtests preflight failed while connecting or running read-only checks"
+            print_sanitized_remote_output
             exit 1
           fi
 

--- a/.github/workflows/pr-gate-build-artifact.yml
+++ b/.github/workflows/pr-gate-build-artifact.yml
@@ -122,10 +122,15 @@ jobs:
           preflight_result="failed"
 
           write_summary() {
+            ssh_target="missing"
+            if [ -n "${SSH_HOST:-}" ]; then
+              ssh_target="configured"
+            fi
             {
               echo "### dev-sim-prtests preflight"
               echo ""
               echo "- Target environment: \`dev-sim-prtests\`"
+              echo "- SSH target: \`${ssh_target}\`"
               echo "- Artifact name: \`${ARTIFACT_NAME}\`"
               echo "- PR number: \`${PR_NUMBER}\`"
               echo "- PR head SHA: \`${HEAD_SHA}\`"


### PR DESCRIPTION
Adds secure read-only SSH preflight, concurrency protection, dry-run deployment planning, and clearer diagnostics for the manual PR Gate workflow.

No deployment is performed.
No existing CI flow is changed.
No Slack or required checks are added.