### PR TITLE
feat(smart-router/debug): add endpoint-state, chain-state, provider-routing read endpoints (MAG-2202)

### DIFF
--- a/protocol/chainstate/chain_state.go
+++ b/protocol/chainstate/chain_state.go
@@ -287,6 +287,36 @@ func (cs *ChainState) HasConsensusBaseline() (int64, bool) {
 	return cs.baseline, cs.hasBaseline
 }
 
+// ChainStateSnapshot is the RAW, NON-TTL-gated view of ChainState for read-only debug introspection
+// (MAG-2202 /debug/chain-state). Unlike GetLatestBlock / GetConsensusBaseline it never applies the
+// TTL freshness gate: black-box tests assert TTL expiry, downward realignment, and empty-snapshot
+// baseline clearing from the raw (block, timestamp) pairs — a gated getter would hide exactly those
+// transitions by collapsing to (0, false). BaselineSince is the establishment time (distinct from
+// the TTL-freshness baselineAt that GetConsensusBaselineWithTime exposes).
+type ChainStateSnapshot struct {
+	ObservedTip       int64
+	LastObservedAt    time.Time
+	ConsensusBaseline int64
+	HasBaseline       bool
+	BaselineSince     time.Time
+	Initialized       bool
+}
+
+// DebugSnapshot returns the raw ChainState fields under one read lock, without the TTL gate the
+// production getters apply. For telemetry / black-box introspection only — not a sync-scoring path.
+func (cs *ChainState) DebugSnapshot() ChainStateSnapshot {
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	return ChainStateSnapshot{
+		ObservedTip:       cs.latestBlock,
+		LastObservedAt:    cs.lastObservedAt,
+		ConsensusBaseline: cs.baseline,
+		HasBaseline:       cs.hasBaseline,
+		BaselineSince:     cs.baselineSince,
+		Initialized:       cs.initialized,
+	}
+}
+
 // computeMajorityBaseline implements the locked consensus rules over a snapshot:
 //   - fresh-only: drop observations older than StalenessWindow and non-positive blocks;
 //   - dedup by URL: each endpoint votes once, with its most recent observation;

--- a/protocol/chainstate/debug_snapshot_test.go
+++ b/protocol/chainstate/debug_snapshot_test.go
@@ -1,0 +1,52 @@
+package chainstate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDebugSnapshot_RawUngatedFields verifies DebugSnapshot reports the raw ChainState fields —
+// including a tip that the production GetLatestBlock getter would hide as TTL-expired — so the
+// MAG-2202 /debug/chain-state black-box tests can observe TTL expiry and baseline establishment
+// directly rather than seeing a collapsed (0, false).
+func TestDebugSnapshot_RawUngatedFields(t *testing.T) {
+	cs, clk := newTestState(t)
+
+	// Cold start: nothing observed yet — every field is zero/false.
+	snap := cs.DebugSnapshot()
+	require.False(t, snap.Initialized)
+	require.Equal(t, int64(0), snap.ObservedTip)
+	require.False(t, snap.HasBaseline)
+	require.True(t, snap.LastObservedAt.IsZero())
+	require.True(t, snap.BaselineSince.IsZero())
+
+	// Observe a tip and establish a 3-endpoint strict-majority baseline.
+	cs.SetLatestBlock(1000)
+	observedAt := clk.now()
+	cs.Recompute([]BlockObservation{
+		{URL: "a", Block: 1000, ObservedAt: clk.now()},
+		{URL: "b", Block: 1000, ObservedAt: clk.now()},
+		{URL: "c", Block: 1000, ObservedAt: clk.now()},
+	})
+	baselineSince := clk.now()
+
+	snap = cs.DebugSnapshot()
+	require.True(t, snap.Initialized)
+	require.Equal(t, int64(1000), snap.ObservedTip)
+	require.True(t, snap.HasBaseline)
+	require.Equal(t, int64(1000), snap.ConsensusBaseline)
+	require.Equal(t, observedAt, snap.LastObservedAt)
+	require.Equal(t, baselineSince, snap.BaselineSince)
+
+	// Age past the 10s TTL: GetLatestBlock now gates the tip to (0,false), but the RAW snapshot
+	// still exposes the underlying block + its (now stale) timestamp so a test can assert that the
+	// expiry actually happened rather than seeing a value that silently disappeared.
+	clk.advance(11 * time.Second)
+	_, fresh := cs.GetLatestBlock()
+	require.False(t, fresh, "GetLatestBlock applies the TTL gate")
+	snap = cs.DebugSnapshot()
+	require.Equal(t, int64(1000), snap.ObservedTip, "DebugSnapshot is NOT TTL-gated")
+	require.True(t, snap.Initialized, "initialized is sticky across TTL expiry")
+}

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -151,6 +151,34 @@ func (csm *ConsumerSessionManager) GetProviderOptimizer() ProviderOptimizer {
 	return csm.providerOptimizer
 }
 
+// ProviderRoutingSnapshot is a consistent copy of the CSM's routing-pool state for read-only debug
+// introspection (MAG-2202 /debug/provider-routing): the addresses currently eligible to route, the
+// primary providers blocked this epoch, and the blocked backup providers. Every slice is a copy, so
+// the caller never aliases CSM-internal state; backup providers are sorted for deterministic output.
+// All slices are non-nil (empty rather than nil) so the JSON encodes as [] rather than null.
+type ProviderRoutingSnapshot struct {
+	ValidAddresses                    []string
+	CurrentlyBlockedProviderAddresses []string
+	BlockedBackupProviders            []string
+}
+
+// ProviderRoutingSnapshot returns a copy of this CSM's valid / blocked / blocked-backup provider
+// addresses under csm.lock. Read-only — it never mutates routing state.
+func (csm *ConsumerSessionManager) ProviderRoutingSnapshot() ProviderRoutingSnapshot {
+	csm.lock.RLock()
+	defer csm.lock.RUnlock()
+	backups := make([]string, 0, len(csm.blockedBackupProviders))
+	for addr := range csm.blockedBackupProviders {
+		backups = append(backups, addr)
+	}
+	sort.Strings(backups)
+	return ProviderRoutingSnapshot{
+		ValidAddresses:                    append([]string{}, csm.validAddresses...),
+		CurrentlyBlockedProviderAddresses: append([]string{}, csm.currentlyBlockedProviderAddresses...),
+		BlockedBackupProviders:            backups,
+	}
+}
+
 func (csm *ConsumerSessionManager) GetNumberOfValidProviders() int {
 	csm.lock.RLock()
 	defer csm.lock.RUnlock()

--- a/protocol/lavasession/consumer_types.go
+++ b/protocol/lavasession/consumer_types.go
@@ -218,6 +218,32 @@ func (e *Endpoint) IsEnabled() bool {
 	return e.Enabled
 }
 
+// EndpointHealthSnapshot is a consistent, point-in-time view of an endpoint's enable/recovery state
+// for read-only debug introspection (MAG-2202 /debug/endpoint-state). Captured under e.mu so a caller
+// never observes a half-applied MarkUnhealthy / RecordProbeVerdict transition. DisabledAt and
+// LastRecoveryPoll are zero while the endpoint is enabled / has never disabled.
+type EndpointHealthSnapshot struct {
+	Enabled                  bool
+	DisabledAt               time.Time
+	ConsecutiveHealthyProbes uint64 // distinct post-disable successful polls counted toward F1 re-enable
+	LastRecoveryPoll         time.Time
+}
+
+// HealthSnapshot returns the endpoint's enable/recovery state under e.mu. Read-only companion to
+// IsEnabled for debug introspection — it never mutates state. The unexported recovery fields
+// (disabledAt / consecutiveHealthyProbes / lastRecoveryPoll) are otherwise invisible outside the
+// package, so this is the only synchronized read path for them.
+func (e *Endpoint) HealthSnapshot() EndpointHealthSnapshot {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return EndpointHealthSnapshot{
+		Enabled:                  e.Enabled,
+		DisabledAt:               e.disabledAt,
+		ConsecutiveHealthyProbes: e.consecutiveHealthyProbes,
+		LastRecoveryPoll:         e.lastRecoveryPoll,
+	}
+}
+
 // IsProviderRelay returns true if this endpoint uses provider-relay connections (consumer mode)
 func (e *Endpoint) IsProviderRelay() bool {
 	return len(e.Connections) > 0

--- a/protocol/lavasession/debug_snapshots_test.go
+++ b/protocol/lavasession/debug_snapshots_test.go
@@ -1,0 +1,75 @@
+package lavasession
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEndpointHealthSnapshot_TracksDisableAndRecovery verifies HealthSnapshot exposes the unexported
+// enable/recovery fields (disabledAt / consecutiveHealthyProbes / lastRecoveryPoll) that back the
+// MAG-2202 /debug/endpoint-state F1 checks, across the disable → hysteresis → re-enable lifecycle.
+func TestEndpointHealthSnapshot_TracksDisableAndRecovery(t *testing.T) {
+	e := &Endpoint{NetworkAddress: "http://ep", Enabled: true}
+
+	// Enabled, never disabled.
+	s := e.HealthSnapshot()
+	require.True(t, s.Enabled)
+	require.True(t, s.DisabledAt.IsZero())
+	require.Equal(t, uint64(0), s.ConsecutiveHealthyProbes)
+	require.True(t, s.LastRecoveryPoll.IsZero())
+
+	// Disable via the relay-path failure threshold; disabledAt is stamped edge-triggered.
+	t0 := time.Unix(1_700_000_000, 0)
+	e.ConnectionRefusals = MaxConsecutiveConnectionAttempts - 1
+	e.markUnhealthyAt(t0)
+	s = e.HealthSnapshot()
+	require.False(t, s.Enabled)
+	require.Equal(t, t0, s.DisabledAt)
+
+	// One post-disable healthy probe advances the F1 streak but does not yet re-enable (K=3).
+	require.False(t, e.RecordProbeVerdict(t0.Add(time.Second), true, 3))
+	s = e.HealthSnapshot()
+	require.False(t, s.Enabled)
+	require.Equal(t, uint64(1), s.ConsecutiveHealthyProbes)
+	require.Equal(t, t0.Add(time.Second), s.LastRecoveryPoll)
+
+	// Two more distinct post-disable polls cross K=3 → re-enabled; streak + disabledAt cleared.
+	require.False(t, e.RecordProbeVerdict(t0.Add(2*time.Second), true, 3))
+	require.True(t, e.RecordProbeVerdict(t0.Add(3*time.Second), true, 3))
+	s = e.HealthSnapshot()
+	require.True(t, s.Enabled)
+	require.True(t, s.DisabledAt.IsZero())
+	require.Equal(t, uint64(0), s.ConsecutiveHealthyProbes)
+}
+
+// TestProviderRoutingSnapshot_CopiesAndSortsNonNil verifies ProviderRoutingSnapshot returns non-nil
+// (JSON-array, not null) copies of the three routing slices, with backups sorted deterministically.
+func TestProviderRoutingSnapshot_CopiesAndSortsNonNil(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+
+	// Empty CSM: every slice is non-nil so /debug/provider-routing emits [] not null.
+	s := csm.ProviderRoutingSnapshot()
+	require.NotNil(t, s.ValidAddresses)
+	require.NotNil(t, s.CurrentlyBlockedProviderAddresses)
+	require.NotNil(t, s.BlockedBackupProviders)
+	require.Empty(t, s.ValidAddresses)
+
+	// Populate routing state directly (in-package).
+	csm.lock.Lock()
+	csm.validAddresses = []string{"lava@valid1", "lava@valid2"}
+	csm.currentlyBlockedProviderAddresses = []string{"lava@blocked1"}
+	csm.blockedBackupProviders = map[string]struct{}{"lava@b2": {}, "lava@b1": {}}
+	csm.lock.Unlock()
+
+	s = csm.ProviderRoutingSnapshot()
+	require.Equal(t, []string{"lava@valid1", "lava@valid2"}, s.ValidAddresses)
+	require.Equal(t, []string{"lava@blocked1"}, s.CurrentlyBlockedProviderAddresses)
+	require.Equal(t, []string{"lava@b1", "lava@b2"}, s.BlockedBackupProviders, "backups sorted deterministically")
+
+	// The returned slices are copies: mutating one must not corrupt CSM-internal state.
+	s.ValidAddresses[0] = "MUTATED"
+	again := csm.ProviderRoutingSnapshot()
+	require.Equal(t, "lava@valid1", again.ValidAddresses[0], "snapshot must copy, not alias")
+}

--- a/protocol/rpcsmartrouter/debug_server_test.go
+++ b/protocol/rpcsmartrouter/debug_server_test.go
@@ -298,8 +298,8 @@ func getDebugRouter(mux http.Handler, path string) *httptest.ResponseRecorder {
 	return rr
 }
 
-// stateEndpointPaths are the three read-only state endpoints added for MAG-2202.
-var stateEndpointPaths = []string{"/debug/endpoint-state", "/debug/chain-state", "/debug/provider-routing"}
+// stateEndpointPaths are the read-only state endpoints added for MAG-2202.
+var stateEndpointPaths = []string{"/debug/endpoint-state", "/debug/chain-state", "/debug/provider-routing", "/debug/probe-loop"}
 
 // TestDebugStateEndpoints_MethodNotAllowed: all three are GET-only (the acceptance criterion that any
 // non-GET method returns 405).
@@ -421,6 +421,41 @@ func TestDebugEndpointState_WiringSafe(t *testing.T) {
 	rr := getDebugRouter(mux, "/debug/endpoint-state")
 	require.Equal(t, http.StatusOK, rr.Code)
 	require.JSONEq(t, `[]`, rr.Body.String(), "no session manager wired for the chain → empty array, no panic")
+}
+
+// TestDebugProbeLoop_ReportsCycleStats verifies the per-chain probe-cycle record: interval +
+// last-cycle snapshot (durations as integer ms, start as RFC3339), and that a listenEndpoint-less
+// server is skipped.
+func TestDebugProbeLoop_ReportsCycleStats(t *testing.T) {
+	var offsetNano atomic.Int64
+	server := &RPCSmartRouterServer{listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"}}
+	server.probeStats.setInterval(5 * time.Second)
+	server.probeStats.recordCycle(time.Now(), 7*time.Millisecond, 4, 1, 2)
+
+	router := &RPCSmartRouter{
+		rpcServers: map[string]*RPCSmartRouterServer{
+			"ETH1-jsonrpc": server,
+			"NIL-rest":     {listenEndpoint: nil}, // skipped, not panic
+		},
+	}
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano, router: router})
+
+	rr := getDebugRouter(mux, "/debug/probe-loop")
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &rows))
+	require.Len(t, rows, 1, "the listenEndpoint-less server is skipped")
+	row := rows[0]
+	require.Equal(t, "ETH1", row["ChainID"])
+	require.Equal(t, "jsonrpc", row["ApiInterface"])
+	require.Equal(t, float64(5000), row["CycleIntervalMs"], "interval reported in milliseconds")
+	require.Equal(t, float64(1), row["CyclesCompleted"])
+	require.Equal(t, float64(7), row["LastCycleDurationMs"], "duration in milliseconds")
+	require.Equal(t, float64(4), row["EndpointsScored"])
+	require.Equal(t, float64(1), row["ReEnabledCount"])
+	require.Equal(t, float64(2), row["SyncOmittedCount"])
+	require.NotEmpty(t, row["LastCycleStartedAt"], "cycle start carries an RFC3339 timestamp")
 }
 
 // corruptedMsTimestampBlock is the exact value reported in the 2026-05-14

--- a/protocol/rpcsmartrouter/debug_server_test.go
+++ b/protocol/rpcsmartrouter/debug_server_test.go
@@ -11,8 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/magma-Devs/smart-router/protocol/chainstate"
 	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/endpointstate"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
 	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
 	"github.com/magma-Devs/smart-router/protocol/relaycore"
 	"github.com/magma-Devs/smart-router/utils"
@@ -285,6 +287,140 @@ func TestDebugResetAll_SmartRouter_NilRouterIsSafe(t *testing.T) {
 
 	rr := postResetAllRouter(mux)
 	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+// --- MAG-2202 read-only state endpoints -------------------------------------------------
+
+func getDebugRouter(mux http.Handler, path string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	return rr
+}
+
+// stateEndpointPaths are the three read-only state endpoints added for MAG-2202.
+var stateEndpointPaths = []string{"/debug/endpoint-state", "/debug/chain-state", "/debug/provider-routing"}
+
+// TestDebugStateEndpoints_MethodNotAllowed: all three are GET-only (the acceptance criterion that any
+// non-GET method returns 405).
+func TestDebugStateEndpoints_MethodNotAllowed(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano})
+	for _, path := range stateEndpointPaths {
+		req := httptest.NewRequest(http.MethodPost, path, nil)
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusMethodNotAllowed, rr.Code, path)
+	}
+}
+
+// TestDebugStateEndpoints_NilRouterIsSafe: usable from a fixture that didn't wire a full router —
+// each returns 200 with an empty object rather than panicking, so the suite can probe unconditionally.
+func TestDebugStateEndpoints_NilRouterIsSafe(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano, router: nil})
+	for _, path := range stateEndpointPaths {
+		rr := getDebugRouter(mux, path)
+		require.Equal(t, http.StatusOK, rr.Code, path)
+		require.JSONEq(t, `[]`, rr.Body.String(), path)
+	}
+}
+
+// TestDebugChainState_ReportsRawSnapshot wires a real per-chain ChainState and verifies the JSON
+// shape (flat Go-identifier keys, RFC3339 BaselineSince) and that a nil-chainState server is skipped.
+func TestDebugChainState_ReportsRawSnapshot(t *testing.T) {
+	var offsetNano atomic.Int64
+	cs := chainstate.New("ETH1", chainstate.Config{
+		BucketWidth: 2, OutlierThreshold: 100, StalenessWindow: 10 * time.Second, TTL: 10 * time.Second,
+	})
+	cs.SetLatestBlock(1000)
+	now := time.Now()
+	cs.Recompute([]chainstate.BlockObservation{
+		{URL: "a", Block: 1000, ObservedAt: now},
+		{URL: "b", Block: 1000, ObservedAt: now},
+		{URL: "c", Block: 1000, ObservedAt: now},
+	})
+
+	router := &RPCSmartRouter{
+		rpcServers: map[string]*RPCSmartRouterServer{
+			"ETH1-jsonrpc": {chainState: cs, listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"}},
+			"NIL-rest":     {chainState: nil}, // skipped, not panic
+		},
+	}
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano, router: router})
+
+	rr := getDebugRouter(mux, "/debug/chain-state")
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &rows))
+	require.Len(t, rows, 1, "only the wired chainState contributes a row; the nil-chainState server is skipped")
+	row := rows[0]
+	require.Equal(t, "ETH1", row["ChainID"])
+	require.Equal(t, "jsonrpc", row["ApiInterface"])
+	require.Equal(t, float64(1000), row["ObservedTip"])
+	require.Equal(t, float64(1000), row["ConsensusBaseline"])
+	require.Equal(t, true, row["HasBaseline"])
+	require.Equal(t, true, row["Initialized"])
+	require.NotEmpty(t, row["BaselineSince"], "established baseline carries an RFC3339 timestamp")
+}
+
+// TestDebugProviderRouting_ReportsPerCSMShape verifies the handler keys output per session manager and
+// emits the three address fields as JSON arrays (non-null) even when empty, and skips a nil CSM.
+func TestDebugProviderRouting_ReportsPerCSMShape(t *testing.T) {
+	var offsetNano atomic.Int64
+	optimizer := provideroptimizer.NewProviderOptimizer(provideroptimizer.StrategyBalanced, time.Second, uint(1), nil, "ETH1")
+	csm := lavasession.NewConsumerSessionManager(
+		&lavasession.RPCEndpoint{NetworkAddress: "stub", ChainID: "ETH1", ApiInterface: "jsonrpc", HealthCheckPath: "/"},
+		optimizer, nil, "lava@test", lavasession.NewActiveSubscriptionProvidersStorage(),
+	)
+	router := &RPCSmartRouter{
+		sessionManagers: map[string]*lavasession.ConsumerSessionManager{
+			"ETH1-jsonrpc": csm,
+			"NIL-rest":     nil, // skipped, not panic
+		},
+	}
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano, router: router})
+
+	rr := getDebugRouter(mux, "/debug/provider-routing")
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &rows))
+	require.Len(t, rows, 1, "nil CSM is skipped")
+	row := rows[0]
+	require.Equal(t, "ETH1", row["ChainID"])
+	require.Equal(t, "jsonrpc", row["ApiInterface"])
+	for _, k := range []string{"ValidAddresses", "CurrentlyBlockedProviderAddresses", "BlockedBackupProviders"} {
+		require.Contains(t, row, k)
+		require.IsType(t, []any{}, row[k], k+" must be a JSON array, not null")
+	}
+}
+
+// TestDebugEndpointState_WiringSafe verifies per-chain iteration, the nil-manager skip, and that a
+// chain whose session manager has no endpoints yields an empty (non-panicking) object. The full
+// observation↔health join is covered by the lavasession/endpointstate accessor tests.
+func TestDebugEndpointState_WiringSafe(t *testing.T) {
+	var offsetNano atomic.Int64
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	monitor := endpointstate.NewEndpointMonitor(ctx, endpointstate.EndpointChainTrackerConfig{
+		ChainID: "ETH1", ApiInterface: "jsonrpc", AverageBlockTime: 12 * time.Second, BlocksToSave: 10,
+	})
+	defer monitor.Stop()
+
+	router := &RPCSmartRouter{
+		rpcServers: map[string]*RPCSmartRouterServer{
+			"ETH1-jsonrpc": {endpointChainTrackerManager: monitor, listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"}},
+			"NIL-rest":     {endpointChainTrackerManager: nil}, // skipped, not panic
+		},
+		sessionManagers: map[string]*lavasession.ConsumerSessionManager{}, // no CSM for the chain → no rows, no panic
+	}
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano, router: router})
+
+	rr := getDebugRouter(mux, "/debug/endpoint-state")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.JSONEq(t, `[]`, rr.Body.String(), "no session manager wired for the chain → empty array, no panic")
 }
 
 // corruptedMsTimestampBlock is the exact value reported in the 2026-05-14

--- a/protocol/rpcsmartrouter/probe_loop_test.go
+++ b/protocol/rpcsmartrouter/probe_loop_test.go
@@ -222,6 +222,61 @@ func TestProbeCycle_NoObservationIsUnhealthy(t *testing.T) {
 	require.False(t, rec.calls[0].hasSync, "no telemetry → no sync sample")
 }
 
+// TestProbeCycleCore_ReturnsCycleCounts asserts the per-cycle telemetry runProbeCycleCore returns for
+// /debug/probe-loop (MAG-2202 endpoint 4): endpoints scored, endpoints re-enabled (F1), and providers
+// whose sample fed no sync evidence (F5).
+func TestProbeCycleCore_ReturnsCycleCounts(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	healthy := func(string) (endpointstate.EndpointObservation, bool) {
+		return freshObs(1000, now.Add(-time.Second), now.Add(-time.Second), 20*time.Millisecond), true
+	}
+	endpoints := []*lavasession.EndpointWithDirectConnection{
+		ep("http://a:8545", "p1", true),
+		ep("http://b:8545", "p2", true),
+	}
+
+	// Fresh baseline → sync fed for both providers, nothing omitted.
+	scored, reEnabled, syncOmitted := runProbeCycleCore(
+		endpoints, healthy, 1000, true,
+		provideroptimizer.SyncReference{ConsensusConfigured: true, Block: 1000, Time: now, Fresh: true},
+		now, probeCfg(), &recordingAppender{}, nil)
+	require.Equal(t, 2, scored, "both endpoints scored")
+	require.Equal(t, 0, reEnabled, "already-enabled endpoints are never re-enabled")
+	require.Equal(t, 0, syncOmitted, "fresh baseline → no sync omitted")
+
+	// No baseline → F5: sync omitted for every provider sample.
+	_, _, syncOmitted = runProbeCycleCore(
+		endpoints, healthy, 0, false,
+		provideroptimizer.SyncReference{ConsensusConfigured: true},
+		now, probeCfg(), &recordingAppender{}, nil)
+	require.Equal(t, 2, syncOmitted, "no fresh baseline → both providers' sync omitted (F5)")
+}
+
+// TestProbeCycleCore_CountsReEnable: the cycle that crosses the K-hysteresis reports exactly one
+// re-enable, and earlier cycles report none.
+func TestProbeCycleCore_CountsReEnable(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	dc := ep("http://ep:8545", "provider1", false) // disabled, disabledAt zero
+	endpoints := []*lavasession.EndpointWithDirectConnection{dc}
+
+	K := int(probeCfg().ReEnableHysteresis)
+	var lastReEnabled int
+	for i := 1; i <= K; i++ {
+		pollTime := base.Add(time.Duration(i) * time.Second) // strictly advancing distinct polls
+		now := pollTime.Add(time.Millisecond)
+		getObs := func(string) (endpointstate.EndpointObservation, bool) {
+			return freshObs(1000, now.Add(-time.Second), pollTime, 20*time.Millisecond), true
+		}
+		_, reEnabled, _ := runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{}, now, probeCfg(), nil, nil)
+		lastReEnabled = reEnabled
+		if i < K {
+			require.Equal(t, 0, reEnabled, "no re-enable before the K-th distinct healthy poll")
+		}
+	}
+	require.True(t, dc.Endpoint.Enabled)
+	require.Equal(t, 1, lastReEnabled, "the K-th cycle reports exactly one re-enable")
+}
+
 // TestValidatedProbeCadence pins the F6 validation: a non-positive configured cadence is rejected to
 // the default; a positive value passes through.
 func TestValidatedProbeCadence(t *testing.T) {

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"net/http"
 	"os/signal"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -855,7 +856,155 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 		fmt.Fprint(w, `{"cleared":true}`)
 	})
 
+	// GET /debug/endpoint-state — per-endpoint poll-health + enable/recovery state (MAG-2202 endpoint 1).
+	// Returns a flat array of self-describing records (ChainID + ApiInterface + NetworkAddress identify
+	// each row; no object nesting), joining the per-endpoint observation record
+	// (EndpointMonitor.SnapshotObservations: LatestBlock/ObservedAt/Source + poll-health) with the
+	// endpoint's enable/recovery state (Endpoint.HealthSnapshot: Enabled/DisabledAt/
+	// ConsecutiveHealthyProbes). Lets the automation suite verify F1 re-enable, recovery latency, the
+	// relay-vs-poll Source gate, and failure-streak reset from the wire. Read-only; nil-router safe.
+	mux.HandleFunc("/debug/endpoint-state", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "GET only", http.StatusMethodNotAllowed)
+			return
+		}
+		rows := []map[string]any{}
+		if deps.router != nil {
+			deps.router.mu.Lock()
+			for chainKey, server := range deps.router.rpcServers {
+				if server == nil || server.endpointChainTrackerManager == nil || server.listenEndpoint == nil {
+					continue
+				}
+				csm := deps.router.sessionManagers[chainKey]
+				if csm == nil {
+					continue
+				}
+				observations := server.endpointChainTrackerManager.SnapshotObservations()
+				for _, ep := range csm.GetAllDirectRPCEndpoints() {
+					if ep == nil || ep.Endpoint == nil {
+						continue
+					}
+					url := ep.Endpoint.NetworkAddress
+					health := ep.Endpoint.HealthSnapshot()
+					obs := observations[url] // zero value when no observation recorded yet
+					rows = append(rows, map[string]any{
+						"ChainID":                  server.listenEndpoint.ChainID,
+						"ApiInterface":             server.listenEndpoint.ApiInterface,
+						"NetworkAddress":           url,
+						"Enabled":                  health.Enabled,
+						"DisabledAt":               debugTimeRFC3339(health.DisabledAt),
+						"ConsecutiveHealthyProbes": health.ConsecutiveHealthyProbes,
+						"ConsecutivePollFailures":  obs.ConsecutivePollFailures,
+						"LastSuccessfulPoll":       debugTimeRFC3339(obs.LastSuccessfulPoll),
+						"LatestBlock":              obs.LatestBlock,
+						"ObservedAt":               debugTimeRFC3339(obs.ObservedAt),
+						"Source":                   obs.Source.String(),
+					})
+				}
+			}
+			deps.router.mu.Unlock()
+		}
+		writeDebugRows(w, rows)
+	})
+
+	// GET /debug/chain-state — per-chain consensus/tip state (MAG-2202 endpoint 2). Flat array of
+	// self-describing records (ChainID + ApiInterface). Raw, NON-TTL-gated snapshot
+	// (ChainState.DebugSnapshot) so the suite can assert anti-lie outlier rejection, downward
+	// realignment, TTL expiry, empty-snapshot baseline clearing, and cold-start bootstrap from the raw
+	// (block, timestamp) pairs — a TTL-gated getter would hide exactly those transitions. Read-only;
+	// nil-router safe.
+	mux.HandleFunc("/debug/chain-state", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "GET only", http.StatusMethodNotAllowed)
+			return
+		}
+		rows := []map[string]any{}
+		if deps.router != nil {
+			deps.router.mu.Lock()
+			for _, server := range deps.router.rpcServers {
+				if server == nil || server.chainState == nil || server.listenEndpoint == nil {
+					continue
+				}
+				s := server.chainState.DebugSnapshot()
+				rows = append(rows, map[string]any{
+					"ChainID":           server.listenEndpoint.ChainID,
+					"ApiInterface":      server.listenEndpoint.ApiInterface,
+					"ObservedTip":       s.ObservedTip,
+					"LastObservedAt":    debugTimeRFC3339(s.LastObservedAt),
+					"ConsensusBaseline": s.ConsensusBaseline,
+					"HasBaseline":       s.HasBaseline,
+					"BaselineSince":     debugTimeRFC3339(s.BaselineSince),
+					"Initialized":       s.Initialized,
+				})
+			}
+			deps.router.mu.Unlock()
+		}
+		writeDebugRows(w, rows)
+	})
+
+	// GET /debug/provider-routing — per-CSM routing-pool state (MAG-2202 endpoint 3). Flat array of
+	// self-describing records (ChainID + ApiInterface): ValidAddresses / CurrentlyBlockedProviderAddresses
+	// / BlockedBackupProviders, so the suite can confirm a re-enabled provider is actually back in the
+	// routing pool rather than enabled-but-unroutable (F2). Read-only; nil-router safe.
+	mux.HandleFunc("/debug/provider-routing", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "GET only", http.StatusMethodNotAllowed)
+			return
+		}
+		rows := []map[string]any{}
+		if deps.router != nil {
+			deps.router.mu.Lock()
+			for _, csm := range deps.router.sessionManagers {
+				if csm == nil {
+					continue
+				}
+				ep := csm.RPCEndpoint()
+				s := csm.ProviderRoutingSnapshot()
+				rows = append(rows, map[string]any{
+					"ChainID":                           ep.ChainID,
+					"ApiInterface":                      ep.ApiInterface,
+					"ValidAddresses":                    s.ValidAddresses,
+					"CurrentlyBlockedProviderAddresses": s.CurrentlyBlockedProviderAddresses,
+					"BlockedBackupProviders":            s.BlockedBackupProviders,
+				})
+			}
+			deps.router.mu.Unlock()
+		}
+		writeDebugRows(w, rows)
+	})
+
 	return mux
+}
+
+// debugTimeRFC3339 formats a timestamp for the read-only /debug/* state endpoints, matching the
+// /debug/time convention (UTC RFC3339). A zero time renders as the empty string rather than the
+// Go zero-date ("0001-01-01T00:00:00Z"), so a test can cheaply distinguish "never happened"
+// (e.g. DisabledAt on an enabled endpoint) from a real instant.
+func debugTimeRFC3339(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+// debugRowKey is the deterministic sort key for a /debug/* state row: ChainID, then ApiInterface,
+// then NetworkAddress (absent on chain/CSM rows → ""). comma-ok avoids a panic on the missing key.
+func debugRowKey(m map[string]any) string {
+	cid, _ := m["ChainID"].(string)
+	api, _ := m["ApiInterface"].(string)
+	na, _ := m["NetworkAddress"].(string)
+	return cid + "\x00" + api + "\x00" + na
+}
+
+// writeDebugRows sorts the records deterministically (so Go map-iteration order never leaks into the
+// response, keeping output stable for test fixtures and humans) and encodes them as a JSON array.
+// rows is always non-nil, so an empty result encodes as [] rather than null.
+func writeDebugRows(w http.ResponseWriter, rows []map[string]any) {
+	sort.Slice(rows, func(i, j int) bool { return debugRowKey(rows[i]) < debugRowKey(rows[j]) })
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(rows); err != nil {
+		utils.LavaFormatWarning("failed encoding debug response", err)
+	}
 }
 
 func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -973,6 +973,42 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 		writeDebugRows(w, rows)
 	})
 
+	// GET /debug/probe-loop — per-chain proactive-prober cycle telemetry (MAG-2202 endpoint 4). Flat
+	// array of self-describing records (ChainID + ApiInterface): the configured --probe-loop-interval
+	// cadence (CycleIntervalMs) plus a snapshot of the last completed runProbeCycle — start/duration,
+	// endpoints scored, endpoints re-enabled (F1), and providers whose QoS sample fed no sync evidence
+	// (F5). CyclesCompleted is the monotonic liveness counter for verifying the prober ticks on its own
+	// cadence (F6). Read-only; nil-router safe. Timestamps/durations: RFC3339 + integer milliseconds.
+	mux.HandleFunc("/debug/probe-loop", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "GET only", http.StatusMethodNotAllowed)
+			return
+		}
+		rows := []map[string]any{}
+		if deps.router != nil {
+			deps.router.mu.Lock()
+			for _, server := range deps.router.rpcServers {
+				if server == nil || server.listenEndpoint == nil {
+					continue
+				}
+				s := server.probeStats.snapshot()
+				rows = append(rows, map[string]any{
+					"ChainID":             server.listenEndpoint.ChainID,
+					"ApiInterface":        server.listenEndpoint.ApiInterface,
+					"CycleIntervalMs":     s.CycleIntervalMs,
+					"CyclesCompleted":     s.CyclesCompleted,
+					"LastCycleStartedAt":  debugTimeRFC3339(s.LastCycleStartedAt),
+					"LastCycleDurationMs": s.LastCycleDurationMs,
+					"EndpointsScored":     s.EndpointsScored,
+					"ReEnabledCount":      s.ReEnabledCount,
+					"SyncOmittedCount":    s.SyncOmittedCount,
+				})
+			}
+			deps.router.mu.Unlock()
+		}
+		writeDebugRows(w, rows)
+	})
+
 	return mux
 }
 

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -85,6 +86,10 @@ type RPCSmartRouterServer struct {
 
 	// Per-method cross-validation policy resolver (nil/empty => header-driven CV only).
 	crossValidationResolver *CrossValidationPolicyResolver
+
+	// probeStats holds the most-recent runProbeLoop cycle telemetry for /debug/probe-loop
+	// (MAG-2202 endpoint 4). Written off the data plane by runProbeCycle; read by the debug handler.
+	probeStats probeLoopStats
 }
 
 func (rpcss *RPCSmartRouterServer) ServeRPCRequests(
@@ -1819,6 +1824,67 @@ func validatedProbeCadence(configured time.Duration) time.Duration {
 	return configured
 }
 
+// probeLoopStats holds the most-recent runProbeLoop cycle telemetry for /debug/probe-loop (MAG-2202
+// endpoint 4): the configured cadence plus a snapshot of the LAST completed cycle. Written once per
+// cycle by runProbeCycle (off the data plane) and read by the debug handler, under its own mutex so
+// a debug read never contends with relay/probe state. One per RPCSmartRouterServer, like the chain
+// it probes. The zero value is a valid "no cycle run yet" state.
+type probeLoopStats struct {
+	mu               sync.Mutex
+	cycleIntervalMs  int64     // configured --probe-loop-interval; set once when the loop starts
+	cyclesCompleted  uint64    // monotonic count of completed cycles (F6 liveness)
+	lastCycleStarted time.Time // wall-clock the last cycle began (zero before the first cycle)
+	lastCycleDurMs   int64     // wall-clock duration of the last cycle
+	endpointsScored  int       // endpoints scored in the last cycle
+	reEnabledCount   int       // endpoints the probe re-enabled in the last cycle (F1)
+	syncOmittedCount int       // providers whose last-cycle QoS sample fed no sync evidence (F5)
+}
+
+// setInterval publishes the effective probe cadence. Called once at loop start.
+func (s *probeLoopStats) setInterval(d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cycleIntervalMs = d.Milliseconds()
+}
+
+// recordCycle overwrites the last-cycle snapshot and bumps the completed-cycle counter.
+func (s *probeLoopStats) recordCycle(startedAt time.Time, dur time.Duration, scored, reEnabled, syncOmitted int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cyclesCompleted++
+	s.lastCycleStarted = startedAt
+	s.lastCycleDurMs = dur.Milliseconds()
+	s.endpointsScored = scored
+	s.reEnabledCount = reEnabled
+	s.syncOmittedCount = syncOmitted
+}
+
+// probeLoopSnapshot is the read-only view the /debug/probe-loop handler emits per chain.
+type probeLoopSnapshot struct {
+	CycleIntervalMs     int64
+	CyclesCompleted     uint64
+	LastCycleStartedAt  time.Time
+	LastCycleDurationMs int64
+	EndpointsScored     int
+	ReEnabledCount      int
+	SyncOmittedCount    int
+}
+
+// snapshot returns a consistent copy of the stats under the lock (no mutex in the returned value).
+func (s *probeLoopStats) snapshot() probeLoopSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return probeLoopSnapshot{
+		CycleIntervalMs:     s.cycleIntervalMs,
+		CyclesCompleted:     s.cyclesCompleted,
+		LastCycleStartedAt:  s.lastCycleStarted,
+		LastCycleDurationMs: s.lastCycleDurMs,
+		EndpointsScored:     s.endpointsScored,
+		ReEnabledCount:      s.reEnabledCount,
+		SyncOmittedCount:    s.syncOmittedCount,
+	}
+}
+
 // runProbeLoop is the Topic D proactive health prober (MAG-2161). On its own cadence it reads stored
 // per-endpoint telemetry (Topic A) + the consensus baseline (Topic C) — making NO upstream call —
 // renders a health verdict for EVERY direct-RPC endpoint (regular AND backup), proactively
@@ -1831,6 +1897,9 @@ func (rpcss *RPCSmartRouterServer) runProbeLoop(ctx context.Context, cadence tim
 	if cadence <= 0 {
 		cadence = defaultProbeCadence
 	}
+	// Publish the effective cadence for /debug/probe-loop (CycleIntervalMs) before the first tick,
+	// so the endpoint reports the interval even before a cycle has completed.
+	rpcss.probeStats.setInterval(cadence)
 	// The optimizer's AppendProbeData is optional (inline assertion) so the loop degrades to
 	// re-enable-only if a future optimizer lacks it, rather than failing to start.
 	appender, _ := rpcss.sessionManager.GetProviderOptimizer().(probeQoSAppender)
@@ -1860,18 +1929,25 @@ func (rpcss *RPCSmartRouterServer) runProbeCycle(appender probeQoSAppender, cfg 
 			syncRef.Block, syncRef.Time, syncRef.Fresh = uint64(block), at, true
 		}
 	}
-	runProbeCycleCore(
+	startedAt := time.Now()
+	scored, reEnabled, syncOmitted := runProbeCycleCore(
 		rpcss.sessionManager.GetAllDirectRPCEndpoints(),
 		rpcss.endpointChainTrackerManager.GetObservation,
-		baseline, hasBaseline, syncRef, time.Now(), cfg, appender,
+		baseline, hasBaseline, syncRef, startedAt, cfg, appender,
 		rpcss.sessionManager.RestoreRecoveredProvider,
 	)
+	rpcss.probeStats.recordCycle(startedAt, time.Since(startedAt), scored, reEnabled, syncOmitted)
 }
 
 // runProbeCycleCore is the pure probe-cycle body (no rpcss fields), so it is testable with
 // constructed endpoints + a fake observation getter + a fake appender. For every endpoint it renders
 // a verdict, applies the proactive re-enable, then feeds ONE aggregated QoS sample per provider
 // (rule E2). A nil appender still performs the re-enable (QoS feed simply skipped).
+//
+// Returns the per-cycle telemetry for /debug/probe-loop (MAG-2202 endpoint 4): scored = endpoints
+// that received a verdict; reEnabled = endpoints the probe re-enabled this cycle (F1); syncOmitted =
+// providers whose QoS sample fed NO sync evidence (F5: no fresh consensus baseline, or no block in
+// the sample). syncOmitted is 0 when appender is nil (no QoS feed happens, so nothing is omitted).
 func runProbeCycleCore(
 	endpoints []*lavasession.EndpointWithDirectConnection,
 	getObservation func(url string) (endpointstate.EndpointObservation, bool),
@@ -1882,26 +1958,30 @@ func runProbeCycleCore(
 	cfg probing.VerdictConfig,
 	appender probeQoSAppender,
 	onRecover func(provider string),
-) {
+) (scored, reEnabled, syncOmitted int) {
 	// One verdict per endpoint (regular + backup), grouped by provider for the single-sample rule.
 	verdictsByProvider := make(map[string][]probing.EndpointVerdict)
 	for _, ep := range endpoints {
 		if ep == nil || ep.Endpoint == nil {
 			continue
 		}
+		scored++
 		obs, _ := getObservation(ep.Endpoint.NetworkAddress)
 		verdict := probing.RenderEndpointVerdict(obs, baseline, hasBaseline, now, cfg)
 		// Proactive re-enable from POST-DISABLE successful-poll evidence only (F1). RecordProbeVerdict
 		// releases the endpoint mutex before returning, so onRecover (which takes csm.lock) cannot
 		// nest under endpoint.mu — no lock-order inversion (F2).
-		if ep.Endpoint.RecordProbeVerdict(verdict.Recovery.LastSuccessfulPoll, verdict.Recovery.PollHealthy, cfg.ReEnableHysteresis) && onRecover != nil {
-			onRecover(ep.ProviderAddress)
+		if ep.Endpoint.RecordProbeVerdict(verdict.Recovery.LastSuccessfulPoll, verdict.Recovery.PollHealthy, cfg.ReEnableHysteresis) {
+			reEnabled++
+			if onRecover != nil {
+				onRecover(ep.ProviderAddress)
+			}
 		}
 		verdictsByProvider[ep.ProviderAddress] = append(verdictsByProvider[ep.ProviderAddress], verdict)
 	}
 
 	if appender == nil {
-		return // re-enable still happened above; QoS feed unavailable
+		return scored, reEnabled, syncOmitted // re-enable still happened above; QoS feed unavailable
 	}
 	for provider, verdicts := range verdictsByProvider {
 		sample, ok := probing.AggregateProviderSample(verdicts)
@@ -1911,8 +1991,12 @@ func runProbeCycleCore(
 		// hasSync only when an accepted consensus baseline exists (F5): no baseline → no sync evidence,
 		// never the legacy max-across-providers reference. syncRef carries the same baseline.
 		hasSync := sample.HasBlock && hasBaseline
+		if !hasSync {
+			syncOmitted++ // F5: this provider's QoS sample carries no sync evidence this cycle
+		}
 		appender.AppendProbeData(provider, sample.Availability, sample.Latency, sample.HasLatency, sample.Block, hasSync, syncRef)
 	}
+	return scored, reEnabled, syncOmitted
 }
 
 // harvestAndUpdateTipFromRelay applies a served relay's block to TIP state — but only when the


### PR DESCRIPTION
## What

Adds the first three of the four read-only debug endpoints requested in [MAG-2202](https://magmadevs.atlassian.net/browse/MAG-2202), so the MAG-2201 automation suite can read ChainTracker/Probing-redesign state from the wire instead of scraping logs or counting relays:

- `GET /debug/endpoint-state` — per-endpoint poll-health + enable/recovery (F1)
- `GET /debug/chain-state` — per-chain consensus/tip state (anti-lie, TTL, realignment)
- `GET /debug/provider-routing` — per-CSM valid / blocked / blocked-backup addresses (F2)

The backing state already exists on this base branch (Topics A/C + the F1 hysteresis fields), so this PR only adds **read accessors + HTTP handlers** — no behavior change to the data plane.

## ⚠️ Stacked on `chaintracker-redesign` (PR #143)

Base branch is **`chaintracker-redesign`, not `main`** — these endpoints read `protocol/chainstate` and `protocol/endpointstate`, which only exist there. This merges **after #143**.

`/debug/probe-loop` (endpoint 4) is intentionally **not** here — it needs counter instrumentation on the existing `runProbeLoop` rather than new read plumbing, so it lands in a separate fast-follow PR (see the corrected ticket comment).

## Response shape — please sanity-check, @victoria

The ticket specifies the per-record fields but not the envelope. I read *"flat top-level keys per endpoint, no nesting"* literally and made each endpoint return a **flat array of self-describing records** (identified by `ChainID` + `ApiInterface`, plus `NetworkAddress` for endpoint-state), deterministically sorted, no object nesting. Concrete examples:

**`/debug/endpoint-state`**
```json
[
  {
    "ChainID": "ETH1", "ApiInterface": "jsonrpc", "NetworkAddress": "http://node-a:8545",
    "Enabled": true, "DisabledAt": "", "ConsecutiveHealthyProbes": 0,
    "ConsecutivePollFailures": 0, "LastSuccessfulPoll": "2026-06-25T09:30:00Z",
    "LatestBlock": 21000000, "ObservedAt": "2026-06-25T09:30:01Z", "Source": "poll"
  }
]
```
(`ConsecutiveHealthyProbes` added beyond the ticket's list — it's the literal F1 quantity; field names are "suggestions" per the ticket.)

**`/debug/chain-state`**
```json
[
  {
    "ChainID": "ETH1", "ApiInterface": "jsonrpc",
    "ObservedTip": 21000000, "LastObservedAt": "2026-06-25T09:30:01Z",
    "ConsensusBaseline": 21000000, "HasBaseline": true,
    "BaselineSince": "2026-06-25T09:29:40Z", "Initialized": true
  }
]
```

**`/debug/provider-routing`**
```json
[
  {
    "ChainID": "ETH1", "ApiInterface": "jsonrpc",
    "ValidAddresses": ["lava@a", "lava@b"],
    "CurrentlyBlockedProviderAddresses": [],
    "BlockedBackupProviders": []
  }
]
```

Conventions honored: Go-identifier keys; timestamps RFC3339 UTC matching `/debug/time` (empty string for a zero time, e.g. `DisabledAt` on an enabled endpoint); millisecond integers N/A here (no durations in these three); address slices non-nil so empties encode as `[]` not `null`; `ChainID`/`ApiInterface` sourced from `listenEndpoint` / `csm.RPCEndpoint()`, never by splitting the chain key.

If the suite would rather have a map keyed by `chainID-apiInterface` (or chain→endpoint), say so and I'll switch — easier to change now than after the tests build to it.

## Acceptance criteria

- [x] Each endpoint returns HTTP 200 with the fields above, reflecting live process state
- [x] Any method other than GET returns HTTP 405
- [x] Registered only when `--debug-address` is set (added inside `buildDebugMux`); production builds unaffected
- [x] nil-router safe (returns `[]`) so a partial test fixture can probe unconditionally

## Test plan

- Accessor unit tests in home packages: `Endpoint.HealthSnapshot` (disable → K=3 hysteresis → re-enable), `ConsumerSessionManager.ProviderRoutingSnapshot` (copies, sorted, non-nil), `ChainState.DebugSnapshot` (raw fields incl. TTL-expired tip still visible).
- Handler tests: 405 (all three), nil-router safety, plus populated-row shape for chain-state and provider-routing and a wiring/skip test for endpoint-state.
- `go build ./...`, `gofmt`, and `go test -race` over `chainstate` / `lavasession` / `rpcsmartrouter` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MAG-2202]: https://magmadevs.atlassian.net/browse/MAG-2202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ