### PR TITLE
refactor!: drop the lava prefix from smart-router metric names

### DIFF
--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -2,7 +2,7 @@
 #
 # Scrapes the smart-router's metrics endpoint (metrics-listen-address in the
 # router config, default 0.0.0.0:7779). The dashboard backend then runs PromQL
-# against this Prometheus (lava_rpcsmartrouter_* series) to build its panels.
+# against this Prometheus (smartrouter_* series) to build its panels.
 global:
   scrape_interval: 15s
   evaluation_interval: 15s

--- a/docs/ERROR-REGISTRY-DESIGN.md
+++ b/docs/ERROR-REGISTRY-DESIGN.md
@@ -519,7 +519,7 @@ Log output automatically includes:
 ### Phase 2: Logging Integration
 - [x] Add `LavaFormatCodedError` helper to `utils/lavalog.go` that takes a `LavaError` code
 - [x] Ensure coded errors emit `error_code`, `error_name`, `error_category`, `retryable`, `chain_error_code`, `chain_error_message` fields in structured logs
-- [x] Add Prometheus counter that auto-increments per error code (`lava_errors_total{code, name, category, retryable, chain_id}`)
+- [x] Add Prometheus counter that auto-increments per error code (`smartrouter_errors_total{code, name, category, retryable, chain_id}`)
 - [x] Write unit tests for coded error logging
 
 ### Phase 3: Migrate Existing Errors — Protocol Layer
@@ -554,10 +554,10 @@ Log output automatically includes:
 - [x] Update provider server (`rpcprovider/rpcprovider_server.go`) to log with codes
 
 ### Phase 6: Metrics & Observability
-- [x] Verify Prometheus counter `lava_errors_total{code, name, category, retryable}` works end-to-end
-- [x] Update `protocol/metrics/consumer_metrics_manager.go` to use error codes (lava_errors_total auto-fires via LogCodedError — existing incident metrics kept for backwards compat)
+- [x] Verify Prometheus counter `smartrouter_errors_total{code, name, category, retryable}` works end-to-end
+- [x] Update `protocol/metrics/consumer_metrics_manager.go` to use error codes (smartrouter_errors_total auto-fires via LogCodedError — existing incident metrics kept for backwards compat)
 - [x] Update `protocol/metrics/rpcconsumer_logs.go` to use error codes (same — LogCodedError handles it)
-- [x] Verify error codes appear in existing dashboards/alerts (lava_errors_total emits all labels needed for dashboards)
+- [x] Verify error codes appear in existing dashboards/alerts (smartrouter_errors_total emits all labels needed for dashboards)
 
 ### Phase 7: Refactor — Replace Legacy Errors with LavaError
 - [x] Remove `UnsupportedMethodError` / `SolanaNonRetryableError` custom types, replace with `LavaWrappedError` + `LavaError.SubCategory` / `LavaError.Retryable`

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -208,4 +208,4 @@ Defined in [`error_metrics.go`](../protocol/metrics/error_metrics.go).
 
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
-| `lava_errors_total` | Counter | `error_name`, `error_category`, `retryable`, `chain_id` | Errors classified by name, category, retryability, and chain. |
+| `smartrouter_errors_total` | Counter | `error_name`, `error_category`, `retryable`, `chain_id` | Errors classified by name, category, retryability, and chain. |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -202,7 +202,7 @@ assert `/debug/reset-all` emptied each store (see MAG-1762). All drop to `0` aft
 
 ## Shared metrics
 
-### Classified errors — `lava_errors_*`
+### Classified errors — `smartrouter_errors_*`
 
 Defined in [`error_metrics.go`](../protocol/metrics/error_metrics.go).
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -19,7 +19,7 @@ metrics manager.
 | Flag / env | Default | Effect |
 | --- | --- | --- |
 | `--metrics-listen-address` | `disabled` | Address to expose Prometheus metrics on, e.g. `:7779` or `localhost:7779`. The literal `disabled` turns the metrics server off entirely. |
-| `--optimizer-qos-sampling-interval` | `1s` | How often the optimizer-QoS sampler refreshes the `lava_rpc_optimizer_selection_score` gauge and — when `--usage-otel-enabled` is set — emits `optimizer_qos` events to the OTel usage pipeline. |
+| `--optimizer-qos-sampling-interval` | `1s` | How often the optimizer-QoS sampler refreshes the `rpc_optimizer_selection_score` gauge and — when `--usage-otel-enabled` is set — emits `optimizer_qos` events to the OTel usage pipeline. |
 
 ```bash
 # enable, then scrape
@@ -33,7 +33,7 @@ name and the `disabled` sentinel live in
 [`flags.go`](../protocol/metrics/flags.go#L8).
 
 > **Optimizer scores are always on.** The optimizer-QoS client is created
-> unconditionally, so `lava_rpc_optimizer_selection_score` is populated on `/metrics`
+> unconditionally, so `rpc_optimizer_selection_score` is populated on `/metrics`
 > regardless of telemetry config. Remote shipping of these reports now flows through the
 > OTel usage pipeline (`--usage-otel-enabled`), not a dedicated push address. (There is no
 > separate `GET /provider_optimizer_metrics` endpoint; that handler was removed along with
@@ -65,53 +65,53 @@ name and the `disabled` sentinel live in
 
 These are the metrics specific to running as a Smart Router, defined in
 [`smartrouter_metrics_manager.go`](../protocol/metrics/smartrouter_metrics_manager.go).
-They split into **endpoint-scoped** (`lava_rpc_endpoint_*`) and **router-scoped**
-(`lava_rpcsmartrouter_*`) families.
+They split into **endpoint-scoped** (`rpc_endpoint_*`) and **router-scoped**
+(`smartrouter_*`) families.
 
-### Endpoint-scoped — `lava_rpc_endpoint_*`
+### Endpoint-scoped — `rpc_endpoint_*`
 
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
-| `lava_rpc_endpoint_total_relays_serviced` | Counter | `spec`, `apiInterface`, `endpoint_id`, `function` | Relays successfully served by this endpoint. |
-| `lava_rpc_endpoint_total_errored` | Counter | `spec`, `apiInterface`, `endpoint_id`, `function` | Errored relays for this endpoint. |
-| `lava_rpc_endpoint_requests_in_flight` | Gauge | `spec`, `apiInterface`, `endpoint_id`, `function` | Relays currently in flight to this endpoint. |
-| `lava_rpc_endpoint_end_to_end_latency_milliseconds` | Histogram | `spec`, `apiInterface`, `endpoint_id`, `function` | End-to-end latency per function for this endpoint. |
-| `lava_rpc_endpoint_overall_health` | Gauge | `spec`, `apiInterface`, `endpoint_id` | Endpoint health (1 healthy / 0 unhealthy). |
-| `lava_rpc_endpoint_overall_health_breakdown` | Gauge | `spec`, `apiInterface` | Aggregate health per chain/interface. |
-| `lava_rpc_endpoint_selection_score` | Gauge | `spec`, `apiInterface`, `endpoint_id`, `score_type` | Selection scores by `score_type` (availability / latency / sync / stake / composite). |
-| `lava_rpc_endpoint_latest_block` | Gauge | `spec`, `apiInterface`, `endpoint_id` | Latest block reported by the endpoint. |
-| `lava_rpc_endpoint_fetch_latest_fails` | Counter | `spec`, `apiInterface`, `endpoint_id` | Failed latest-block fetches. |
-| `lava_rpc_endpoint_fetch_block_fails` | Counter | `spec`, `apiInterface`, `endpoint_id` | Failed specific-block fetches. |
-| `lava_rpc_endpoint_fetch_latest_success` | Counter | `spec`, `apiInterface`, `endpoint_id` | Successful latest-block fetches. |
-| `lava_rpc_endpoint_fetch_block_success` | Counter | `spec`, `apiInterface`, `endpoint_id` | Successful specific-block fetches. |
+| `rpc_endpoint_total_relays_serviced` | Counter | `spec`, `apiInterface`, `endpoint_id`, `function` | Relays successfully served by this endpoint. |
+| `rpc_endpoint_total_errored` | Counter | `spec`, `apiInterface`, `endpoint_id`, `function` | Errored relays for this endpoint. |
+| `rpc_endpoint_requests_in_flight` | Gauge | `spec`, `apiInterface`, `endpoint_id`, `function` | Relays currently in flight to this endpoint. |
+| `rpc_endpoint_end_to_end_latency_milliseconds` | Histogram | `spec`, `apiInterface`, `endpoint_id`, `function` | End-to-end latency per function for this endpoint. |
+| `rpc_endpoint_overall_health` | Gauge | `spec`, `apiInterface`, `endpoint_id` | Endpoint health (1 healthy / 0 unhealthy). |
+| `rpc_endpoint_overall_health_breakdown` | Gauge | `spec`, `apiInterface` | Aggregate health per chain/interface. |
+| `rpc_endpoint_selection_score` | Gauge | `spec`, `apiInterface`, `endpoint_id`, `score_type` | Selection scores by `score_type` (availability / latency / sync / stake / composite). |
+| `rpc_endpoint_latest_block` | Gauge | `spec`, `apiInterface`, `endpoint_id` | Latest block reported by the endpoint. |
+| `rpc_endpoint_fetch_latest_fails` | Counter | `spec`, `apiInterface`, `endpoint_id` | Failed latest-block fetches. |
+| `rpc_endpoint_fetch_block_fails` | Counter | `spec`, `apiInterface`, `endpoint_id` | Failed specific-block fetches. |
+| `rpc_endpoint_fetch_latest_success` | Counter | `spec`, `apiInterface`, `endpoint_id` | Successful latest-block fetches. |
+| `rpc_endpoint_fetch_block_success` | Counter | `spec`, `apiInterface`, `endpoint_id` | Successful specific-block fetches. |
 
 ### Optimizer
 
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
-| `lava_rpc_optimizer_selection_score` | Gauge | `spec`, `endpoint_id`, `score_type` | Periodic optimizer selection score per provider, by `score_type`. |
+| `rpc_optimizer_selection_score` | Gauge | `spec`, `endpoint_id`, `score_type` | Periodic optimizer selection score per provider, by `score_type`. |
 
-### Router-scoped — `lava_rpcsmartrouter_*`
+### Router-scoped — `smartrouter_*`
 
 #### Core relay & health
 
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
-| `lava_rpcsmartrouter_total_relays_serviced` | Counter | `spec`, `apiInterface`, `function` | Relays served by the router. |
-| `lava_rpcsmartrouter_total_errored` | Counter | `spec`, `apiInterface`, `function` | Errored relays. |
-| `lava_rpcsmartrouter_end_to_end_latency_milliseconds` | Histogram | `spec`, `apiInterface`, `function` | Router-level end-to-end latency. |
-| `lava_rpcsmartrouter_overall_health` | Gauge | — | Overall router health (1 / 0). |
-| `lava_rpcsmartrouter_overall_health_breakdown` | Gauge | `spec`, `apiInterface` | Per-chain/interface health. |
-| `lava_rpcsmartrouter_latest_block` | Gauge | `spec`, `apiInterface` | Latest block known to the router. |
-| `lava_rpcsmartrouter_protocol_version` | Gauge | `version` | Encoded protocol version. |
+| `smartrouter_total_relays_serviced` | Counter | `spec`, `apiInterface`, `function` | Relays served by the router. |
+| `smartrouter_total_errored` | Counter | `spec`, `apiInterface`, `function` | Errored relays. |
+| `smartrouter_end_to_end_latency_milliseconds` | Histogram | `spec`, `apiInterface`, `function` | Router-level end-to-end latency. |
+| `smartrouter_overall_health` | Gauge | — | Overall router health (1 / 0). |
+| `smartrouter_overall_health_breakdown` | Gauge | `spec`, `apiInterface` | Per-chain/interface health. |
+| `smartrouter_latest_block` | Gauge | `spec`, `apiInterface` | Latest block known to the router. |
+| `smartrouter_protocol_version` | Gauge | `version` | Encoded protocol version. |
 
 #### WebSocket
 
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
-| `lava_rpcsmartrouter_ws_connections_active` | Gauge | `spec`, `apiInterface` | Active WebSocket connections. |
-| `lava_rpcsmartrouter_ws_subscriptions_total` | Counter | `spec`, `apiInterface` | Total WebSocket subscription requests. |
-| `lava_rpcsmartrouter_ws_subscription_errors_total` | Counter | `spec`, `apiInterface` | Failed WebSocket subscription requests. |
+| `smartrouter_ws_connections_active` | Gauge | `spec`, `apiInterface` | Active WebSocket connections. |
+| `smartrouter_ws_subscriptions_total` | Counter | `spec`, `apiInterface` | Total WebSocket subscription requests. |
+| `smartrouter_ws_subscription_errors_total` | Counter | `spec`, `apiInterface` | Failed WebSocket subscription requests. |
 
 #### Request breakdown
 
@@ -121,59 +121,59 @@ with read/write.
 
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
-| `lava_rpcsmartrouter_requests_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | All requests. |
-| `lava_rpcsmartrouter_requests_success_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Successful requests. |
-| `lava_rpcsmartrouter_requests_failed_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Failed requests. |
-| `lava_rpcsmartrouter_requests_read_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Read (stateless) requests. |
-| `lava_rpcsmartrouter_requests_write_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Write (stateful) requests. |
-| `lava_rpcsmartrouter_requests_debug_trace_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Debug/trace addon requests. |
-| `lava_rpcsmartrouter_requests_archive_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Archive requests. |
-| `lava_rpcsmartrouter_requests_batch_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Batch requests. |
+| `smartrouter_requests_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | All requests. |
+| `smartrouter_requests_success_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Successful requests. |
+| `smartrouter_requests_failed_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Failed requests. |
+| `smartrouter_requests_read_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Read (stateless) requests. |
+| `smartrouter_requests_write_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Write (stateful) requests. |
+| `smartrouter_requests_debug_trace_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Debug/trace addon requests. |
+| `smartrouter_requests_archive_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Archive requests. |
+| `smartrouter_requests_batch_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Batch requests. |
 
 #### Errors
 
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
-| `lava_rpcsmartrouter_node_errors_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Node errors returned by endpoints. |
-| `lava_rpcsmartrouter_protocol_errors_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Protocol/transport errors (connection/session failures). |
+| `smartrouter_node_errors_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Node errors returned by endpoints. |
+| `smartrouter_protocol_errors_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Protocol/transport errors (connection/session failures). |
 
 #### Retries
 
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
-| `lava_rpcsmartrouter_retries_total` | Counter | `spec`, `apiInterface`, `method` | Retry attempts triggered (beyond the first try). |
-| `lava_rpcsmartrouter_retries_success_total` | Counter | `spec`, `apiInterface`, `method` | Retried requests that succeeded. |
-| `lava_rpcsmartrouter_retries_failed_total` | Counter | `spec`, `apiInterface`, `method` | Retried requests that failed. |
-| `lava_rpcsmartrouter_retry_attempts` | Histogram | `spec`, `apiInterface`, `method` | Attempts per retried request (buckets 1…10). |
+| `smartrouter_retries_total` | Counter | `spec`, `apiInterface`, `method` | Retry attempts triggered (beyond the first try). |
+| `smartrouter_retries_success_total` | Counter | `spec`, `apiInterface`, `method` | Retried requests that succeeded. |
+| `smartrouter_retries_failed_total` | Counter | `spec`, `apiInterface`, `method` | Retried requests that failed. |
+| `smartrouter_retry_attempts` | Histogram | `spec`, `apiInterface`, `method` | Attempts per retried request (buckets 1…10). |
 
 #### Consistency
 
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
-| `lava_rpcsmartrouter_consistency_total` | Counter | `spec`, `apiInterface`, `method` | Requests enforcing consistency (seenBlock). |
-| `lava_rpcsmartrouter_consistency_success_total` | Counter | `spec`, `apiInterface`, `method` | Consistency-enforced requests that succeeded. |
-| `lava_rpcsmartrouter_consistency_failed_total` | Counter | `spec`, `apiInterface`, `method` | Consistency-enforced requests that failed. |
+| `smartrouter_consistency_total` | Counter | `spec`, `apiInterface`, `method` | Requests enforcing consistency (seenBlock). |
+| `smartrouter_consistency_success_total` | Counter | `spec`, `apiInterface`, `method` | Consistency-enforced requests that succeeded. |
+| `smartrouter_consistency_failed_total` | Counter | `spec`, `apiInterface`, `method` | Consistency-enforced requests that failed. |
 
 #### Hedging
 
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
-| `lava_rpcsmartrouter_hedge_total` | Counter | `spec`, `apiInterface`, `method` | Hedge (batch-ticker) relays sent. |
-| `lava_rpcsmartrouter_hedge_success_total` | Counter | `spec`, `apiInterface`, `method` | Hedged requests that succeeded. |
-| `lava_rpcsmartrouter_hedge_failed_total` | Counter | `spec`, `apiInterface`, `method` | Hedged requests that failed. |
-| `lava_rpcsmartrouter_hedge_attempts` | Histogram | `spec`, `apiInterface`, `method` | Hedge relays per request (buckets 1…10). |
+| `smartrouter_hedge_total` | Counter | `spec`, `apiInterface`, `method` | Hedge (batch-ticker) relays sent. |
+| `smartrouter_hedge_success_total` | Counter | `spec`, `apiInterface`, `method` | Hedged requests that succeeded. |
+| `smartrouter_hedge_failed_total` | Counter | `spec`, `apiInterface`, `method` | Hedged requests that failed. |
+| `smartrouter_hedge_attempts` | Histogram | `spec`, `apiInterface`, `method` | Hedge relays per request (buckets 1…10). |
 
 #### Cross-validation
 
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
-| `lava_rpcsmartrouter_cross_validation_requests_total` | Counter | `spec`, `apiInterface`, `method` | Cross-validated requests. Includes request-time structural fail-fasts (`insufficient-capacity` / `insufficient-groups`) that abort **before fanning out to any provider**, so this is *not* the same as the number of provider fan-outs. |
-| `lava_rpcsmartrouter_cross_validation_success_total` | Counter | `spec`, `apiInterface`, `method` | Requests that reached consensus. |
-| `lava_rpcsmartrouter_cross_validation_failed_total` | Counter | `spec`, `apiInterface`, `method` | Requests that did not return a consensus answer — quorum-time failures (no-agreement / diversity / per-group) **and** request-time structural fail-fasts that never tried (`insufficient-capacity` / `insufficient-groups`). `requests_total == success_total + failed_total`. |
-| `lava_rpcsmartrouter_cross_validation_provider_agreements_total` | Counter | `spec`, `apiInterface`, `method`, `provider_address` | Times a provider agreed with consensus. |
-| `lava_rpcsmartrouter_cross_validation_provider_disagreements_total` | Counter | `spec`, `apiInterface`, `method`, `provider_address` | Times a provider disagreed with consensus. |
-| `lava_rpcsmartrouter_cross_validation_mismatch_total` | Counter | `spec`, `apiInterface`, `method`, `group`, `finality` | **Content outliers** by group: one increment **per distinct outlier group per successful deterministic cross-validation request** (a response whose `SHA256(reply.data)` diverged from the reached consensus) — not a per-provider counter. Only emitted when a quorum was reached; quorum failures and node/protocol errors are excluded (failures report a `lava-cross-validation-failure-reason` instead). `finality` is `finalized` / `not_finalized` / `unknown`; post-finality divergence is the high-signal alert. Bounded cardinality (keyed by operator-defined `group`, not provider address). |
-| `lava_rpcsmartrouter_cross_validation_failures_total` | Counter | `spec`, `apiInterface`, `method`, `reason` | **Failures by reason** — the by-reason breakdown of `cross_validation_failed_total` (which stays unlabeled, so existing dashboards are unaffected). `reason` is the closed `lava-cross-validation-failure-reason` enum: quorum-time `no-agreement` / `insufficient-responses` / `diversity-unmet` / `group-quorum-unmet`, or request-time structural `insufficient-capacity` / `insufficient-groups`. Use it to separate a structural failure (client should fall back) from a quorum disagreement (a retry may help). Bounded cardinality (the reason set is a closed enum). |
+| `smartrouter_cross_validation_requests_total` | Counter | `spec`, `apiInterface`, `method` | Cross-validated requests. Includes request-time structural fail-fasts (`insufficient-capacity` / `insufficient-groups`) that abort **before fanning out to any provider**, so this is *not* the same as the number of provider fan-outs. |
+| `smartrouter_cross_validation_success_total` | Counter | `spec`, `apiInterface`, `method` | Requests that reached consensus. |
+| `smartrouter_cross_validation_failed_total` | Counter | `spec`, `apiInterface`, `method` | Requests that did not return a consensus answer — quorum-time failures (no-agreement / diversity / per-group) **and** request-time structural fail-fasts that never tried (`insufficient-capacity` / `insufficient-groups`). `requests_total == success_total + failed_total`. |
+| `smartrouter_cross_validation_provider_agreements_total` | Counter | `spec`, `apiInterface`, `method`, `provider_address` | Times a provider agreed with consensus. |
+| `smartrouter_cross_validation_provider_disagreements_total` | Counter | `spec`, `apiInterface`, `method`, `provider_address` | Times a provider disagreed with consensus. |
+| `smartrouter_cross_validation_mismatch_total` | Counter | `spec`, `apiInterface`, `method`, `group`, `finality` | **Content outliers** by group: one increment **per distinct outlier group per successful deterministic cross-validation request** (a response whose `SHA256(reply.data)` diverged from the reached consensus) — not a per-provider counter. Only emitted when a quorum was reached; quorum failures and node/protocol errors are excluded (failures report a `lava-cross-validation-failure-reason` instead). `finality` is `finalized` / `not_finalized` / `unknown`; post-finality divergence is the high-signal alert. Bounded cardinality (keyed by operator-defined `group`, not provider address). |
+| `smartrouter_cross_validation_failures_total` | Counter | `spec`, `apiInterface`, `method`, `reason` | **Failures by reason** — the by-reason breakdown of `cross_validation_failed_total` (which stays unlabeled, so existing dashboards are unaffected). `reason` is the closed `lava-cross-validation-failure-reason` enum: quorum-time `no-agreement` / `insufficient-responses` / `diversity-unmet` / `group-quorum-unmet`, or request-time structural `insufficient-capacity` / `insufficient-groups`. Use it to separate a structural failure (client should fall back) from a quorum disagreement (a retry may help). Bounded cardinality (the reason set is a closed enum). |
 
 > The `_mismatch_total` series is the group-level alerting surface for [outliers](../protocol/rpcsmartrouter/README.md#outlier-behavior). When enough providers still agree, a divergent provider is outvoted and recorded here; per-provider detail lives in the `cross-validation outlier detected` info log and the `lava-cross-validation-disagreeing-providers` header.
 
@@ -181,10 +181,10 @@ with read/write.
 
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
-| `lava_rpcsmartrouter_cache_requests_total` | Counter | `spec`, `apiInterface`, `method` | Cache lookup attempts. |
-| `lava_rpcsmartrouter_cache_success_total` | Counter | `spec`, `apiInterface`, `method` | Cache hits. |
-| `lava_rpcsmartrouter_cache_failed_total` | Counter | `spec`, `apiInterface`, `method` | Cache misses. |
-| `lava_rpcsmartrouter_cache_latency_milliseconds` | Histogram | `spec`, `apiInterface`, `method` | Cache lookup latency. |
+| `smartrouter_cache_requests_total` | Counter | `spec`, `apiInterface`, `method` | Cache lookup attempts. |
+| `smartrouter_cache_success_total` | Counter | `spec`, `apiInterface`, `method` | Cache hits. |
+| `smartrouter_cache_failed_total` | Counter | `spec`, `apiInterface`, `method` | Cache misses. |
+| `smartrouter_cache_latency_milliseconds` | Histogram | `spec`, `apiInterface`, `method` | Cache lookup latency. |
 
 #### CSM state-store sizes (diagnostics)
 
@@ -193,10 +193,10 @@ assert `/debug/reset-all` emptied each store (see MAG-1762). All drop to `0` aft
 
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
-| `lava_rpcsmartrouter_csm_blocked_providers` | Gauge | `spec`, `apiInterface` | Size of the previous-epoch blocked-providers store. |
-| `lava_rpcsmartrouter_csm_blocked_backup_providers` | Gauge | `spec`, `apiInterface` | Size of the blocked-backup-providers store. |
-| `lava_rpcsmartrouter_csm_sticky_sessions` | Gauge | `spec`, `apiInterface` | Live sticky-session affinities. |
-| `lava_rpcsmartrouter_csm_reported_providers` | Gauge | `spec`, `apiInterface` | Size of the reported-providers register. |
+| `smartrouter_csm_blocked_providers` | Gauge | `spec`, `apiInterface` | Size of the previous-epoch blocked-providers store. |
+| `smartrouter_csm_blocked_backup_providers` | Gauge | `spec`, `apiInterface` | Size of the blocked-backup-providers store. |
+| `smartrouter_csm_sticky_sessions` | Gauge | `spec`, `apiInterface` | Live sticky-session affinities. |
+| `smartrouter_csm_reported_providers` | Gauge | `spec`, `apiInterface` | Size of the reported-providers register. |
 
 ---
 

--- a/protocol/common/error_registry.go
+++ b/protocol/common/error_registry.go
@@ -460,7 +460,7 @@ type errorMapping struct {
 //   - The relay-race design sends one attempt per provider per retry, not
 //     a tight loop against a single struggling provider.
 //
-// If a new unknown-error class starts dominating lava_errors_total in
+// If a new unknown-error class starts dominating smartrouter_errors_total in
 // production, the right response is to add a matcher for it in
 // error_classifier.go (demoting it from Unknown to a specific code with
 // the appropriate Retryable flag), not to flip this default.

--- a/protocol/metrics/error_metrics.go
+++ b/protocol/metrics/error_metrics.go
@@ -39,7 +39,7 @@ func InitErrorMetrics() {
 		// structured logs for operator search; the Prometheus series only
 		// needs one identity key.
 		counter := prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "lava_errors_total",
+			Name: "smartrouter_errors_total",
 			Help: "Total classified errors by name, category, retryability, and chain.",
 		}, []string{"error_name", "error_category", "retryable", "chain_id"})
 
@@ -50,7 +50,7 @@ func InitErrorMetrics() {
 		//     collector so both callers share the same counter.
 		//  3. Any OTHER registration failure (collector with same name but
 		//     mismatched labels, Prometheus internal error, etc.) → log a
-		//     warning so operators know lava_errors_total will not be
+		//     warning so operators know smartrouter_errors_total will not be
 		//     scrapable. The callback is still wired up so the counter
 		//     keeps accumulating in-process and can be reached via direct
 		//     introspection, but /metrics will be missing the series.
@@ -60,7 +60,7 @@ func InitErrorMetrics() {
 					counter = reused
 				}
 			} else {
-				utils.LavaFormatWarning("failed to register lava_errors_total Prometheus counter; metric will not appear in /metrics scrapes", err)
+				utils.LavaFormatWarning("failed to register smartrouter_errors_total Prometheus counter; metric will not appear in /metrics scrapes", err)
 			}
 		}
 

--- a/protocol/metrics/error_metrics_integration_test.go
+++ b/protocol/metrics/error_metrics_integration_test.go
@@ -16,7 +16,7 @@ func TestErrorMetrics_EndToEnd(t *testing.T) {
 	// Use a fresh registry to avoid interference from other tests
 	reg := prometheus.NewRegistry()
 	counter := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_errors_total_e2e",
+		Name: "smartrouter_errors_total_e2e",
 		Help: "End-to-end test counter",
 	}, []string{"error_code", "error_name", "error_category", "retryable", "chain_id"})
 	reg.MustRegister(counter)
@@ -49,7 +49,7 @@ func TestErrorMetrics_EndToEnd(t *testing.T) {
 	require.Len(t, families, 1)
 
 	family := families[0]
-	assert.Equal(t, "lava_errors_total_e2e", *family.Name)
+	assert.Equal(t, "smartrouter_errors_total_e2e", *family.Name)
 	assert.Len(t, family.Metric, 3) // 3 distinct label combos
 
 	for _, m := range family.Metric {

--- a/protocol/metrics/error_metrics_test.go
+++ b/protocol/metrics/error_metrics_test.go
@@ -14,7 +14,7 @@ func TestInitErrorMetrics(t *testing.T) {
 	reg := prometheus.NewRegistry()
 
 	counter := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_errors_total_test",
+		Name: "smartrouter_errors_total_test",
 		Help: "Test counter",
 	}, []string{"error_code", "error_name", "error_category", "retryable", "chain_id"})
 	reg.MustRegister(counter)
@@ -50,7 +50,7 @@ func TestInitErrorMetrics(t *testing.T) {
 	require.Len(t, families, 1)
 
 	family := families[0]
-	assert.Equal(t, "lava_errors_total_test", *family.Name)
+	assert.Equal(t, "smartrouter_errors_total_test", *family.Name)
 	assert.Len(t, family.Metric, 2) // 2 distinct label combos
 
 	// Find the ETH1 nonce metric

--- a/protocol/metrics/health_breakdown_metrics_test.go
+++ b/protocol/metrics/health_breakdown_metrics_test.go
@@ -16,7 +16,7 @@ func newSmartRouterForHealthBreakdownTest() *SmartRouterMetricsManager {
 	}
 }
 
-// ---- lava_rpcsmartrouter_overall_health_breakdown ----
+// ---- smartrouter_overall_health_breakdown ----
 
 func TestSmartRouterUpdateHealthcheckStatusBreakdown_Healthy(t *testing.T) {
 	m := newSmartRouterForHealthBreakdownTest()
@@ -59,7 +59,7 @@ func TestSmartRouterUpdateHealthcheckStatusBreakdown_NilSafe(t *testing.T) {
 	require.NotPanics(t, func() { m.UpdateHealthcheckStatusBreakdown("ETH1", "jsonrpc", true) })
 }
 
-// ---- lava_rpc_endpoint_overall_health_breakdown ----
+// ---- rpc_endpoint_overall_health_breakdown ----
 
 func TestSmartRouterSetEndpointOverallHealthBreakdown_Healthy(t *testing.T) {
 	m := newSmartRouterForHealthBreakdownTest()

--- a/protocol/metrics/otel_usage_sink.go
+++ b/protocol/metrics/otel_usage_sink.go
@@ -252,11 +252,10 @@ func applyOTelSinkDefaults(cfg *OTelUsageSinkConfig) {
 	if cfg.ExportTimeout <= 0 {
 		cfg.ExportTimeout = defaultOTelExportTimeout
 	}
-	// ServiceName intentionally has no package-level default — the consumer
-	// and smart router each set their own via their respective cobra flag's
-	// defValue ("lava-rpcconsumer" / "lava-rpcsmartrouter"), and the
-	// constructor logs the resolved value so an empty one is visible to the
-	// operator at startup.
+	// ServiceName intentionally has no package-level default — the smart
+	// router sets its own via its cobra flag's defValue ("smartrouter"), and
+	// the constructor logs the resolved value so an empty one is visible to
+	// the operator at startup.
 	if cfg.ServiceInstanceID == "" {
 		// Default to hostname-pid so multiple consumer processes on the
 		// same bare-metal host (e.g., one process per chain) get unique

--- a/protocol/metrics/smartrouter_metrics_manager.go
+++ b/protocol/metrics/smartrouter_metrics_manager.go
@@ -36,38 +36,38 @@ var _ ConsumerMetricsManagerInf = (*SmartRouterMetricsManager)(nil)
 
 // SmartRouterMetricsManager manages metrics for the RPC Smart Router.
 // It follows the post-unification metric spec with:
-// - Endpoint-scoped metrics: lava_rpc_endpoint_*
-// - Router-scoped metrics: lava_rpcsmartrouter_*
+// - Endpoint-scoped metrics: rpc_endpoint_*
+// - Router-scoped metrics: smartrouter_*
 //
 // Relay/latency metrics include a `function` label so a single metric covers
 // both the per-function breakdown and, via sum aggregation, the endpoint/router
 // aggregate — no duplicate metrics needed.
 type SmartRouterMetricsManager struct {
 	// Endpoint-scoped metrics (labels: spec, apiInterface, endpoint_id, function)
-	endpointTotalRelaysServiced *MappedLabelsCounterVec  // lava_rpc_endpoint_total_relays_serviced
-	endpointTotalErrored        *MappedLabelsCounterVec  // lava_rpc_endpoint_total_errored
-	endpointEndToEndLatency     *prometheus.HistogramVec // lava_rpc_endpoint_end_to_end_latency_milliseconds
-	endpointInFlight            *MappedLabelsGaugeVec    // lava_rpc_endpoint_requests_in_flight
+	endpointTotalRelaysServiced *MappedLabelsCounterVec  // rpc_endpoint_total_relays_serviced
+	endpointTotalErrored        *MappedLabelsCounterVec  // rpc_endpoint_total_errored
+	endpointEndToEndLatency     *prometheus.HistogramVec // rpc_endpoint_end_to_end_latency_milliseconds
+	endpointInFlight            *MappedLabelsGaugeVec    // rpc_endpoint_requests_in_flight
 
 	// Endpoint-scoped metrics (labels: spec, apiInterface, endpoint_id)
-	endpointOverallHealth          *MappedLabelsGaugeVec   // lava_rpc_endpoint_overall_health
-	endpointOverallHealthBreakdown *prometheus.GaugeVec    // lava_rpc_endpoint_overall_health_breakdown {spec, apiInterface}
-	endpointSelectionScore         *prometheus.GaugeVec    // lava_rpc_endpoint_selection_score {spec, apiInterface, endpoint_id, score_type}
-	optimizerSelectionScore        *prometheus.GaugeVec    // lava_rpc_optimizer_selection_score {spec, endpoint_id, score_type}
-	endpointLatestBlock            *MappedLabelsGaugeVec   // lava_rpc_endpoint_latest_block
-	endpointFetchLatestFails       *MappedLabelsCounterVec // lava_rpc_endpoint_fetch_latest_fails
-	endpointFetchBlockFails        *MappedLabelsCounterVec // lava_rpc_endpoint_fetch_block_fails
-	endpointFetchLatestSuccess     *MappedLabelsCounterVec // lava_rpc_endpoint_fetch_latest_success
-	endpointFetchBlockSuccess      *MappedLabelsCounterVec // lava_rpc_endpoint_fetch_block_success
+	endpointOverallHealth          *MappedLabelsGaugeVec   // rpc_endpoint_overall_health
+	endpointOverallHealthBreakdown *prometheus.GaugeVec    // rpc_endpoint_overall_health_breakdown {spec, apiInterface}
+	endpointSelectionScore         *prometheus.GaugeVec    // rpc_endpoint_selection_score {spec, apiInterface, endpoint_id, score_type}
+	optimizerSelectionScore        *prometheus.GaugeVec    // rpc_optimizer_selection_score {spec, endpoint_id, score_type}
+	endpointLatestBlock            *MappedLabelsGaugeVec   // rpc_endpoint_latest_block
+	endpointFetchLatestFails       *MappedLabelsCounterVec // rpc_endpoint_fetch_latest_fails
+	endpointFetchBlockFails        *MappedLabelsCounterVec // rpc_endpoint_fetch_block_fails
+	endpointFetchLatestSuccess     *MappedLabelsCounterVec // rpc_endpoint_fetch_latest_success
+	endpointFetchBlockSuccess      *MappedLabelsCounterVec // rpc_endpoint_fetch_block_success
 
 	// Router-scoped metrics (labels: spec, apiInterface, function)
-	routerTotalRelaysServiced *prometheus.CounterVec   // lava_rpcsmartrouter_total_relays_serviced
-	routerTotalErrored        *prometheus.CounterVec   // lava_rpcsmartrouter_total_errored
-	routerEndToEndLatency     *prometheus.HistogramVec // lava_rpcsmartrouter_end_to_end_latency_milliseconds
+	routerTotalRelaysServiced *prometheus.CounterVec   // smartrouter_total_relays_serviced
+	routerTotalErrored        *prometheus.CounterVec   // smartrouter_total_errored
+	routerEndToEndLatency     *prometheus.HistogramVec // smartrouter_end_to_end_latency_milliseconds
 
 	// Router-scoped scalar metrics (no labels)
 	routerOverallHealth          prometheus.Gauge
-	routerOverallHealthBreakdown *prometheus.GaugeVec // lava_rpcsmartrouter_overall_health_breakdown {spec, apiInterface}
+	routerOverallHealthBreakdown *prometheus.GaugeVec // smartrouter_overall_health_breakdown {spec, apiInterface}
 
 	// Router-scoped metrics (labels: spec, apiInterface)
 	routerLatestBlock          *prometheus.GaugeVec
@@ -77,42 +77,42 @@ type SmartRouterMetricsManager struct {
 	routerWsSubscriptionErrors *prometheus.CounterVec
 
 	// Cross-validation group metrics
-	crossValidationRequestsTotalMetric              *prometheus.CounterVec // lava_rpcsmartrouter_cross_validation_requests_total        {spec, apiInterface, method}
-	crossValidationSuccessTotalMetric               *prometheus.CounterVec // lava_rpcsmartrouter_cross_validation_success_total         {spec, apiInterface, method}
-	crossValidationFailedTotalMetric                *prometheus.CounterVec // lava_rpcsmartrouter_cross_validation_failed_total          {spec, apiInterface, method}
-	crossValidationProviderAgreementsTotalMetric    *prometheus.CounterVec // lava_rpcsmartrouter_cross_validation_provider_agreements_total    {spec, apiInterface, method, provider_address}
-	crossValidationProviderDisagreementsTotalMetric *prometheus.CounterVec // lava_rpcsmartrouter_cross_validation_provider_disagreements_total {spec, apiInterface, method, provider_address}
-	crossValidationMismatchTotalMetric              *prometheus.CounterVec // lava_rpcsmartrouter_cross_validation_mismatch_total {spec, apiInterface, method, group, finality} — bounded alerting surface
-	crossValidationFailuresTotalMetric              *prometheus.CounterVec // lava_rpcsmartrouter_cross_validation_failures_total {spec, apiInterface, method, reason} — bounded by the CrossValidationReason* enum
+	crossValidationRequestsTotalMetric              *prometheus.CounterVec // smartrouter_cross_validation_requests_total        {spec, apiInterface, method}
+	crossValidationSuccessTotalMetric               *prometheus.CounterVec // smartrouter_cross_validation_success_total         {spec, apiInterface, method}
+	crossValidationFailedTotalMetric                *prometheus.CounterVec // smartrouter_cross_validation_failed_total          {spec, apiInterface, method}
+	crossValidationProviderAgreementsTotalMetric    *prometheus.CounterVec // smartrouter_cross_validation_provider_agreements_total    {spec, apiInterface, method, provider_address}
+	crossValidationProviderDisagreementsTotalMetric *prometheus.CounterVec // smartrouter_cross_validation_provider_disagreements_total {spec, apiInterface, method, provider_address}
+	crossValidationMismatchTotalMetric              *prometheus.CounterVec // smartrouter_cross_validation_mismatch_total {spec, apiInterface, method, group, finality} — bounded alerting surface
+	crossValidationFailuresTotalMetric              *prometheus.CounterVec // smartrouter_cross_validation_failures_total {spec, apiInterface, method, reason} — bounded by the CrossValidationReason* enum
 
 	// Incident group metrics
-	incidentNodeErrorsTotalMetric     *prometheus.CounterVec   // lava_rpcsmartrouter_node_errors_total         {spec, apiInterface, provider_address, method}
-	incidentProtocolErrorsTotalMetric *prometheus.CounterVec   // lava_rpcsmartrouter_protocol_errors_total     {spec, apiInterface, provider_address, method}
-	incidentRetriesTotalMetric        *prometheus.CounterVec   // lava_rpcsmartrouter_retries_total             {spec, apiInterface, method}
-	incidentRetriesSuccessMetric      *prometheus.CounterVec   // lava_rpcsmartrouter_retries_success_total     {spec, apiInterface, method}
-	incidentRetriesFailedMetric       *prometheus.CounterVec   // lava_rpcsmartrouter_retries_failed_total      {spec, apiInterface, method}
-	incidentRetryAttemptsHistogram    *prometheus.HistogramVec // lava_rpcsmartrouter_retry_attempts            {spec, apiInterface, method}
-	incidentConsistencyTotalMetric    *prometheus.CounterVec   // lava_rpcsmartrouter_consistency_total         {spec, apiInterface, method}
-	incidentConsistencySuccessMetric  *prometheus.CounterVec   // lava_rpcsmartrouter_consistency_success_total {spec, apiInterface, method}
-	incidentConsistencyFailedMetric   *prometheus.CounterVec   // lava_rpcsmartrouter_consistency_failed_total  {spec, apiInterface, method}
-	incidentHedgeTotalMetric          *prometheus.CounterVec   // lava_rpcsmartrouter_hedge_total               {spec, apiInterface, method}
-	incidentHedgeSuccessMetric        *prometheus.CounterVec   // lava_rpcsmartrouter_hedge_success_total       {spec, apiInterface, method}
-	incidentHedgeFailedMetric         *prometheus.CounterVec   // lava_rpcsmartrouter_hedge_failed_total        {spec, apiInterface, method}
-	incidentHedgeAttemptsHistogram    *prometheus.HistogramVec // lava_rpcsmartrouter_hedge_attempts            {spec, apiInterface, method}
+	incidentNodeErrorsTotalMetric     *prometheus.CounterVec   // smartrouter_node_errors_total         {spec, apiInterface, provider_address, method}
+	incidentProtocolErrorsTotalMetric *prometheus.CounterVec   // smartrouter_protocol_errors_total     {spec, apiInterface, provider_address, method}
+	incidentRetriesTotalMetric        *prometheus.CounterVec   // smartrouter_retries_total             {spec, apiInterface, method}
+	incidentRetriesSuccessMetric      *prometheus.CounterVec   // smartrouter_retries_success_total     {spec, apiInterface, method}
+	incidentRetriesFailedMetric       *prometheus.CounterVec   // smartrouter_retries_failed_total      {spec, apiInterface, method}
+	incidentRetryAttemptsHistogram    *prometheus.HistogramVec // smartrouter_retry_attempts            {spec, apiInterface, method}
+	incidentConsistencyTotalMetric    *prometheus.CounterVec   // smartrouter_consistency_total         {spec, apiInterface, method}
+	incidentConsistencySuccessMetric  *prometheus.CounterVec   // smartrouter_consistency_success_total {spec, apiInterface, method}
+	incidentConsistencyFailedMetric   *prometheus.CounterVec   // smartrouter_consistency_failed_total  {spec, apiInterface, method}
+	incidentHedgeTotalMetric          *prometheus.CounterVec   // smartrouter_hedge_total               {spec, apiInterface, method}
+	incidentHedgeSuccessMetric        *prometheus.CounterVec   // smartrouter_hedge_success_total       {spec, apiInterface, method}
+	incidentHedgeFailedMetric         *prometheus.CounterVec   // smartrouter_hedge_failed_total        {spec, apiInterface, method}
+	incidentHedgeAttemptsHistogram    *prometheus.HistogramVec // smartrouter_hedge_attempts            {spec, apiInterface, method}
 
 	// Cache group metrics (labels: spec, apiInterface, method)
-	cacheRequestsTotalMetric *prometheus.CounterVec   // lava_rpcsmartrouter_cache_requests_total
-	cacheSuccessTotalMetric  *prometheus.CounterVec   // lava_rpcsmartrouter_cache_success_total
-	cacheFailedTotalMetric   *prometheus.CounterVec   // lava_rpcsmartrouter_cache_failed_total
-	cacheLatencyHistogram    *prometheus.HistogramVec // lava_rpcsmartrouter_cache_latency_milliseconds
+	cacheRequestsTotalMetric *prometheus.CounterVec   // smartrouter_cache_requests_total
+	cacheSuccessTotalMetric  *prometheus.CounterVec   // smartrouter_cache_success_total
+	cacheFailedTotalMetric   *prometheus.CounterVec   // smartrouter_cache_failed_total
+	cacheLatencyHistogram    *prometheus.HistogramVec // smartrouter_cache_latency_milliseconds
 
 	// CSM state-store size gauges (labels: spec, apiInterface). Expose otherwise
 	// black-box internal state so integration tests can verify /debug/reset-all
 	// emptied each store. See MAG-1762.
-	csmBlockedProvidersCount       *prometheus.GaugeVec // lava_rpcsmartrouter_csm_blocked_providers
-	csmBlockedBackupProvidersCount *prometheus.GaugeVec // lava_rpcsmartrouter_csm_blocked_backup_providers
-	csmStickySessionsCount         *prometheus.GaugeVec // lava_rpcsmartrouter_csm_sticky_sessions
-	csmReportedProvidersCount      *prometheus.GaugeVec // lava_rpcsmartrouter_csm_reported_providers
+	csmBlockedProvidersCount       *prometheus.GaugeVec // smartrouter_csm_blocked_providers
+	csmBlockedBackupProvidersCount *prometheus.GaugeVec // smartrouter_csm_blocked_backup_providers
+	csmStickySessionsCount         *prometheus.GaugeVec // smartrouter_csm_sticky_sessions
+	csmReportedProvidersCount      *prometheus.GaugeVec // smartrouter_csm_reported_providers
 
 	// Router-scoped request group metrics (labels: spec, apiInterface, provider_address, method)
 	routerRequestsTotal      *prometheus.CounterVec
@@ -165,7 +165,7 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	}
 
 	// =========================================================================
-	// Endpoint-scoped metrics (lava_rpc_endpoint_*)
+	// Endpoint-scoped metrics (rpc_endpoint_*)
 	// labels: spec, apiInterface, endpoint_id, function
 	// Aggregate with sum by (...) to drop labels you don't need.
 	// =========================================================================
@@ -174,78 +174,78 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	endpointLabels := []string{"spec", "apiInterface", "endpoint_id"}
 
 	endpointTotalRelaysServiced := NewMappedLabelsCounterVec(MappedLabelsMetricOpts{
-		Name:       "lava_rpc_endpoint_total_relays_serviced",
+		Name:       "rpc_endpoint_total_relays_serviced",
 		Help:       "Total relays successfully serviced by this RPC endpoint, by function.",
 		Labels:     endpointFunctionLabels,
 		Registerer: prometheus.DefaultRegisterer,
 	})
 
 	endpointTotalErrored := NewMappedLabelsCounterVec(MappedLabelsMetricOpts{
-		Name:       "lava_rpc_endpoint_total_errored",
+		Name:       "rpc_endpoint_total_errored",
 		Help:       "Total errored relays for this RPC endpoint, by function.",
 		Labels:     endpointFunctionLabels,
 		Registerer: prometheus.DefaultRegisterer,
 	})
 
 	endpointInFlight := NewMappedLabelsGaugeVec(MappedLabelsMetricOpts{
-		Name:       "lava_rpc_endpoint_requests_in_flight",
+		Name:       "rpc_endpoint_requests_in_flight",
 		Help:       "Current number of in-flight relays for this RPC endpoint, by function.",
 		Labels:     endpointFunctionLabels,
 		Registerer: prometheus.DefaultRegisterer,
 	})
 
 	endpointOverallHealth := NewMappedLabelsGaugeVec(MappedLabelsMetricOpts{
-		Name:       "lava_rpc_endpoint_overall_health",
+		Name:       "rpc_endpoint_overall_health",
 		Help:       "Health status of this RPC endpoint (1=healthy, 0=unhealthy).",
 		Labels:     endpointLabels,
 		Registerer: prometheus.DefaultRegisterer,
 	})
 
 	endpointOverallHealthBreakdown := registerOrReuse(prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "lava_rpc_endpoint_overall_health_breakdown",
+		Name: "rpc_endpoint_overall_health_breakdown",
 		Help: "Health check status per chain for RPC endpoints (1=healthy, 0=unhealthy).",
 	}, []string{"spec", "apiInterface"}))
 
 	endpointSelectionScore := registerOrReuse(prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "lava_rpc_endpoint_selection_score",
+		Name: "rpc_endpoint_selection_score",
 		Help: "Latest selection score for each RPC endpoint by score type (availability/latency/sync/stake/composite).",
 	}, []string{"spec", "apiInterface", "endpoint_id", "score_type"}))
 
 	optimizerSelectionScore := registerOrReuse(prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "lava_rpc_optimizer_selection_score",
+		Name: "rpc_optimizer_selection_score",
 		Help: "Periodic optimizer selection score per provider by score type (availability/latency/sync/stake/composite). Chain-level, not scoped to apiInterface.",
 	}, []string{"spec", "endpoint_id", "score_type"}))
 
 	endpointLatestBlock := NewMappedLabelsGaugeVec(MappedLabelsMetricOpts{
-		Name:       "lava_rpc_endpoint_latest_block",
+		Name:       "rpc_endpoint_latest_block",
 		Help:       "Latest block known by this RPC endpoint.",
 		Labels:     endpointLabels,
 		Registerer: prometheus.DefaultRegisterer,
 	})
 
 	endpointFetchLatestFails := NewMappedLabelsCounterVec(MappedLabelsMetricOpts{
-		Name:       "lava_rpc_endpoint_fetch_latest_fails",
+		Name:       "rpc_endpoint_fetch_latest_fails",
 		Help:       "Total failed latest-block fetch operations for this RPC endpoint.",
 		Labels:     endpointLabels,
 		Registerer: prometheus.DefaultRegisterer,
 	})
 
 	endpointFetchBlockFails := NewMappedLabelsCounterVec(MappedLabelsMetricOpts{
-		Name:       "lava_rpc_endpoint_fetch_block_fails",
+		Name:       "rpc_endpoint_fetch_block_fails",
 		Help:       "Total failed specific-block fetch operations for this RPC endpoint.",
 		Labels:     endpointLabels,
 		Registerer: prometheus.DefaultRegisterer,
 	})
 
 	endpointFetchLatestSuccess := NewMappedLabelsCounterVec(MappedLabelsMetricOpts{
-		Name:       "lava_rpc_endpoint_fetch_latest_success",
+		Name:       "rpc_endpoint_fetch_latest_success",
 		Help:       "Total successful latest-block fetch operations for this RPC endpoint.",
 		Labels:     endpointLabels,
 		Registerer: prometheus.DefaultRegisterer,
 	})
 
 	endpointFetchBlockSuccess := NewMappedLabelsCounterVec(MappedLabelsMetricOpts{
-		Name:       "lava_rpc_endpoint_fetch_block_success",
+		Name:       "rpc_endpoint_fetch_block_success",
 		Help:       "Total successful specific-block fetch operations for this RPC endpoint.",
 		Labels:     endpointLabels,
 		Registerer: prometheus.DefaultRegisterer,
@@ -256,91 +256,91 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	// =========================================================================
 
 	endpointEndToEndLatency := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "lava_rpc_endpoint_end_to_end_latency_milliseconds",
+		Name:    "rpc_endpoint_end_to_end_latency_milliseconds",
 		Help:    "Distribution of end-to-end relay latency for this RPC endpoint by function in milliseconds. Use histogram_quantile() for percentiles.",
 		Buckets: latencyBuckets,
 	}, endpointFunctionLabels)
 
 	// =========================================================================
-	// Router-scoped metrics (lava_rpcsmartrouter_*)
+	// Router-scoped metrics (smartrouter_*)
 	// labels: spec, apiInterface, function  — aggregate with sum by to drop function
 	// =========================================================================
 
 	routerFunctionLabels := []string{"spec", "apiInterface", "function"}
 
 	routerTotalRelaysServiced := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_total_relays_serviced",
+		Name: "smartrouter_total_relays_serviced",
 		Help: "Total relays successfully serviced by the smart router, by function.",
 	}, routerFunctionLabels)
 
 	routerTotalErrored := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_total_errored",
+		Name: "smartrouter_total_errored",
 		Help: "Total errored relays on the smart router, by function.",
 	}, routerFunctionLabels)
 
 	routerEndToEndLatency := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "lava_rpcsmartrouter_end_to_end_latency_milliseconds",
+		Name:    "smartrouter_end_to_end_latency_milliseconds",
 		Help:    "Distribution of end-to-end relay latency across all endpoints on the smart router by function in milliseconds. Use histogram_quantile() for percentiles.",
 		Buckets: latencyBuckets,
 	}, routerFunctionLabels)
 
 	routerOverallHealth := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "lava_rpcsmartrouter_overall_health",
+		Name: "smartrouter_overall_health",
 		Help: "Overall health of the RPC smart router (1=healthy, 0=unhealthy).",
 	})
 	routerOverallHealth = registerOrReuse(routerOverallHealth)
 	routerOverallHealth.Set(1)
 
 	routerOverallHealthBreakdown := registerOrReuse(prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "lava_rpcsmartrouter_overall_health_breakdown",
+		Name: "smartrouter_overall_health_breakdown",
 		Help: "Health check status per chain on the smart router (1=healthy, 0=unhealthy).",
 	}, []string{"spec", "apiInterface"}))
 
 	routerLatestBlock := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "lava_rpcsmartrouter_latest_block",
+		Name: "smartrouter_latest_block",
 		Help: "Latest block known by the RPC smart router for this chain/interface.",
 	}, []string{"spec", "apiInterface"})
 
 	routerProtocolVersion := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "lava_rpcsmartrouter_protocol_version",
+		Name: "smartrouter_protocol_version",
 		Help: "Protocol version of the RPC smart router encoded as major*1e6+minor*1e3+patch.",
 	}, []string{"version"})
 
 	routerWsConnectionsActive := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "lava_rpcsmartrouter_ws_connections_active",
+		Name: "smartrouter_ws_connections_active",
 		Help: "Number of currently active WebSocket connections served by the smart router.",
 	}, []string{"spec", "apiInterface"})
 
 	routerWsSubscriptionsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_ws_subscriptions_total",
+		Name: "smartrouter_ws_subscriptions_total",
 		Help: "Total WebSocket subscription requests received by the smart router.",
 	}, []string{"spec", "apiInterface"})
 
 	routerWsSubscriptionErrors := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_ws_subscription_errors_total",
+		Name: "smartrouter_ws_subscription_errors_total",
 		Help: "Total failed WebSocket subscription requests on the smart router.",
 	}, []string{"spec", "apiInterface"})
 
 	crossValidationLabels := []string{"spec", "apiInterface", "method"}
 	crossValidationProviderLabels := []string{"spec", "apiInterface", "method", "provider_address"}
 	crossValidationRequestsTotalMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_cross_validation_requests_total",
+		Name: "smartrouter_cross_validation_requests_total",
 		Help: "Total number of cross-validated requests.",
 	}, crossValidationLabels)
 	crossValidationSuccessTotalMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_cross_validation_success_total",
+		Name: "smartrouter_cross_validation_success_total",
 		Help: "Total number of cross-validated requests that reached consensus.",
 	}, crossValidationLabels)
 	crossValidationFailedTotalMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_cross_validation_failed_total",
+		Name: "smartrouter_cross_validation_failed_total",
 		Help: "Total number of cross-validated requests that failed to reach consensus.",
 	}, crossValidationLabels)
 	crossValidationProviderAgreementsTotalMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_cross_validation_provider_agreements_total",
+		Name: "smartrouter_cross_validation_provider_agreements_total",
 		Help: "Total number of times a provider agreed with the cross-validation consensus.",
 	}, crossValidationProviderLabels)
 	crossValidationProviderDisagreementsTotalMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_cross_validation_provider_disagreements_total",
+		Name: "smartrouter_cross_validation_provider_disagreements_total",
 		Help: "Total number of times a provider's response disagreed with the cross-validation consensus.",
 	}, crossValidationProviderLabels)
 	// Bounded alerting surface: keyed by group (operator-defined, low cardinality) and finality
@@ -349,7 +349,7 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	// deterministic methods — NOT quorum failures or node/protocol errors (see
 	// SetCrossValidationMismatchMetric).
 	crossValidationMismatchTotalMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_cross_validation_mismatch_total",
+		Name: "smartrouter_cross_validation_mismatch_total",
 		Help: "Successful cross-validation content outliers (a successful response that disagreed with a reached consensus on a deterministic method), by provider group and finality. Excludes quorum failures and node/protocol errors.",
 	}, []string{"spec", "apiInterface", "method", "group", "finality"})
 	// Bounded failure breakdown: the existing cross_validation_failed_total is unlabeled-by-reason, so a
@@ -357,7 +357,7 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	// help). This series adds the reason, drawn from the closed CrossValidationReason* enum (low cardinality),
 	// without touching the existing series' label sets. Covers both quorum-time and request-time fail-fast.
 	crossValidationFailuresTotalMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_cross_validation_failures_total",
+		Name: "smartrouter_cross_validation_failures_total",
 		Help: "Cross-validation failures by reason (CrossValidationReason* enum: insufficient-responses, no-agreement, diversity-unmet, group-quorum-unmet, insufficient-capacity, insufficient-groups). Bounded — the reason set is a closed enum.",
 	}, []string{"spec", "apiInterface", "method", "reason"})
 
@@ -368,56 +368,56 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	incidentMethodLabels := []string{"spec", "apiInterface", "method"}
 
 	incidentNodeErrorsTotalMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_node_errors_total",
+		Name: "smartrouter_node_errors_total",
 		Help: "Total node errors received from RPC endpoints by the smart router.",
 	}, incidentProviderLabels)
 	incidentProtocolErrorsTotalMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_protocol_errors_total",
+		Name: "smartrouter_protocol_errors_total",
 		Help: "Total protocol errors (transport/timeout) encountered by the smart router.",
 	}, incidentProviderLabels)
 	incidentRetriesTotalMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_retries_total",
+		Name: "smartrouter_retries_total",
 		Help: "Total relay retries attempted by the smart router (extra attempts beyond the first).",
 	}, incidentMethodLabels)
 	incidentRetriesSuccessMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_retries_success_total",
+		Name: "smartrouter_retries_success_total",
 		Help: "Retried relay requests on the smart router that ultimately succeeded.",
 	}, incidentMethodLabels)
 	incidentRetriesFailedMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_retries_failed_total",
+		Name: "smartrouter_retries_failed_total",
 		Help: "Retried relay requests on the smart router that ultimately failed.",
 	}, incidentMethodLabels)
 	incidentRetryAttemptsHistogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "lava_rpcsmartrouter_retry_attempts",
+		Name:    "smartrouter_retry_attempts",
 		Help:    "Distribution of how many provider attempts were needed per retried request.",
 		Buckets: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 	}, incidentMethodLabels)
 	incidentConsistencyTotalMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_consistency_total",
+		Name: "smartrouter_consistency_total",
 		Help: "Total relay requests on the smart router that enforced a minimum seen block (consistency).",
 	}, incidentMethodLabels)
 	incidentConsistencySuccessMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_consistency_success_total",
+		Name: "smartrouter_consistency_success_total",
 		Help: "Consistency-enforced relay requests on the smart router that succeeded.",
 	}, incidentMethodLabels)
 	incidentConsistencyFailedMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_consistency_failed_total",
+		Name: "smartrouter_consistency_failed_total",
 		Help: "Consistency-enforced relay requests on the smart router that failed.",
 	}, incidentMethodLabels)
 	incidentHedgeTotalMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_hedge_total",
+		Name: "smartrouter_hedge_total",
 		Help: "Total relay requests on the smart router that triggered a hedge (batch ticker).",
 	}, incidentMethodLabels)
 	incidentHedgeSuccessMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_hedge_success_total",
+		Name: "smartrouter_hedge_success_total",
 		Help: "Hedged relay requests on the smart router that succeeded.",
 	}, incidentMethodLabels)
 	incidentHedgeFailedMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_hedge_failed_total",
+		Name: "smartrouter_hedge_failed_total",
 		Help: "Hedged relay requests on the smart router that failed.",
 	}, incidentMethodLabels)
 	incidentHedgeAttemptsHistogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "lava_rpcsmartrouter_hedge_attempts",
+		Name:    "smartrouter_hedge_attempts",
 		Help:    "Distribution of how many hedge relays were sent per hedged request.",
 		Buckets: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 	}, incidentMethodLabels)
@@ -430,19 +430,19 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	// =========================================================================
 	csmStateLabels := []string{"spec", "apiInterface"}
 	csmBlockedProvidersCount := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "lava_rpcsmartrouter_csm_blocked_providers",
+		Name: "smartrouter_csm_blocked_providers",
 		Help: "Size of ConsumerSessionManager.previousEpochBlockedProviders (cross-epoch known-bad provider memory). Goes to 0 after /debug/reset-all.",
 	}, csmStateLabels)
 	csmBlockedBackupProvidersCount := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "lava_rpcsmartrouter_csm_blocked_backup_providers",
+		Name: "smartrouter_csm_blocked_backup_providers",
 		Help: "Size of ConsumerSessionManager.blockedBackupProviders (per-epoch backup-provider failure memory). Goes to 0 after /debug/reset-all.",
 	}, csmStateLabels)
 	csmStickySessionsCount := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "lava_rpcsmartrouter_csm_sticky_sessions",
+		Name: "smartrouter_csm_sticky_sessions",
 		Help: "Number of live sticky-session affinities tracked by the smart router. Goes to 0 after /debug/reset-all.",
 	}, csmStateLabels)
 	csmReportedProvidersCount := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "lava_rpcsmartrouter_csm_reported_providers",
+		Name: "smartrouter_csm_reported_providers",
 		Help: "Number of providers currently in the ReportedProviders unresponsiveness register. Goes to 0 after /debug/reset-all.",
 	}, csmStateLabels)
 
@@ -452,53 +452,53 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	routerRequestLabels := []string{"spec", "apiInterface", "provider_address", "method"}
 
 	routerRequestsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_requests_total",
+		Name: "smartrouter_requests_total",
 		Help: "Total number of requests on the smart router.",
 	}, routerRequestLabels)
 	routerRequestsSuccess := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_requests_success_total",
+		Name: "smartrouter_requests_success_total",
 		Help: "Total number of successful requests on the smart router.",
 	}, routerRequestLabels)
 	routerRequestsFailed := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_requests_failed_total",
+		Name: "smartrouter_requests_failed_total",
 		Help: "Total number of failed requests on the smart router.",
 	}, routerRequestLabels)
 	routerRequestsRead := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_requests_read_total",
+		Name: "smartrouter_requests_read_total",
 		Help: "Total number of read (stateful=0) requests on the smart router.",
 	}, routerRequestLabels)
 	routerRequestsWrite := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_requests_write_total",
+		Name: "smartrouter_requests_write_total",
 		Help: "Total number of write (stateful=1) requests on the smart router.",
 	}, routerRequestLabels)
 	routerRequestsDebugTrace := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_requests_debug_trace_total",
+		Name: "smartrouter_requests_debug_trace_total",
 		Help: "Total number of debug/trace addon requests on the smart router.",
 	}, routerRequestLabels)
 	routerRequestsArchive := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_requests_archive_total",
+		Name: "smartrouter_requests_archive_total",
 		Help: "Total number of archive requests on the smart router.",
 	}, routerRequestLabels)
 	routerRequestsBatch := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_requests_batch_total",
+		Name: "smartrouter_requests_batch_total",
 		Help: "Total number of batch requests on the smart router.",
 	}, routerRequestLabels)
 
 	cacheLabels := []string{"spec", "apiInterface", "method"}
 	cacheRequestsTotalMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_cache_requests_total",
+		Name: "smartrouter_cache_requests_total",
 		Help: "Total number of cache lookup attempts.",
 	}, cacheLabels)
 	cacheSuccessTotalMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_cache_success_total",
+		Name: "smartrouter_cache_success_total",
 		Help: "Total number of cache lookups that returned a cached response (hits).",
 	}, cacheLabels)
 	cacheFailedTotalMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "lava_rpcsmartrouter_cache_failed_total",
+		Name: "smartrouter_cache_failed_total",
 		Help: "Total number of cache lookups that did not find a cached response (misses).",
 	}, cacheLabels)
 	cacheLatencyHistogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "lava_rpcsmartrouter_cache_latency_milliseconds",
+		Name:    "smartrouter_cache_latency_milliseconds",
 		Help:    "Distribution of cache lookup latency in milliseconds.",
 		Buckets: latencyBuckets,
 	}, cacheLabels)

--- a/protocol/rpcsmartrouter/README.md
+++ b/protocol/rpcsmartrouter/README.md
@@ -226,7 +226,7 @@ An outlier provider is **not penalized, blocked, or deprioritized** by cross-val
 scoring is separate). It is recorded for observability only, and *only* when a quorum was
 actually reached on a deterministic method:
 
-- `lava_rpcsmartrouter_cross_validation_mismatch_total{spec, apiInterface, method, group, finality}`
+- `smartrouter_cross_validation_mismatch_total{spec, apiInterface, method, group, finality}`
   is incremented **once per distinct outlier group** for a successful deterministic quorum — not
   once per provider. (Non-deterministic methods legitimately differ and are not counted; a quorum
   *failure* emits a `lava-cross-validation-failure-reason` instead, never this metric.) The
@@ -267,7 +267,7 @@ inlinable no-op call and nothing else.
 ```bash
 --usage-otel-enabled                       # master switch (both event types); off by default
 --usage-otel-endpoint "127.0.0.1:4318"     # OTLP/HTTP collector endpoint
---usage-otel-service-name "lava-rpcsmartrouter"
+--usage-otel-service-name "smartrouter"
 --usage-otel-service-instance-id "$HOSTNAME-eth"  # default: hostname-pid
 ```
 

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -268,7 +268,7 @@ func (rpsr *RPCSmartRouter) Start(ctx context.Context, options *rpcSmartRouterSt
 	usageSink := newUsageSinkFromOptions(options)
 	rpsr.usageSink = usageSink
 
-	// Always collect optimizer QoS reports so the lava_rpc_optimizer_selection_score
+	// Always collect optimizer QoS reports so the rpc_optimizer_selection_score
 	// metric is exposed on /metrics regardless of OTel. Each sampling tick also
 	// fires the reports at usageSink (Noop when OTel is off).
 	smartRouterOptimizerQoSClient := metrics.NewConsumerOptimizerQoSClient(smartRouterIdentifier, usageSink)
@@ -2115,7 +2115,7 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	cmdRPCSmartRouter.Flags().Int(metrics.UsageOTelBatchSizeFlagName, 1000, "usage event batch-size flush trigger")
 	cmdRPCSmartRouter.Flags().Duration(metrics.UsageOTelFlushIntervalFlagName, 500*time.Millisecond, "usage event time-based flush trigger")
 	cmdRPCSmartRouter.Flags().Duration(metrics.UsageOTelExportTimeoutFlagName, 10*time.Second, "OTLP per-batch export timeout")
-	cmdRPCSmartRouter.Flags().String(metrics.UsageOTelServiceNameFlagName, "lava-rpcsmartrouter", "OTel service.name resource attribute")
+	cmdRPCSmartRouter.Flags().String(metrics.UsageOTelServiceNameFlagName, "smartrouter", "OTel service.name resource attribute")
 	cmdRPCSmartRouter.Flags().String(metrics.UsageOTelInstanceIDFlagName, "", "OTel service.instance.id (default: hostname-pid); useful when running multiple processes per host")
 	cmdRPCSmartRouter.Flags().Bool(DebugRelaysFlagName, false, "adding debug information to relays")
 	cmdRPCSmartRouter.Flags().Bool(common.EnableSelectionStatsHeaderFlag, false, "enable selection stats header for debugging provider selection")
@@ -2208,7 +2208,7 @@ func (rpsr *RPCSmartRouter) updateEpoch(ctx context.Context, epoch uint64) {
 		// Resolve the per-chain metrics manager once so endpoint health resets below
 		// can also reset the corresponding Prometheus gauge. Without this, #2256's
 		// endpoint.ResetHealth() fixes the in-memory struct but the
-		// lava_rpc_endpoint_overall_health gauge stays stuck at 0 (unhealthy) forever,
+		// rpc_endpoint_overall_health gauge stays stuck at 0 (unhealthy) forever,
 		// since the only path back to 1 is a successful relay that calls
 		// SetEndpointOverallHealth(..., true) — which a backup may never receive.
 		var epochMetrics *metrics.SmartRouterMetricsManager

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2450,7 +2450,7 @@ func (rpcss *RPCSmartRouterServer) relayInnerDirect(
 		// same rule.
 		//
 		// Compute the cancellation flag BEFORE logging so race losers don't get
-		// tagged as errors and don't pollute lava_errors_total — on a busy router
+		// tagged as errors and don't pollute smartrouter_errors_total — on a busy router
 		// doing parallel races, the race-loser count would otherwise swamp the
 		// real error count.
 		isClientCancel := common.IsClientCancellation(err, ctx)

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -458,7 +458,7 @@ func TestAppendHeadersToRelayResult_MismatchMetric(t *testing.T) {
 		require.NoError(t, err)
 		var total float64
 		for _, mf := range mfs {
-			if mf.GetName() != "lava_rpcsmartrouter_cross_validation_mismatch_total" {
+			if mf.GetName() != "smartrouter_cross_validation_mismatch_total" {
 				continue
 			}
 			for _, m := range mf.GetMetric() {
@@ -567,9 +567,9 @@ func TestCrossValidationFailFast_EmitsRequestFailedMetrics(t *testing.T) {
 	const method = "cv_failfast_metric"
 	pm := &MockProtocolMessage{api: &spectypes.Api{Name: method}}
 
-	reqName := "lava_rpcsmartrouter_cross_validation_requests_total"
-	failName := "lava_rpcsmartrouter_cross_validation_failed_total"
-	successName := "lava_rpcsmartrouter_cross_validation_success_total"
+	reqName := "smartrouter_cross_validation_requests_total"
+	failName := "smartrouter_cross_validation_failed_total"
+	successName := "smartrouter_cross_validation_success_total"
 	reqBefore := cvRequestCounter(t, reqName, method)
 	failBefore := cvRequestCounter(t, failName, method)
 	successBefore := cvRequestCounter(t, successName, method)

--- a/protocol/rpcsmartrouter/rpcsmartrouter_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// gatherHealthGauge reads the lava_rpc_endpoint_overall_health gauge directly from the
+// gatherHealthGauge reads the rpc_endpoint_overall_health gauge directly from the
 // default Prometheus gatherer for a specific (spec, apiInterface, endpoint_id) tuple.
 // Returns (value, true) if found, (0, false) otherwise.
 func gatherHealthGauge(t *testing.T, spec, apiInterface, endpointID string) (float64, bool) {
@@ -27,7 +27,7 @@ func gatherHealthGauge(t *testing.T, spec, apiInterface, endpointID string) (flo
 	families, err := prometheus.DefaultGatherer.Gather()
 	require.NoError(t, err)
 	for _, mf := range families {
-		if mf.GetName() != "lava_rpc_endpoint_overall_health" {
+		if mf.GetName() != "rpc_endpoint_overall_health" {
 			continue
 		}
 		for _, m := range mf.GetMetric() {
@@ -262,7 +262,7 @@ func TestUpdateEpoch_ResetsDisabledEndpoints(t *testing.T) {
 }
 
 // TestUpdateEpoch_ResetsHealthMetric is the companion to the struct-level reset above:
-// it verifies that updateEpoch also resets the Prometheus lava_rpc_endpoint_overall_health
+// it verifies that updateEpoch also resets the Prometheus rpc_endpoint_overall_health
 // gauge back to 1 for both primary and backup providers. Prior to this fix, #2256 reset
 // the in-memory endpoint struct but left the metric stuck at 0, so operators saw 0% uptime
 // on backups even after the router considered them healthy again.

--- a/scripts/pre_setups/test_uc1_smartrouter_lava.sh
+++ b/scripts/pre_setups/test_uc1_smartrouter_lava.sh
@@ -307,7 +307,7 @@ fi
 echo ""
 echo "[D] cross_validation_requests_total{method=\"$CV_METHOD\"} must be >= 1"
 metric_line=$(curl -sS "http://127.0.0.1:$METRICS_PORT/metrics" 2>/dev/null \
-	| grep '^lava_rpcsmartrouter_cross_validation_requests_total' | grep "method=\"$CV_METHOD\"")
+	| grep '^smartrouter_cross_validation_requests_total' | grep "method=\"$CV_METHOD\"")
 metric_val=$(echo "$metric_line" | awk '{print $NF}' | head -n1)
 echo "      ${metric_line:-<metric not found>}"
 if [[ "$metric_val" =~ ^[0-9]+(\.[0-9]+)?$ ]] && awk "BEGIN{exit !($metric_val >= 1)}"; then

--- a/scripts/pre_setups/test_uc2_smartrouter_lava.sh
+++ b/scripts/pre_setups/test_uc2_smartrouter_lava.sh
@@ -478,7 +478,7 @@ fi
 echo ""
 echo "[C] cross_validation_requests_total{method=\"$CV_METHOD\"} must be >= 1"
 metric_line=$(curl -sS "http://127.0.0.1:$METRICS_PORT/metrics" 2>/dev/null \
-	| grep '^lava_rpcsmartrouter_cross_validation_requests_total' | grep "method=\"$CV_METHOD\"")
+	| grep '^smartrouter_cross_validation_requests_total' | grep "method=\"$CV_METHOD\"")
 metric_val=$(echo "$metric_line" | awk '{print $NF}' | head -n1)
 echo "      ${metric_line:-<metric not found>}"
 if [[ "$metric_val" =~ ^[0-9]+(\.[0-9]+)?$ ]] && awk "BEGIN{exit !($metric_val >= 1)}"; then
@@ -548,7 +548,7 @@ else
 	fail "per-group quorum spans only ${pg_ngroups:-0} group(s) — expected >= $PG_MIN_GROUPS"
 fi
 pg_metric=$(curl -sS "http://127.0.0.1:$METRICS_PORT/metrics" 2>/dev/null \
-	| grep '^lava_rpcsmartrouter_cross_validation_requests_total' | grep "method=\"$PG_METHOD\"" | awk '{print $NF}' | head -n1)
+	| grep '^smartrouter_cross_validation_requests_total' | grep "method=\"$PG_METHOD\"" | awk '{print $NF}' | head -n1)
 if [[ "$pg_metric" =~ ^[0-9]+(\.[0-9]+)?$ ]] && awk "BEGIN{exit !($pg_metric >= 1)}"; then
 	pass "requests_total counted the per-group '$PG_METHOD' request ($pg_metric)"
 else

--- a/scripts/pre_setups/test_uc4_smartrouter_sim.sh
+++ b/scripts/pre_setups/test_uc4_smartrouter_sim.sh
@@ -277,7 +277,7 @@ cv_disagreeing()    { grep -i '^lava-cross-validation-disagreeing-providers:' "$
 # metric_value <name-fragment> <label-grep> : the value of the first matching metric line, or "" .
 metric_value() {
 	curl -sS "http://127.0.0.1:$METRICS_PORT/metrics" 2>/dev/null \
-		| grep "^lava_rpcsmartrouter_cross_validation_$1" | grep "$2" | awk '{print $NF}' | head -n1
+		| grep "^smartrouter_cross_validation_$1" | grep "$2" | awk '{print $NF}' | head -n1
 }
 ge1() { [[ "$1" =~ ^[0-9]+(\.[0-9]+)?$ ]] && awk "BEGIN{exit !($1 >= 1)}"; }
 
@@ -320,7 +320,7 @@ else
 fi
 # THE UC-4 HEADLINE: a bounded group+finality-labeled mismatch metric fired.
 mismatch_line=$(curl -sS "http://127.0.0.1:$METRICS_PORT/metrics" 2>/dev/null \
-	| grep '^lava_rpcsmartrouter_cross_validation_mismatch_total' | grep "group=\"$DISSENTER_GROUP\"" | grep "method=\"$CV_METHOD\"")
+	| grep '^smartrouter_cross_validation_mismatch_total' | grep "group=\"$DISSENTER_GROUP\"" | grep "method=\"$CV_METHOD\"")
 echo "      ${mismatch_line:-<mismatch metric not found>}"
 mismatch_val=$(echo "$mismatch_line" | awk '{print $NF}' | head -n1)
 if ge1 "$mismatch_val"; then


### PR DESCRIPTION
## Summary

Strips the legacy `lava_` prefix from **every Prometheus metric** the smart-router emits, plus the OTel `service.name` default. The smart-router now owns its metric namespace outright:

| Old | New |
| --- | --- |
| `lava_rpcsmartrouter_*` | `smartrouter_*` |
| `lava_rpc_endpoint_*` | `rpc_endpoint_*` |
| `lava_rpc_optimizer_*` | `rpc_optimizer_*` |
| `lava_errors_total` | `smartrouter_errors_total` |
| `lava-rpcsmartrouter` (OTel `service.name` default) | `smartrouter` |

Also removes the now-irrelevant `lava-rpcconsumer` reference from the OTel usage-sink comment — there is no consumer in this repo.

## Changes
- `protocol/metrics/smartrouter_metrics_manager.go` — all rpcsmartrouter/endpoint/optimizer metric registrations renamed
- `protocol/metrics/error_metrics.go` — `lava_errors_total` → `smartrouter_errors_total` (+ `_test` / `_e2e` test variants)
- `protocol/metrics/otel_usage_sink.go` — comment cleanup (drop `lava-rpcconsumer`)
- `protocol/rpcsmartrouter/rpcsmartrouter.go` — `--usage-otel-service-name` default → `smartrouter`
- `protocol/common/error_registry.go`, `protocol/rpcsmartrouter/rpcsmartrouter_server.go` — inline comments naming the metric
- `docs/METRICS.md`, `docs/ERROR-REGISTRY-DESIGN.md`, `protocol/rpcsmartrouter/README.md` — docs updated
- `docker/prometheus.yml` — scrape comment updated
- `scripts/pre_setups/test_uc{1,2,4}_*.sh` — integration scripts that grep `/metrics`
- Unit tests updated to assert the new names

**Intentionally left untouched** (protocol/on-chain identities, not metrics): the `lava_chain_id` relay field, the `"lava"` cosmos app name / `~/.lava` home dir, the `lava_` structured-log `EventPrefix`, the `lavanet.lava.*` gRPC `ServiceName`s, and the external `lava-rpc.publicnode.com` hostname.

## Test plan
- `go build ./...` ✅
- `go test ./protocol/metrics/... ./protocol/rpcsmartrouter/... ./protocol/common/...` ✅
- Full-repo scan confirms no metric-shaped `lava_*` token remains

## ⚠️ Breaking change
All Prometheus metric names emitted by the smart-router are renamed. **Any dashboard, alerting rule, recording rule, or scrape relabeling referencing the old `lava_rpc*` / `lava_errors_total` names must be updated** to the new `smartrouter_*` / `rpc_*` names. The default OTel `service.name` also changes from `lava-rpcsmartrouter` to `smartrouter`.

The companion dashboard update is in **smart-router-dashboard** (Magma-Devs/smart-router-dashboard#50).