### PR TITLE
feat(smart-router/debug): add /debug/probe-loop prober-cycle telemetry (MAG-2202 endpoint 4)

### DIFF
--- a/protocol/rpcsmartrouter/debug_server_test.go
+++ b/protocol/rpcsmartrouter/debug_server_test.go
@@ -298,8 +298,8 @@ func getDebugRouter(mux http.Handler, path string) *httptest.ResponseRecorder {
 	return rr
 }
 
-// stateEndpointPaths are the three read-only state endpoints added for MAG-2202.
-var stateEndpointPaths = []string{"/debug/endpoint-state", "/debug/chain-state", "/debug/provider-routing"}
+// stateEndpointPaths are the read-only state endpoints added for MAG-2202.
+var stateEndpointPaths = []string{"/debug/endpoint-state", "/debug/chain-state", "/debug/provider-routing", "/debug/probe-loop"}
 
 // TestDebugStateEndpoints_MethodNotAllowed: all three are GET-only (the acceptance criterion that any
 // non-GET method returns 405).
@@ -421,6 +421,41 @@ func TestDebugEndpointState_WiringSafe(t *testing.T) {
 	rr := getDebugRouter(mux, "/debug/endpoint-state")
 	require.Equal(t, http.StatusOK, rr.Code)
 	require.JSONEq(t, `[]`, rr.Body.String(), "no session manager wired for the chain → empty array, no panic")
+}
+
+// TestDebugProbeLoop_ReportsCycleStats verifies the per-chain probe-cycle record: interval +
+// last-cycle snapshot (durations as integer ms, start as RFC3339), and that a listenEndpoint-less
+// server is skipped.
+func TestDebugProbeLoop_ReportsCycleStats(t *testing.T) {
+	var offsetNano atomic.Int64
+	server := &RPCSmartRouterServer{listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"}}
+	server.probeStats.setInterval(5 * time.Second)
+	server.probeStats.recordCycle(time.Now(), 7*time.Millisecond, 4, 1, 2)
+
+	router := &RPCSmartRouter{
+		rpcServers: map[string]*RPCSmartRouterServer{
+			"ETH1-jsonrpc": server,
+			"NIL-rest":     {listenEndpoint: nil}, // skipped, not panic
+		},
+	}
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano, router: router})
+
+	rr := getDebugRouter(mux, "/debug/probe-loop")
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &rows))
+	require.Len(t, rows, 1, "the listenEndpoint-less server is skipped")
+	row := rows[0]
+	require.Equal(t, "ETH1", row["ChainID"])
+	require.Equal(t, "jsonrpc", row["ApiInterface"])
+	require.Equal(t, float64(5000), row["CycleIntervalMs"], "interval reported in milliseconds")
+	require.Equal(t, float64(1), row["CyclesCompleted"])
+	require.Equal(t, float64(7), row["LastCycleDurationMs"], "duration in milliseconds")
+	require.Equal(t, float64(4), row["EndpointsScored"])
+	require.Equal(t, float64(1), row["ReEnabledCount"])
+	require.Equal(t, float64(2), row["SyncOmittedCount"])
+	require.NotEmpty(t, row["LastCycleStartedAt"], "cycle start carries an RFC3339 timestamp")
 }
 
 // corruptedMsTimestampBlock is the exact value reported in the 2026-05-14

--- a/protocol/rpcsmartrouter/probe_loop_test.go
+++ b/protocol/rpcsmartrouter/probe_loop_test.go
@@ -222,6 +222,61 @@ func TestProbeCycle_NoObservationIsUnhealthy(t *testing.T) {
 	require.False(t, rec.calls[0].hasSync, "no telemetry → no sync sample")
 }
 
+// TestProbeCycleCore_ReturnsCycleCounts asserts the per-cycle telemetry runProbeCycleCore returns for
+// /debug/probe-loop (MAG-2202 endpoint 4): endpoints scored, endpoints re-enabled (F1), and providers
+// whose sample fed no sync evidence (F5).
+func TestProbeCycleCore_ReturnsCycleCounts(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	healthy := func(string) (endpointstate.EndpointObservation, bool) {
+		return freshObs(1000, now.Add(-time.Second), now.Add(-time.Second), 20*time.Millisecond), true
+	}
+	endpoints := []*lavasession.EndpointWithDirectConnection{
+		ep("http://a:8545", "p1", true),
+		ep("http://b:8545", "p2", true),
+	}
+
+	// Fresh baseline → sync fed for both providers, nothing omitted.
+	scored, reEnabled, syncOmitted := runProbeCycleCore(
+		endpoints, healthy, 1000, true,
+		provideroptimizer.SyncReference{ConsensusConfigured: true, Block: 1000, Time: now, Fresh: true},
+		now, probeCfg(), &recordingAppender{}, nil)
+	require.Equal(t, 2, scored, "both endpoints scored")
+	require.Equal(t, 0, reEnabled, "already-enabled endpoints are never re-enabled")
+	require.Equal(t, 0, syncOmitted, "fresh baseline → no sync omitted")
+
+	// No baseline → F5: sync omitted for every provider sample.
+	_, _, syncOmitted = runProbeCycleCore(
+		endpoints, healthy, 0, false,
+		provideroptimizer.SyncReference{ConsensusConfigured: true},
+		now, probeCfg(), &recordingAppender{}, nil)
+	require.Equal(t, 2, syncOmitted, "no fresh baseline → both providers' sync omitted (F5)")
+}
+
+// TestProbeCycleCore_CountsReEnable: the cycle that crosses the K-hysteresis reports exactly one
+// re-enable, and earlier cycles report none.
+func TestProbeCycleCore_CountsReEnable(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	dc := ep("http://ep:8545", "provider1", false) // disabled, disabledAt zero
+	endpoints := []*lavasession.EndpointWithDirectConnection{dc}
+
+	K := int(probeCfg().ReEnableHysteresis)
+	var lastReEnabled int
+	for i := 1; i <= K; i++ {
+		pollTime := base.Add(time.Duration(i) * time.Second) // strictly advancing distinct polls
+		now := pollTime.Add(time.Millisecond)
+		getObs := func(string) (endpointstate.EndpointObservation, bool) {
+			return freshObs(1000, now.Add(-time.Second), pollTime, 20*time.Millisecond), true
+		}
+		_, reEnabled, _ := runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{}, now, probeCfg(), nil, nil)
+		lastReEnabled = reEnabled
+		if i < K {
+			require.Equal(t, 0, reEnabled, "no re-enable before the K-th distinct healthy poll")
+		}
+	}
+	require.True(t, dc.Endpoint.Enabled)
+	require.Equal(t, 1, lastReEnabled, "the K-th cycle reports exactly one re-enable")
+}
+
 // TestValidatedProbeCadence pins the F6 validation: a non-positive configured cadence is rejected to
 // the default; a positive value passes through.
 func TestValidatedProbeCadence(t *testing.T) {

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -973,6 +973,42 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 		writeDebugRows(w, rows)
 	})
 
+	// GET /debug/probe-loop — per-chain proactive-prober cycle telemetry (MAG-2202 endpoint 4). Flat
+	// array of self-describing records (ChainID + ApiInterface): the configured --probe-loop-interval
+	// cadence (CycleIntervalMs) plus a snapshot of the last completed runProbeCycle — start/duration,
+	// endpoints scored, endpoints re-enabled (F1), and providers whose QoS sample fed no sync evidence
+	// (F5). CyclesCompleted is the monotonic liveness counter for verifying the prober ticks on its own
+	// cadence (F6). Read-only; nil-router safe. Timestamps/durations: RFC3339 + integer milliseconds.
+	mux.HandleFunc("/debug/probe-loop", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "GET only", http.StatusMethodNotAllowed)
+			return
+		}
+		rows := []map[string]any{}
+		if deps.router != nil {
+			deps.router.mu.Lock()
+			for _, server := range deps.router.rpcServers {
+				if server == nil || server.listenEndpoint == nil {
+					continue
+				}
+				s := server.probeStats.snapshot()
+				rows = append(rows, map[string]any{
+					"ChainID":             server.listenEndpoint.ChainID,
+					"ApiInterface":        server.listenEndpoint.ApiInterface,
+					"CycleIntervalMs":     s.CycleIntervalMs,
+					"CyclesCompleted":     s.CyclesCompleted,
+					"LastCycleStartedAt":  debugTimeRFC3339(s.LastCycleStartedAt),
+					"LastCycleDurationMs": s.LastCycleDurationMs,
+					"EndpointsScored":     s.EndpointsScored,
+					"ReEnabledCount":      s.ReEnabledCount,
+					"SyncOmittedCount":    s.SyncOmittedCount,
+				})
+			}
+			deps.router.mu.Unlock()
+		}
+		writeDebugRows(w, rows)
+	})
+
 	return mux
 }
 

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -85,6 +86,10 @@ type RPCSmartRouterServer struct {
 
 	// Per-method cross-validation policy resolver (nil/empty => header-driven CV only).
 	crossValidationResolver *CrossValidationPolicyResolver
+
+	// probeStats holds the most-recent runProbeLoop cycle telemetry for /debug/probe-loop
+	// (MAG-2202 endpoint 4). Written off the data plane by runProbeCycle; read by the debug handler.
+	probeStats probeLoopStats
 }
 
 func (rpcss *RPCSmartRouterServer) ServeRPCRequests(
@@ -1819,6 +1824,67 @@ func validatedProbeCadence(configured time.Duration) time.Duration {
 	return configured
 }
 
+// probeLoopStats holds the most-recent runProbeLoop cycle telemetry for /debug/probe-loop (MAG-2202
+// endpoint 4): the configured cadence plus a snapshot of the LAST completed cycle. Written once per
+// cycle by runProbeCycle (off the data plane) and read by the debug handler, under its own mutex so
+// a debug read never contends with relay/probe state. One per RPCSmartRouterServer, like the chain
+// it probes. The zero value is a valid "no cycle run yet" state.
+type probeLoopStats struct {
+	mu               sync.Mutex
+	cycleIntervalMs  int64     // configured --probe-loop-interval; set once when the loop starts
+	cyclesCompleted  uint64    // monotonic count of completed cycles (F6 liveness)
+	lastCycleStarted time.Time // wall-clock the last cycle began (zero before the first cycle)
+	lastCycleDurMs   int64     // wall-clock duration of the last cycle
+	endpointsScored  int       // endpoints scored in the last cycle
+	reEnabledCount   int       // endpoints the probe re-enabled in the last cycle (F1)
+	syncOmittedCount int       // providers whose last-cycle QoS sample fed no sync evidence (F5)
+}
+
+// setInterval publishes the effective probe cadence. Called once at loop start.
+func (s *probeLoopStats) setInterval(d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cycleIntervalMs = d.Milliseconds()
+}
+
+// recordCycle overwrites the last-cycle snapshot and bumps the completed-cycle counter.
+func (s *probeLoopStats) recordCycle(startedAt time.Time, dur time.Duration, scored, reEnabled, syncOmitted int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cyclesCompleted++
+	s.lastCycleStarted = startedAt
+	s.lastCycleDurMs = dur.Milliseconds()
+	s.endpointsScored = scored
+	s.reEnabledCount = reEnabled
+	s.syncOmittedCount = syncOmitted
+}
+
+// probeLoopSnapshot is the read-only view the /debug/probe-loop handler emits per chain.
+type probeLoopSnapshot struct {
+	CycleIntervalMs     int64
+	CyclesCompleted     uint64
+	LastCycleStartedAt  time.Time
+	LastCycleDurationMs int64
+	EndpointsScored     int
+	ReEnabledCount      int
+	SyncOmittedCount    int
+}
+
+// snapshot returns a consistent copy of the stats under the lock (no mutex in the returned value).
+func (s *probeLoopStats) snapshot() probeLoopSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return probeLoopSnapshot{
+		CycleIntervalMs:     s.cycleIntervalMs,
+		CyclesCompleted:     s.cyclesCompleted,
+		LastCycleStartedAt:  s.lastCycleStarted,
+		LastCycleDurationMs: s.lastCycleDurMs,
+		EndpointsScored:     s.endpointsScored,
+		ReEnabledCount:      s.reEnabledCount,
+		SyncOmittedCount:    s.syncOmittedCount,
+	}
+}
+
 // runProbeLoop is the Topic D proactive health prober (MAG-2161). On its own cadence it reads stored
 // per-endpoint telemetry (Topic A) + the consensus baseline (Topic C) — making NO upstream call —
 // renders a health verdict for EVERY direct-RPC endpoint (regular AND backup), proactively
@@ -1831,6 +1897,9 @@ func (rpcss *RPCSmartRouterServer) runProbeLoop(ctx context.Context, cadence tim
 	if cadence <= 0 {
 		cadence = defaultProbeCadence
 	}
+	// Publish the effective cadence for /debug/probe-loop (CycleIntervalMs) before the first tick,
+	// so the endpoint reports the interval even before a cycle has completed.
+	rpcss.probeStats.setInterval(cadence)
 	// The optimizer's AppendProbeData is optional (inline assertion) so the loop degrades to
 	// re-enable-only if a future optimizer lacks it, rather than failing to start.
 	appender, _ := rpcss.sessionManager.GetProviderOptimizer().(probeQoSAppender)
@@ -1860,18 +1929,25 @@ func (rpcss *RPCSmartRouterServer) runProbeCycle(appender probeQoSAppender, cfg 
 			syncRef.Block, syncRef.Time, syncRef.Fresh = uint64(block), at, true
 		}
 	}
-	runProbeCycleCore(
+	startedAt := time.Now()
+	scored, reEnabled, syncOmitted := runProbeCycleCore(
 		rpcss.sessionManager.GetAllDirectRPCEndpoints(),
 		rpcss.endpointChainTrackerManager.GetObservation,
-		baseline, hasBaseline, syncRef, time.Now(), cfg, appender,
+		baseline, hasBaseline, syncRef, startedAt, cfg, appender,
 		rpcss.sessionManager.RestoreRecoveredProvider,
 	)
+	rpcss.probeStats.recordCycle(startedAt, time.Since(startedAt), scored, reEnabled, syncOmitted)
 }
 
 // runProbeCycleCore is the pure probe-cycle body (no rpcss fields), so it is testable with
 // constructed endpoints + a fake observation getter + a fake appender. For every endpoint it renders
 // a verdict, applies the proactive re-enable, then feeds ONE aggregated QoS sample per provider
 // (rule E2). A nil appender still performs the re-enable (QoS feed simply skipped).
+//
+// Returns the per-cycle telemetry for /debug/probe-loop (MAG-2202 endpoint 4): scored = endpoints
+// that received a verdict; reEnabled = endpoints the probe re-enabled this cycle (F1); syncOmitted =
+// providers whose QoS sample fed NO sync evidence (F5: no fresh consensus baseline, or no block in
+// the sample). syncOmitted is 0 when appender is nil (no QoS feed happens, so nothing is omitted).
 func runProbeCycleCore(
 	endpoints []*lavasession.EndpointWithDirectConnection,
 	getObservation func(url string) (endpointstate.EndpointObservation, bool),
@@ -1882,26 +1958,30 @@ func runProbeCycleCore(
 	cfg probing.VerdictConfig,
 	appender probeQoSAppender,
 	onRecover func(provider string),
-) {
+) (scored, reEnabled, syncOmitted int) {
 	// One verdict per endpoint (regular + backup), grouped by provider for the single-sample rule.
 	verdictsByProvider := make(map[string][]probing.EndpointVerdict)
 	for _, ep := range endpoints {
 		if ep == nil || ep.Endpoint == nil {
 			continue
 		}
+		scored++
 		obs, _ := getObservation(ep.Endpoint.NetworkAddress)
 		verdict := probing.RenderEndpointVerdict(obs, baseline, hasBaseline, now, cfg)
 		// Proactive re-enable from POST-DISABLE successful-poll evidence only (F1). RecordProbeVerdict
 		// releases the endpoint mutex before returning, so onRecover (which takes csm.lock) cannot
 		// nest under endpoint.mu — no lock-order inversion (F2).
-		if ep.Endpoint.RecordProbeVerdict(verdict.Recovery.LastSuccessfulPoll, verdict.Recovery.PollHealthy, cfg.ReEnableHysteresis) && onRecover != nil {
-			onRecover(ep.ProviderAddress)
+		if ep.Endpoint.RecordProbeVerdict(verdict.Recovery.LastSuccessfulPoll, verdict.Recovery.PollHealthy, cfg.ReEnableHysteresis) {
+			reEnabled++
+			if onRecover != nil {
+				onRecover(ep.ProviderAddress)
+			}
 		}
 		verdictsByProvider[ep.ProviderAddress] = append(verdictsByProvider[ep.ProviderAddress], verdict)
 	}
 
 	if appender == nil {
-		return // re-enable still happened above; QoS feed unavailable
+		return scored, reEnabled, syncOmitted // re-enable still happened above; QoS feed unavailable
 	}
 	for provider, verdicts := range verdictsByProvider {
 		sample, ok := probing.AggregateProviderSample(verdicts)
@@ -1911,8 +1991,12 @@ func runProbeCycleCore(
 		// hasSync only when an accepted consensus baseline exists (F5): no baseline → no sync evidence,
 		// never the legacy max-across-providers reference. syncRef carries the same baseline.
 		hasSync := sample.HasBlock && hasBaseline
+		if !hasSync {
+			syncOmitted++ // F5: this provider's QoS sample carries no sync evidence this cycle
+		}
 		appender.AppendProbeData(provider, sample.Availability, sample.Latency, sample.HasLatency, sample.Block, hasSync, syncRef)
 	}
+	return scored, reEnabled, syncOmitted
 }
 
 // harvestAndUpdateTipFromRelay applies a served relay's block to TIP state — but only when the


### PR DESCRIPTION
## What

Adds the fourth and final [MAG-2202](https://magmadevs.atlassian.net/browse/MAG-2202) debug endpoint, **`GET /debug/probe-loop`**, by instrumenting the existing Topic-D proactive prober (`runProbeLoop`) with per-cycle counters. **No data-plane behavior change** — pure observation.

- `runProbeCycleCore` now returns `(scored, reEnabled, syncOmitted)`. Existing callers ignore the returns; `RecordProbeVerdict` is still called identically (it was the left operand of `&&` before, so it always executed).
- `runProbeCycle` times each cycle and writes the snapshot to a per-server, mutex-guarded `probeLoopStats` (off the data plane). `runProbeLoop` publishes the configured `--probe-loop-interval` cadence before the first tick.
- `GET /debug/probe-loop` returns a flat array of per-chain records, reusing `writeDebugRows` / `debugTimeRFC3339` from #155. GET-only (405 otherwise), nil-router safe (`[]`).

This closes out MAG-2202 (the ticket I'd earlier — wrongly — flagged as design-blocked; the prober, `--probe-loop-interval`, F1 re-enable, and F5 sync-omit all already existed, so this only needed counters).

## ⚠️ Stacked on #155

Base is **`feat/mag-2202-debug-state-endpoints` (PR #155)**, not `main` — it reuses the `writeDebugRows`/`debugTimeRFC3339` helpers and the flat-array shape from #155. **Retarget to `chaintracker-redesign` once #155 merges**, then it rides into `main` behind #143.

## Response shape — please confirm the semantics, @victoria

Example (one record per chain interface, flat, self-describing — same convention as #155):
```json
[
  {
    "ChainID": "ETH1", "ApiInterface": "jsonrpc",
    "CycleIntervalMs": 5000,
    "CyclesCompleted": 142,
    "LastCycleStartedAt": "2026-06-25T10:05:00Z",
    "LastCycleDurationMs": 3,
    "EndpointsScored": 6,
    "ReEnabledCount": 0,
    "SyncOmittedCount": 2
  }
]
```

Two semantic decisions to confirm:

1. **The three counts are LAST-cycle, not cumulative.** `EndpointsScored` / `ReEnabledCount` / `SyncOmittedCount` reflect the most recent completed cycle only (matching the ticket's "*per-cycle* re-enable counting / F5 sync-omitted count"). **Consequence for the suite:** `ReEnabledCount` is nonzero *only on the exact cycle* a re-enable happens, so an F1 blackbox test should **confirm re-enable via `/debug/endpoint-state` (the `Enabled` flip) and use `CyclesCompleted` to confirm the loop is advancing — not poll for `ReEnabledCount > 0`** (that's racy). If you'd rather these be cumulative counters, it's a ~3-line change — say the word.

2. **`CyclesCompleted` is an addition beyond the ticket's field list** (cumulative, monotonic). It's the clean liveness signal for F6 ("prober runs on its own `--probe-loop-interval` cadence"): read twice ~`CycleIntervalMs` apart and assert it advanced. (Same spirit as the bonus `ConsecutiveHealthyProbes` on `/debug/endpoint-state` in #155.)

## Field → source

| Field | Source |
|---|---|
| `CycleIntervalMs` | `--probe-loop-interval` (validated; default 5000) |
| `LastCycleStartedAt` / `LastCycleDurationMs` | recorded around `runProbeCycleCore` per tick |
| `EndpointsScored` | endpoints given a verdict last cycle |
| `ReEnabledCount` | `RecordProbeVerdict` returned true last cycle (F1) |
| `SyncOmittedCount` | provider samples with `!hasSync` last cycle (F5: no fresh baseline) |
| `CyclesCompleted` | monotonic completed-cycle counter |

## Acceptance criteria

- [x] HTTP 200 with the fields above reflecting live process state
- [x] Non-GET → HTTP 405
- [x] Registered only under `--debug-address`; production builds unaffected
- [x] nil-router safe (`[]`)

## Test plan

- `runProbeCycleCore` return counts: `scored` / `reEnabled` (K-th cycle = exactly 1) / `syncOmitted` (F5: no baseline → every provider omitted).
- Existing prober tests unchanged and green (signature change is return-only).
- Handler: 405 + nil-safety (added `/debug/probe-loop` to the shared coverage) + populated-row shape via `probeStats.recordCycle`.
- `go build ./...`, `gofmt`, `go test -race ./protocol/rpcsmartrouter/` all green.

Known untested seam (accepted, low risk): the `runProbeCycle → recordCycle` hand-off of the three `int` counts is not covered end-to-end (would need a full running server); the counts and the handler are each tested in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MAG-2202]: https://magmadevs.atlassian.net/browse/MAG-2202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ