### PR TITLE
feat(release): force changelog regen for recreated tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:
       release_tag:
         description: "The desired tag for the release (e.g. v1.1.0)."
         required: true
+      regenerate_changelog:
+        description: "Force-regenerate the CHANGELOG.md section for this version, replacing any existing one. Use when a tag was deleted and recreated from scratch so the stale section must be rebuilt from the new commit range."
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -110,9 +114,22 @@ jobs:
           # commit via `GET /commits/{sha}/pulls`. Default GITHUB_TOKEN
           # has the required read access and isn't rate-limited (5000/hr).
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # When the regenerate_changelog input is set (workflow_dispatch
+          # only; empty on tag-push), force the bumper to replace an
+          # existing section instead of skipping it. Threads through as
+          # FORCE=1 to scripts/changelog-bump.sh.
+          REGENERATE_CHANGELOG: ${{ github.event.inputs.regenerate_changelog }}
         run: |
           v_re=$(printf '%s' "$RELEASE_VERSION" | sed -e 's/[][().*+?^$\|/]/\\&/g')
-          if grep -qE "^## ${v_re}( |\$)" CHANGELOG.md 2>/dev/null; then
+          if [ "${REGENERATE_CHANGELOG}" = "true" ]; then
+            # Override path: a deleted+recreated tag leaves a stale section
+            # on main. Rebuild it from the new commit range, replacing the
+            # old one (FORCE=1). Always regenerates, even if the section
+            # exists — that's the whole point of the override.
+            echo "regenerate_changelog=true — force-rebuilding the ${RELEASE_VERSION} section"
+            VERSION="$RELEASE_VERSION" AI=1 EDIT=0 FORCE=1 scripts/changelog-bump.sh
+            echo "did_generate=true" >> "$GITHUB_OUTPUT"
+          elif grep -qE "^## ${v_re}( |\$)" CHANGELOG.md 2>/dev/null; then
             echo "CHANGELOG.md already has a section for ${RELEASE_VERSION} — skipping bumper"
             echo "did_generate=false" >> "$GITHUB_OUTPUT"
           else

--- a/scripts/changelog-bump.sh
+++ b/scripts/changelog-bump.sh
@@ -25,6 +25,11 @@
 #   VERSION         required  - e.g. v1.0.0
 #   AI              optional  - 0 to skip Gemini draft (default 1)
 #   EDIT            optional  - 0 to skip $EDITOR (default 1)
+#   FORCE           optional  - 1 to REPLACE an existing '## <version>'
+#                               section instead of refusing (default 0).
+#                               Use when a tag was deleted + recreated from
+#                               scratch and the stale section must be
+#                               regenerated from the new commit range.
 #   EDITOR          optional  - defaults to vim
 #   GEMINI_API_KEY  optional  - passed through to changelog-ai.sh
 #   REPO_URL        optional  - default: https://github.com/magma-Devs/smart-router
@@ -53,14 +58,39 @@ fi
 cd "$(git rev-parse --show-toplevel)"
 script_dir="$(dirname "$(readlink -f "$0")")"
 
-# Refuse to clobber an existing section. The release workflow detects
-# this and skips the bumper entirely on re-runs; if the user is hitting
-# this locally, they should either bump VERSION or hand-edit CHANGELOG.md.
+# An existing '## <version>' section normally means a re-run: refuse to
+# add a duplicate. FORCE=1 overrides this — it strips the old section so
+# the fresh one (built below) replaces it. That's the path for a tag that
+# was deleted and recreated from scratch: the CHANGELOG.md on main still
+# carries the stale section, and we want it regenerated from the new
+# commit range, not preserved.
 v_re_escaped="$(printf '%s' "$VERSION" | sed -e 's/[][().*+?^$\|/]/\\&/g')"
 if [ -f CHANGELOG.md ] && grep -qE "^## ${v_re_escaped}( |\$)" CHANGELOG.md; then
-  echo "changelog-bump: CHANGELOG.md already has a '## ${VERSION}' section - refusing to add a duplicate" >&2
-  echo "changelog-bump: edit the existing section by hand, or remove it first" >&2
-  exit 1
+  if [ "${FORCE:-0}" = "1" ]; then
+    echo "changelog-bump: FORCE=1 - replacing existing '## ${VERSION}' section" >&2
+    # Delete the old section: from its '## <version>' heading up to (but
+    # not including) the next '## ' heading, or EOF if it's the last one.
+    # We match the heading by exact string, not regex, so a version whose
+    # name is a prefix of another (v1.1.0 vs v1.1.0-rc1) can't cross-match:
+    # the line must be exactly "## <version>" OR "## <version> " (space +
+    # date suffix). awk `index()`/substr on the raw literal avoids any
+    # regex-escaping and the `\.`/`\$` warnings that came with it.
+    awk -v hdr="## ${VERSION}" '
+      # Start skipping at the EXACT target heading (bare, or "## <ver> <date>").
+      # The exact/space-prefixed test means a longer version that merely
+      # starts with this one (v1.1.0 vs v1.1.0-rc1) is not matched here.
+      $0 == hdr || substr($0, 1, length(hdr) + 1) == hdr " " { skip = 1; next }
+      # Any subsequent "## " heading is, by definition, a different section
+      # (the target already consumed itself via next), so it ends the skip.
+      skip && /^## / { skip = 0 }
+      !skip { print }
+    ' CHANGELOG.md > CHANGELOG.md.tmp
+    mv CHANGELOG.md.tmp CHANGELOG.md
+  else
+    echo "changelog-bump: CHANGELOG.md already has a '## ${VERSION}' section - refusing to add a duplicate" >&2
+    echo "changelog-bump: edit the existing section by hand, remove it first, or re-run with FORCE=1" >&2
+    exit 1
+  fi
 fi
 
 # --exclude "$VERSION" is critical when the release workflow runs on a


### PR DESCRIPTION
## Summary

When you delete a release **and** its tag, then recreate the tag from scratch, the `CHANGELOG.md` section for that version still lives on `main`. Two existing guards then produce a stale changelog:

1. The release workflow's generate step sees `## <version>` already exists → sets `did_generate=false` → **skips regeneration** and ships the old section as the release body.
2. `changelog-bump.sh` itself refuses (exit 1) to overwrite an existing section.

This adds an **opt-in override** to force a fresh regeneration.

## Changes

- **`scripts/changelog-bump.sh`** — new `FORCE=1` env. When set and the `## <version>` section already exists, it **strips the old section and rebuilds it** from the current commit range instead of refusing. The strip matches the heading by **exact string** (not regex), so a prefix-sharing version (`v1.1.0-rc1` vs `v1.1.0`) can't be cross-deleted. Section boundary is the next `## ` heading or EOF.
- **`.github/workflows/release.yml`** — new `regenerate_changelog` boolean `workflow_dispatch` input. When `true`, it passes `FORCE=1` and **always** regenerates, bypassing the "already exists → skip" branch. Empty on tag-push triggers, so normal releases are completely unaffected.

## Usage

Re-run the release via **Actions → Publish Smart Router Release → Run workflow**, set `release_tag` to the recreated tag and tick **regenerate_changelog**.

## Test plan

- `python3 yaml.safe_load` on the workflow — valid.
- `bash -n scripts/changelog-bump.sh` — clean.
- **Section-strip matrix** (throwaway fixture): stripping `v1.1.0` keeps `v1.1.0-rc1` and `v1.0.5`; stripping the last section (EOF boundary) and a middle section both behave; no `awk` escape warnings.
- **End-to-end with real git history**: generated a `v1.1.0` section, deleted+recreated the tag with a new commit, ran with `FORCE=1` → exactly one `## v1.1.0` heading (no duplicate), section rebuilt from the new range, prior-version sections untouched.

## Notes

- Independent of #185 (SBOM fix); branches off clean `main`, no overlap.
- The regenerated range is whatever's reachable from the recreated tag minus the previous version tag — so dropped/rebased commits are correctly excluded, and merely re-tagged history is included as-is.

## Breaking changes

None — the override is opt-in; default `false` preserves current behavior.