### PR TITLE
chore: open-source public-readiness fixes (license, CLA, contacts)

### DIFF
--- a/.github/workflows/pr-gate-build-artifact.yml
+++ b/.github/workflows/pr-gate-build-artifact.yml
@@ -599,8 +599,8 @@ jobs:
       - name: Run smart-router-automation public readiness smoke
         working-directory: smart-router-automation
         env:
-          CLUSTER_HOST: prtests.magmadevs.com
-          SERVER_HOST: prtests.magmadevs.com
+          CLUSTER_HOST: ${{ vars.CLUSTER_HOST }}
+          SERVER_HOST: ${{ vars.CLUSTER_HOST }}
           SMART_ROUTER_FETCH_VALUES_YML: "0"
         run: |
           set -euo pipefail

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -56,7 +56,8 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at <>.
+reported to the community leaders responsible for enforcement at
+[conduct@magmadevs.com](mailto:conduct@magmadevs.com).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 This project and everyone participating in it is governed by the
 [Smart Router Code of Conduct](https://github.com/magma-Devs/smart-router/blob/main/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
-to <>.
+to [conduct@magmadevs.com](mailto:conduct@magmadevs.com).
 
 
 ## I Have a Question
@@ -99,7 +99,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 <!-- omit in toc -->
 #### How Do I Submit a Good Bug Report?
 
-> You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to <>.
+> You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to [security@magmadevs.com](mailto:security@magmadevs.com) (see [SECURITY.md](./SECURITY.md)).
 <!-- You may add a PGP key to allow the messages to be sent encrypted as well. -->
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,18 @@ Depending on how large the project is, you may want to outsource the questioning
 
 ## I Want To Contribute
 
-> ### Legal Notice <!-- omit in toc -->
-> When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project license.
+> ### Legal Notice — Contributor License Grant <!-- omit in toc -->
+> Smart Router is offered under a source-available license for noncommercial use, and separately under a paid Enterprise License for commercial use (see [LICENSE.md](./LICENSE.md)). To keep this dual model workable, contributions must be licensed to Magma Devs broadly enough to be included in **both** distributions.
+>
+> By submitting a contribution (a pull request, patch, or any other content) to this project, you agree that:
+>
+> 1. You have authored 100% of the content, or you otherwise have the necessary rights to submit it, and submitting it does not violate any third party's rights or any agreement you are bound by.
+> 2. You grant Magma Devs a perpetual, worldwide, non-exclusive, royalty-free, irrevocable copyright and patent license to use, reproduce, modify, prepare derivative works of, publicly display, sublicense, and distribute your contribution and such derivative works — **under any license terms, including the PolyForm Noncommercial License, the Magma Devs Enterprise License, and any future or commercial license terms** Magma Devs may choose.
+> 3. This grant does not transfer ownership: you retain copyright in your contribution and may continue to use it for any purpose.
+>
+> If you are contributing on behalf of your employer or another entity, you confirm you are authorized to make this grant on its behalf. If you cannot make this grant, please do not submit a contribution.
+>
+> For substantial contributions we may ask you to sign a separate Contributor License Agreement (CLA) recording the same grant; submitting a pull request indicates your agreement to these terms in the meantime.
 
 ### Reporting Bugs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,6 @@ All types of contributions are encouraged and valued. See the [Table of Contents
   - [Improving The Documentation](#improving-the-documentation)
 - [Styleguides](#styleguides)
   - [Commit Messages](#commit-messages)
-- [Join The Project Team](#join-the-project-team)
 
 
 ## Code of Conduct
@@ -142,9 +141,6 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/magma-
 - **Explain why this enhancement would be useful** to most Smart Router users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
 
 <!-- You might want to create an issue template for enhancement suggestions that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->
-
-## Join The Project Team
-<!-- TODO -->
 
 <!-- omit in toc -->
 ## Attribution

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,8 @@
 # Smart Router Source-Available License Notice
 
+<!-- SPDX-License-Identifier: LicenseRef-MagmaDevs-SourceAvailable -->
+SPDX-License-Identifier: LicenseRef-MagmaDevs-SourceAvailable
+
 Required Notice: Copyright 2026 Magma Devs
 
 This repository is made source-available under the PolyForm Noncommercial

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -10,7 +10,7 @@ Noncommercial use is permitted subject to the PolyForm Noncommercial License
 1.0.0 terms below, including personal, educational, research, evaluation,
 development, and testing use. For the avoidance of doubt the  "permitted purpose" under this license (including under the PolyForm Noncommercial License 1.0.0) is limited to noncommercial use. Further, any distribution of software hereunder (including under the PolyForm Noncommercial License 1.0.0) must be distributed with these licenses and subject to the terms hereof such that any use of the software shall only be permitted under these licenses, and limited to noncommercial use.
 
-The following uses (the "noncommercial use") require a separate written Enterprise License from Magma Devs:
+The following uses (the "commercial use") require a separate written Enterprise License from Magma Devs:
 
 - Any commercial use.
 - Any production use by or for a commercial entity.


### PR DESCRIPTION
Pre-publication cleanup for making the repo public (source-available + Enterprise dual license). One logical fix per commit.

## Summary
- **ci**: move the internal CI/test cluster host (`prtests.magmadevs.com`) out of the workflow file into a `vars.CLUSTER_HOST` repo variable so it isn't disclosed in a public tree.
- **license (legal)**: fix the inverted defined term in `LICENSE.md` — the clause gating paid use defined it as `"noncommercial use"` then listed commercial uses; corrected to `"commercial use"`.
- **contributing (CLA)**: replace the weak "under the project license" grant with an explicit contributor license grant allowing Magma Devs to relicense contributions under **any** terms (incl. commercial/Enterprise). Required for the dual-license model to be legally sound.
- **contacts**: fill empty `<>` placeholders — `conduct@magmadevs.com` (CoC) and `security@magmadevs.com` (sensitive bugs, matching SECURITY.md).
- **contributing**: drop the empty `## Join The Project Team` `<!-- TODO -->` stub (+ its TOC entry).
- **license (tooling)**: add `SPDX-License-Identifier: LicenseRef-MagmaDevs-SourceAvailable` so scanners classify the custom license.

## Notes / follow-ups (NOT in this PR)
- ⚠️ **Blocking, repo-level**: do **not** publish the `feat/smart-router-enterprise` branch — its history carries a real signed production Enterprise license blob (`licensing/embedded_license.txt`). It is **not** reachable from `main`. Publish `main` only, or delete that remote branch before flipping visibility.
- Contributor **personal emails** remain in commit-author metadata across history; intentionally **not** addressed here (a `.mailmap` was considered and dropped). A `git filter-repo` history rewrite would be required to scrub them from published objects.
- `CLUSTER_HOST` Actions **variable** has been set in repo settings so the maintainer-only pr-gate step resolves a real host.
- Consider adding a CLA-bot + signed CLA for substantial contributions (the grant text references this).

## Test plan
- [x] No `<>` placeholders, no plaintext internal host remaining in tree.
- [x] Each fix is an isolated commit.