### PR TITLE
feat: add example configs for all bundled chains (arbitrum, base, solana, multichain)

### DIFF
--- a/config/smartrouter_examples/smartrouter_arbitrum.yml
+++ b/config/smartrouter_examples/smartrouter_arbitrum.yml
@@ -1,0 +1,27 @@
+# Smart Router Direct RPC Configuration — Arbitrum One (ARBITRUM)
+# Mode: Direct connection to an Arbitrum JSON-RPC endpoint (no Lava providers!)
+#
+# Upstream: the Lava public gateway (arbitrum.lava.build), HTTP + WebSocket.
+# The ARBITRUM spec imports ETH1 and requires a ws:// leg for subscriptions,
+# so each provider pairs its https:// url with a wss:// one.
+#
+# Run it:
+#   smartrouter config/smartrouter_examples/smartrouter_arbitrum.yml --use-static-spec specs/
+
+# Prometheus metrics (scrape at http://<host>:7779/metrics). "disabled" turns it off.
+metrics-listen-address: "0.0.0.0:7779"
+
+endpoints:
+  - listen-address: "0.0.0.0:3360"
+    chain-id: "ARBITRUM"
+    api-interface: "jsonrpc"
+    network-address: "0.0.0.0:3360"
+
+direct-rpc:
+  - name: "arb-lava-build"
+    group-label: "lava"
+    chain-id: "ARBITRUM"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://arbitrum.lava.build"
+      - url: "wss://arbitrum.lava.build/websocket"

--- a/config/smartrouter_examples/smartrouter_base.yml
+++ b/config/smartrouter_examples/smartrouter_base.yml
@@ -1,0 +1,27 @@
+# Smart Router Direct RPC Configuration — Base (BASE)
+# Mode: Direct connection to a Base JSON-RPC endpoint (no Lava providers!)
+#
+# Upstream: the Lava public gateway (base.lava.build), HTTP + WebSocket.
+# The BASE spec imports ETH1 and requires a ws:// leg for subscriptions,
+# so each provider pairs its https:// url with a wss:// one.
+#
+# Run it:
+#   smartrouter config/smartrouter_examples/smartrouter_base.yml --use-static-spec specs/
+
+# Prometheus metrics (scrape at http://<host>:7779/metrics). "disabled" turns it off.
+metrics-listen-address: "0.0.0.0:7779"
+
+endpoints:
+  - listen-address: "0.0.0.0:3360"
+    chain-id: "BASE"
+    api-interface: "jsonrpc"
+    network-address: "0.0.0.0:3360"
+
+direct-rpc:
+  - name: "base-lava-build"
+    group-label: "lava"
+    chain-id: "BASE"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://base.lava.build"
+      - url: "wss://base.lava.build/websocket"

--- a/config/smartrouter_examples/smartrouter_multichain.yml
+++ b/config/smartrouter_examples/smartrouter_multichain.yml
@@ -1,18 +1,23 @@
-# Smart Router Direct RPC Configuration — multi-chain (Ethereum + Arbitrum + Base)
-# Mode: Direct connections to public RPC endpoints (no Lava providers!)
+# Smart Router Direct RPC Configuration — multi-chain (all bundled example chains)
+# Mode: Direct connections to the Lava public gateways (no Lava providers!)
 #
-# Three JSON-RPC chains on three ports, each with 2 upstreams (HTTP + WS).
-# The ETH1 spec — which ARBITRUM and BASE both import — requires websocket
-# support, so every provider pairs an http url with a wss url; http-only
-# providers are excluded at startup.
-#   - Lava public gateway (<chain>.lava.build, ws at /websocket)
-#   - PublicNode
-# All endpoints verified live (correct eth_chainId, blockNumber + ws handshake).
+# Serves every chain that ships with a standalone example, each on its own port,
+# all via <chain>.lava.build (no API key required):
+#   3360  ETH1     jsonrpc        eth1.lava.build
+#   3361  ARBITRUM jsonrpc        arbitrum.lava.build
+#   3362  BASE     jsonrpc        base.lava.build
+#   3363  SOLANA   jsonrpc        solana.lava.build
+#   3364  LAVA     rest           lava.rest.lava.build
+#   3365  LAVA     tendermintrpc  lava.tendermintrpc.lava.build
+#   3366  LAVA     grpc           lava.grpc.lava.build
 #
-# Specs required (resolve via --use-static-spec specs/):
-#   ETH1     -> specs/ethereum.json   (already in repo)
-#   ARBITRUM -> specs/arbitrum.json   (imports ETH1)  — from Magma-Devs/lava-specs
-#   BASE     -> specs/base.json       (imports ETH1)  — from Magma-Devs/lava-specs
+# The EVM chains (ETH1/ARBITRUM/BASE, which import ETH1) require a ws:// leg, so
+# each pairs an https url with a wss one. SOLANA is HTTP-only here, so start the
+# router with --skip-websocket-verification (the docker-compose example does this).
+#
+# Specs resolve from the bundled specs/ (pass --use-static-spec specs/): ETH1,
+# ARBITRUM (imports ETH1), BASE (imports ETH1), SOLANA, and LAVA (imports
+# COSMOSSDK, which imports IBC + TENDERMINT) — all present in the repo.
 
 # Prometheus metrics (scrape at http://<host>:7779/metrics). Set to
 # "disabled" to turn off. Read via viper, so the --metrics-listen-address
@@ -35,6 +40,26 @@ endpoints:
     api-interface: "jsonrpc"
     network-address: "0.0.0.0:3362"
 
+  - listen-address: "0.0.0.0:3363"
+    chain-id: "SOLANA"
+    api-interface: "jsonrpc"
+    network-address: "0.0.0.0:3363"
+
+  - listen-address: "0.0.0.0:3364"
+    chain-id: "LAVA"
+    api-interface: "rest"
+    network-address: "0.0.0.0:3364"
+
+  - listen-address: "0.0.0.0:3365"
+    chain-id: "LAVA"
+    api-interface: "tendermintrpc"
+    network-address: "0.0.0.0:3365"
+
+  - listen-address: "0.0.0.0:3366"
+    chain-id: "LAVA"
+    api-interface: "grpc"
+    network-address: "0.0.0.0:3366"
+
 direct-rpc:
   # ---- Ethereum (ETH1, chainId 0x1) ----
   - name: "eth-lava-build"
@@ -44,13 +69,6 @@ direct-rpc:
       - url: "https://eth1.lava.build"
       - url: "wss://eth1.lava.build/websocket"
 
-  - name: "eth-publicnode"
-    chain-id: "ETH1"
-    api-interface: "jsonrpc"
-    node-urls:
-      - url: "https://ethereum-rpc.publicnode.com"
-      - url: "wss://ethereum-rpc.publicnode.com"
-
   # ---- Arbitrum One (ARBITRUM, chainId 0xa4b1) ----
   - name: "arb-lava-build"
     chain-id: "ARBITRUM"
@@ -58,13 +76,6 @@ direct-rpc:
     node-urls:
       - url: "https://arbitrum.lava.build"
       - url: "wss://arbitrum.lava.build/websocket"
-
-  - name: "arb-publicnode"
-    chain-id: "ARBITRUM"
-    api-interface: "jsonrpc"
-    node-urls:
-      - url: "https://arbitrum-one-rpc.publicnode.com"
-      - url: "wss://arbitrum-one-rpc.publicnode.com"
 
   # ---- Base (BASE, chainId 0x2105) ----
   - name: "base-lava-build"
@@ -74,9 +85,33 @@ direct-rpc:
       - url: "https://base.lava.build"
       - url: "wss://base.lava.build/websocket"
 
-  - name: "base-publicnode"
-    chain-id: "BASE"
+  # ---- Solana (SOLANA) — HTTP-only; run with --skip-websocket-verification ----
+  - name: "sol-lava-build"
+    chain-id: "SOLANA"
     api-interface: "jsonrpc"
     node-urls:
-      - url: "https://base-rpc.publicnode.com"
-      - url: "wss://base-rpc.publicnode.com"
+      - url: "https://solana.lava.build"
+
+  # ---- Lava (LAVA) — REST + Tendermint RPC + gRPC via the Lava gateways ----
+  - name: "lava-rest-lava-build"
+    chain-id: "LAVA"
+    api-interface: "rest"
+    node-urls:
+      - url: "https://lava.rest.lava.build"
+        timeout: 10s
+
+  - name: "lava-tendermintrpc-lava-build"
+    chain-id: "LAVA"
+    api-interface: "tendermintrpc"
+    node-urls:
+      - url: "https://lava.tendermintrpc.lava.build"
+        timeout: 10s
+      - url: "wss://lava.tendermintrpc.lava.build/websocket"
+
+  - name: "lava-grpc-lava-build"
+    chain-id: "LAVA"
+    api-interface: "grpc"
+    node-urls:
+      - url: "grpcs://lava.grpc.lava.build:443"
+        auth-config:
+          use-tls: true

--- a/config/smartrouter_examples/smartrouter_solana.yml
+++ b/config/smartrouter_examples/smartrouter_solana.yml
@@ -1,0 +1,27 @@
+# Smart Router Direct RPC Configuration — Solana (SOLANA)
+# Mode: Direct connection to a Solana JSON-RPC endpoint (no Lava providers!)
+#
+# Upstream: the Lava public gateway (solana.lava.build), HTTP.
+# Solana serves subscriptions over a separate ws endpoint; this example is
+# HTTP-only, so start the router with --skip-websocket-verification.
+#
+# Run it:
+#   smartrouter config/smartrouter_examples/smartrouter_solana.yml \
+#     --use-static-spec specs/ --skip-websocket-verification
+
+# Prometheus metrics (scrape at http://<host>:7779/metrics). "disabled" turns it off.
+metrics-listen-address: "0.0.0.0:7779"
+
+endpoints:
+  - listen-address: "0.0.0.0:3360"
+    chain-id: "SOLANA"
+    api-interface: "jsonrpc"
+    network-address: "0.0.0.0:3360"
+
+direct-rpc:
+  - name: "sol-lava-build"
+    group-label: "lava"
+    chain-id: "SOLANA"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://solana.lava.build"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,6 +27,10 @@
 #   3360  ETH1 jsonrpc (eth, multichain)
 #   3361  ARBITRUM jsonrpc (multichain)
 #   3362  BASE jsonrpc (multichain)
+#   3363  SOLANA jsonrpc (solana, multichain)
+#   3364  LAVA rest (multichain; lava example uses 3360)
+#   3365  LAVA tendermintrpc (multichain; lava example uses 3362)
+#   3366  LAVA grpc (multichain; lava example uses 3361)
 #   7779  router prometheus metrics
 
 name: smart-router
@@ -57,8 +61,17 @@ services:
       - "${SR_LOG_LEVEL:-info}"
       - "--log-format"
       - "${SR_LOG_FORMAT:-json}"
+      # Some bundled examples have HTTP-only listeners (e.g. SOLANA in the solana
+      # and multichain configs). Skip the startup websocket reachability check so
+      # those boot cleanly; ws subscriptions still work at runtime where a wss url
+      # is configured (the EVM examples pair https + wss).
+      - "--skip-websocket-verification"
     ports:
       - "3360:3360" # ETH1 jsonrpc
       - "3361:3361" # ARBITRUM jsonrpc
       - "3362:3362" # BASE jsonrpc
+      - "3363:3363" # SOLANA jsonrpc
+      - "3364:3364" # LAVA rest
+      - "3365:3365" # LAVA tendermintrpc
+      - "3366:3366" # LAVA grpc
       - "7779:7779" # router prometheus metrics


### PR DESCRIPTION
The bundled `specs/` ships ETH1, ARBITRUM, BASE, LAVA, and SOLANA, but only Ethereum and Lava had standalone direct-rpc example configs — Arbitrum/Base were only covered by the multichain example, and Solana had none committed.

Adds one ready-to-run config per chain, each pointing at the chain's Lava public gateway (`<chain>.lava.build`) so they run with no API key:

| File | Chain | Interface | Upstream |
|---|---|---|---|
| `smartrouter_arbitrum.yml` | `ARBITRUM` | jsonrpc | `arbitrum.lava.build` (HTTP + WS) |
| `smartrouter_base.yml` | `BASE` | jsonrpc | `base.lava.build` (HTTP + WS) |
| `smartrouter_solana.yml` | `SOLANA` | jsonrpc | `solana.lava.build` (HTTP) |

Run, e.g.:
```bash
smartrouter config/smartrouter_examples/smartrouter_arbitrum.yml --use-static-spec specs/
```

Force-added past the `config/smartrouter_examples/smartrouter_*.yml` ignore rule, matching how the existing tracked template configs (`smartrouter_eth.yml`, `smartrouter_lava.yml`, …) are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)