### PR TITLE
fix(chaintracker): guard nil oldBlockCallback on wss upstream timeout (MAG-2219)

### DIFF
--- a/protocol/chaintracker/chain_tracker.go
+++ b/protocol/chaintracker/chain_tracker.go
@@ -458,6 +458,12 @@ func (cs *ChainTracker) fetchAllPreviousBlocksIfNecessary(ctx context.Context) (
 }
 
 func (cs *ChainTracker) notUpdated() {
+	// oldBlockCallback is optional and is never wired up in normal operation, so
+	// it is usually nil. With no callback there is nothing to notify; skip rather
+	// than dereference a nil func, which segfaults the tracker's poll goroutine.
+	if cs.oldBlockCallback == nil {
+		return
+	}
 	latestBlockTime := cs.getLatestChangeTime()
 	if latestBlockTime.IsZero() {
 		latestBlockTime = cs.startupTime

--- a/protocol/chaintracker/chain_tracker_nil_oldblockcallback_test.go
+++ b/protocol/chaintracker/chain_tracker_nil_oldblockcallback_test.go
@@ -1,0 +1,79 @@
+package chaintracker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/utils"
+	"github.com/stretchr/testify/require"
+)
+
+// timeoutChainFetcher is a minimal ChainFetcher whose latest-block fetch always
+// fails with the exact error shape a wss upstream produces on a deadline: a
+// wrappedLavaError (from utils.LavaFormatWarning) wrapping context.DeadlineExceeded.
+//
+// This mirrors production: SVMChainTracker.FetchLatestBlockNum wraps the raw
+// CallContext error returned by WebSocketDirectRPCConnection.SendRequest via
+// LavaFormatWarning, yielding a *wrappedLavaError whose single Unwrap() exposes a
+// net.Error. That is precisely what drives the net.Error branch of
+// fetchAllPreviousBlocksIfNecessary. (HTTP upstreams are shielded because
+// HTTPDirectRPCConnection.SendRequest wraps with fmt.Errorf, so one Unwrap() yields
+// a *fmt.wrapError, not a net.Error.)
+type timeoutChainFetcher struct{}
+
+func (timeoutChainFetcher) FetchLatestBlockNum(ctx context.Context) (int64, error) {
+	return 0, utils.LavaFormatWarning("[test] simulated wss latest-block timeout", context.DeadlineExceeded)
+}
+
+func (timeoutChainFetcher) FetchBlockHashByNum(ctx context.Context, blockNum int64) (string, error) {
+	return "", nil
+}
+
+func (timeoutChainFetcher) FetchEndpoint() lavasession.RPCProviderEndpoint {
+	return lavasession.RPCProviderEndpoint{}
+}
+
+func (timeoutChainFetcher) CustomMessage(ctx context.Context, path string, data []byte, connectionType string, apiName string) ([]byte, error) {
+	return nil, nil
+}
+
+// TestFetchAllPreviousBlocksIfNecessary_UpstreamTimeoutIsHandled reproduces MAG-2219.
+//
+// When a wss upstream's latest-block fetch times out, the error reaching
+// fetchAllPreviousBlocksIfNecessary unwraps to a net.Error, so the net.Error branch
+// calls notUpdated() WITHOUT the `oldBlockCallback != nil` guard that the sibling
+// call has. OldBlockCallback is never assigned anywhere in the codebase, so it is
+// always nil and notUpdated() dereferences a nil func -> SIGSEGV, crash-looping the
+// router.
+//
+// Desired behaviour: an upstream latest-block timeout is handled and surfaced as an
+// error; the tracker keeps running. This test fails today (nil-pointer panic) and
+// passes once the call site is guarded. OldBlockCallback is intentionally left unset
+// to reflect every real deployment.
+func TestFetchAllPreviousBlocksIfNecessary_UpstreamTimeoutIsHandled(t *testing.T) {
+	config := ChainTrackerConfig{
+		BlocksToSave:          1,
+		AverageBlockTime:      time.Millisecond,
+		ServerBlockMemory:     10,
+		ParseDirectiveEnabled: true,
+	}
+
+	tracker, err := NewChainTracker(context.Background(), timeoutChainFetcher{}, config)
+	require.NoError(t, err)
+
+	cs, ok := tracker.(*ChainTracker)
+	require.True(t, ok, "expected NewChainTracker to return a *ChainTracker")
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("MAG-2219: fetchAllPreviousBlocksIfNecessary panicked on a wss upstream timeout instead of handling it: %v", r)
+		}
+	}()
+
+	gotErr := cs.fetchAllPreviousBlocksIfNecessary(context.Background())
+	require.Error(t, gotErr, "an upstream latest-block timeout should surface as an error, not crash the router")
+	require.True(t, errors.Is(gotErr, context.DeadlineExceeded), "the returned error should preserve the upstream deadline cause")
+}


### PR DESCRIPTION
## Summary

Fixes **[MAG-2219](https://magmadevs.atlassian.net/browse/MAG-2219)** — `solana-router` crash-loops (SIGSEGV, 200+ restarts) whenever a `wss` upstream's latest-block fetch times out.

The `net.Error` branch of `fetchAllPreviousBlocksIfNecessary` (`chain_tracker.go:412`) calls `notUpdated()` **without** the `oldBlockCallback != nil` guard that its sibling at `:452` has. `OldBlockCallback` is never wired up anywhere in the codebase, so it is always nil and `notUpdated()` dereferences a nil func → panic in the tracker's poll goroutine.

This guards the nil inside `notUpdated()` itself, so **every** caller is protected (not just the one wss path).

## Why only `wss` triggers it

- `WebSocketDirectRPCConnection.SendRequest` returns the `CallContext` error **raw**. After `SVMChainTracker.FetchLatestBlockNum` wraps it via `LavaFormatWarning`, a single `Unwrap()` exposes `context.DeadlineExceeded`, which satisfies `net.Error` → the unguarded branch fires.
- HTTP/HTTPS upstreams wrap with `fmt.Errorf("http request failed: %w", err)`, so one `Unwrap()` yields a `*fmt.wrapError`, not a `net.Error` → branch never fires.
- Solana's deployed config has a `wss` LavaGateway upstream, so its tracker hits the unshielded path.

## Test

Includes the MAG-2219 repro test (`chain_tracker_nil_oldblockcallback_test.go`, originally from #146) which drives `fetchAllPreviousBlocksIfNecessary` with the exact production error shape (`wrappedLavaError{cause: context.DeadlineExceeded}`) and a nil `oldBlockCallback`.

| Scenario | Result |
|----------|--------|
| Repro test against unfixed `main` | ❌ FAIL — exact nil-pointer panic in `notUpdated` |
| Repro test with this fix | ✅ PASS |
| Full `chaintracker` package | ✅ PASS — no regressions |

> ⚠️ Note: smart-router CI does not run `go test`, so the repro test must be run locally to be exercised. Supersedes the test-only #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MAG-2219]: https://magmadevs.atlassian.net/browse/MAG-2219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ