### PR TITLE
feat(smart-router/debug): add GET /debug/runtime-config

### DIFF
--- a/protocol/rpcsmartrouter/debug_server_test.go
+++ b/protocol/rpcsmartrouter/debug_server_test.go
@@ -14,9 +14,11 @@ import (
 
 	"github.com/magma-Devs/smart-router/protocol/chaintracker"
 	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
 	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
 	"github.com/magma-Devs/smart-router/protocol/relaycore"
 	"github.com/magma-Devs/smart-router/utils"
+	scoreutils "github.com/magma-Devs/smart-router/utils/score"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -716,6 +718,133 @@ func TestDebugLogsClear_SmartRouter_MethodNotAllowed(t *testing.T) {
 	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano})
 
 	req := httptest.NewRequest(http.MethodGet, "/debug/logs/clear", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}
+
+func getRuntimeConfigRouter(mux http.Handler) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/debug/runtime-config", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	return rr
+}
+
+// TestDebugRuntimeConfig_SmartRouter_ReturnsValues asserts every exposed value against
+// its source symbol — never a hardcoded literal. That is the whole point of the
+// endpoint, and it keeps this test from drifting the same way the hand-copied
+// constants in the Python suite do.
+func TestDebugRuntimeConfig_SmartRouter_ReturnsValues(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano})
+
+	rr := getRuntimeConfigRouter(mux)
+	require.Equal(t, http.StatusOK, rr.Code, "body=%q", rr.Body.String())
+	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+
+	// Wire-format contract. The struct round-trip below verifies VALUES, but Marshal and
+	// Unmarshal both key off the same Go field names — so a field rename would round-trip
+	// green while silently breaking every consumer that greps the key by name (the exact
+	// failure this endpoint exists to prevent). The ticket requires each key to be the
+	// exact Go identifier of its source symbol, so decode into a raw map and assert the
+	// literal identifier strings. "Contains", not "equals", so the schema can grow
+	// additively.
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &raw))
+	for _, k := range []string{
+		"SchemaVersion",
+		"MaxConsecutiveConnectionAttempts",
+		"TimeoutForEstablishingAConnection",
+		"MaximumNumberOfFailuresAllowedPerConsumerSession",
+		"RelayRetryLimit",
+		"DisableBatchRequestRetry",
+		"MaximumNumberOfTickerRelayRetries",
+		"SendRelayAttempts",
+		"EnableCircuitBreaker",
+		"CircuitBreakerThreshold",
+		"EnableTimeoutPriority",
+		"TimePerCU",
+		"MinimumTimePerRelayDelay",
+		"DefaultTimeout",
+		"CacheTimeout",
+		"ProbeUpdateWeight",
+		"DefaultProbeUpdateWeight",
+		"MinAcceptableAvailability",
+		"HighCuThreshold",
+		"MidCuThreshold",
+		"MostFrequentPollingMultiplier",
+		"MinPollingTimeMultiplier",
+		"PollingUpdateLength",
+		"EffectivePollingMultiplier",
+		"AvailabilityWeight",
+		"LatencyWeight",
+		"SyncWeight",
+		"StakeWeight",
+		"MinSelectionChance",
+		"PerChainOptimizer",
+	} {
+		require.Contains(t, raw, k, "missing wire key %q", k)
+	}
+
+	var resp routerConfigResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	require.Equal(t, 1, resp.SchemaVersion)
+
+	require.Equal(t, lavasession.MaxConsecutiveConnectionAttempts, resp.MaxConsecutiveConnectionAttempts)
+	require.Equal(t, lavasession.MaximumNumberOfFailuresAllowedPerConsumerSession, resp.MaximumNumberOfFailuresAllowedPerConsumerSession)
+
+	require.Equal(t, relaycore.RelayRetryLimit, resp.RelayRetryLimit)
+	require.Equal(t, relaycore.DisableBatchRequestRetry, resp.DisableBatchRequestRetry)
+
+	require.Equal(t, MaximumNumberOfTickerRelayRetries, resp.MaximumNumberOfTickerRelayRetries)
+	require.Equal(t, SendRelayAttempts, resp.SendRelayAttempts)
+
+	smConfig := SmartRouterStateMachineConfig()
+	require.Equal(t, smConfig.EnableCircuitBreaker, resp.EnableCircuitBreaker)
+	require.Equal(t, smConfig.CircuitBreakerThreshold, resp.CircuitBreakerThreshold)
+	require.Equal(t, smConfig.EnableTimeoutPriority, resp.EnableTimeoutPriority)
+
+	// Durations are integer milliseconds, asserted against their source symbols. TimePerCU
+	// is a uint64 of nanoseconds (not a time.Duration), so it divides by time.Millisecond;
+	// the rest are time.Duration and use .Milliseconds().
+	require.Equal(t, int64(common.TimePerCU)/int64(time.Millisecond), resp.TimePerCU)
+	require.Equal(t, common.MinimumTimePerRelayDelay.Milliseconds(), resp.MinimumTimePerRelayDelay)
+	require.Equal(t, common.DefaultTimeout.Milliseconds(), resp.DefaultTimeout)
+	require.Equal(t, common.CacheTimeout.Milliseconds(), resp.CacheTimeout)
+	require.Equal(t, lavasession.TimeoutForEstablishingAConnection.Milliseconds(), resp.TimeoutForEstablishingAConnection)
+
+	require.Equal(t, scoreutils.ProbeUpdateWeight, resp.ProbeUpdateWeight)
+	require.Equal(t, scoreutils.DefaultProbeUpdateWeight, resp.DefaultProbeUpdateWeight)
+	require.Equal(t, scoreutils.MinAcceptableAvailability, resp.MinAcceptableAvailability)
+	require.Equal(t, scoreutils.HighCuThreshold, resp.HighCuThreshold)
+	require.Equal(t, scoreutils.MidCuThreshold, resp.MidCuThreshold)
+
+	require.Equal(t, chaintracker.MostFrequentPollingMultiplier, resp.MostFrequentPollingMultiplier)
+	require.Equal(t, chaintracker.MinPollingTimeMultiplier, resp.MinPollingTimeMultiplier)
+	require.Equal(t, chaintracker.PollingUpdateLength, resp.PollingUpdateLength)
+	require.Equal(t, chaintracker.EffectivePollingMultiplier(), resp.EffectivePollingMultiplier)
+
+	// Optimizer defaults are flat top-level keys (the ticket's Phase 2 shape rule),
+	// asserted against DefaultWeightedSelectorConfig().
+	def := provideroptimizer.DefaultWeightedSelectorConfig()
+	require.Equal(t, def.AvailabilityWeight, resp.AvailabilityWeight)
+	require.Equal(t, def.LatencyWeight, resp.LatencyWeight)
+	require.Equal(t, def.SyncWeight, resp.SyncWeight)
+	require.Equal(t, def.StakeWeight, resp.StakeWeight)
+	require.Equal(t, def.MinSelectionChance, resp.MinSelectionChance)
+
+	// PerChainOptimizer must be an object ({}), never null, even with no optimizers wired.
+	require.NotNil(t, resp.PerChainOptimizer)
+	require.Empty(t, resp.PerChainOptimizer)
+}
+
+func TestDebugRuntimeConfig_SmartRouter_MethodNotAllowed(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano})
+
+	req := httptest.NewRequest(http.MethodPost, "/debug/runtime-config", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 

--- a/protocol/rpcsmartrouter/debug_server_test.go
+++ b/protocol/rpcsmartrouter/debug_server_test.go
@@ -850,3 +850,51 @@ func TestDebugRuntimeConfig_SmartRouter_MethodNotAllowed(t *testing.T) {
 
 	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
 }
+
+// TestDebugRuntimeConfig_SmartRouter_PerChainOptimizer exercises the only branching
+// logic in the handler: the live optimizers map is ranged and each entry's config is
+// run through toWeights into PerChainOptimizer. The _ReturnsValues test above always
+// sees an empty map, so the field mapping and the chainID keying are otherwise
+// unverified.
+//
+// Each chain uses four DISTINCT weights that already sum to 1.0. Distinct so a
+// field-swap in toWeights (e.g. Sync<->Stake) can't pass — the default weights would
+// mask it, since they are pairwise equal (0.3/0.3, 0.2/0.2). Summing to 1.0 so
+// NewWeightedSelector's normalizer leaves them untouched and the assertions stay exact.
+// Two chains with non-overlapping weight sets prove the map is keyed per chainID rather
+// than collapsing or cross-wiring entries.
+func TestDebugRuntimeConfig_SmartRouter_PerChainOptimizer(t *testing.T) {
+	newConfiguredOptimizer := func(chainID string, cfg provideroptimizer.WeightedSelectorConfig) *provideroptimizer.ProviderOptimizer {
+		opt := provideroptimizer.NewProviderOptimizer(provideroptimizer.StrategyBalanced, time.Second, uint(1), nil, chainID)
+		opt.ConfigureWeightedSelector(cfg)
+		return opt
+	}
+
+	want := map[string]routerConfigOptimizerWeights{
+		"ETH1": {AvailabilityWeight: 0.4, LatencyWeight: 0.3, SyncWeight: 0.2, StakeWeight: 0.1, MinSelectionChance: 0.05},
+		"BTC1": {AvailabilityWeight: 0.1, LatencyWeight: 0.2, SyncWeight: 0.3, StakeWeight: 0.4, MinSelectionChance: 0.07},
+	}
+
+	optimizers := newEmptyOptimizersRouter()
+	for chainID, w := range want {
+		optimizers.Store(chainID, newConfiguredOptimizer(chainID, provideroptimizer.WeightedSelectorConfig{
+			AvailabilityWeight: w.AvailabilityWeight,
+			LatencyWeight:      w.LatencyWeight,
+			SyncWeight:         w.SyncWeight,
+			StakeWeight:        w.StakeWeight,
+			MinSelectionChance: w.MinSelectionChance,
+		}))
+	}
+
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: optimizers, offsetNano: &offsetNano})
+
+	rr := getRuntimeConfigRouter(mux)
+	require.Equal(t, http.StatusOK, rr.Code, "body=%q", rr.Body.String())
+
+	var resp routerConfigResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	// Exactly the chains we wired — no extras, none dropped.
+	require.Equal(t, want, resp.PerChainOptimizer)
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -572,6 +572,81 @@ func resetEndpointHealthAndGauge(deps debugMuxDeps) int {
 	return total
 }
 
+// routerConfigOptimizerWeights is the JSON shape for a single provider-optimizer's
+// active selection weights, used for each per-chain entry in the PerChainOptimizer map
+// returned by GET /debug/runtime-config. Fields carry no json tags, so each key marshals
+// as the bare Go identifier — tests grep the same string in test code and router source.
+type routerConfigOptimizerWeights struct {
+	AvailabilityWeight float64
+	LatencyWeight      float64
+	SyncWeight         float64
+	StakeWeight        float64
+	MinSelectionChance float64
+}
+
+// routerConfigResponse is the JSON body of GET /debug/runtime-config. It exposes the
+// router's live tuning values so the test suite can read them at runtime instead of
+// hardcoding copies that silently drift when the source changes (e.g. when
+// MaxConsecutiveConnectionAttempts was raised from 5 to 50). Each field carries no json
+// tag, so every key marshals as the exact Go identifier of its source symbol (no
+// snake_case, no package prefix) — a test greps the same string in test code and router
+// source. Durations are integer milliseconds.
+type routerConfigResponse struct {
+	SchemaVersion int
+
+	// lavasession
+	MaxConsecutiveConnectionAttempts                 int
+	TimeoutForEstablishingAConnection                int64 // milliseconds
+	MaximumNumberOfFailuresAllowedPerConsumerSession int
+
+	// relaycore (flag-bound package vars — these report the live value)
+	RelayRetryLimit          int
+	DisableBatchRequestRetry bool
+
+	// rpcsmartrouter retry/attempt ceilings
+	MaximumNumberOfTickerRelayRetries int
+	SendRelayAttempts                 int
+
+	// SmartRouter state-machine config (read from SmartRouterStateMachineConfig())
+	EnableCircuitBreaker    bool
+	CircuitBreakerThreshold int
+	EnableTimeoutPriority   bool
+
+	// timeouts (integer milliseconds)
+	TimePerCU                int64
+	MinimumTimePerRelayDelay int64
+	DefaultTimeout           int64
+	CacheTimeout             int64
+
+	// score config
+	ProbeUpdateWeight         float64
+	DefaultProbeUpdateWeight  float64
+	MinAcceptableAvailability float64
+	HighCuThreshold           uint64
+	MidCuThreshold            uint64
+
+	// chain-tracker polling. There is no fixed probe interval — the tracker polls
+	// adaptively at averageBlockTime/multiplier — so the multipliers are what a test
+	// timing assumption actually depends on. Extension beyond the ticket's listed
+	// symbols; bare Go identifiers, no package prefix.
+	MostFrequentPollingMultiplier int
+	MinPollingTimeMultiplier      int
+	PollingUpdateLength           int
+	EffectivePollingMultiplier    int
+
+	// optimizer selection weights from DefaultWeightedSelectorConfig(), as flat
+	// top-level keys (the ticket's Phase 2 shape rule).
+	AvailabilityWeight float64
+	LatencyWeight      float64
+	SyncWeight         float64
+	StakeWeight        float64
+	MinSelectionChance float64
+
+	// Live per-chain optimizer weights — extension beyond the ticket. Keyed by chainID,
+	// so it is inherently nested and sits alongside the flat defaults above.
+	PerChainOptimizer map[string]routerConfigOptimizerWeights
+}
+
 // buildDebugMux constructs the /debug/time-warp, /debug/time, /debug/reset-scores,
 // and /debug/reset-all HTTP handlers.
 //
@@ -926,6 +1001,97 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 		reenabled := resetEndpointHealthAndGauge(deps)
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"reset":true,"endpoints_reenabled":%d}`, reenabled)
+	})
+
+	// GET /debug/runtime-config — expose the router's live tuning values as JSON so the
+	// test suite can read them at runtime instead of hardcoding copies that silently
+	// drift when the source changes. Read-only; registered only in debug mode like the
+	// rest of /debug/*. Values are read straight from their source symbols (and, for the
+	// flag-bound vars, report the live value); the per-chain optimizer section is read
+	// from the same optimizers map /debug/reset-scores uses.
+	mux.HandleFunc("/debug/runtime-config", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "GET only", http.StatusMethodNotAllowed)
+			return
+		}
+
+		toWeights := func(c provideroptimizer.WeightedSelectorConfig) routerConfigOptimizerWeights {
+			return routerConfigOptimizerWeights{
+				AvailabilityWeight: c.AvailabilityWeight,
+				LatencyWeight:      c.LatencyWeight,
+				SyncWeight:         c.SyncWeight,
+				StakeWeight:        c.StakeWeight,
+				MinSelectionChance: c.MinSelectionChance,
+			}
+		}
+
+		// Non-nil so the JSON is {} rather than null when no optimizers are wired
+		// (e.g. test fixtures).
+		perChain := map[string]routerConfigOptimizerWeights{}
+		if optimizers != nil {
+			optimizers.Range(func(chainID string, opt *provideroptimizer.ProviderOptimizer) bool {
+				perChain[chainID] = toWeights(opt.GetWeightedSelectorConfig())
+				return true
+			})
+		}
+
+		smConfig := SmartRouterStateMachineConfig()
+
+		optimizerDefaults := provideroptimizer.DefaultWeightedSelectorConfig()
+
+		resp := routerConfigResponse{
+			SchemaVersion: 1,
+
+			MaxConsecutiveConnectionAttempts:                 lavasession.MaxConsecutiveConnectionAttempts,
+			TimeoutForEstablishingAConnection:                lavasession.TimeoutForEstablishingAConnection.Milliseconds(),
+			MaximumNumberOfFailuresAllowedPerConsumerSession: lavasession.MaximumNumberOfFailuresAllowedPerConsumerSession,
+
+			RelayRetryLimit:          relaycore.RelayRetryLimit,
+			DisableBatchRequestRetry: relaycore.DisableBatchRequestRetry,
+
+			MaximumNumberOfTickerRelayRetries: MaximumNumberOfTickerRelayRetries,
+			SendRelayAttempts:                 SendRelayAttempts,
+
+			EnableCircuitBreaker:    smConfig.EnableCircuitBreaker,
+			CircuitBreakerThreshold: smConfig.CircuitBreakerThreshold,
+			EnableTimeoutPriority:   smConfig.EnableTimeoutPriority,
+
+			// TimePerCU is a uint64 of nanoseconds (not a time.Duration), so it is
+			// divided by time.Millisecond rather than using .Milliseconds().
+			TimePerCU:                int64(common.TimePerCU) / int64(time.Millisecond),
+			MinimumTimePerRelayDelay: common.MinimumTimePerRelayDelay.Milliseconds(),
+			DefaultTimeout:           common.DefaultTimeout.Milliseconds(),
+			CacheTimeout:             common.CacheTimeout.Milliseconds(),
+
+			ProbeUpdateWeight:         scoreutils.ProbeUpdateWeight,
+			DefaultProbeUpdateWeight:  scoreutils.DefaultProbeUpdateWeight,
+			MinAcceptableAvailability: scoreutils.MinAcceptableAvailability,
+			HighCuThreshold:           scoreutils.HighCuThreshold,
+			MidCuThreshold:            scoreutils.MidCuThreshold,
+
+			MostFrequentPollingMultiplier: chaintracker.MostFrequentPollingMultiplier,
+			MinPollingTimeMultiplier:      chaintracker.MinPollingTimeMultiplier,
+			PollingUpdateLength:           chaintracker.PollingUpdateLength,
+			EffectivePollingMultiplier:    chaintracker.EffectivePollingMultiplier(),
+
+			AvailabilityWeight: optimizerDefaults.AvailabilityWeight,
+			LatencyWeight:      optimizerDefaults.LatencyWeight,
+			SyncWeight:         optimizerDefaults.SyncWeight,
+			StakeWeight:        optimizerDefaults.StakeWeight,
+			MinSelectionChance: optimizerDefaults.MinSelectionChance,
+
+			PerChainOptimizer: perChain,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		body, err := json.Marshal(resp)
+		if err != nil {
+			// resp is a flat struct of scalars + a string-keyed map — Marshal can't
+			// realistically fail; surface a 500 rather than a half-written body.
+			http.Error(w, "failed to marshal router config", http.StatusInternalServerError)
+			return
+		}
+		w.Write(body)
 	})
 
 	return mux


### PR DESCRIPTION
## What

Adds `GET /debug/runtime-config` to the smart-router debug HTTP server. It returns the router's live tuning values — retry/attempt limits, timeouts, optimizer selection weights, state-machine circuit-breaker config, chain-tracker polling multipliers, and more — as JSON.

## Why

The simulator test suite needs these values to set up scenarios. Today tests keep hand-copied values that go stale silently when the source changes. Concrete case: when `MaxConsecutiveConnectionAttempts` went 5 → 50, tests that bursted ~10 requests to trip URL-disable became no-ops — the precondition was no longer reachable, so they kept passing while testing nothing. This endpoint lets tests read the values at runtime and self-correct.

## Response shape (per MAG-2135)

- **Each key is the exact Go identifier** of its source symbol — no snake_case, no package prefix — so a test greps the same string in test code and router source.
- **Durations are integer milliseconds** (e.g. `TimePerCU: 100`, `MinimumTimePerRelayDelay: 1000`, `TimeoutForEstablishingAConnection: 1500`). `TimePerCU` is a `uint64` of nanoseconds, so it is divided by `time.Millisecond`; the rest are `time.Duration` and use `.Milliseconds()`.
- **Optimizer default weights are flat top-level keys** (`AvailabilityWeight: 0.3`, …), not nested under a parent object.
- Values are read live from their source symbols, so flag-bound vars (`RelayRetryLimit`, `MinimumTimePerRelayDelay`, …) report the running value, not a compile-time default; circuit-breaker / timeout-priority fields come from `SmartRouterStateMachineConfig()`.

Trimmed example:

```json
{
  "SchemaVersion": 1,
  "MaxConsecutiveConnectionAttempts": 50,
  "RelayRetryLimit": 2,
  "MaximumNumberOfTickerRelayRetries": 10,
  "SendRelayAttempts": 3,
  "TimePerCU": 100,
  "MinimumTimePerRelayDelay": 1000,
  "DefaultTimeout": 30000,
  "CacheTimeout": 50,
  "TimeoutForEstablishingAConnection": 1500,
  "MaximumNumberOfFailuresAllowedPerConsumerSession": 15,
  "ProbeUpdateWeight": 0.25, "DefaultProbeUpdateWeight": 0.25,
  "MinAcceptableAvailability": 0.8,
  "HighCuThreshold": 100, "MidCuThreshold": 50,
  "AvailabilityWeight": 0.3, "LatencyWeight": 0.3, "SyncWeight": 0.2, "StakeWeight": 0.2,
  "MinSelectionChance": 0.01,
  "CircuitBreakerThreshold": 2, "EnableCircuitBreaker": true, "EnableTimeoutPriority": true,
  "PerChainOptimizer": {}
}
```

## Scope / acceptance

- GET → 200 with all 13 Phase 1 symbols + the Phase 2 values; non-GET → 405.
- Registered only when `--debug-address` is set (inside `buildDebugMux`); no effect on production builds.
- Schema is flat and additive.

## Beyond the ticket (additive extras)

Exposed with the same shape rules, on top of the symbols the ticket lists:

- `PerChainOptimizer` — the **live** per-chain optimizer weights, keyed by chainID. Inherently nested, so it sits alongside the flat defaults rather than replacing them. Always `{}` (never `null`) when no optimizers are wired.
- Chain-tracker polling multipliers — `MostFrequentPollingMultiplier`, `MinPollingTimeMultiplier`, `PollingUpdateLength`, `EffectivePollingMultiplier`. There is no fixed probe interval (the tracker polls at `averageBlockTime / multiplier`), so the multipliers are what a test timing assumption actually depends on.
- `DisableBatchRequestRetry`.

## Tests

`debug_server_test.go`:
- A values test that asserts each field against its **source symbol** (never a literal), so the test can't drift the way hand-copied constants do.
- The wire-key names are pinned via a raw-map decode — decoding into the same struct would let a field rename round-trip green and silently break consumers that read the key by name.
- A 405 method test.

`go build ./...`, `go vet ./...` (== `make lint`), and the full `rpcsmartrouter` package test all pass.

## Notes / follow-ups

- Consumer-side work (a Python `get_runtime_config()` helper + rewriting threshold-fragile tests to read it) is a separate follow-up.

Part of MAG-2135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
