### PR TITLE
feat(logging): redact RPC headers + payloads by default, add --log-unsafe-payloads

### DIFF
--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/grpcMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/grpcMessage.go
@@ -45,7 +45,7 @@ func (gm *GrpcMessage) GetRawRequestHash() ([]byte, error) {
 	headers := gm.GetHeaders()
 	headersByteArray, err := json.Marshal(headers)
 	if err != nil {
-		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headerCount", len(headers)))
+		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headers", utils.RedactPayloadAny(headers)))
 		return []byte{}, err
 	}
 	pathByteArray := []byte(gm.Path)

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/grpcMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/grpcMessage.go
@@ -45,7 +45,7 @@ func (gm *GrpcMessage) GetRawRequestHash() ([]byte, error) {
 	headers := gm.GetHeaders()
 	headersByteArray, err := json.Marshal(headers)
 	if err != nil {
-		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headers", headers))
+		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headerCount", len(headers)))
 		return []byte{}, err
 	}
 	pathByteArray := []byte(gm.Path)

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCMessage.go
@@ -41,7 +41,7 @@ func (jm *JsonrpcMessage) GetRawRequestHash() ([]byte, error) {
 	headers := jm.GetHeaders()
 	headersByteArray, err := json.Marshal(headers)
 	if err != nil {
-		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headers", headers))
+		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headerCount", len(headers)))
 		return []byte{}, err
 	}
 
@@ -49,7 +49,7 @@ func (jm *JsonrpcMessage) GetRawRequestHash() ([]byte, error) {
 
 	paramsByteArray, err := json.Marshal(jm.Params)
 	if err != nil {
-		utils.LavaFormatError("Failed marshalling params on jsonRpc message", err, utils.LogAttr("headers", jm.Params))
+		utils.LavaFormatError("Failed marshalling params on jsonRpc message", err, utils.LogAttr("method", jm.Method))
 		return []byte{}, err
 	}
 	return sigs.HashMsg(append(append(methodByteArray, paramsByteArray...), headersByteArray...)), nil
@@ -95,7 +95,7 @@ func truncateForLog(data []byte) string {
 func checkJsonrpcEnvelope(data []byte, kind string) (hasError bool, errorMessage string, resultBytes []byte) {
 	scan, err := scanJsonrpcEnvelope(data)
 	if err != nil {
-		utils.LavaFormatWarning("malformed "+kind+" response", err, utils.LogAttr("data", truncateForLog(data)))
+		utils.LavaFormatWarning("malformed "+kind+" response", err, utils.LogAttr("data", utils.RedactPayload(truncateForLog(data))))
 		return true, fmt.Sprintf("malformed %s response: %v", kind, err), nil
 	}
 	hasErr := scan.hasError && !isJSONNull(scan.errorBytes)
@@ -363,7 +363,7 @@ func CheckResponseErrorForJsonRpcBatch(data []byte, httpStatusCode int) (hasErro
 	})
 
 	if walkErr != nil {
-		utils.LavaFormatWarning("malformed JSON-RPC batch response", walkErr, utils.LogAttr("data", truncateForLog(data)))
+		utils.LavaFormatWarning("malformed JSON-RPC batch response", walkErr, utils.LogAttr("data", utils.RedactPayload(truncateForLog(data))))
 		return true, fmt.Sprintf("malformed JSON-RPC batch response: %v", walkErr)
 	}
 

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCMessage.go
@@ -41,7 +41,7 @@ func (jm *JsonrpcMessage) GetRawRequestHash() ([]byte, error) {
 	headers := jm.GetHeaders()
 	headersByteArray, err := json.Marshal(headers)
 	if err != nil {
-		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headerCount", len(headers)))
+		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headers", utils.RedactPayloadAny(headers)))
 		return []byte{}, err
 	}
 
@@ -49,7 +49,7 @@ func (jm *JsonrpcMessage) GetRawRequestHash() ([]byte, error) {
 
 	paramsByteArray, err := json.Marshal(jm.Params)
 	if err != nil {
-		utils.LavaFormatError("Failed marshalling params on jsonRpc message", err, utils.LogAttr("method", jm.Method))
+		utils.LavaFormatError("Failed marshalling params on jsonRpc message", err, utils.LogAttr("params", utils.RedactPayloadAny(jm.Params)))
 		return []byte{}, err
 	}
 	return sigs.HashMsg(append(append(methodByteArray, paramsByteArray...), headersByteArray...)), nil

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage.go
@@ -42,7 +42,7 @@ func (rm *RestMessage) GetRawRequestHash() ([]byte, error) {
 	headers := rm.GetHeaders()
 	headersByteArray, err := json.Marshal(headers)
 	if err != nil {
-		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headerCount", len(headers)))
+		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headers", utils.RedactPayloadAny(headers)))
 		return []byte{}, err
 	}
 	pathByteArray := []byte(rm.Path)

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage.go
@@ -42,7 +42,7 @@ func (rm *RestMessage) GetRawRequestHash() ([]byte, error) {
 	headers := rm.GetHeaders()
 	headersByteArray, err := json.Marshal(headers)
 	if err != nil {
-		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headers", headers))
+		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headerCount", len(headers)))
 		return []byte{}, err
 	}
 	pathByteArray := []byte(rm.Path)
@@ -125,7 +125,7 @@ func extractErrorMessage(data []byte, httpStatusCode int) string {
 func checkGenericRESTError(data []byte) (bool, string) {
 	result := make(map[string]interface{})
 	if err := json.Unmarshal(data, &result); err != nil {
-		utils.LavaFormatWarning("Failed unmarshalling REST error response", err, utils.LogAttr("data", string(data)))
+		utils.LavaFormatWarning("Failed unmarshalling REST error response", err, utils.LogAttr("data", utils.RedactPayload(string(data))))
 		return false, ""
 	}
 

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/tendermintRPCMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/tendermintRPCMessage.go
@@ -22,7 +22,7 @@ type TendermintrpcMessage struct {
 func (tm TendermintrpcMessage) SubscriptionIdExtractor(reply *rpcclient.JsonrpcMessage) string {
 	params, err := json.Marshal(tm.GetParams())
 	if err != nil {
-		utils.LavaFormatWarning("failed marshaling params", err, utils.LogAttr("request", tm))
+		utils.LavaFormatWarning("failed marshaling params", err, utils.LogAttr("method", tm.Method))
 		return ""
 	}
 	return string(params)
@@ -33,14 +33,14 @@ func (tm *TendermintrpcMessage) GetRawRequestHash() ([]byte, error) {
 	headers := tm.GetHeaders()
 	headersByteArray, err := json.Marshal(headers)
 	if err != nil {
-		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headers", headers))
+		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headerCount", len(headers)))
 		return []byte{}, err
 	}
 	methodByteArray := []byte(tm.Method + tm.Path)
 
 	paramsByteArray, err := json.Marshal(tm.Params)
 	if err != nil {
-		utils.LavaFormatError("Failed marshalling params on jsonRpc message", err, utils.LogAttr("headers", tm.Params))
+		utils.LavaFormatError("Failed marshalling params on jsonRpc message", err, utils.LogAttr("method", tm.Method))
 		return []byte{}, err
 	}
 	return sigs.HashMsg(append(append(methodByteArray, paramsByteArray...), headersByteArray...)), nil

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/tendermintRPCMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/tendermintRPCMessage.go
@@ -22,7 +22,7 @@ type TendermintrpcMessage struct {
 func (tm TendermintrpcMessage) SubscriptionIdExtractor(reply *rpcclient.JsonrpcMessage) string {
 	params, err := json.Marshal(tm.GetParams())
 	if err != nil {
-		utils.LavaFormatWarning("failed marshaling params", err, utils.LogAttr("method", tm.Method))
+		utils.LavaFormatWarning("failed marshaling params", err, utils.LogAttr("request", utils.RedactPayloadAny(tm)))
 		return ""
 	}
 	return string(params)
@@ -33,14 +33,14 @@ func (tm *TendermintrpcMessage) GetRawRequestHash() ([]byte, error) {
 	headers := tm.GetHeaders()
 	headersByteArray, err := json.Marshal(headers)
 	if err != nil {
-		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headerCount", len(headers)))
+		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headers", utils.RedactPayloadAny(headers)))
 		return []byte{}, err
 	}
 	methodByteArray := []byte(tm.Method + tm.Path)
 
 	paramsByteArray, err := json.Marshal(tm.Params)
 	if err != nil {
-		utils.LavaFormatError("Failed marshalling params on jsonRpc message", err, utils.LogAttr("method", tm.Method))
+		utils.LavaFormatError("Failed marshalling params on jsonRpc message", err, utils.LogAttr("params", utils.RedactPayloadAny(tm.Params)))
 		return []byte{}, err
 	}
 	return sigs.HashMsg(append(append(methodByteArray, paramsByteArray...), headersByteArray...)), nil

--- a/protocol/chainlib/chainproxy/rpcclient/handler.go
+++ b/protocol/chainlib/chainproxy/rpcclient/handler.go
@@ -283,7 +283,7 @@ func (h *handler) handleSubscriptionResultEthereum(msg *JsonrpcMessage) {
 	if err := json.Unmarshal(msg.Params, &result); err != nil {
 		utils.LavaFormatTrace("Dropping invalid ethereum subscription message",
 			utils.LogAttr("err", err),
-			utils.LogAttr("params", string(msg.Params)),
+			utils.LogAttr("params", utils.RedactPayload(string(msg.Params))),
 		)
 		h.log.Debug("Dropping invalid subscription message")
 		return
@@ -298,7 +298,7 @@ func (h *handler) handleSubscriptionResultSolana(msg *JsonrpcMessage) {
 	if err := json.Unmarshal(msg.Params, &result); err != nil {
 		utils.LavaFormatTrace("Dropping invalid solana subscription message",
 			utils.LogAttr("err", err),
-			utils.LogAttr("params", string(msg.Params)),
+			utils.LogAttr("params", utils.RedactPayload(string(msg.Params))),
 		)
 		h.log.Debug("Dropping invalid subscription message")
 		return

--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -442,6 +442,77 @@ func GetHeaderFromCachedMap(headers map[string][]string, key string, defaultValu
 	return defaultValue
 }
 
+// sensitiveHeaderNames is the set of header keys whose values must never reach
+// the logs. Request bodies and headers are logged across the chainlib request
+// paths (jsonRPC / REST / tendermint / grpc); without this filter an
+// Authorization bearer, a cookie, an API key, or a provider key pasted into a
+// header would be written verbatim to container logs, log collectors, and
+// support bundles. Keys are matched case-insensitively.
+var sensitiveHeaderNames = map[string]struct{}{
+	"authorization":       {},
+	"proxy-authorization": {},
+	"cookie":              {},
+	"set-cookie":          {},
+	"x-api-key":           {},
+	"api-key":             {},
+	"apikey":              {},
+	"x-auth-token":        {},
+	"x-access-token":      {},
+	"token":               {},
+}
+
+const redactedHeaderValue = "[REDACTED]"
+
+func isSensitiveHeader(name string) bool {
+	_, ok := sensitiveHeaderNames[strings.ToLower(strings.TrimSpace(name))]
+	return ok
+}
+
+// redactSensitiveMetadata returns a copy of the metadata slice with the values
+// of credential-bearing headers replaced by a placeholder. The input is left
+// untouched so redaction never affects the headers actually forwarded upstream.
+func redactSensitiveMetadata(md []pairingtypes.Metadata) []pairingtypes.Metadata {
+	out := make([]pairingtypes.Metadata, len(md))
+	for i, m := range md {
+		if isSensitiveHeader(m.Name) {
+			out[i] = pairingtypes.Metadata{Name: m.Name, Value: redactedHeaderValue}
+			continue
+		}
+		out[i] = m
+	}
+	return out
+}
+
+// redactSensitiveHeaderMap returns a copy of a map-shaped header set (e.g.
+// http.Header / map[string][]string) with credential-bearing values redacted.
+// The original map is never mutated.
+func redactSensitiveHeaderMap(headers map[string][]string) map[string][]string {
+	out := make(map[string][]string, len(headers))
+	for k, v := range headers {
+		if isSensitiveHeader(k) {
+			out[k] = []string{redactedHeaderValue}
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// redactSensitiveStringMap is the map[string]string variant (e.g. the grpc
+// metadataMap), with credential-bearing values redacted. The original map is
+// never mutated.
+func redactSensitiveStringMap(headers map[string]string) map[string]string {
+	out := make(map[string]string, len(headers))
+	for k, v := range headers {
+		if isSensitiveHeader(k) {
+			out[k] = redactedHeaderValue
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
 // rest request headers are formatted like map[string]string
 func convertToMetadataMap(md map[string][]string) []pairingtypes.Metadata {
 	metadata := make([]pairingtypes.Metadata, len(md))

--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -468,49 +468,62 @@ func isSensitiveHeader(name string) bool {
 	return ok
 }
 
-// RedactSensitiveMetadata returns a copy of the metadata slice with the values
-// of credential-bearing headers replaced by a placeholder. The input is left
-// untouched so redaction never affects the headers actually forwarded upstream.
+// RedactSensitiveMetadata returns a copy of the metadata slice safe for
+// logging: credential-bearing headers (Authorization, Cookie, x-api-key, …)
+// are blanked, and any API key / IP that slipped into another header value is
+// scrubbed. When --log-unsafe-payloads is set the input is returned verbatim.
+// The input is never mutated, so the headers forwarded upstream are unchanged.
 // Exported so other packages that log relay metadata (e.g. relaycore) share the
 // same redaction list instead of growing a divergent copy.
 func RedactSensitiveMetadata(md []pairingtypes.Metadata) []pairingtypes.Metadata {
+	if utils.LogUnsafePayloadsEnabled() {
+		return md
+	}
 	out := make([]pairingtypes.Metadata, len(md))
 	for i, m := range md {
 		if isSensitiveHeader(m.Name) {
 			out[i] = pairingtypes.Metadata{Name: m.Name, Value: redactedHeaderValue}
 			continue
 		}
-		out[i] = m
+		out[i] = pairingtypes.Metadata{Name: m.Name, Value: utils.ScrubSecrets(m.Value)}
 	}
 	return out
 }
 
-// RedactSensitiveHeaderMap returns a copy of a map-shaped header set (e.g.
-// http.Header / map[string][]string) with credential-bearing values redacted.
-// The original map is never mutated.
+// RedactSensitiveHeaderMap is the map-shaped variant (e.g. http.Header /
+// map[string][]string). Same semantics as RedactSensitiveMetadata.
 func RedactSensitiveHeaderMap(headers map[string][]string) map[string][]string {
+	if utils.LogUnsafePayloadsEnabled() {
+		return headers
+	}
 	out := make(map[string][]string, len(headers))
 	for k, v := range headers {
 		if isSensitiveHeader(k) {
 			out[k] = []string{redactedHeaderValue}
 			continue
 		}
-		out[k] = v
+		scrubbed := make([]string, len(v))
+		for i, val := range v {
+			scrubbed[i] = utils.ScrubSecrets(val)
+		}
+		out[k] = scrubbed
 	}
 	return out
 }
 
 // RedactSensitiveStringMap is the map[string]string variant (e.g. the grpc
-// metadataMap), with credential-bearing values redacted. The original map is
-// never mutated.
+// metadataMap). Same semantics as RedactSensitiveMetadata.
 func RedactSensitiveStringMap(headers map[string]string) map[string]string {
+	if utils.LogUnsafePayloadsEnabled() {
+		return headers
+	}
 	out := make(map[string]string, len(headers))
 	for k, v := range headers {
 		if isSensitiveHeader(k) {
 			out[k] = redactedHeaderValue
 			continue
 		}
-		out[k] = v
+		out[k] = utils.ScrubSecrets(v)
 	}
 	return out
 }

--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -468,10 +468,12 @@ func isSensitiveHeader(name string) bool {
 	return ok
 }
 
-// redactSensitiveMetadata returns a copy of the metadata slice with the values
+// RedactSensitiveMetadata returns a copy of the metadata slice with the values
 // of credential-bearing headers replaced by a placeholder. The input is left
 // untouched so redaction never affects the headers actually forwarded upstream.
-func redactSensitiveMetadata(md []pairingtypes.Metadata) []pairingtypes.Metadata {
+// Exported so other packages that log relay metadata (e.g. relaycore) share the
+// same redaction list instead of growing a divergent copy.
+func RedactSensitiveMetadata(md []pairingtypes.Metadata) []pairingtypes.Metadata {
 	out := make([]pairingtypes.Metadata, len(md))
 	for i, m := range md {
 		if isSensitiveHeader(m.Name) {
@@ -483,10 +485,10 @@ func redactSensitiveMetadata(md []pairingtypes.Metadata) []pairingtypes.Metadata
 	return out
 }
 
-// redactSensitiveHeaderMap returns a copy of a map-shaped header set (e.g.
+// RedactSensitiveHeaderMap returns a copy of a map-shaped header set (e.g.
 // http.Header / map[string][]string) with credential-bearing values redacted.
 // The original map is never mutated.
-func redactSensitiveHeaderMap(headers map[string][]string) map[string][]string {
+func RedactSensitiveHeaderMap(headers map[string][]string) map[string][]string {
 	out := make(map[string][]string, len(headers))
 	for k, v := range headers {
 		if isSensitiveHeader(k) {
@@ -498,10 +500,10 @@ func redactSensitiveHeaderMap(headers map[string][]string) map[string][]string {
 	return out
 }
 
-// redactSensitiveStringMap is the map[string]string variant (e.g. the grpc
+// RedactSensitiveStringMap is the map[string]string variant (e.g. the grpc
 // metadataMap), with credential-bearing values redacted. The original map is
 // never mutated.
-func redactSensitiveStringMap(headers map[string]string) map[string]string {
+func RedactSensitiveStringMap(headers map[string]string) map[string]string {
 	out := make(map[string]string, len(headers))
 	for k, v := range headers {
 		if isSensitiveHeader(k) {

--- a/protocol/chainlib/consumer_websocket_manager.go
+++ b/protocol/chainlib/consumer_websocket_manager.go
@@ -364,7 +364,7 @@ func (cwm *ConsumerWebsocketManager) ListenToMessages(ctx context.Context) {
 				utils.LogAttr("GUID", webSocketCtx),
 				utils.LogAttr("dappID", dappID),
 				utils.LogAttr("userIp", userIp),
-				utils.LogAttr("params", protocolMessage.GetRPCMessage().GetParams()),
+				utils.LogAttr("params", utils.RedactPayloadAny(protocolMessage.GetRPCMessage().GetParams())),
 			)
 
 			formatterMsg := logger.AnalyzeWebSocketErrorAndGetFormattedMessage(websocketConn.LocalAddr().String(), utils.LavaFormatError("could not start subscription", err), msgSeed, msg, cwm.apiInterface, time.Since(startTime))
@@ -399,7 +399,7 @@ func (cwm *ConsumerWebsocketManager) ListenToMessages(ctx context.Context) {
 					utils.LogAttr("GUID", webSocketCtx),
 					utils.LogAttr("dappID", dappID),
 					utils.LogAttr("userIp", userIp),
-					utils.LogAttr("params", protocolMessage.GetRPCMessage().GetParams()),
+					utils.LogAttr("params", utils.RedactPayloadAny(protocolMessage.GetRPCMessage().GetParams())),
 				)
 
 				for subscriptionMsgReply := range subscriptionMsgsChan {
@@ -421,7 +421,7 @@ func (cwm *ConsumerWebsocketManager) ListenToMessages(ctx context.Context) {
 					utils.LogAttr("GUID", webSocketCtx),
 					utils.LogAttr("dappID", dappID),
 					utils.LogAttr("userIp", userIp),
-					utils.LogAttr("params", protocolMessage.GetRPCMessage().GetParams()),
+					utils.LogAttr("params", utils.RedactPayloadAny(protocolMessage.GetRPCMessage().GetParams())),
 				)
 			}()
 		}

--- a/protocol/chainlib/consumer_websocket_manager.go
+++ b/protocol/chainlib/consumer_websocket_manager.go
@@ -269,7 +269,7 @@ func (cwm *ConsumerWebsocketManager) ListenToMessages(ctx context.Context) {
 		utils.LavaFormatDebug("ws in <<<",
 			utils.LogAttr("seed", msgSeed),
 			utils.LogAttr("GUID", webSocketCtx),
-			utils.LogAttr("msg", logFormattedMsg),
+			utils.LogAttr("msg", utils.RedactPayload(logFormattedMsg)),
 			utils.LogAttr("dappID", dappID),
 		)
 
@@ -277,7 +277,7 @@ func (cwm *ConsumerWebsocketManager) ListenToMessages(ctx context.Context) {
 
 		protocolMessage, err := cwm.relaySender.ParseRelay(webSocketCtx, "", string(msg), cwm.connectionType, dappID, userIp, nil)
 		if err != nil {
-			utils.LavaFormatDebug("ws manager could not parse message", utils.LogAttr("message", msg), utils.LogAttr("err", err))
+			utils.LavaFormatDebug("ws manager could not parse message", utils.LogAttr("message", utils.RedactPayload(string(msg))), utils.LogAttr("err", err))
 			formatterMsg := logger.AnalyzeWebSocketErrorAndGetFormattedMessage(websocketConn.LocalAddr().String(), err, msgSeed, msg, cwm.apiInterface, time.Since(startTime))
 			if formatterMsg != nil {
 				sendWS(webSocketMsgWithType{messageType: messageType, msg: formatterMsg})

--- a/protocol/chainlib/grpc.go
+++ b/protocol/chainlib/grpc.go
@@ -325,7 +325,7 @@ func (apil *GrpcChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 		utils.LavaFormatDebug("in <<< GRPC Relay ",
 			utils.LogAttr("GUID", ctx),
 			utils.LogAttr("_method", method),
-			utils.LogAttr("headers", redactSensitiveMetadata(grpcHeaders)),
+			utils.LogAttr("headers", RedactSensitiveMetadata(grpcHeaders)),
 		)
 		metricsData := metrics.NewRelayAnalytics(dappID, apil.endpoint.ChainID, apiInterface)
 		metricsData.SetProcessingTimestampBeforeRelay(startTime)
@@ -562,7 +562,7 @@ func (cp *GrpcChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{}, 
 
 	utils.LavaFormatTrace("provider sending node message",
 		utils.LogAttr("_method", nodeMessage.Path),
-		utils.LogAttr("headers", redactSensitiveStringMap(metadataMap)),
+		utils.LogAttr("headers", RedactSensitiveStringMap(metadataMap)),
 		utils.LogAttr("apiInterface", "grpc"),
 	)
 

--- a/protocol/chainlib/grpc.go
+++ b/protocol/chainlib/grpc.go
@@ -325,7 +325,7 @@ func (apil *GrpcChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 		utils.LavaFormatDebug("in <<< GRPC Relay ",
 			utils.LogAttr("GUID", ctx),
 			utils.LogAttr("_method", method),
-			utils.LogAttr("headers", grpcHeaders),
+			utils.LogAttr("headers", redactSensitiveMetadata(grpcHeaders)),
 		)
 		metricsData := metrics.NewRelayAnalytics(dappID, apil.endpoint.ChainID, apiInterface)
 		metricsData.SetProcessingTimestampBeforeRelay(startTime)
@@ -562,7 +562,7 @@ func (cp *GrpcChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{}, 
 
 	utils.LavaFormatTrace("provider sending node message",
 		utils.LogAttr("_method", nodeMessage.Path),
-		utils.LogAttr("headers", metadataMap),
+		utils.LogAttr("headers", redactSensitiveStringMap(metadataMap)),
 		utils.LogAttr("apiInterface", "grpc"),
 	)
 

--- a/protocol/chainlib/grpcproxy/grpcproxy.go
+++ b/protocol/chainlib/grpcproxy/grpcproxy.go
@@ -120,7 +120,7 @@ func makeProxyFunc(callBack ProxyCallBack) grpc.StreamHandler {
 		md = lowercaseMD
 
 		if err := stream.SetHeader(md); err != nil {
-			utils.LavaFormatError("Got error when setting header", err, utils.LogAttr("headerCount", len(md)))
+			utils.LavaFormatError("Got error when setting header", err, utils.LogAttr("headers", utils.RedactPayloadAny(md)))
 		}
 		return stream.SendMsg(respBytes)
 	}

--- a/protocol/chainlib/grpcproxy/grpcproxy.go
+++ b/protocol/chainlib/grpcproxy/grpcproxy.go
@@ -120,7 +120,7 @@ func makeProxyFunc(callBack ProxyCallBack) grpc.StreamHandler {
 		md = lowercaseMD
 
 		if err := stream.SetHeader(md); err != nil {
-			utils.LavaFormatError("Got error when setting header", err, utils.LogAttr("headers", md))
+			utils.LavaFormatError("Got error when setting header", err, utils.LogAttr("headerCount", len(md)))
 		}
 		return stream.SendMsg(respBytes)
 	}
@@ -139,7 +139,7 @@ func (RawBytesCodec) Marshal(v interface{}) ([]byte, error) {
 func (RawBytesCodec) Unmarshal(data []byte, v interface{}) error {
 	bufferPtr, ok := v.(*[]byte)
 	if !ok {
-		return utils.LavaFormatDebug("cannot decode into type", utils.LogAttr("v", v), utils.LogAttr("data", data))
+		return utils.LavaFormatDebug("cannot decode into type", utils.LogAttr("v", v), utils.LogAttr("data", utils.RedactPayload(string(data))))
 	}
 	*bufferPtr = data
 	return nil

--- a/protocol/chainlib/jsonRPC.go
+++ b/protocol/chainlib/jsonRPC.go
@@ -469,6 +469,10 @@ func (apil *JsonRPCChainListener) Serve(ctx context.Context, cmdFlags common.Con
 		}
 
 		path := "/" + fiberCtx.Params("*")
+		// The request body and headers are sensitive (wallet addresses, tx data,
+		// dapp ids, credentials). Log them at debug level only, with the body
+		// redacted unless --log-unsafe-payloads is set, so nothing leaks at the
+		// default (info) verbosity. A safe info line still records the request.
 		utils.LavaFormatInfo("Consumer received a new JSON-RPC request",
 			utils.LogAttr("GUID", guid),
 			utils.LogAttr(utils.KEY_REQUEST_ID, ctx),
@@ -476,8 +480,12 @@ func (apil *JsonRPCChainListener) Serve(ctx context.Context, cmdFlags common.Con
 			utils.LogAttr(utils.KEY_TRANSACTION_ID, ctx),
 			utils.LogAttr("path", path),
 			utils.LogAttr("seed", msgSeed),
-			utils.LogAttr("body", logFormattedMsg),
 			utils.LogAttr("dappID", dappID),
+		)
+		utils.LavaFormatDebug("JSON-RPC request payload",
+			utils.LogAttr("GUID", guid),
+			utils.LogAttr("seed", msgSeed),
+			utils.LogAttr("body", utils.RedactPayload(logFormattedMsg)),
 			utils.LogAttr("headers", redactSensitiveMetadata(headers)),
 		)
 

--- a/protocol/chainlib/jsonRPC.go
+++ b/protocol/chainlib/jsonRPC.go
@@ -469,23 +469,18 @@ func (apil *JsonRPCChainListener) Serve(ctx context.Context, cmdFlags common.Con
 		}
 
 		path := "/" + fiberCtx.Params("*")
-		// The request body and headers are sensitive (wallet addresses, tx data,
-		// dapp ids, credentials). Log them at debug level only, with the body
-		// redacted unless --log-unsafe-payloads is set, so nothing leaks at the
-		// default (info) verbosity. A safe info line still records the request.
-		utils.LavaFormatInfo("Consumer received a new JSON-RPC request",
+		// Request body/headers are sensitive — logged at debug, with API keys and
+		// IPs scrubbed from the body and credential headers redacted unless
+		// --log-unsafe-payloads is set.
+		utils.LavaFormatDebug("Consumer received a new JSON-RPC request",
 			utils.LogAttr("GUID", guid),
 			utils.LogAttr(utils.KEY_REQUEST_ID, ctx),
 			utils.LogAttr(utils.KEY_TASK_ID, ctx),
 			utils.LogAttr(utils.KEY_TRANSACTION_ID, ctx),
 			utils.LogAttr("path", path),
 			utils.LogAttr("seed", msgSeed),
-			utils.LogAttr("dappID", dappID),
-		)
-		utils.LavaFormatDebug("JSON-RPC request payload",
-			utils.LogAttr("GUID", guid),
-			utils.LogAttr("seed", msgSeed),
 			utils.LogAttr("body", utils.RedactPayload(logFormattedMsg)),
+			utils.LogAttr("dappID", dappID),
 			utils.LogAttr("headers", RedactSensitiveMetadata(headers)),
 		)
 

--- a/protocol/chainlib/jsonRPC.go
+++ b/protocol/chainlib/jsonRPC.go
@@ -486,7 +486,7 @@ func (apil *JsonRPCChainListener) Serve(ctx context.Context, cmdFlags common.Con
 			utils.LogAttr("GUID", guid),
 			utils.LogAttr("seed", msgSeed),
 			utils.LogAttr("body", utils.RedactPayload(logFormattedMsg)),
-			utils.LogAttr("headers", redactSensitiveMetadata(headers)),
+			utils.LogAttr("headers", RedactSensitiveMetadata(headers)),
 		)
 
 		relayResult, err := apil.relaySender.SendRelay(ctx, path, msg, http.MethodPost, dappID, userIp, metricsData, headers)

--- a/protocol/chainlib/jsonRPC.go
+++ b/protocol/chainlib/jsonRPC.go
@@ -478,7 +478,7 @@ func (apil *JsonRPCChainListener) Serve(ctx context.Context, cmdFlags common.Con
 			utils.LogAttr("seed", msgSeed),
 			utils.LogAttr("body", logFormattedMsg),
 			utils.LogAttr("dappID", dappID),
-			utils.LogAttr("headers", headers),
+			utils.LogAttr("headers", redactSensitiveMetadata(headers)),
 		)
 
 		relayResult, err := apil.relaySender.SendRelay(ctx, path, msg, http.MethodPost, dappID, userIp, metricsData, headers)

--- a/protocol/chainlib/redact_headers_test.go
+++ b/protocol/chainlib/redact_headers_test.go
@@ -32,7 +32,7 @@ func TestRedactSensitiveMetadata(t *testing.T) {
 		{Name: "X-Lava-Dapp-Id", Value: "dapp-42"},        // safe, preserved
 	}
 
-	out := redactSensitiveMetadata(in)
+	out := RedactSensitiveMetadata(in)
 
 	require.Equal(t, redactedHeaderValue, valueFor(t, out, "Authorization"))
 	require.Equal(t, redactedHeaderValue, valueFor(t, out, "authorization"))
@@ -55,7 +55,7 @@ func TestRedactSensitiveHeaderMap(t *testing.T) {
 		"Accept":        {"application/json"},
 	}
 
-	out := redactSensitiveHeaderMap(in)
+	out := RedactSensitiveHeaderMap(in)
 
 	require.Equal(t, []string{redactedHeaderValue}, out["Authorization"])
 	require.Equal(t, []string{redactedHeaderValue}, out["Set-Cookie"])
@@ -74,7 +74,7 @@ func TestRedactSensitiveStringMap(t *testing.T) {
 		"user-agent":     "smart-router-test",
 	}
 
-	out := redactSensitiveStringMap(in)
+	out := RedactSensitiveStringMap(in)
 
 	require.Equal(t, redactedHeaderValue, out["authorization"])
 	require.Equal(t, redactedHeaderValue, out["apikey"])

--- a/protocol/chainlib/redact_headers_test.go
+++ b/protocol/chainlib/redact_headers_test.go
@@ -1,0 +1,85 @@
+package chainlib
+
+import (
+	"net/http"
+	"testing"
+
+	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
+	"github.com/stretchr/testify/require"
+)
+
+// valueFor returns the logged value for header name in a redacted metadata
+// slice. Fails the test if the header is absent.
+func valueFor(t *testing.T, md []pairingtypes.Metadata, name string) string {
+	t.Helper()
+	for _, m := range md {
+		if m.Name == name {
+			return m.Value
+		}
+	}
+	t.Fatalf("header %q not present in redacted output", name)
+	return ""
+}
+
+func TestRedactSensitiveMetadata(t *testing.T) {
+	in := []pairingtypes.Metadata{
+		{Name: "Authorization", Value: "Bearer secret-token"},
+		{Name: "authorization", Value: "Bearer lower-case"}, // case-insensitive match
+		{Name: "Cookie", Value: "session=abc123"},
+		{Name: "X-Api-Key", Value: "live_key_should_not_leak"},
+		{Name: "Token", Value: "raw-token"},
+		{Name: "Content-Type", Value: "application/json"}, // safe, preserved
+		{Name: "X-Lava-Dapp-Id", Value: "dapp-42"},        // safe, preserved
+	}
+
+	out := redactSensitiveMetadata(in)
+
+	require.Equal(t, redactedHeaderValue, valueFor(t, out, "Authorization"))
+	require.Equal(t, redactedHeaderValue, valueFor(t, out, "authorization"))
+	require.Equal(t, redactedHeaderValue, valueFor(t, out, "Cookie"))
+	require.Equal(t, redactedHeaderValue, valueFor(t, out, "X-Api-Key"))
+	require.Equal(t, redactedHeaderValue, valueFor(t, out, "Token"))
+	require.Equal(t, "application/json", valueFor(t, out, "Content-Type"))
+	require.Equal(t, "dapp-42", valueFor(t, out, "X-Lava-Dapp-Id"))
+
+	// Input must be untouched — redaction must never alter the headers forwarded
+	// upstream, only the logged copy.
+	require.Equal(t, "Bearer secret-token", in[0].Value, "input slice must not be mutated")
+}
+
+func TestRedactSensitiveHeaderMap(t *testing.T) {
+	in := http.Header{
+		"Authorization": {"Bearer secret-token"},
+		"Set-Cookie":    {"session=abc123"},
+		"X-API-Key":     {"live_key"},
+		"Accept":        {"application/json"},
+	}
+
+	out := redactSensitiveHeaderMap(in)
+
+	require.Equal(t, []string{redactedHeaderValue}, out["Authorization"])
+	require.Equal(t, []string{redactedHeaderValue}, out["Set-Cookie"])
+	require.Equal(t, []string{redactedHeaderValue}, out["X-API-Key"])
+	require.Equal(t, []string{"application/json"}, out["Accept"])
+
+	// Input untouched.
+	require.Equal(t, []string{"Bearer secret-token"}, in["Authorization"], "input map must not be mutated")
+}
+
+func TestRedactSensitiveStringMap(t *testing.T) {
+	in := map[string]string{
+		"authorization": "Bearer secret-token",
+		"apikey":        "live_key",
+		"x-access-token": "access-secret",
+		"user-agent":     "smart-router-test",
+	}
+
+	out := redactSensitiveStringMap(in)
+
+	require.Equal(t, redactedHeaderValue, out["authorization"])
+	require.Equal(t, redactedHeaderValue, out["apikey"])
+	require.Equal(t, redactedHeaderValue, out["x-access-token"])
+	require.Equal(t, "smart-router-test", out["user-agent"])
+
+	require.Equal(t, "Bearer secret-token", in["authorization"], "input map must not be mutated")
+}

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -307,7 +307,7 @@ func (apil *RestChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 			utils.LogAttr("GUID", guid),
 			utils.LogAttr("msgSeed", msgSeed),
 			utils.LogAttr("body", utils.RedactPayload(requestBody)),
-			utils.LogAttr("headers", redactSensitiveMetadata(restHeaders)),
+			utils.LogAttr("headers", RedactSensitiveMetadata(restHeaders)),
 		)
 		relayResult, err := apil.relaySender.SendRelay(ctx, path+query, requestBody, http.MethodPost, dappID, userIp, analytics, restHeaders)
 		reply := relayResult.GetReply()
@@ -368,6 +368,8 @@ func (apil *RestChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 		}
 		defer cancel() // incase there's a problem make sure to cancel the connection
 		userIp := GetHeaderFromCachedMap(metadataValues, common.IP_FORWARDING_HEADER_NAME, fiberCtx.IP())
+		// Headers are sensitive — log them at debug only (redacted), keeping the
+		// info line to safe metadata. A non-POST request carries no body.
 		utils.LavaFormatInfo("Consumer received a new REST non-POST request",
 			utils.LogAttr("GUID", guid),
 			utils.LogAttr(utils.KEY_REQUEST_ID, ctx),
@@ -376,7 +378,11 @@ func (apil *RestChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 			utils.LogAttr("path", path),
 			utils.LogAttr("seed", msgSeed),
 			utils.LogAttr("dappID", dappID),
-			utils.LogAttr("headers", redactSensitiveMetadata(restHeaders)),
+		)
+		utils.LavaFormatDebug("REST non-POST request headers",
+			utils.LogAttr("GUID", guid),
+			utils.LogAttr("seed", msgSeed),
+			utils.LogAttr("headers", RedactSensitiveMetadata(restHeaders)),
 		)
 
 		relayResult, err := apil.relaySender.SendRelay(ctx, path+query, "", fiberCtx.Method(), dappID, userIp, analytics, restHeaders)
@@ -510,9 +516,11 @@ func (rcp *RestChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{},
 	rcp.NodeUrl.SetAuthHeaders(ctx, req.Header.Set)
 	rcp.NodeUrl.SetIpForwardingIfNecessary(ctx, req.Header.Set)
 
-	utils.LavaFormatInfo("Sending request to node from provider",
+	// req.Header now carries upstream provider auth (set just above), so log it
+	// at debug only and redacted — never at the default info level.
+	utils.LavaFormatDebug("Sending request to node from provider",
 		utils.LogAttr("_method", nodeMessage.Path),
-		utils.LogAttr("headers", redactSensitiveHeaderMap(req.Header)),
+		utils.LogAttr("headers", RedactSensitiveHeaderMap(req.Header)),
 		utils.LogAttr("apiInterface", "rest"),
 	)
 

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -301,7 +301,7 @@ func (apil *RestChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 			utils.LogAttr("dappID", dappID),
 			utils.LogAttr("msgSeed", msgSeed),
 			utils.LogAttr("body", requestBody),
-			utils.LogAttr("headers", restHeaders),
+			utils.LogAttr("headers", redactSensitiveMetadata(restHeaders)),
 		)
 		relayResult, err := apil.relaySender.SendRelay(ctx, path+query, requestBody, http.MethodPost, dappID, userIp, analytics, restHeaders)
 		reply := relayResult.GetReply()
@@ -370,7 +370,7 @@ func (apil *RestChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 			utils.LogAttr("path", path),
 			utils.LogAttr("seed", msgSeed),
 			utils.LogAttr("dappID", dappID),
-			utils.LogAttr("headers", restHeaders),
+			utils.LogAttr("headers", redactSensitiveMetadata(restHeaders)),
 		)
 
 		relayResult, err := apil.relaySender.SendRelay(ctx, path+query, "", fiberCtx.Method(), dappID, userIp, analytics, restHeaders)
@@ -506,7 +506,7 @@ func (rcp *RestChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{},
 
 	utils.LavaFormatInfo("Sending request to node from provider",
 		utils.LogAttr("_method", nodeMessage.Path),
-		utils.LogAttr("headers", req.Header),
+		utils.LogAttr("headers", redactSensitiveHeaderMap(req.Header)),
 		utils.LogAttr("apiInterface", "rest"),
 	)
 

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -292,6 +292,8 @@ func (apil *RestChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 		analytics.SetProcessingTimestampBeforeRelay(startTime)
 		userIp := GetHeaderFromCachedMap(metadataValues, common.IP_FORWARDING_HEADER_NAME, fiberCtx.IP())
 		requestBody := string(fiberCtx.Body())
+		// Body and headers are sensitive — log them at debug only, body redacted
+		// unless --log-unsafe-payloads is set, so nothing leaks at info level.
 		utils.LavaFormatInfo("Consumer received a new REST POST request",
 			utils.LogAttr("GUID", guid),
 			utils.LogAttr(utils.KEY_REQUEST_ID, ctx),
@@ -300,7 +302,11 @@ func (apil *RestChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 			utils.LogAttr("path", path),
 			utils.LogAttr("dappID", dappID),
 			utils.LogAttr("msgSeed", msgSeed),
-			utils.LogAttr("body", requestBody),
+		)
+		utils.LavaFormatDebug("REST POST request payload",
+			utils.LogAttr("GUID", guid),
+			utils.LogAttr("msgSeed", msgSeed),
+			utils.LogAttr("body", utils.RedactPayload(requestBody)),
 			utils.LogAttr("headers", redactSensitiveMetadata(restHeaders)),
 		)
 		relayResult, err := apil.relaySender.SendRelay(ctx, path+query, requestBody, http.MethodPost, dappID, userIp, analytics, restHeaders)

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -292,19 +292,16 @@ func (apil *RestChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 		analytics.SetProcessingTimestampBeforeRelay(startTime)
 		userIp := GetHeaderFromCachedMap(metadataValues, common.IP_FORWARDING_HEADER_NAME, fiberCtx.IP())
 		requestBody := string(fiberCtx.Body())
-		// Body and headers are sensitive — log them at debug only, body redacted
-		// unless --log-unsafe-payloads is set, so nothing leaks at info level.
-		utils.LavaFormatInfo("Consumer received a new REST POST request",
+		// Body/headers are sensitive — logged at debug, with API keys and IPs
+		// scrubbed from the body and credential headers redacted unless
+		// --log-unsafe-payloads is set.
+		utils.LavaFormatDebug("Consumer received a new REST POST request",
 			utils.LogAttr("GUID", guid),
 			utils.LogAttr(utils.KEY_REQUEST_ID, ctx),
 			utils.LogAttr(utils.KEY_TASK_ID, ctx),
 			utils.LogAttr(utils.KEY_TRANSACTION_ID, ctx),
 			utils.LogAttr("path", path),
 			utils.LogAttr("dappID", dappID),
-			utils.LogAttr("msgSeed", msgSeed),
-		)
-		utils.LavaFormatDebug("REST POST request payload",
-			utils.LogAttr("GUID", guid),
 			utils.LogAttr("msgSeed", msgSeed),
 			utils.LogAttr("body", utils.RedactPayload(requestBody)),
 			utils.LogAttr("headers", RedactSensitiveMetadata(restHeaders)),
@@ -368,9 +365,9 @@ func (apil *RestChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 		}
 		defer cancel() // incase there's a problem make sure to cancel the connection
 		userIp := GetHeaderFromCachedMap(metadataValues, common.IP_FORWARDING_HEADER_NAME, fiberCtx.IP())
-		// Headers are sensitive — log them at debug only (redacted), keeping the
-		// info line to safe metadata. A non-POST request carries no body.
-		utils.LavaFormatInfo("Consumer received a new REST non-POST request",
+		// Headers are sensitive — logged at debug, credential headers redacted
+		// unless --log-unsafe-payloads is set. A non-POST request carries no body.
+		utils.LavaFormatDebug("Consumer received a new REST non-POST request",
 			utils.LogAttr("GUID", guid),
 			utils.LogAttr(utils.KEY_REQUEST_ID, ctx),
 			utils.LogAttr(utils.KEY_TASK_ID, ctx),
@@ -378,10 +375,6 @@ func (apil *RestChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 			utils.LogAttr("path", path),
 			utils.LogAttr("seed", msgSeed),
 			utils.LogAttr("dappID", dappID),
-		)
-		utils.LavaFormatDebug("REST non-POST request headers",
-			utils.LogAttr("GUID", guid),
-			utils.LogAttr("seed", msgSeed),
 			utils.LogAttr("headers", RedactSensitiveMetadata(restHeaders)),
 		)
 

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -489,7 +489,7 @@ func (apil *TendermintRpcChainListener) Serve(ctx context.Context, cmdFlags comm
 			utils.LogAttr("seed", msgSeed),
 			utils.LogAttr("_msg", utils.RedactPayload(logFormattedMsg)),
 			utils.LogAttr("dappID", dappID),
-			utils.LogAttr("headers", redactSensitiveMetadata(headers)),
+			utils.LogAttr("headers", RedactSensitiveMetadata(headers)),
 		)
 		relayResult, err := apil.relaySender.SendRelay(ctx, "", msg, "", dappID, userIp, metricsData, headers)
 		reply := relayResult.GetReply()
@@ -558,9 +558,11 @@ func (apil *TendermintRpcChainListener) Serve(ctx context.Context, cmdFlags comm
 		userIp := GetHeaderFromCachedMap(metadataValues, common.IP_FORWARDING_HEADER_NAME, fiberCtx.IP())
 		utils.LavaFormatDebug("urirpc in <<<",
 			utils.LogAttr("GUID", ctx),
-			utils.LogAttr("_msg", path),
+			// The URI path can carry query-string credentials (?api_key=…), so
+			// redact it unless --log-unsafe-payloads is set.
+			utils.LogAttr("_msg", utils.RedactPayload(path)),
 			utils.LogAttr("dappID", dappID),
-			utils.LogAttr("headers", redactSensitiveMetadata(headers)),
+			utils.LogAttr("headers", RedactSensitiveMetadata(headers)),
 		)
 		relayResult, err := apil.relaySender.SendRelay(ctx, path+query, "", "", dappID, userIp, metricsData, headers)
 		msgSeed := strconv.FormatUint(guid, 10)
@@ -882,7 +884,7 @@ func (cp *tendermintRpcChainProxy) SendRPC(ctx context.Context, nodeMessage *rpc
 		}
 		subscriptionID, ok = paramsMap["query"].(string)
 		if !ok {
-			utils.LavaFormatTrace("could not get subscriptionID from query params", utils.LogAttr("params", params))
+			utils.LavaFormatTrace("could not get subscriptionID from query params", utils.LogAttr("params", utils.RedactPayloadAny(params)))
 			// This is probably because of a misuse, therefore the provider will return a node error to the user as the subscription failed
 			subscriptionID = ""
 		}

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -487,7 +487,7 @@ func (apil *TendermintRpcChainListener) Serve(ctx context.Context, cmdFlags comm
 		utils.LavaFormatDebug("in <<<",
 			utils.LogAttr("GUID", ctx),
 			utils.LogAttr("seed", msgSeed),
-			utils.LogAttr("_msg", logFormattedMsg),
+			utils.LogAttr("_msg", utils.RedactPayload(logFormattedMsg)),
 			utils.LogAttr("dappID", dappID),
 			utils.LogAttr("headers", redactSensitiveMetadata(headers)),
 		)

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -489,7 +489,7 @@ func (apil *TendermintRpcChainListener) Serve(ctx context.Context, cmdFlags comm
 			utils.LogAttr("seed", msgSeed),
 			utils.LogAttr("_msg", logFormattedMsg),
 			utils.LogAttr("dappID", dappID),
-			utils.LogAttr("headers", headers),
+			utils.LogAttr("headers", redactSensitiveMetadata(headers)),
 		)
 		relayResult, err := apil.relaySender.SendRelay(ctx, "", msg, "", dappID, userIp, metricsData, headers)
 		reply := relayResult.GetReply()
@@ -560,7 +560,7 @@ func (apil *TendermintRpcChainListener) Serve(ctx context.Context, cmdFlags comm
 			utils.LogAttr("GUID", ctx),
 			utils.LogAttr("_msg", path),
 			utils.LogAttr("dappID", dappID),
-			utils.LogAttr("headers", headers),
+			utils.LogAttr("headers", redactSensitiveMetadata(headers)),
 		)
 		relayResult, err := apil.relaySender.SendRelay(ctx, path+query, "", "", dappID, userIp, metricsData, headers)
 		msgSeed := strconv.FormatUint(guid, 10)

--- a/protocol/common/cobra_common.go
+++ b/protocol/common/cobra_common.go
@@ -37,6 +37,11 @@ const (
 	// BatchNodeErrorOnAny controls batch request error detection for JSON-RPC batch requests
 	BatchNodeErrorOnAnyFlag = "batch-node-error-on-any"
 
+	// LogUnsafePayloadsFlagName enables verbatim logging of RPC request/response
+	// bodies. Off by default — bodies are redacted to a length-only placeholder.
+	// Local-debugging only; never enable on a publicly reachable deployment.
+	LogUnsafePayloadsFlagName = "log-unsafe-payloads"
+
 	// UseStaticSpecFlag allows loading specs from various sources instead of the blockchain.
 	// This flag can be specified multiple times to aggregate specs from multiple sources.
 	// Later sources override earlier ones for the same chain ID (last-wins).

--- a/protocol/metrics/rpcconsumer_logs.go
+++ b/protocol/metrics/rpcconsumer_logs.go
@@ -199,11 +199,16 @@ func (rpccl *RPCConsumerLogs) AnalyzeWebSocketErrorAndGetFormattedMessage(webSoc
 }
 
 func (rpccl *RPCConsumerLogs) LogRequestAndResponse(module string, hasError bool, method, path, req, resp, msgSeed string, timeTaken time.Duration, err error) {
+	// req/resp are raw RPC payloads — redact unless --log-unsafe-payloads is set.
+	// The error branch logs at error level (always emitted), so redaction here is
+	// what keeps payloads out of the logs at the default verbosity.
+	loggedReq := utils.RedactPayload(req)
+	loggedResp := utils.RedactPayload(parser.CapStringLen(resp))
 	if hasError && err != nil {
-		utils.LavaFormatError(module, err, []utils.Attribute{{Key: "GUID", Value: msgSeed}, {Key: "timeTaken", Value: timeTaken}, {Key: "request", Value: req}, {Key: "response", Value: parser.CapStringLen(resp)}, {Key: "method", Value: method}, {Key: "path", Value: path}, {Key: "HasError", Value: hasError}}...)
+		utils.LavaFormatError(module, err, []utils.Attribute{{Key: "GUID", Value: msgSeed}, {Key: "timeTaken", Value: timeTaken}, {Key: "request", Value: loggedReq}, {Key: "response", Value: loggedResp}, {Key: "method", Value: method}, {Key: "path", Value: path}, {Key: "HasError", Value: hasError}}...)
 		return
 	}
-	utils.LavaFormatDebug(module, []utils.Attribute{{Key: "GUID", Value: msgSeed}, {Key: "timeTaken", Value: timeTaken}, {Key: "request", Value: req}, {Key: "response", Value: parser.CapStringLen(resp)}, {Key: "method", Value: method}, {Key: "path", Value: path}, {Key: "HasError", Value: hasError}}...)
+	utils.LavaFormatDebug(module, []utils.Attribute{{Key: "GUID", Value: msgSeed}, {Key: "timeTaken", Value: timeTaken}, {Key: "request", Value: loggedReq}, {Key: "response", Value: loggedResp}, {Key: "method", Value: method}, {Key: "path", Value: path}, {Key: "HasError", Value: hasError}}...)
 }
 
 func (rpccl *RPCConsumerLogs) LogStartTransaction(name string) func() {

--- a/protocol/parser/parser.go
+++ b/protocol/parser/parser.go
@@ -116,7 +116,7 @@ func ParseRawBlock(rpcInput RPCInput, parsedInput *ParsedInput, defaultValue str
 				parsedInput.UsedDefaultValue = true
 			}
 			utils.LavaFormatDebug("Failed parsing block from string, assuming default value",
-				utils.LogAttr("params", rpcInput.GetParams()),
+				utils.LogAttr("params", utils.RedactPayloadAny(rpcInput.GetParams())),
 				utils.LogAttr("failed_parsed_value", rawBlock),
 				utils.LogAttr("default_value", defaultValue),
 				utils.LogAttr("parsedBlock", parsedBlock),
@@ -844,7 +844,7 @@ func parseDictionaryOrOrdered(rpcInput RPCInput, input []string, dataSource int)
 
 		// Else return not set error)
 		utils.LavaFormatDebug("Failed parsing parseDictionaryOrOrdered",
-			utils.LogAttr("params", rpcInput.GetParams()),
+			utils.LogAttr("params", utils.RedactPayloadAny(rpcInput.GetParams())),
 			utils.LogAttr("propName", propName),
 			utils.LogAttr("inp", inp),
 			utils.LogAttr("unmarshalledDataTyped", unmarshalledDataTyped),

--- a/protocol/relaycore/results_manager.go
+++ b/protocol/relaycore/results_manager.go
@@ -8,6 +8,7 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/chainlib"
 	common "github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/parser"
+	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
 	spectypes "github.com/magma-Devs/smart-router/types/spec"
 	"github.com/magma-Devs/smart-router/utils"
 )
@@ -136,7 +137,7 @@ func (rp *ResultsManagerInst) setValidResponse(response *RelayResponse, protocol
 		// Log node error payload and headers for troubleshooting
 		// also log the original request payload and request headers if available
 		reqPayload := ""
-		var reqHeaders interface{}
+		var reqHeaders []pairingtypes.Metadata
 		if response.RelayResult.Request != nil && response.RelayResult.Request.RelayData != nil {
 			reqPayload = string(response.RelayResult.Request.RelayData.Data)
 			reqHeaders = response.RelayResult.Request.RelayData.Metadata
@@ -170,10 +171,10 @@ func (rp *ResultsManagerInst) setValidResponse(response *RelayResponse, protocol
 			utils.LogAttr("statusCode", response.RelayResult.StatusCode),
 			utils.LogAttr("api", protocolMessage.GetApi().Name),
 			utils.LogAttr("requestUrl", requestUrl),
-			utils.LogAttr("payload", parser.CapStringLen(string(response.RelayResult.Reply.Data))),
-			utils.LogAttr("headers", response.RelayResult.Reply.Metadata),
-			utils.LogAttr("requestPayload", parser.CapStringLen(reqPayload)),
-			utils.LogAttr("requestHeaders", reqHeaders),
+			utils.LogAttr("payload", utils.RedactPayload(parser.CapStringLen(string(response.RelayResult.Reply.Data)))),
+			utils.LogAttr("headers", chainlib.RedactSensitiveMetadata(response.RelayResult.Reply.Metadata)),
+			utils.LogAttr("requestPayload", utils.RedactPayload(parser.CapStringLen(reqPayload))),
+			utils.LogAttr("requestHeaders", chainlib.RedactSensitiveMetadata(reqHeaders)),
 		)
 		rp.nodeResponseErrors.AddError(RelayError{Err: err, ProviderInfo: response.RelayResult.ProviderInfo, Response: response, LavaError: nodeClassified})
 		return err

--- a/protocol/rpcsmartrouter/endpoint_chain_fetcher.go
+++ b/protocol/rpcsmartrouter/endpoint_chain_fetcher.go
@@ -112,7 +112,7 @@ func (ecf *EndpointChainFetcher) FetchLatestBlockNum(ctx context.Context) (int64
 			utils.LogAttr("chainID", ecf.chainID),
 			utils.LogAttr("endpoint", ecf.endpointURL),
 			utils.LogAttr("method", parsing.ApiName),
-			utils.LogAttr("response", parser.CapStringLen(string(responseData))),
+			utils.LogAttr("response", utils.RedactPayload(parser.CapStringLen(string(responseData)))),
 			utils.LogAttr("error", err),
 		)
 	}
@@ -124,7 +124,7 @@ func (ecf *EndpointChainFetcher) FetchLatestBlockNum(ctx context.Context) (int64
 			utils.LogAttr("chainID", ecf.chainID),
 			utils.LogAttr("endpoint", ecf.endpointURL),
 			utils.LogAttr("method", parsing.ApiName),
-			utils.LogAttr("response", parser.CapStringLen(string(responseData))),
+			utils.LogAttr("response", utils.RedactPayload(parser.CapStringLen(string(responseData)))),
 		)
 	}
 
@@ -237,7 +237,7 @@ func (ecf *EndpointChainFetcher) fetchSingleBlockHash(
 			utils.LogAttr("chainID", ecf.chainID),
 			utils.LogAttr("endpoint", ecf.endpointURL),
 			utils.LogAttr("method", parsing.ApiName),
-			utils.LogAttr("response", parser.CapStringLen(string(responseData))),
+			utils.LogAttr("response", utils.RedactPayload(parser.CapStringLen(string(responseData)))),
 		)
 	}
 
@@ -248,7 +248,7 @@ func (ecf *EndpointChainFetcher) fetchSingleBlockHash(
 			utils.LogAttr("chainID", ecf.chainID),
 			utils.LogAttr("endpoint", ecf.endpointURL),
 			utils.LogAttr("method", parsing.ApiName),
-			utils.LogAttr("response", parser.CapStringLen(string(responseData))),
+			utils.LogAttr("response", utils.RedactPayload(parser.CapStringLen(string(responseData)))),
 		)
 	}
 

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -1861,6 +1861,15 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 			}
 			utils.SetGlobalLoggingLevel(logLevel)
 
+			logUnsafePayloads, err := cmd.Flags().GetBool(common.LogUnsafePayloadsFlagName)
+			if err != nil {
+				utils.LavaFormatFatal("failed to read log-unsafe-payloads flag", err)
+			}
+			utils.SetLogUnsafePayloads(logUnsafePayloads)
+			if logUnsafePayloads {
+				utils.LavaFormatWarning("UNSAFE: --log-unsafe-payloads is enabled — raw RPC request/response bodies will be written to logs verbatim. Use for local debugging only; never on a publicly reachable or shared-logging deployment.", nil)
+			}
+
 			test_mode, err := cmd.Flags().GetBool(common.TestModeFlagName)
 			if err != nil {
 				utils.LavaFormatFatal("failed to read test_mode flag", err)
@@ -2218,6 +2227,7 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	// Log level/format flags (previously provided by cosmos-sdk AddTxFlagsToCmd)
 	cmdRPCSmartRouter.Flags().String("log-level", "info", "log level (debug|info|warn|error|fatal)")
 	cmdRPCSmartRouter.Flags().String("log-format", "text", "log format (text|json)")
+	cmdRPCSmartRouter.Flags().Bool(common.LogUnsafePayloadsFlagName, false, "UNSAFE: log raw RPC request/response bodies verbatim instead of redacting them. Local debugging only — never enable on a publicly reachable or shared-logging deployment.")
 	return cmdRPCSmartRouter
 }
 

--- a/utils/debug.go
+++ b/utils/debug.go
@@ -2,17 +2,17 @@ package utils
 
 import (
 	"fmt"
+	"regexp"
 	"sync/atomic"
 )
 
 var DebugPaymentE2E = "" // using "debug_payment_e2e" build option, this string will be "debug_payment_e2e"
 
-// logUnsafePayloads gates whether raw RPC request/response payloads (bodies)
-// are written to logs verbatim. It defaults to false: payloads are redacted to
-// a length-only placeholder so wallet addresses, transaction data, dapp
-// identifiers, and credentials embedded in bodies do not leak into container
-// logs, log collectors, or support bundles. Operators set it to true via the
-// --log-unsafe-payloads flag for local debugging only.
+// logUnsafePayloads gates whether RPC request/response payloads are logged
+// without scrubbing. It defaults to false: API keys and IP addresses embedded
+// in bodies, params, and URLs are replaced with a placeholder so they do not
+// leak into container logs, log collectors, or support bundles. Operators set
+// it to true via the --log-unsafe-payloads flag for local debugging only.
 //
 // Stored as an atomic so it can be read from the hot relay path on every
 // request without a lock; it is written exactly once at startup.
@@ -29,28 +29,60 @@ func LogUnsafePayloadsEnabled() bool {
 	return logUnsafePayloads.Load()
 }
 
-const redactedPayloadValue = "[REDACTED]"
+const redactedSecretValue = "[REDACTED]"
 
-// RedactPayload returns the payload as-is when unsafe payload logging is
-// enabled, otherwise a length-only placeholder. Use it on every log attribute
-// that carries an RPC request or response body. The byte length is preserved
-// in the redacted form so operators can still see traffic shape and spot
-// empty-vs-non-empty bodies without exposing contents.
+// Scrubbing patterns. Deliberately narrow: we only want to strip API keys and
+// IP addresses, not mangle the rest of the payload. Over-broad patterns would
+// redact legitimate hex (block hashes, addresses) and make logs useless.
+var (
+	// API keys carried in URL paths/queries: ?key=… / ?api_key=… / ?apikey=… /
+	// ?token=… / ?access_token=… / ?auth=… — capture the param name, redact the
+	// value up to the next & or whitespace or quote.
+	urlKeyQueryRegex = regexp.MustCompile(`(?i)([?&](?:api[_-]?key|key|token|access[_-]?token|auth)=)[^&\s"']+`)
+
+	// API keys carried as a provider URL path segment, e.g.
+	// /v2/<32+ char token>, /v3/<token>, /ethereum/<token>. Match a long
+	// (>=20 char) opaque segment that looks like a credential, not a normal path.
+	urlKeyPathRegex = regexp.MustCompile(`(/(?:v\d+|rpc|gateway|[a-z]+))/([A-Za-z0-9_\-]{20,})`)
+
+	// IPv4 addresses.
+	ipv4Regex = regexp.MustCompile(`\b(?:\d{1,3}\.){3}\d{1,3}\b`)
+
+	// IPv6 addresses (compressed or full). Conservative: requires at least two
+	// colon-separated hextet groups so we don't match ordinary "a:b" text.
+	ipv6Regex = regexp.MustCompile(`\b(?:[0-9A-Fa-f]{1,4}:){2,7}[0-9A-Fa-f]{1,4}\b`)
+)
+
+// ScrubSecrets removes API keys and IP addresses from s, leaving the rest of
+// the content readable. Used by the payload log helpers when unsafe logging is
+// off. Order matters: URL key patterns run before the IP patterns so a token
+// that happens to contain dotted digits is handled as a key first.
+func ScrubSecrets(s string) string {
+	if s == "" {
+		return s
+	}
+	s = urlKeyQueryRegex.ReplaceAllString(s, "${1}"+redactedSecretValue)
+	s = urlKeyPathRegex.ReplaceAllString(s, "${1}/"+redactedSecretValue)
+	s = ipv4Regex.ReplaceAllString(s, redactedSecretValue)
+	s = ipv6Regex.ReplaceAllString(s, redactedSecretValue)
+	return s
+}
+
+// RedactPayload returns the payload verbatim when unsafe payload logging is
+// enabled, otherwise a copy with API keys and IP addresses scrubbed out. The
+// body stays readable for debugging; only secrets are removed. Use it on every
+// log attribute that carries an RPC request/response body, URL, or param.
 func RedactPayload(payload string) string {
 	if LogUnsafePayloadsEnabled() {
 		return payload
 	}
-	if payload == "" {
-		return ""
-	}
-	return fmt.Sprintf("%s(%d bytes)", redactedPayloadValue, len(payload))
+	return ScrubSecrets(payload)
 }
 
 // RedactPayloadAny is the any-typed variant for log attributes that carry
-// already-parsed RPC params/values (interface{}). When unsafe logging is off it
-// returns a fixed placeholder rather than the value, so wallet addresses, tx
-// data, or query arguments embedded in params do not leak. When on, it returns
-// the value unchanged for verbatim local debugging.
+// already-parsed params/values (interface{}). When unsafe logging is on it
+// returns the value unchanged; otherwise it renders the value to a string and
+// scrubs API keys and IPs out of it.
 func RedactPayloadAny(payload interface{}) interface{} {
 	if LogUnsafePayloadsEnabled() {
 		return payload
@@ -58,5 +90,5 @@ func RedactPayloadAny(payload interface{}) interface{} {
 	if payload == nil {
 		return nil
 	}
-	return redactedPayloadValue
+	return ScrubSecrets(fmt.Sprintf("%v", payload))
 }

--- a/utils/debug.go
+++ b/utils/debug.go
@@ -1,3 +1,47 @@
 package utils
 
+import (
+	"fmt"
+	"sync/atomic"
+)
+
 var DebugPaymentE2E = "" // using "debug_payment_e2e" build option, this string will be "debug_payment_e2e"
+
+// logUnsafePayloads gates whether raw RPC request/response payloads (bodies)
+// are written to logs verbatim. It defaults to false: payloads are redacted to
+// a length-only placeholder so wallet addresses, transaction data, dapp
+// identifiers, and credentials embedded in bodies do not leak into container
+// logs, log collectors, or support bundles. Operators set it to true via the
+// --log-unsafe-payloads flag for local debugging only.
+//
+// Stored as an atomic so it can be read from the hot relay path on every
+// request without a lock; it is written exactly once at startup.
+var logUnsafePayloads atomic.Bool
+
+// SetLogUnsafePayloads enables or disables verbatim payload logging. Call once
+// at startup from the --log-unsafe-payloads flag.
+func SetLogUnsafePayloads(enabled bool) {
+	logUnsafePayloads.Store(enabled)
+}
+
+// LogUnsafePayloadsEnabled reports whether verbatim payload logging is on.
+func LogUnsafePayloadsEnabled() bool {
+	return logUnsafePayloads.Load()
+}
+
+const redactedPayloadValue = "[REDACTED]"
+
+// RedactPayload returns the payload as-is when unsafe payload logging is
+// enabled, otherwise a length-only placeholder. Use it on every log attribute
+// that carries an RPC request or response body. The byte length is preserved
+// in the redacted form so operators can still see traffic shape and spot
+// empty-vs-non-empty bodies without exposing contents.
+func RedactPayload(payload string) string {
+	if LogUnsafePayloadsEnabled() {
+		return payload
+	}
+	if payload == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s(%d bytes)", redactedPayloadValue, len(payload))
+}

--- a/utils/debug.go
+++ b/utils/debug.go
@@ -45,3 +45,18 @@ func RedactPayload(payload string) string {
 	}
 	return fmt.Sprintf("%s(%d bytes)", redactedPayloadValue, len(payload))
 }
+
+// RedactPayloadAny is the any-typed variant for log attributes that carry
+// already-parsed RPC params/values (interface{}). When unsafe logging is off it
+// returns a fixed placeholder rather than the value, so wallet addresses, tx
+// data, or query arguments embedded in params do not leak. When on, it returns
+// the value unchanged for verbatim local debugging.
+func RedactPayloadAny(payload interface{}) interface{} {
+	if LogUnsafePayloadsEnabled() {
+		return payload
+	}
+	if payload == nil {
+		return nil
+	}
+	return redactedPayloadValue
+}

--- a/utils/debug_test.go
+++ b/utils/debug_test.go
@@ -1,0 +1,40 @@
+package utils_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactPayload(t *testing.T) {
+	// Ensure the global toggle is restored regardless of how the test exits, so
+	// other tests in the package are not affected by the writes below.
+	t.Cleanup(func() { utils.SetLogUnsafePayloads(false) })
+
+	const body = `{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0xdeadbeef"]}`
+
+	// Default (safe): payload is redacted to a length-only placeholder, and the
+	// raw contents never appear.
+	utils.SetLogUnsafePayloads(false)
+	require.False(t, utils.LogUnsafePayloadsEnabled())
+
+	redacted := utils.RedactPayload(body)
+	require.NotContains(t, redacted, "eth_sendRawTransaction")
+	require.NotContains(t, redacted, "0xdeadbeef")
+	require.Contains(t, redacted, "REDACTED")
+	require.Contains(t, redacted, "bytes", "redacted form should preserve the byte length for traffic shape")
+
+	// Empty bodies stay empty (no noisy "[REDACTED](0 bytes)").
+	require.Equal(t, "", utils.RedactPayload(""))
+
+	// Unsafe mode: the raw payload passes through verbatim.
+	utils.SetLogUnsafePayloads(true)
+	require.True(t, utils.LogUnsafePayloadsEnabled())
+	require.Equal(t, body, utils.RedactPayload(body))
+
+	// Toggling back off re-redacts.
+	utils.SetLogUnsafePayloads(false)
+	require.True(t, strings.HasPrefix(utils.RedactPayload(body), "[REDACTED]"))
+}

--- a/utils/debug_test.go
+++ b/utils/debug_test.go
@@ -1,40 +1,79 @@
 package utils_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/magma-Devs/smart-router/utils"
 	"github.com/stretchr/testify/require"
 )
 
-func TestRedactPayload(t *testing.T) {
-	// Ensure the global toggle is restored regardless of how the test exits, so
-	// other tests in the package are not affected by the writes below.
+func TestScrubSecrets(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          string
+		mustNotHave []string
+		mustHave    []string // structure that should survive scrubbing
+	}{
+		{
+			name:        "url query api key",
+			in:          `provider https://node.example.com/rpc?api_key=SECRETKEY12345 ok`,
+			mustNotHave: []string{"SECRETKEY12345"},
+			mustHave:    []string{"node.example.com", "api_key=[REDACTED]"},
+		},
+		{
+			name:        "url path token",
+			in:          `https://lb.drpc.live/ethereum/AbCdEf0123456789AbCdEf0123456789`,
+			mustNotHave: []string{"AbCdEf0123456789AbCdEf0123456789"},
+			mustHave:    []string{"lb.drpc.live", "[REDACTED]"},
+		},
+		{
+			name:        "ipv4 scrubbed, method kept",
+			in:          `{"method":"eth_call","client":"192.168.1.42"}`,
+			mustNotHave: []string{"192.168.1.42"},
+			mustHave:    []string{"eth_call", "[REDACTED]"},
+		},
+		{
+			name:        "no secrets left intact",
+			in:          `{"method":"eth_blockNumber","params":[]}`,
+			mustNotHave: []string{"[REDACTED]"},
+			mustHave:    []string{"eth_blockNumber"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := utils.ScrubSecrets(tc.in)
+			for _, s := range tc.mustNotHave {
+				require.NotContains(t, out, s, "secret/IP should be scrubbed")
+			}
+			for _, s := range tc.mustHave {
+				require.Contains(t, out, s, "readable structure should survive")
+			}
+		})
+	}
+}
+
+func TestRedactPayloadHonorsUnsafeFlag(t *testing.T) {
 	t.Cleanup(func() { utils.SetLogUnsafePayloads(false) })
 
-	const body = `{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0xdeadbeef"]}`
+	const body = `{"method":"eth_call","key":"https://x/v2/SECRET_TOKEN_VALUE_123","ip":"10.0.0.1"}`
 
-	// Default (safe): payload is redacted to a length-only placeholder, and the
-	// raw contents never appear.
+	// Safe (default): keys/IPs scrubbed, structure readable.
 	utils.SetLogUnsafePayloads(false)
-	require.False(t, utils.LogUnsafePayloadsEnabled())
-
 	redacted := utils.RedactPayload(body)
-	require.NotContains(t, redacted, "eth_sendRawTransaction")
-	require.NotContains(t, redacted, "0xdeadbeef")
-	require.Contains(t, redacted, "REDACTED")
-	require.Contains(t, redacted, "bytes", "redacted form should preserve the byte length for traffic shape")
+	require.NotContains(t, redacted, "SECRET_TOKEN_VALUE_123")
+	require.NotContains(t, redacted, "10.0.0.1")
+	require.Contains(t, redacted, "eth_call")
 
-	// Empty bodies stay empty (no noisy "[REDACTED](0 bytes)").
+	// Empty stays empty.
 	require.Equal(t, "", utils.RedactPayload(""))
 
-	// Unsafe mode: the raw payload passes through verbatim.
+	// Unsafe: verbatim passthrough.
 	utils.SetLogUnsafePayloads(true)
-	require.True(t, utils.LogUnsafePayloadsEnabled())
 	require.Equal(t, body, utils.RedactPayload(body))
 
-	// Toggling back off re-redacts.
+	// any-typed variant follows the same flag.
+	require.Equal(t, body, utils.RedactPayloadAny(body))
 	utils.SetLogUnsafePayloads(false)
-	require.True(t, strings.HasPrefix(utils.RedactPayload(body), "[REDACTED]"))
+	require.NotContains(t, utils.RedactPayloadAny(body).(string), "SECRET_TOKEN_VALUE_123")
 }


### PR DESCRIPTION
## Summary

Logging hardening for the public release (Ticket 2): keep RPC logs useful for debugging while ensuring **API keys and IPs never leak** at the default verbosity.

### Uniform model (all interfaces)

1. **Everything at `debug`.** Every consumer request log (JSON-RPC, REST POST, REST non-POST) is a single `debug` line, matching tendermint/gRPC/websocket. The provider "Sending request to node" log is `debug` too. **Nothing request/payload-level is logged at `info`.** Default `--log-level` stays `info`, so payloads are off by default.

2. **Scrub-in-place, not blank.** `utils.ScrubSecrets` removes only:
   - **API keys** — URL `?key=`/`?api_key=`/`?token=`/`?access_token=`/`?auth=` query values, and long opaque provider URL path segments (`/v2/<token>`, `/ethereum/<token>`, …).
   - **IP addresses** — IPv4 and IPv6.

   The rest of the body/params stays readable. Verified it does **not** touch block hashes or hex block numbers (no false positives).

3. **`--log-unsafe-payloads` flag (default off).** When set, all helpers pass values through **verbatim** for local debugging. Logs a loud startup warning. Never enable on a publicly reachable / shared-logging deployment.

### Redaction helpers (one source of truth)

- `RedactPayload(string)` / `RedactPayloadAny(any)` — scrub bodies/params/URLs unless unsafe.
- `RedactSensitiveMetadata` / `RedactSensitiveHeaderMap` / `RedactSensitiveStringMap` — blank credential headers by allowlist (`authorization`, `cookie`, `x-api-key`, …) **and** scrub keys/IPs from the remaining values. Exported so `relaycore` shares the same list instead of a divergent copy.

### Coverage

Every header/body/payload/params log site across `jsonRPC.go`, `rest.go`, `tendermintRPC.go`, `grpc.go`, `consumer_websocket_manager.go`, `relaycore/results_manager.go` (the always-emitted node-error dump), `endpoint_chain_fetcher.go`, `parser.go`, `rpcclient/handler.go`, and the `rpcInterfaceMessages` / `grpcproxy` marshal-error logs. A final sweep confirms no unredacted live-traffic log remains.

### Debugging full payloads

`--log-unsafe-payloads --log-level debug` → verbatim bodies, params, headers, and URLs.

## Test plan

- `go build ./...` clean; `go vet` clean on touched packages.
- `go test` passes for utils, chainlib (+ subpackages), relaycore, metrics, parser.
- New `utils` tests: `ScrubSecrets` (key/IP scrubbed, structure + block hashes preserved) and flag-honoring passthrough; chainlib header-redaction tests retained.
- Pre-existing unrelated failure: `grpcproxy/dyncodec TestRemotes` (gRPC reflection test needing a live server) fails on clean `main` too.

## Scope note

Sibling Ticket 2 items (CORS T4, `0.0.0.0` bindings T3, docs/license T5) remain out of scope and tracked separately.