### PR TITLE
chore: bump Go toolchain 1.26.2 -> 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/magma-Devs/smart-router
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/cometbft/cometbft v0.38.21

--- a/tools/wizard/go.mod
+++ b/tools/wizard/go.mod
@@ -5,7 +5,7 @@
 // Charm UI dependency tree lives only here. Build via `make wizard`.
 module github.com/magma-Devs/smart-router/tools/wizard
 
-go 1.25.0
+go 1.26.4
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0


### PR DESCRIPTION
## Summary
- Bumps the `go` directive in `go.mod` from `1.26.2` to `1.26.4` (two patch releases).
- Also bumps `tools/wizard/go.mod` from `1.25.0` to `1.26.4` (the separate Charm-TUI wizard module).

## Why
Picks up the security backports in:
- **1.26.3** — `crypto/tls`, `net/http`, `html/template`, etc.
- **1.26.4** — `crypto/x509`, `mime`, `net/textproto`.

These are pure point releases — no language or API changes.

## Scope
- Root `go.mod` change drives CI automatically via `go-version-file: go.mod`, and the Docker image via the floating `golang:1.26` tag.
- `tools/wizard/go.mod` is a separate module (Charm TUI dependency tree); `go mod tidy` produced no `go.sum` changes.

## Test plan
- `GOTOOLCHAIN=go1.26.4 go build ./...` passes at the repo root (exit 0).
- In `tools/wizard`: `GOTOOLCHAIN=go1.26.4 go mod tidy` and `GOTOOLCHAIN=go1.26.4 go build ./...` both pass (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)