### PR TITLE
fix(cache): stop exposing /debug/pprof on the cache metrics endpoint

### DIFF
--- a/cmd/smartrouter/main.go
+++ b/cmd/smartrouter/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	_ "net/http/pprof"
 	"os"
 
 	"github.com/magma-Devs/smart-router/ecosystem/cache"

--- a/ecosystem/cache/metrics.go
+++ b/ecosystem/cache/metrics.go
@@ -62,10 +62,16 @@ func NewCacheMetricsServer(listenAddress string) *CacheMetrics {
 	prometheus.MustRegister(totalExpired)
 	prometheus.MustRegister(currentCacheSize)
 	prometheus.MustRegister(apiSpecifics)
-	http.Handle("/metrics", promhttp.Handler())
+	// Serve metrics on a dedicated mux rather than http.DefaultServeMux. A nil
+	// handler would serve the default mux, which any blank `net/http/pprof`
+	// import elsewhere in the binary silently populates with /debug/pprof/* —
+	// exposing heap/goroutine dumps and CPU profiling (a DoS lever) on this
+	// listener. An explicit mux serves only the routes we register here.
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
 	go func() {
 		utils.LavaFormatInfo("prometheus endpoint listening", utils.Attribute{Key: "Listen Address", Value: listenAddress})
-		http.ListenAndServe(listenAddress, nil) //nolint:errcheck
+		http.ListenAndServe(listenAddress, mux) //nolint:errcheck
 	}()
 
 	totalExpired.WithLabelValues(totalExpiredKey).Add(0)

--- a/ecosystem/cache/metrics_test.go
+++ b/ecosystem/cache/metrics_test.go
@@ -1,0 +1,62 @@
+package cache
+
+import (
+	"net/http"
+	"net/http/httptest"
+	_ "net/http/pprof" // registers /debug/pprof/* on http.DefaultServeMux at init — the leak we guard against
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/stretchr/testify/require"
+)
+
+// metricsMux mirrors the route wiring NewCacheMetricsServer installs on its
+// dedicated mux. Kept in lockstep with metrics.go so the test exercises the
+// same handler set the server exposes without standing up a real listener.
+func metricsMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	return mux
+}
+
+// Regression: the cache metrics endpoint must serve ONLY /metrics, never the
+// /debug/pprof/* suite. Historically the server passed a nil handler to
+// http.ListenAndServe (= http.DefaultServeMux) while cmd/smartrouter blank-
+// imported net/http/pprof, which registers heap/goroutine/CPU-profiling
+// handlers on the default mux. The net effect was an unauthenticated pprof
+// surface on the public cache metrics port (0.0.0.0:5555 in the example
+// compose) — a DoS and info-leak lever. We now serve a dedicated mux.
+//
+// This file blank-imports net/http/pprof, so /debug/pprof/* is live on
+// http.DefaultServeMux for the duration of the test (exactly the real leak
+// source). We prove the dedicated cache metrics mux is immune to it.
+func TestCacheMetricsMuxDoesNotExposePprof(t *testing.T) {
+	// Sanity check: the pprof handlers really are on the default mux, so a
+	// "not found" on our mux below is meaningful and not a false negative.
+	defRec := httptest.NewRecorder()
+	http.DefaultServeMux.ServeHTTP(defRec, httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil))
+	require.NotEqual(t, http.StatusNotFound, defRec.Code,
+		"precondition: net/http/pprof should have registered /debug/pprof/ on the default mux")
+
+	mux := metricsMux()
+
+	// /metrics is served.
+	recMetrics := httptest.NewRecorder()
+	mux.ServeHTTP(recMetrics, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	require.Equal(t, http.StatusOK, recMetrics.Code, "/metrics must be served on the cache metrics mux")
+
+	// /debug/pprof/* must NOT be reachable on the dedicated mux, even though it
+	// is now present on the default mux.
+	for _, path := range []string{
+		"/debug/pprof/",
+		"/debug/pprof/heap",
+		"/debug/pprof/goroutine",
+		"/debug/pprof/profile",
+		"/debug/pprof/-cache-metrics-test",
+	} {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		require.Equalf(t, http.StatusNotFound, rec.Code,
+			"%s must 404 on the cache metrics mux (pprof must not be exposed)", path)
+	}
+}


### PR DESCRIPTION
## Summary

- `cmd/smartrouter` blank-imported `net/http/pprof`, which registers `/debug/pprof/*` (heap, goroutine, CPU profiling) on `http.DefaultServeMux` at init.
- The cache metrics server served that same default mux by passing a `nil` handler to `http.ListenAndServe`, so the **full pprof suite was reachable on the cache metrics port** — bound to `0.0.0.0:5555` in the example compose.
- That is an unauthenticated **DoS lever** (`/debug/pprof/profile` blocks a core for the profile duration) and **info leak** (heap/goroutine dumps reveal memory contents and internal topology) on a public listener — a release blocker for the open-source Freemium launch.

The intentional profiling path is the **opt-in `--pprof-address` server** ([protocol/performance/pprofServer.go](protocol/performance/pprofServer.go), fiber's own pprof middleware, off by default), which does **not** depend on the stdlib blank import. The blank import was therefore pure dead weight whose only effect was this leak.

## Changes

- Drop the unused `_ "net/http/pprof"` import from [cmd/smartrouter/main.go](cmd/smartrouter/main.go).
- Serve the cache metrics endpoint on a dedicated `http.ServeMux` instead of the default mux ([ecosystem/cache/metrics.go](ecosystem/cache/metrics.go)), so a future stray blank import cannot silently re-expose pprof here (defense in depth).
- Add a regression test ([ecosystem/cache/metrics_test.go](ecosystem/cache/metrics_test.go)) asserting the metrics mux serves `/metrics` but 404s every `/debug/pprof/*` path **even while `net/http/pprof` is imported in the test binary**.

## Test plan

- `go build ./...` — clean.
- `go vet ./cmd/... ./ecosystem/cache/...` — clean.
- `go test ./ecosystem/cache/` — passes, including the new `TestCacheMetricsMuxDoesNotExposePprof`.
- Manual: the opt-in `--pprof-address` server is unaffected (separate fiber server, off by default).

## Context

Surfaced by the Smart Router public-release security readiness review — this finding was **not** in the original ticket set; the doc only flagged the `0.0.0.0` binding of the port, not that the port also serves pprof.