### PR TITLE
refactor(flags)!: rename provider-optimizer-* weight flags to qos-*

### DIFF
--- a/protocol/common/cobra_common.go
+++ b/protocol/common/cobra_common.go
@@ -80,11 +80,11 @@ const (
 	EnableSelectionStatsHeaderFlag = "enable-selection-stats" // enable selection stats header for debugging provider selection // allows the user to manually load a spec providing a path, this is useful to test spec changes before they hit the blockchain
 
 	// weighted selection flags (new system replacing tiers)
-	ProviderOptimizerAvailabilityWeight = "provider-optimizer-availability-weight"  // weight for availability score (default: 0.4)
-	ProviderOptimizerLatencyWeight      = "provider-optimizer-latency-weight"       // weight for latency score (default: 0.3)
-	ProviderOptimizerSyncWeight         = "provider-optimizer-sync-weight"          // weight for sync score (default: 0.2)
-	ProviderOptimizerStakeWeight        = "provider-optimizer-stake-weight"         // weight for stake (default: 0.1)
-	ProviderOptimizerMinSelectionChance = "provider-optimizer-min-selection-chance" // minimum selection probability for any provider (default: 0.01)
+	ProviderOptimizerAvailabilityWeight = "qos-availability-weight"  // weight for availability score (default: 0.4)
+	ProviderOptimizerLatencyWeight      = "qos-latency-weight"       // weight for latency score (default: 0.3)
+	ProviderOptimizerSyncWeight         = "qos-sync-weight"          // weight for sync score (default: 0.2)
+	ProviderOptimizerStakeWeight        = "qos-stake-weight"         // weight for stake (default: 0.1)
+	ProviderOptimizerMinSelectionChance = "qos-min-selection-chance" // minimum selection probability for any provider (default: 0.01)
 
 	// optimizer qos sampling cadence — drives the in-memory /metrics
 	// selection-score cache and the OTel optimizer_qos emit.


### PR DESCRIPTION
## Summary
- Renames the five weighted-selection optimizer flags to drop the word **provider**, so the names describe the QoS dimension instead of the entity being scored.

| Old | New |
| --- | --- |
| `--provider-optimizer-availability-weight` | `--qos-availability-weight` |
| `--provider-optimizer-latency-weight` | `--qos-latency-weight` |
| `--provider-optimizer-sync-weight` | `--qos-sync-weight` |
| `--provider-optimizer-stake-weight` | `--qos-stake-weight` |
| `--provider-optimizer-min-selection-chance` | `--qos-min-selection-chance` |

Only the user-facing flag **strings** in `protocol/common/cobra_common.go` change. The internal constant identifiers (`ProviderOptimizerAvailabilityWeight`, …) and all viper bindings/lookups are untouched, so the diff is a single-file, five-line rename.

## ⚠️ Breaking change — coordinated rollout
The command has **no unknown-flag whitelist**, so any caller still passing the old flag names will crash-loop with `Error: unknown flag`. The helm chart passes these flags.

**Companion chart PR** (must merge/release only *after* a binary carrying this change ships): `smart-router-helm-chart` → switches the deployment template to the new `--qos-*` names.

## Test plan
- [x] `go build ./protocol/common/ ./protocol/rpcsmartrouter/` passes
- [x] grep confirms no `provider-optimizer-*-weight` / `-min-selection-chance` strings remain anywhere in the repo