### PR TITLE
ci: fix concurrent-providers YAML indentation

### DIFF
--- a/.github/workflows/pr-gate-build-artifact.yml
+++ b/.github/workflows/pr-gate-build-artifact.yml
@@ -453,12 +453,14 @@ jobs:
               ($arg == "--show-provider-address-in-metrics") or
               ($arg | startswith("--show-provider-address-in-metrics=")) or
               ($arg == "--geolocation") or
-              ($arg | startswith("--geolocation="));
+              ($arg | startswith("--geolocation=")) or
+              ($arg == "--concurrent-providers") or
+              ($arg | startswith("--concurrent-providers="));
             def retired_flag_without_value($arg):
               ($arg == "--optimizer-qos-listen") or
               ($arg == "--show-provider-address-in-metrics") or
               ($arg == "--geolocation") or
-    ($arg == "--concurrent-providers");
+              ($arg == "--concurrent-providers");
             reduce .[] as $arg ({out: [], drop_next: false};
               if .drop_next then
                 if ($arg | startswith("--")) then


### PR DESCRIPTION
Fixes indentation and full stripping for --concurrent-providers in the PR Gate workflow.