### PR TITLE
fix(smart-router): fail over from a pinned provider on retry (MAG-2228)

### DIFF
--- a/protocol/lavasession/used_providers.go
+++ b/protocol/lavasession/used_providers.go
@@ -367,3 +367,32 @@ func (up *UsedProviders) GetUnwantedProvidersToSend(routerKey RouterKey) map[str
 	}
 	return unwantedProvidersToSend
 }
+
+// MigrateUnwantedProviders copies every provider already tried under the src
+// routerKey (whether still in-flight in providers, or already responded and moved
+// to unwantedProviders) into the unwanted set of the dst routerKey.
+//
+// The used/unwanted exclusion is partitioned per routerKey, and routerKey is derived
+// from the request's extensions. When a retry toggles an extension (e.g. the
+// speculative archive add/remove) the routerKey changes, so a provider that just
+// failed under the old key would not be excluded under the new one and could be
+// re-selected for the retry (MAG-2228). Calling this on a toggle keeps an
+// already-tried provider excluded across the change.
+func (up *UsedProviders) MigrateUnwantedProviders(src, dst RouterKey) {
+	if up == nil {
+		return
+	}
+	if src.String() == dst.String() {
+		return
+	}
+	up.lock.Lock()
+	defer up.lock.Unlock()
+	srcProviders := up.createOrUseUniqueUsedProvidersForKey(src)
+	dstProviders := up.createOrUseUniqueUsedProvidersForKey(dst)
+	for provider := range srcProviders.providers {
+		dstProviders.unwantedProviders[provider] = struct{}{}
+	}
+	for provider := range srcProviders.unwantedProviders {
+		dstProviders.unwantedProviders[provider] = struct{}{}
+	}
+}

--- a/protocol/lavasession/used_providers_mag2228_test.go
+++ b/protocol/lavasession/used_providers_mag2228_test.go
@@ -1,0 +1,48 @@
+package lavasession
+
+import "testing"
+
+// TestMigrateUnwantedProviders covers MAG-2228 Mechanism B: a provider already tried
+// under one routerKey (e.g. the no-extension lane) must stay excluded after a retry
+// toggles an extension and the routerKey changes (e.g. to the archive lane). Without the
+// migration, the per-routerKey exclusion would not cover it and it could be re-selected.
+func TestMigrateUnwantedProviders(t *testing.T) {
+	emptyKey := GetEmptyRouterKey()
+	archiveKey := NewRouterKey([]string{"archive"})
+
+	t.Run("unwanted provider carries across a routerKey toggle", func(t *testing.T) {
+		up := NewUsedProviders(nil)
+		up.AddUnwantedAddresses("providerA", emptyKey) // tried+failed under the no-extension key
+
+		if _, excluded := up.GetUnwantedProvidersToSend(archiveKey)["providerA"]; excluded {
+			t.Fatalf("providerA must NOT be excluded under archive key before migration (this is the bug)")
+		}
+
+		up.MigrateUnwantedProviders(emptyKey, archiveKey)
+
+		if _, excluded := up.GetUnwantedProvidersToSend(archiveKey)["providerA"]; !excluded {
+			t.Fatalf("providerA should be excluded under archive key after migration")
+		}
+	})
+
+	t.Run("in-flight (used) provider also carries", func(t *testing.T) {
+		up := NewUsedProviders(nil)
+		// nil Session => the empty routerKey; puts providerB in providers[empty]
+		up.AddUsed(ConsumerSessionsMap{"providerB": &SessionInfo{}}, nil)
+
+		up.MigrateUnwantedProviders(emptyKey, archiveKey)
+
+		if _, excluded := up.GetUnwantedProvidersToSend(archiveKey)["providerB"]; !excluded {
+			t.Fatalf("in-flight providerB should be excluded under archive key after migration")
+		}
+	})
+
+	t.Run("same-key migration is a safe no-op", func(t *testing.T) {
+		up := NewUsedProviders(nil)
+		up.AddUnwantedAddresses("providerC", emptyKey)
+		up.MigrateUnwantedProviders(emptyKey, emptyKey) // must not panic / must be idempotent
+		if _, excluded := up.GetUnwantedProvidersToSend(emptyKey)["providerC"]; !excluded {
+			t.Fatalf("providerC should remain excluded under its own key")
+		}
+	})
+}

--- a/protocol/relaycore/unified_relay_state_machine.go
+++ b/protocol/relaycore/unified_relay_state_machine.go
@@ -174,6 +174,17 @@ func (sm *UnifiedRelayStateMachine) stateTransition(relayState *RelayState, numb
 			upgradedProtocolMessage = UpgradeToArchiveIfNeeded(sm.ctx, protocolMessage, archiveStatus, sm.relaySender, sm.relayRetriesManager, batchNumber, numberOfNodeErrors)
 		}
 
+		// MAG-2228: a mutation that changes the extensions (archive add/remove) rebuilds the
+		// message under a different routerKey. The used/unwanted-provider exclusion is keyed
+		// by routerKey, so providers already tried under the old key would not be excluded
+		// under the new one and a just-failed provider could be re-selected for the retry.
+		// Carry the exclusion across the toggle.
+		oldRouterKey := lavasession.NewRouterKeyFromExtensions(protocolMessage.GetExtensions())
+		newRouterKey := lavasession.NewRouterKeyFromExtensions(upgradedProtocolMessage.GetExtensions())
+		if oldRouterKey.String() != newRouterKey.String() {
+			sm.usedProviders.MigrateUnwantedProviders(oldRouterKey, newRouterKey)
+		}
+
 		nextState = NewRelayState(sm.ctx, upgradedProtocolMessage, relayState.GetStateNumber()+1, sm.relayRetriesManager, sm.relaySender, archiveStatus)
 	}
 	sm.appendRelayState(nextState)

--- a/protocol/rpcsmartrouter/resolve_pin_directives_test.go
+++ b/protocol/rpcsmartrouter/resolve_pin_directives_test.go
@@ -1,0 +1,45 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+)
+
+// TestResolvePinDirectives covers MAG-2228 Fix 1: lava-select-provider / lava-stickiness
+// are honored on the FIRST attempt but dropped on retries so the relay can fall through to
+// a different provider instead of re-pinning the one that just failed.
+func TestResolvePinDirectives(t *testing.T) {
+	headers := map[string]string{
+		common.SELECT_PROVIDER_HEADER_NAME: "simprovider1",
+		common.STICKINESS_HEADER_NAME:      "sticky-1",
+	}
+
+	t.Run("first attempt honors the pin", func(t *testing.T) {
+		sel, sticky := resolvePinDirectives(context.Background(), headers, true)
+		if sel != "simprovider1" {
+			t.Fatalf("first attempt: selectedProvider = %q, want simprovider1", sel)
+		}
+		if sticky != "sticky-1" {
+			t.Fatalf("first attempt: stickiness = %q, want sticky-1", sticky)
+		}
+	})
+
+	t.Run("retry drops the pin so failover can pick a different provider", func(t *testing.T) {
+		sel, sticky := resolvePinDirectives(context.Background(), headers, false)
+		if sel != "" {
+			t.Fatalf("retry: selectedProvider = %q, want empty", sel)
+		}
+		if sticky != "" {
+			t.Fatalf("retry: stickiness = %q, want empty", sticky)
+		}
+	})
+
+	t.Run("no headers yields no pin on first attempt", func(t *testing.T) {
+		sel, sticky := resolvePinDirectives(context.Background(), map[string]string{}, true)
+		if sel != "" || sticky != "" {
+			t.Fatalf("no headers: got (%q, %q), want empty", sel, sticky)
+		}
+	})
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -1960,6 +1960,29 @@ func (rpcss *RPCSmartRouterServer) tryCacheWrite(
 	}()
 }
 
+// resolvePinDirectives returns the lava-select-provider and lava-stickiness directives,
+// honored only on the first attempt. On a retry (firstAttempt == false) both are returned
+// empty so the relay falls through to a different provider instead of re-pinning the one
+// that just failed — otherwise a pinned provider that returned a retryable node error gets
+// re-selected, or the retry dead-ends on "Selected provider already failed in this request"
+// (MAG-2228). firstAttempt is BatchNumber()==0, which stays 0 when attempt 1 never reached a
+// provider (e.g. PairingListEmpty), so the pin is correctly re-honored in that case. Mirrors
+// preserveRetrySafeDirectives, which omits both directives on a rebuilt archive retry.
+func resolvePinDirectives(ctx context.Context, directiveHeaders map[string]string, firstAttempt bool) (selectedProvider, stickiness string) {
+	if !firstAttempt {
+		return "", ""
+	}
+	if id, ok := directiveHeaders[common.STICKINESS_HEADER_NAME]; ok {
+		stickiness = id
+		utils.LavaFormatTrace("found stickiness header", utils.LogAttr("id", stickiness), utils.LogAttr("GUID", ctx))
+	}
+	if providerAddr, exists := directiveHeaders[common.SELECT_PROVIDER_HEADER_NAME]; exists {
+		selectedProvider = providerAddr
+		utils.LavaFormatTrace("found provider selection header", utils.LogAttr("provider", selectedProvider), utils.LogAttr("GUID", ctx))
+	}
+	return selectedProvider, stickiness
+}
+
 func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 	ctx context.Context,
 	numOfEndpoints int,
@@ -2211,18 +2234,10 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 	usedProviders := relayProcessor.GetUsedProviders()
 	directiveHeaders := protocolMessage.GetDirectiveHeaders()
 
-	// stickines id for future use
-	stickiness, ok := directiveHeaders[common.STICKINESS_HEADER_NAME]
-	if ok {
-		utils.LavaFormatTrace("found stickiness header", utils.LogAttr("id", stickiness), utils.LogAttr("GUID", ctx))
-	}
-
-	// provider selection via header (smartrouter only)
-	selectedProvider := ""
-	if providerAddr, exists := directiveHeaders[common.SELECT_PROVIDER_HEADER_NAME]; exists {
-		selectedProvider = providerAddr
-		utils.LavaFormatTrace("found provider selection header", utils.LogAttr("provider", selectedProvider), utils.LogAttr("GUID", ctx))
-	}
+	// MAG-2228: honor lava-select-provider / lava-stickiness only on the FIRST attempt.
+	// On a retry (a provider batch has already been dispatched, so BatchNumber > 0) the
+	// relay must be free to fall through to a different provider. See resolvePinDirectives.
+	selectedProvider, stickiness := resolvePinDirectives(ctx, directiveHeaders, usedProviders.BatchNumber() == 0)
 
 	// Group-aware fan-out: when a cross-validation policy requires group diversity, select across at
 	// least MinGroups distinct provider groups (1.2a). Default 1 leaves selection group-blind. For


### PR DESCRIPTION
## Problem

A request pinning a provider with `lava-select-provider` should apply the pin to the **first attempt only** and fail over to a different provider on retry. It didn't — via two distinct mechanisms producing the same "pinned provider doesn't fail over" symptom (MAG-2228).

- **Mechanism A** (no-toggle / already-archive requests): the pin was only stripped as a side effect of the archive add/remove rebuild (`preserveRetrySafeDirectives`). On a retry without a toggle the pin survived → the retry re-read it and dead-ended on `Selected provider already failed in this request` with no failover (HTTP 500 when no node-error result was available to return).
- **Mechanism B** (plain `eth_blockNumber`): the first retry speculatively adds the `archive` extension, which strips the pin (as designed) but changes the `routerKey`. The used/unwanted-provider exclusion is keyed by `routerKey`, so the just-failed provider — recorded under the no-extension key — was not excluded under the archive key and got re-selected ~50% of the time on a QoS-unbiased router.

## Fix

- **Fix 1** (`rpcsmartrouter_server.go`): honor `lava-select-provider` / `lava-stickiness` only on the first attempt (`usedProviders.BatchNumber() == 0`); drop them on retries so selection can fall through to a different provider. Extracted `resolvePinDirectives` for clarity and unit coverage.
- **Fix 2a** (`used_providers.go` + `unified_relay_state_machine.go`): new `UsedProviders.MigrateUnwantedProviders(src, dst)`, called from `stateTransition` when an extension toggle changes the `routerKey`, so a provider already tried under the old key stays excluded under the new one.

## Testing

Unit: `TestResolvePinDirectives`, `TestMigrateUnwantedProviders`; full `lavasession` / `relaycore` / `rpcsmartrouter` suites + `gofmt` + `go vet` all green.

Cluster verification (dev-anna, fix binary on eth-sim-router only, reverted after):

| scenario | before | after |
|---|---|---|
| pinned `eth_blockNumber` + retryable `-32603` (Mechanism B) | ~50% `Lava-Retries: 2`, re-hits the same provider | **10/10** `Lava-Retries: 1`, fails over to a different provider |
| pinned + `lava-extension: archive` (Mechanism A) | deterministic `Lava-Retries: NONE`, node error returned, no failover | **4/4** `Lava-Retries: 1`, success result |

## Known limitation

Fix 2a keys off the state-machine message. `updateProtocolMessageIfNeededWithNewEarliestData` can add `archive` *after* the migrate, but only when `earliestBlockHashRequested != NOT_APPLICABLE` (a no-op for `eth_blockNumber`, so the reported bug is covered). The narrower earliest-block→archive path is not covered; making `GetUnwantedProvidersToSend` union the tried set across all routerKeys ("2b") would close it fully — deferred here to keep the change surgical.

Ticket: MAG-2228

🤖 Generated with [Claude Code](https://claude.com/claude-code)
