### PR TITLE
feat(metrics): add /livez + /readyz k8s health probes

### DIFF
--- a/protocol/metrics/health_probes_test.go
+++ b/protocol/metrics/health_probes_test.go
@@ -1,0 +1,81 @@
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// newSmartRouterForProbeTest builds a minimal manager with just the gauge the
+// health path touches, so we can exercise the HTTP probes without binding a
+// socket or registering against the Prometheus default registerer.
+func newSmartRouterForProbeTest() *SmartRouterMetricsManager {
+	return &SmartRouterMetricsManager{
+		// fail-closed default, matching NewSmartRouterMetricsManager
+		endpointsHealthChecksOk: 0,
+		routerOverallHealth:     prometheus.NewGauge(prometheus.GaugeOpts{Name: "t_sr_router_overall_health"}),
+	}
+}
+
+func probeServer(m *SmartRouterMetricsManager) *httptest.Server {
+	mux := http.NewServeMux()
+	m.registerHTTPHandlers(mux)
+	return httptest.NewServer(mux)
+}
+
+func getStatus(t *testing.T, url string) int {
+	t.Helper()
+	resp, err := http.Get(url)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// /livez is a dumb liveness probe: always 200 regardless of provider health.
+func TestLivez_AlwaysOK(t *testing.T) {
+	m := newSmartRouterForProbeTest()
+	srv := probeServer(m)
+	defer srv.Close()
+
+	// Unhealthy (default) — livez must still be 200.
+	require.Equal(t, http.StatusOK, getStatus(t, srv.URL+"/livez"))
+
+	// Healthy — still 200.
+	m.UpdateHealthCheckStatus(true)
+	require.Equal(t, http.StatusOK, getStatus(t, srv.URL+"/livez"))
+}
+
+// /readyz reflects real serving capacity: fail-closed at boot, 200 once a chain
+// is healthy, back to 503 when health drops.
+func TestReadyz_TracksHealth(t *testing.T) {
+	m := newSmartRouterForProbeTest()
+	srv := probeServer(m)
+	defer srv.Close()
+
+	// Fail-closed at boot: no health check has run yet.
+	require.Equal(t, http.StatusServiceUnavailable, getStatus(t, srv.URL+"/readyz"))
+
+	// Aggregator reports at least one chain healthy.
+	m.UpdateHealthCheckStatus(true)
+	require.Equal(t, http.StatusOK, getStatus(t, srv.URL+"/readyz"))
+
+	// All chains unhealthy again — pod should drop out of rotation.
+	m.UpdateHealthCheckStatus(false)
+	require.Equal(t, http.StatusServiceUnavailable, getStatus(t, srv.URL+"/readyz"))
+}
+
+// /readyz and the legacy /metrics/health-overall alias share the same flag.
+func TestReadyz_AliasesHealthOverall(t *testing.T) {
+	m := newSmartRouterForProbeTest()
+	srv := probeServer(m)
+	defer srv.Close()
+
+	m.UpdateHealthCheckStatus(true)
+	require.Equal(t, getStatus(t, srv.URL+"/metrics/health-overall"), getStatus(t, srv.URL+"/readyz"))
+
+	m.UpdateHealthCheckStatus(false)
+	require.Equal(t, getStatus(t, srv.URL+"/metrics/health-overall"), getStatus(t, srv.URL+"/readyz"))
+}

--- a/protocol/metrics/smartrouter_metrics_manager.go
+++ b/protocol/metrics/smartrouter_metrics_manager.go
@@ -633,7 +633,12 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 		csmReportedProvidersCount:      csmReportedProvidersCount,
 
 		// Internal state
-		endpointsHealthChecksOk: 1,
+		// Start fail-closed (0 = not-ready) so /readyz reports 503 until the
+		// RelaysMonitorAggregator's first health check confirms at least one
+		// chain can serve relays and flips this to 1 via UpdateHealthCheckStatus.
+		// This keeps a freshly-booted pod out of the k8s Service load-balancer
+		// until it has actually verified a provider.
+		endpointsHealthChecksOk: 0,
 		endpointMetrics:         make(map[string]*EndpointMetrics),
 		urlToProviderNames:      make(map[string][]string),
 		optimizerQoSClient:      options.OptimizerQoSClient,
@@ -645,20 +650,7 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	if options.NetworkAddress != "" {
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", promhttp.Handler())
-
-		overallHealthHandler := func(w http.ResponseWriter, r *http.Request) {
-			statusCode := http.StatusOK
-			message := "Health status OK"
-			if atomic.LoadUint64(&manager.endpointsHealthChecksOk) == 0 {
-				statusCode = http.StatusServiceUnavailable
-				message = "Unhealthy"
-			}
-			w.WriteHeader(statusCode)
-			w.Write([]byte(message))
-		}
-
-		mux.HandleFunc("/metrics/overall-health", overallHealthHandler)
-		mux.HandleFunc("/metrics/health-overall", overallHealthHandler)
+		manager.registerHTTPHandlers(mux)
 
 		go func() {
 			utils.LavaFormatInfo("prometheus endpoint listening", utils.Attribute{Key: "Listen Address", Value: options.NetworkAddress})
@@ -669,6 +661,44 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	}
 
 	return manager
+}
+
+// registerHTTPHandlers wires the health/readiness routes onto the given mux.
+// Split out from the constructor so tests can exercise the handlers against a
+// real manager without binding a socket or touching the Prometheus default
+// registerer.
+func (m *SmartRouterMetricsManager) registerHTTPHandlers(mux *http.ServeMux) {
+	// Overall-health / readiness: 200 when at least one chain can serve relays
+	// (endpointsHealthChecksOk == 1, maintained by the RelaysMonitorAggregator),
+	// else 503.
+	overallHealthHandler := func(w http.ResponseWriter, r *http.Request) {
+		statusCode := http.StatusOK
+		message := "Health status OK"
+		if atomic.LoadUint64(&m.endpointsHealthChecksOk) == 0 {
+			statusCode = http.StatusServiceUnavailable
+			message = "Unhealthy"
+		}
+		w.WriteHeader(statusCode)
+		w.Write([]byte(message))
+	}
+
+	mux.HandleFunc("/metrics/overall-health", overallHealthHandler)
+	mux.HandleFunc("/metrics/health-overall", overallHealthHandler)
+
+	// Kubernetes liveness probe. Deliberately dumb: a static 200 that only
+	// proves the process is up and the mux is serving. No dependency checks —
+	// a failing liveness probe restarts the pod, and a restart can't fix
+	// "no healthy providers", so provider health belongs in /readyz, not here.
+	mux.HandleFunc("/livez", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	// Kubernetes readiness probe. Reflects real serving capacity: 200 only when
+	// at least one chain can serve relays, else 503 so k8s pulls the pod out of
+	// the Service load-balancer without restarting it. Shares the flag with
+	// /metrics/health-overall; this is the k8s-idiomatic alias.
+	mux.HandleFunc("/readyz", overallHealthHandler)
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

The router's k8s probes currently both hit `httpGet /metrics`, so **readiness is meaningless** — `/metrics` returns 200 even when the router has zero usable providers. k8s keeps the pod in the Service load-balancer and routes it traffic it can't serve.

This adds two purpose-built probes on the **existing** metrics mux (no new port, no new listener):

| Route | Role | Behavior |
|-------|------|----------|
| `GET /livez` | **Liveness** | Static `200`. Deliberately dumb — proves the process/mux is up. **No** dependency checks: a failing liveness probe *restarts* the pod, and a restart can't fix "no healthy providers", so provider health belongs in readiness, not here. |
| `GET /readyz` | **Readiness** | `200` only when ≥1 chain can serve relays, else `503` — so k8s pulls the pod out of the LB **without** restarting it. |

## How `/readyz` knows

It reuses the **live** `endpointsHealthChecksOk` flag already maintained by the `RelaysMonitorAggregator`:

```
RelaysMonitor (per chain+interface, ticker-driven health relays)
  → RelaysMonitorAggregator.runHealthCheck()   [OR across all chains: ≥1 healthy]
  → manager.UpdateHealthCheckStatus(overallHealth)
  → atomic endpointsHealthChecksOk               ← /readyz + /metrics/health-overall read this
```

`/readyz` is the k8s-idiomatic alias of the existing `/metrics/health-overall` (kept for back-compat).

## Fail-closed at boot

`endpointsHealthChecksOk` now initializes to `0` (was `1`). A freshly-booted pod reports **not-ready** until the aggregator's first health check confirms a healthy chain — keeping it out of the LB until it has actually verified a provider. Safe because the aggregator drives the flag live; verified no other code path gates on the metrics-manager `IsHealthy()`.

The handler wiring was extracted into `registerHTTPHandlers` so the probes are unit-tested against a real manager without binding a socket or touching the Prometheus default registerer.

## ⚠ Sequencing — do not merge the helm change first
The companion `smart-router-helm-chart` PR repoints the router probes to `/livez`+`/readyz`. It must land **only after** this image is built and deployed — pointing a probe at a route the running image doesn't serve causes CrashLoopBackOff (liveness) or the pod being pulled from the LB (readiness).

## Test plan
- [x] `go build ./...` — clean
- [x] New `health_probes_test.go`: `/livez` always 200; `/readyz` 503 at boot → 200 when healthy → 503 when unhealthy; `/readyz` matches `/metrics/health-overall`
- [x] Full `protocol/metrics` package passes (confirms the fail-closed init flip breaks no existing test)