### PR TITLE
test(solana): lock slot-vs-block-height consistency fix (MAG-1591)

### DIFF
--- a/protocol/chaintracker/svm_chain_tracker_test.go
+++ b/protocol/chaintracker/svm_chain_tracker_test.go
@@ -1,0 +1,89 @@
+package chaintracker
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/dgraph-io/ristretto/v2"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/stretchr/testify/require"
+)
+
+// svmMockChainFetcher is a minimal ChainFetcher whose CustomMessage returns a
+// canned getLatestBlockhash body. fetchLatestBlockNumInner reaches the chain only
+// through CustomMessage, so the other three methods are inert stubs.
+type svmMockChainFetcher struct {
+	latestBlockhashResponse []byte
+}
+
+func (m *svmMockChainFetcher) CustomMessage(ctx context.Context, path string, data []byte, connectionType string, apiName string) ([]byte, error) {
+	return m.latestBlockhashResponse, nil
+}
+
+func (m *svmMockChainFetcher) FetchLatestBlockNum(ctx context.Context) (int64, error) { return 0, nil }
+
+func (m *svmMockChainFetcher) FetchBlockHashByNum(ctx context.Context, blockNum int64) (string, error) {
+	return "", nil
+}
+
+func (m *svmMockChainFetcher) FetchEndpoint() lavasession.RPCProviderEndpoint {
+	return lavasession.RPCProviderEndpoint{}
+}
+
+// svmMockDataFetcher stubs IChainTrackerDataFetcher; the slot-vs-block-height
+// assertion does not depend on server memory or the parent's latest block.
+type svmMockDataFetcher struct{}
+
+func (svmMockDataFetcher) GetAtomicLatestBlockNum() int64 { return 0 }
+func (svmMockDataFetcher) GetServerBlockMemory() uint64   { return 0 }
+
+func newTestSVMChainTracker(t *testing.T, latestBlockhashResponse string) *SVMChainTracker {
+	t.Helper()
+	slotCache, err := ristretto.NewCache(&ristretto.Config[int64, int64]{NumCounters: CacheNumCounters, MaxCost: CacheMaxCost, BufferItems: 64, IgnoreInternalCost: true})
+	require.NoError(t, err)
+	hashCache, err := ristretto.NewCache(&ristretto.Config[int64, string]{NumCounters: CacheNumCounters, MaxCost: CacheMaxCost, BufferItems: 64, IgnoreInternalCost: true})
+	require.NoError(t, err)
+	return &SVMChainTracker{
+		slotCache:    slotCache,
+		hashCache:    hashCache,
+		dataFetcher:  svmMockDataFetcher{},
+		chainFetcher: &svmMockChainFetcher{latestBlockhashResponse: []byte(latestBlockhashResponse)},
+	}
+}
+
+// TestSVMChainTracker_TracksSlotNotLastValidBlockHeight locks the MAG-1591 fix
+// (commit 65be9f4): on a getLatestBlockhash reply, SVMChainTracker must expose
+// context.slot — not value.lastValidBlockHeight — as the endpoint's latest block.
+// That value is the per-endpoint tip filterEndpointsByConsistency compares the
+// consumer's seen slot against.
+//
+// The reply below carries both fields with the ~22M divergence seen on Solana
+// mainnet (here scaled to slot=100 vs lastValidBlockHeight=42). The original bug
+// stored lastValidBlockHeight and then compared it, as if it were a slot, against
+// the consumer's seen slot under a ~50-block threshold; every endpoint looked far
+// behind, all were filtered, and getLatestBlockhash returned "No pairings
+// available". A revert to lastValidBlockHeight would make this test observe 42 and
+// fail.
+func TestSVMChainTracker_TracksSlotNotLastValidBlockHeight(t *testing.T) {
+	const (
+		slot                 = int64(100)
+		lastValidBlockHeight = int64(42)
+		response             = `{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":100},"value":{"blockhash":"abc","lastValidBlockHeight":42}}}`
+	)
+
+	tracker := newTestSVMChainTracker(t, response)
+
+	latestBlock, err := tracker.FetchLatestBlockNum(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, slot, latestBlock,
+		"SVMChainTracker must expose context.slot (%d) as the latest block, not value.lastValidBlockHeight (%d)", slot, lastValidBlockHeight)
+	require.NotEqual(t, lastValidBlockHeight, latestBlock,
+		"tracking lastValidBlockHeight is the MAG-1591 regression that filtered every endpoint")
+
+	// seenBlock is the consistency floor filterEndpointsByConsistency reads; it must
+	// also be the slot, not the block height.
+	require.Equal(t, slot, atomic.LoadInt64(&tracker.seenBlock),
+		"the consistency-floor seenBlock must be the slot, not the block height")
+}

--- a/protocol/parser/parser_test.go
+++ b/protocol/parser/parser_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcclient"
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
 	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/magma-Devs/smart-router/utils/keeper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -973,4 +974,56 @@ func TestParseRawBlock(t *testing.T) {
 		ParseRawBlock(&rpcInput, parsedInput, "")
 		require.Equal(t, spectypes.NOT_APPLICABLE, parsedInput.GetBlock())
 	})
+}
+
+// TestSolanaSpec_GetBlocknumParsesSlotNotBlockHeight is the spec-side guard for
+// the MAG-1591 unit mismatch. The two earlier tests cover the runtime sides — the
+// SVMChainTracker exposing context.slot, and filterEndpointsByConsistency rejecting
+// a block-height tip — but both assume the tracked value is a *slot* in the first
+// place. That guarantee originates here: the SOLANA spec's GET_BLOCKNUM parse
+// directive must extract context.slot from a getLatestBlockhash reply, not
+// value.lastValidBlockHeight.
+//
+// This test loads the real specs/solana.json (not a hand-built BlockParser) and
+// runs the directive's actual ResultParsing, so editing the spec to parse
+// lastValidBlockHeight — the field whose ~22M divergence caused the incident —
+// fails here.
+func TestSolanaSpec_GetBlocknumParsesSlotNotBlockHeight(t *testing.T) {
+	const specPath = "../../specs/solana.json"
+
+	specs, err := keeper.GetAllSpecsFromFile(specPath)
+	require.NoError(t, err, "must be able to load %s", specPath)
+
+	solana, ok := specs["SOLANA"]
+	require.True(t, ok, "SOLANA spec must be present in %s", specPath)
+
+	// Locate the GET_BLOCKNUM parse directive — the one the chain tracker uses to
+	// derive the canonical chain position from a getLatestBlockhash reply.
+	var blockParser *spectypes.BlockParser
+	for _, collection := range solana.ApiCollections {
+		for _, directive := range collection.ParseDirectives {
+			if directive.FunctionTag == spectypes.FUNCTION_TAG_GET_BLOCKNUM {
+				bp := directive.ResultParsing
+				blockParser = &bp
+			}
+		}
+	}
+	require.NotNil(t, blockParser, "SOLANA spec must define a GET_BLOCKNUM parse directive")
+
+	// Sanity-check the directive targets the slot path, so a mis-pointed parser_arg
+	// fails with a readable message rather than only via the numeric assertion below.
+	require.Contains(t, blockParser.ParserArg, "slot",
+		"GET_BLOCKNUM must parse context.slot; parser_arg was %v", blockParser.ParserArg)
+	require.NotContains(t, blockParser.ParserArg, "lastValidBlockHeight",
+		"GET_BLOCKNUM must not parse value.lastValidBlockHeight — that is the MAG-1591 unit mismatch")
+
+	// A getLatestBlockhash result with slot and lastValidBlockHeight diverging by
+	// the ~22M gap seen on Solana mainnet (here scaled to 100 vs 42).
+	reply := &RPCInputTest{
+		Result: []byte(`{"context":{"slot":100},"value":{"blockhash":"abc","lastValidBlockHeight":42}}`),
+	}
+
+	parsed := ParseBlockFromReply(reply, *blockParser, nil)
+	require.Equal(t, int64(100), parsed.GetBlock(),
+		"GET_BLOCKNUM must yield context.slot (100), not value.lastValidBlockHeight (42)")
 }

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -2987,3 +2987,84 @@ func TestIsFinalizedForCacheWrite(t *testing.T) {
 		})
 	}
 }
+
+// TestFilterEndpointsByConsistency_SolanaSlotVsBlockHeightUnitMismatch is the
+// symptom-level companion to the chaintracker unit test for MAG-1591. It locks the
+// fix at the decision point where the unit mismatch actually became "No pairings":
+// filterEndpointsByConsistency compares each endpoint's tracked tip against the
+// consumer's seen block. On Solana the seen block is a slot (~424M); if an endpoint's
+// tracker reports value.lastValidBlockHeight (~403M) instead of context.slot, the
+// computed lag is the ~21M unit gap, blows past the threshold, and the endpoint is
+// filtered. With one endpoint that means an all-failed result -> ConsistencyError ->
+// the "No pairings available" the customer saw.
+//
+// The numbers are the real incident values from the GK8 logs:
+// seenBlock=424549212, block-height tip=403165980, gap=21383232.
+func TestFilterEndpointsByConsistency_SolanaSlotVsBlockHeightUnitMismatch(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		seenSlot         = int64(424549212) // consumer's seen block — a Solana slot
+		slotTip          = int64(424549212) // a tracker that correctly reports context.slot
+		blockHeightTip   = int64(403165980) // the buggy tracker reporting value.lastValidBlockHeight
+		expectedBlockGap = int64(21383232)  // seenSlot - blockHeightTip, matches the log's blockGap
+	)
+	require.Equal(t, expectedBlockGap, seenSlot-blockHeightTip, "guard: incident magnitudes are consistent")
+
+	userData := common.UserData{DappId: "test", ConsumerIp: "1.2.3.4"}
+	config := relaycore.DefaultConsistencyValidationConfig()
+	protocolMsg := &MockProtocolMessage{
+		api:            &spectypes.Api{Name: "getLatestBlockhash"},
+		requestedBlock: spectypes.LATEST_BLOCK,
+		userData:       userData,
+	}
+
+	newServer := func() *RPCSmartRouterServer {
+		consistency := newMockConsistency()
+		consistency.SetSeenBlock(seenSlot, userData)
+		return &RPCSmartRouterServer{consistencyConfig: config, smartRouterConsistency: consistency}
+	}
+	endpointSession := func(addr string, latest int64) *lavasession.SessionInfo {
+		ep := &lavasession.Endpoint{NetworkAddress: addr}
+		ep.LatestBlock.Store(latest)
+		return &lavasession.SessionInfo{Session: &lavasession.SingleConsumerSession{
+			Connection: &lavasession.DirectRPCSessionConnection{Endpoint: ep},
+		}}
+	}
+
+	t.Run("slot tip (fixed) is in sync -> endpoint valid", func(t *testing.T) {
+		rpcss := newServer()
+		sessions := lavasession.ConsumerSessionsMap{
+			"http://slot:8899": endpointSession("http://slot:8899", slotTip),
+		}
+		valid, failed, err := rpcss.filterEndpointsByConsistency(ctx, sessions, protocolMsg)
+		require.NoError(t, err)
+		require.Len(t, valid, 1, "a tracker reporting slot is at the seen slot and must pass")
+		require.Len(t, failed, 0)
+	})
+
+	t.Run("block-height tip (regression) looks ~21M behind -> filtered, no pairings", func(t *testing.T) {
+		rpcss := newServer()
+		sessions := lavasession.ConsumerSessionsMap{
+			"http://blockheight:8899": endpointSession("http://blockheight:8899", blockHeightTip),
+		}
+		valid, failed, err := rpcss.filterEndpointsByConsistency(ctx, sessions, protocolMsg)
+		require.Error(t, err, "the only endpoint is filtered, so all-failed -> ConsistencyError (the No-pairings precursor)")
+		require.Len(t, valid, 0)
+		require.Len(t, failed, 1, "the block-height tip is filtered out by the ~21M unit gap")
+	})
+
+	t.Run("mixed fleet -> only the slot tip survives", func(t *testing.T) {
+		rpcss := newServer()
+		sessions := lavasession.ConsumerSessionsMap{
+			"http://slot:8899":        endpointSession("http://slot:8899", slotTip),
+			"http://blockheight:8899": endpointSession("http://blockheight:8899", blockHeightTip),
+		}
+		valid, failed, err := rpcss.filterEndpointsByConsistency(ctx, sessions, protocolMsg)
+		require.NoError(t, err, "at least one endpoint is valid, so no all-failed error")
+		require.Len(t, valid, 1)
+		require.Len(t, failed, 1)
+		_, slotKept := valid["http://slot:8899"]
+		require.True(t, slotKept, "the slot-reporting endpoint must be the survivor")
+	})
+}


### PR DESCRIPTION
## What

Adds a **three-layer regression lock** for the Solana slot/block-height unit mismatch (the GK8 incident, fixed in PR #21 / `v1.0.0`). No production code changes — tests only.

The original bug: the SVM chain tracker stored Solana **block height** (`value.lastValidBlockHeight`) as the consumer's seen block, while provider consistency validation reads **slot** (`context.slot`). On mainnet these diverge by ~22M, so consistency compared a slot against a block height, computed a spurious ~22M gap on stateful relays, and surfaced as `No pairings available`. There was no test guarding the fix.

## Tests added

Each was verified to genuinely lock the fix by reverting the fix and confirming the test fails:

| Test | Layer | File |
|------|-------|------|
| `TestSVMChainTracker_TracksSlotNotLastValidBlockHeight` | Tracker exposes `context.slot`, not `value.lastValidBlockHeight` | `protocol/chaintracker/svm_chain_tracker_test.go` |
| `TestFilterEndpointsByConsistency_SolanaSlotVsBlockHeightUnitMismatch` | At the decision point: a slot tip passes, a block-height tip is filtered → `ConsistencyError` (the "No pairings" precursor) | `protocol/rpcsmartrouter/rpcsmartrouter_server_test.go` |
| `TestSolanaSpec_GetBlocknumParsesSlotNotBlockHeight` | The real `specs/solana.json` `GET_BLOCKNUM` directive parses `context.slot` | `protocol/parser/parser_test.go` |

The consistency-filter test uses the **real incident magnitudes** (`seenBlock=424549212`, `tip=403165980`, `lag=21383232`), so a regression reproduces the customer's exact `blockGap`.

## Why three layers

Tests 1 and 2 assume the tracked value is a *slot*; test 3 guarantees that at the spec level. A revert anywhere in the chain — tracker code, filter logic, or the spec JSON — now fails a test.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./protocol/parser/ ./protocol/chaintracker/ ./protocol/rpcsmartrouter/ -count=1` — all pass
- [x] Each new test verified to fail when the fix is reverted, pass when restored

## Follow-up (not in this PR)

A `sendTransaction`-class **write/consistency integration test** to exercise the stateful path end-to-end (this PR is unit-level coverage of the unit invariant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)