### PR TITLE
docs(license): split commercial terms so GitHub detects the license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,29 +1,12 @@
-# Smart Router Source-Available License Notice
-
-<!-- SPDX-License-Identifier: LicenseRef-MagmaDevs-SourceAvailable -->
-SPDX-License-Identifier: LicenseRef-MagmaDevs-SourceAvailable
-
 Required Notice: Copyright 2026 Magma Devs
 
-This repository is made source-available under the PolyForm Noncommercial
-License 1.0.0 below, with the additional Enterprise License requirements
-described in this notice.
-
-Noncommercial use is permitted subject to the PolyForm Noncommercial License
-1.0.0 terms below, including personal, educational, research, evaluation,
-development, and testing use. For the avoidance of doubt the  "permitted purpose" under this license (including under the PolyForm Noncommercial License 1.0.0) is limited to noncommercial use. Further, any distribution of software hereunder (including under the PolyForm Noncommercial License 1.0.0) must be distributed with these licenses and subject to the terms hereof such that any use of the software shall only be permitted under these licenses, and limited to noncommercial use.
-
-The following uses (the "commercial use") require a separate written Enterprise License from Magma Devs:
-
-- Any commercial use.
-- Any production use by or for a commercial entity.
-- Any hosted, software-as-a-service (SaaS), or managed-service use offered to
-  customers or other third parties as part of a commercial product or service.
-- Any resale, redistribution as part of a commercial offering, or use as part
-  of a paid product.
-- Any use of premium or enterprise features made available by Magma Devs.
-
-For Enterprise licensing, contact Magma Devs at [sales@magmadevs.com](mailto:sales@magmadevs.com).
+<!--
+Smart Router is dual-licensed: noncommercial use under the PolyForm
+Noncommercial License 1.0.0 below, and commercial use under a separate
+Magma Devs Enterprise License. See LICENSING.md for the dual-license
+summary and the commercial terms. For Enterprise licensing, contact
+sales@magmadevs.com.
+-->
 
 # PolyForm Noncommercial License 1.0.0
 

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,44 @@
+# Smart Router Licensing
+
+SPDX-License-Identifier: LicenseRef-MagmaDevs-SourceAvailable
+
+Required Notice: Copyright 2026 Magma Devs
+
+Smart Router is **dual-licensed**:
+
+- **Noncommercial use** is free under the **PolyForm Noncommercial License
+  1.0.0** — see [LICENSE.md](./LICENSE.md). This covers personal, educational,
+  research, evaluation, development, and testing use.
+- **Commercial use** requires a separate written **Enterprise License** from
+  Magma Devs (the "commercial use", described below).
+
+This repository is made source-available under the PolyForm Noncommercial
+License 1.0.0, with the additional Enterprise License requirements described
+here.
+
+Noncommercial use is permitted subject to the PolyForm Noncommercial License
+1.0.0 terms, including personal, educational, research, evaluation, development,
+and testing use. For the avoidance of doubt the "permitted purpose" under that
+license (including under the PolyForm Noncommercial License 1.0.0) is limited to
+noncommercial use. Further, any distribution of software hereunder (including
+under the PolyForm Noncommercial License 1.0.0) must be distributed with these
+licenses and subject to the terms hereof such that any use of the software shall
+only be permitted under these licenses, and limited to noncommercial use.
+
+## Uses that require an Enterprise License
+
+The following uses (the "commercial use") require a separate written Enterprise
+License from Magma Devs:
+
+- Any commercial use.
+- Any production use by or for a commercial entity.
+- Any hosted, software-as-a-service (SaaS), or managed-service use offered to
+  customers or other third parties as part of a commercial product or service.
+- Any resale, redistribution as part of a commercial offering, or use as part
+  of a paid product.
+- Any use of premium or enterprise features made available by Magma Devs.
+
+## Getting an Enterprise License
+
+For Enterprise licensing, contact Magma Devs at
+[sales@magmadevs.com](mailto:sales@magmadevs.com).

--- a/README.md
+++ b/README.md
@@ -487,9 +487,9 @@ For vulnerability reporting, see [SECURITY.md](SECURITY.md). Do **not** open pub
 
 ## License
 
-This repository is source-available under the terms described in [LICENSE.md](LICENSE.md). Noncommercial use is permitted subject to those terms, including personal, educational, research, evaluation, development, and testing use.
+Smart Router is **dual-licensed**. Noncommercial use is free under the [PolyForm Noncommercial License 1.0.0](LICENSE.md), including personal, educational, research, evaluation, development, and testing use. Commercial use requires a separate written Enterprise License from Magma Devs. See [LICENSING.md](LICENSING.md) for the dual-license summary and the full commercial terms.
 
-Any commercial use, production use by or for a commercial entity, hosted/SaaS or managed-service use offered to customers or other third parties as part of a commercial product or service, resale, redistribution as part of a commercial offering, use as part of a paid product, or use of premium/enterprise features requires a separate written Enterprise License from Magma Devs. Review [LICENSE.md](LICENSE.md) for the full terms. For Enterprise licensing, contact Magma Devs at [sales@magmadevs.com](mailto:sales@magmadevs.com).
+Any commercial use, production use by or for a commercial entity, hosted/SaaS or managed-service use offered to customers or other third parties as part of a commercial product or service, resale, redistribution as part of a commercial offering, use as part of a paid product, or use of premium/enterprise features requires a separate written Enterprise License from Magma Devs. For Enterprise licensing, contact Magma Devs at [sales@magmadevs.com](mailto:sales@magmadevs.com).
 
 ## Community
 


### PR DESCRIPTION
Fixes the broken **"View license"** link in the GitHub repo sidebar.

## Problem
GitHub's license detector (`licensee`) couldn't classify `LICENSE.md` because it was a custom composite — the Magma Devs Enterprise notice and a custom `SPDX-License-Identifier: LicenseRef-...` were prepended to the PolyForm text. Unrecognized → sidebar "View license" link broken / shows "Other".

## Fix (conventional dual-license layout)
- **`LICENSE.md`** → now the **verbatim PolyForm Noncommercial 1.0.0** text, with the PolyForm-required `Required Notice:` line and an HTML-comment pointer to the commercial terms. `licensee` recognizes this; the sidebar will show **"PolyForm Noncommercial License 1.0.0"** and the link works.
- **`LICENSING.md`** (new) → dual-license summary + the Enterprise/commercial-use terms + the custom SPDX `LicenseRef`.
- **`README.md`** License section → links to both.

**No change to the actual terms** — this is a packaging change so license tooling classifies the repo correctly.

## Test plan
- [x] `LICENSE.md` opens with verbatim PolyForm (detectable by licensee).
- [x] Commercial terms preserved verbatim in `LICENSING.md`.
- [ ] After merge: confirm repo sidebar "View license" resolves to PolyForm Noncommercial 1.0.0.