### PR TITLE
fix(cors): default empty cors-headers to "*" so browser preflight passes

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -41,6 +41,11 @@ services:
       - "${SR_CONFIG:-config/smartrouter_examples/smartrouter_eth.yml}"
       - "--use-static-spec"
       - "specs/"
+      # Browser dashboards (the live-test panel) preflight cross-origin POSTs
+      # carrying Content-Type: application/json. Echo "*" so the preflight's
+      # Access-Control-Allow-Headers isn't empty — an empty list blocks the call.
+      - "--cors-headers"
+      - "*"
       - "--log-level"
       - "${SR_LOG_LEVEL:-info}"
       - "--log-format"

--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -627,8 +627,16 @@ func createAndSetupBaseAppListener(cmdFlags common.ConsumerCmdFlags, healthCheck
 		if c.Method() == "OPTIONS" {
 			// set up all allowed methods.
 			c.Set("Access-Control-Allow-Methods", cmdFlags.MethodsFlag)
-			// allow headers
-			c.Set("Access-Control-Allow-Headers", cmdFlags.HeadersFlag)
+			// allow headers — the cors-headers flag defaults to "", which would
+			// echo an empty allow-list and make the browser reject any preflight
+			// that carries a non-simple header (e.g. Content-Type: application/json).
+			// Treat empty as "*" so the default posture matches the flag's help text
+			// ("* for all") and the wild-card origin we already set above.
+			allowHeaders := cmdFlags.HeadersFlag
+			if allowHeaders == "" {
+				allowHeaders = "*"
+			}
+			c.Set("Access-Control-Allow-Headers", allowHeaders)
 			// allow credentials
 			c.Set("Access-Control-Allow-Credentials", cmdFlags.CredentialsFlag)
 			// Cache preflight request for 24 hours (in seconds)

--- a/protocol/chainlib/grpcproxy/grpcproxy.go
+++ b/protocol/chainlib/grpcproxy/grpcproxy.go
@@ -58,7 +58,14 @@ func NewGRPCProxyWithReflection(cb ProxyCallBack, healthCheckPath string, cmdFla
 
 		if req.Method == http.MethodOptions {
 			resp.Header().Set("Access-Control-Allow-Methods", cmdFlags.MethodsFlag)
-			resp.Header().Set("Access-Control-Allow-Headers", cmdFlags.HeadersFlag)
+			// Empty cors-headers flag (the default) would echo an empty allow-list and
+			// make the browser reject any preflight carrying a non-simple header. Treat
+			// empty as "*" to match the flag's help text and the wild-card origin above.
+			allowHeaders := cmdFlags.HeadersFlag
+			if allowHeaders == "" {
+				allowHeaders = "*"
+			}
+			resp.Header().Set("Access-Control-Allow-Headers", allowHeaders)
 			resp.Header().Set("Access-Control-Allow-Credentials", cmdFlags.CredentialsFlag)
 			resp.Header().Set("Access-Control-Max-Age", cmdFlags.CDNCacheDuration)
 			resp.WriteHeader(fiber.StatusNoContent)


### PR DESCRIPTION
## Why

The browser-based dashboard's live-test panel fails with a CORS error when calling the router directly (e.g. `localhost:3360`). The router's `cors-headers` flag defaults to `""`, so the CORS preflight (`OPTIONS`) returns an **empty** `Access-Control-Allow-Headers`. The browser then refuses to send the actual POST because it carries a non-simple header (`Content-Type: application/json`).

`curl` succeeds because it ignores CORS entirely — this is purely a browser-preflight problem, not an upstream-relay one (the relayed response already allows headers).

## What changed

- `protocol/chainlib/common.go` — the fiber/REST preflight now treats an empty `HeadersFlag` as `"*"`, matching the flag's own help text (`"* for all"`) and the wild-card origin already set on the same response.
- `protocol/chainlib/grpcproxy/grpcproxy.go` — same fix on the grpc-web proxy preflight path, for consistency.
- `docker/docker-compose.yml` — pass `--cors-headers "*"` explicitly in the dev router command so the dashboard stack is self-documenting and works even against an unpatched binary.

## How to verify

Bring up the dashboard stack and inspect the router preflight:

```
docker compose -f docker/docker-compose.dashboard.yml up -d router
curl -s -i -X OPTIONS http://localhost:3360/ \
  -H 'Origin: http://localhost:3000' \
  -H 'Access-Control-Request-Method: POST' \
  -H 'Access-Control-Request-Headers: content-type' \
  | grep -i access-control-allow-headers
```

Expected: `Access-Control-Allow-Headers: *` (was empty before the fix). The dashboard live-test panel then succeeds in the browser.
