### PR TITLE
chore(rpcsmartrouter): make --geolocation optional

### DIFF
--- a/protocol/rpcsmartrouter/README.md
+++ b/protocol/rpcsmartrouter/README.md
@@ -56,16 +56,16 @@ backup-providers:
 
 ```bash
 # Using standalone binary
-smartrouter config.yml --geolocation 1 --use-static-spec specs/
+smartrouter config.yml --use-static-spec specs/
 
 # Using lavap
-lavap rpcsmartrouter config.yml --geolocation 1 --use-static-spec specs/
+lavap rpcsmartrouter config.yml --use-static-spec specs/
 ```
 
 ### Common Flags
 
 ```bash
---geolocation 1                      # Geographic location code
+--geolocation 1                      # Geographic location code (optional, defaults to 1)
 --cache-be "127.0.0.1:7778"          # Enable caching
 --strategy balanced                   # Provider selection strategy
 --metrics-listen-address ":7779"     # Prometheus metrics

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -1742,11 +1742,11 @@ func CreateRPCSmartRouterCobraCommand() *cobra.Command {
 		if no arguments are passed, assumes default config file: ` + DefaultRPCSmartRouterFileName + `
 		if one argument is passed, its assumed the config file name
 		`,
-		Example: `required flags: --geolocation 1 --static-providers ...
+		Example: `required: --static-providers ...   (--geolocation is optional, defaults to 1)
 rpcsmartrouter <flags>
 rpcsmartrouter rpcsmartrouter_conf <flags>
 rpcsmartrouter 127.0.0.1:3333 OSMOSIS tendermintrpc 127.0.0.1:3334 OSMOSIS rest <flags>
-rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127.0.0.1:7778" --geolocation 1 [--debug-relays] --log_level <debug|warn|...>`,
+rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127.0.0.1:7778" [--geolocation 1] [--debug-relays] --log_level <debug|warn|...>`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			// Optionally run one of the validators provided by cobra
 			if err := cobra.RangeArgs(0, 1)(cmd, args); err == nil {
@@ -1845,7 +1845,7 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 
 			geolocation, err := cmd.Flags().GetUint64(lavasession.GeolocationFlag)
 			if err != nil {
-				utils.LavaFormatFatal("failed to read geolocation flag, required flag", err)
+				utils.LavaFormatFatal("failed to read geolocation flag", err)
 			}
 			rpcEndpoints, err = ParseEndpoints(viper.GetViper(), geolocation)
 			if err != nil || len(rpcEndpoints) == 0 {
@@ -2097,9 +2097,12 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	}
 
 	// RPCSmartRouter command flags - no blockchain flags needed
-	cmdRPCSmartRouter.Flags().Uint64(common.GeolocationFlag, 0, "geolocation to run from")
+	// Optional: smart-router uses static, pre-configured providers and does not
+	// pair on-chain, so geolocation has no effect on provider discovery and only
+	// a dulled effect on QoS reputation (the reputation-nulling branch is skipped
+	// for static providers). Defaults to 1; operators rarely need to set it.
+	cmdRPCSmartRouter.Flags().Uint64(common.GeolocationFlag, 1, "geolocation to run from (optional; static providers don't pair by geo)")
 	cmdRPCSmartRouter.Flags().Uint(common.MaximumConcurrentProvidersFlagName, 3, "max number of concurrent providers to communicate with")
-	cmdRPCSmartRouter.MarkFlagRequired(common.GeolocationFlag)
 	cmdRPCSmartRouter.Flags().Bool(lavasession.AllowInsecureConnectionToProvidersFlag, false, "allow insecure provider-dialing. used for development and testing")
 	cmdRPCSmartRouter.Flags().String(common.ResponseCompressionFlag, common.DefaultResponseCompression, "client-facing response compression: gzip (default), brotli, or off")
 	cmdRPCSmartRouter.Flags().Uint64Var(&lavasession.MaximumStreamsOverASingleConnection, lavasession.MaximumStreamsOverASingleConnectionFlag, lavasession.DefaultMaximumStreamsOverASingleConnection, "maximum number of parallel streams over a single provider connection")


### PR DESCRIPTION
## Summary

Removes the requirement to pass `--geolocation` on the `rpcsmartrouter` command.

In normal Lava, a consumer discovers providers **on-chain** and geolocation drives pairing + QoS reputation. Smart-router instead uses **static, pre-configured providers** and does not pair on-chain, so geolocation:
- has **no effect** on provider discovery, and
- has only a **dulled effect** on QoS reputation — the reputation-nulling branch in `consumer_session_manager.go` is explicitly skipped for static providers (`&& !StaticProvider`).

Forcing every operator to supply `--geolocation` was friction for a value whose teeth are mostly absent in this product's static-provider model.

## Changes

- Drop `MarkFlagRequired(GeolocationFlag)`.
- Default the flag to `1` (matching the value the `test` subcommand already hardcodes for its endpoints).
- The value still propagates to every parsed `RPCEndpoint` via `ParseEndpoints`, so operators who *do* care about geo can still set it explicitly.
- Update the stale `"failed to read geolocation flag, required flag"` fatal message, the cobra `Example` text, and the README.

## Test plan

- `go build ./...` ✅
- `go vet ./protocol/rpcsmartrouter/...` ✅
- `go test ./protocol/rpcsmartrouter/...` ✅ (incl. `TestParseEndpoints_GeolocationFlagBinding`, which still verifies the flag→endpoint roundtrip)

## Breaking changes

None. Callers already passing `--geolocation N` are unaffected. Callers who omitted it (and were previously rejected) now succeed with a default of `1`.