### PR TITLE
feat(wizard): OS-adaptive prerequisite check before the flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,21 @@ build:
 
 # Interactive config wizard (separate go module under tools/wizard). Builds the
 # router first so the wizard's spec-driven `health` checks have a binary, then
-# launches the TUI. The wizard fetches chain specs + icons from the docs at
-# runtime; nothing is vendored.
-wizard: build
-	@cd tools/wizard && go run . --repo $(CURDIR)
+# launches the TUI. On launch the wizard runs an OS-adaptive prerequisite check
+# (docker + compose v2, envsubst, bash) and hard-stops if a required tool is
+# missing — native-Windows users are steered to WSL2/Git Bash. The wizard
+# fetches chain specs + icons from the docs at runtime; nothing is vendored.
+#
+# Preflight runs BEFORE `make build` so a missing docker/envsubst hard-stops
+# up front instead of after a full router compile. The launch still re-runs the
+# gate (step 0) — this just fails fast.
+wizard: wizard-preflight build
+	@cd tools/wizard && go run . --repo $(CURDIR) --skip-preflight
+
+# Check the wizard's external tool prerequisites for this OS and exit (no build,
+# no TUI). Run this first if `make wizard` bails on a missing tool.
+wizard-preflight:
+	@cd tools/wizard && go run . --preflight
 
 # Reprint the run command from the most recent wizard run (no router build, no
 # TUI — just reads the saved record under ~/.config/smartrouter-wizard).
@@ -132,4 +143,4 @@ lint:
 clean:
 	rm -rf build/ dist/
 
-.PHONY: install build wizard wizard-last wizard-build wizard-test setup snapshot changelog test test-short tidy lint clean
+.PHONY: install build wizard wizard-preflight wizard-last wizard-build wizard-test setup snapshot changelog test test-short tidy lint clean

--- a/tools/wizard/README.md
+++ b/tools/wizard/README.md
@@ -9,6 +9,31 @@ make wizard          # from the repo root (builds the router, then launches)
 cd tools/wizard && go run . --repo /path/to/smart-router
 ```
 
+## Prerequisites
+
+On launch the wizard runs an **OS-adaptive tool check** (step 0) before the
+flow, so a missing dependency surfaces up front instead of when the run step
+fails. Check it standalone anytime:
+
+```bash
+make wizard-preflight     # or: cd tools/wizard && go run . --preflight
+go run . --skip-preflight # advanced: bypass the gate
+```
+
+| Tool | Tier | Used for | Install |
+| --- | --- | --- | --- |
+| `bash` | required | the render + up steps run via `bash -c`; `run.sh` is a bash script | macOS/Linux built-in |
+| `envsubst` | required | expands `${VAR}` secrets from `.env` into the rendered config | GNU **gettext** — `brew install gettext` (mac) · `apt install gettext-base` (Debian) · `dnf install gettext` (Fedora) |
+| `docker` + `docker compose` (v2 plugin) | required | builds and runs the stack (`docker compose … up`, **not** legacy `docker-compose`) | Docker Desktop (mac/Win) · Docker Engine + `docker-compose-plugin` (Linux) |
+| `go` | optional | builds the `smartrouter` binary for health checks (skipped if `build/` has one; `make wizard` builds it first) | https://go.dev/dl/ |
+| `gh` | optional | fetches chain specs via the GitHub API — falls back to a plain HTTPS download when absent | https://cli.github.com/ |
+
+**Windows:** the run step needs `bash` + `envsubst`, which native cmd/PowerShell
+don't provide. Preflight detects native Windows without a POSIX shell and steers
+you to **WSL2** or **Git Bash** (Docker Desktop's WSL2 backend still powers
+`docker compose`). A hard stop, not a warning — the bash-based run step can't
+work otherwise.
+
 ## Flow
 
 1. **Chains** — a family-tabbed, fuzzy-searchable multi-select over the live

--- a/tools/wizard/internal/preflight/preflight.go
+++ b/tools/wizard/internal/preflight/preflight.go
@@ -1,0 +1,312 @@
+// Package preflight verifies the external system tools the wizard shells out to
+// are present BEFORE the interactive flow starts — so the user learns about a
+// missing `docker`/`envsubst`/`bash` up front, not three screens in when the
+// run step fails.
+//
+// The wizard is bash-based by design: the run step is `exec.Command("bash",
+// "-c", …)`, it uses `envsubst` to expand ${VAR} refs, and it writes a
+// `#!/usr/bin/env bash` run.sh. That stack exists on macOS and Linux out of the
+// box (envsubst ships in GNU gettext — see the per-tool install hint). On native
+// Windows there is no bash/envsubst, so preflight detects that and points the
+// user at WSL2 / Git Bash rather than pretending the run step will work.
+//
+// Tiers:
+//   - Required — the wizard cannot complete a run without them. A missing
+//     required tool is a hard stop.
+//   - Optional — the wizard degrades gracefully (e.g. `gh` → net/http tarball
+//     fallback, `go` only needed when no prebuilt binary exists). A miss is a
+//     warning, not a stop.
+package preflight
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/magma-Devs/smart-router/tools/wizard/internal/ui"
+)
+
+// Tier classifies how badly a missing tool hurts.
+type Tier int
+
+const (
+	// Required tools block a successful run; missing one is a hard stop.
+	Required Tier = iota
+	// Optional tools have a graceful fallback; missing one is a warning.
+	Optional
+)
+
+// Tool is one external binary the wizard depends on at runtime.
+type Tool struct {
+	// Name is the primary executable looked up on PATH.
+	Name string
+	// Probe, when set, overrides the default `exec.LookPath(Name)` check —
+	// used for `docker compose` (a subcommand, not a bare binary).
+	Probe func() bool
+	// Tier is Required or Optional.
+	Tier Tier
+	// Why explains what the wizard uses the tool for (shown on a miss).
+	Why string
+	// Install is a terse, OS-appropriate install hint (shown on a miss).
+	Install string
+}
+
+// found reports whether the tool resolves on this machine.
+func (t Tool) found() bool {
+	if t.Probe != nil {
+		return t.Probe()
+	}
+	_, err := lookPath(t.Name)
+	return err == nil
+}
+
+// lookPath is indirected so tests can stub tool presence without a real PATH.
+var lookPath = exec.LookPath
+
+// dockerComposeV2 reports whether the Docker Compose **v2 plugin** is available
+// (`docker compose version`, space — NOT the legacy `docker-compose` binary).
+// The wizard's run command is `docker compose …`, so v1 alone won't do.
+var dockerComposeV2 = func() bool {
+	if _, err := lookPath("docker"); err != nil {
+		return false
+	}
+	return exec.Command("docker", "compose", "version").Run() == nil
+}
+
+// Report is the outcome of a preflight sweep.
+type Report struct {
+	// OS is the detected runtime.GOOS.
+	OS string
+	// WindowsNoShell is true on native Windows with no bash on PATH — the
+	// wizard's bash-based run step cannot work; the user is steered to WSL.
+	WindowsNoShell bool
+	// Missing holds every tool that failed its probe, in declaration order.
+	Missing []Tool
+}
+
+// missingRequired reports whether any Required tool is absent.
+func (r Report) missingRequired() bool {
+	for _, t := range r.Missing {
+		if t.Tier == Required {
+			return true
+		}
+	}
+	return false
+}
+
+// OK reports whether the wizard can proceed: no missing required tools and,
+// on Windows, a usable POSIX shell.
+func (r Report) OK() bool {
+	return !r.missingRequired() && !r.WindowsNoShell
+}
+
+// pkgManager is a detected Linux package manager. The zero value (unknown)
+// falls back to listing every common manager, so we never guess wrong.
+type pkgManager struct {
+	// cmd is the install verb, e.g. "apt install" / "dnf install" / "apk add".
+	// Empty means the distro wasn't recognised → hint() prints the full list.
+	cmd string
+}
+
+// hint renders the install line for a package, narrowed to the detected manager
+// when known, or the full apt·dnf·apk list when not. The three args are the
+// package name under apt, dnf, and apk respectively (they differ — e.g. gettext
+// is `gettext-base` on Debian but `gettext` on Fedora/Alpine).
+func (p pkgManager) hint(apt, dnf, apk string) string {
+	switch p.cmd {
+	case "apt install":
+		return "apt install " + apt
+	case "dnf install":
+		return "dnf install " + dnf
+	case "apk add":
+		return "apk add " + apk
+	default: // unknown distro — show every option, let the user pick
+		return "apt install " + apt + "   ·   dnf install " + dnf + "   ·   apk add " + apk
+	}
+}
+
+// readOSRelease is indirected so tests can supply synthetic /etc/os-release
+// contents. It returns the file body (empty on any read error).
+var readOSRelease = func() string {
+	b, err := os.ReadFile("/etc/os-release")
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// detectPkgManager maps the distro's os-release ID / ID_LIKE to a package
+// manager. Falls back to an unknown pkgManager (full-list hint) when the distro
+// isn't recognised or /etc/os-release is unreadable (e.g. minimal containers).
+func detectPkgManager() pkgManager {
+	ids := osReleaseIDs(readOSRelease())
+	for _, id := range ids {
+		switch id {
+		case "debian", "ubuntu", "linuxmint", "pop", "raspbian":
+			return pkgManager{cmd: "apt install"}
+		case "fedora", "rhel", "centos", "rocky", "almalinux":
+			return pkgManager{cmd: "dnf install"}
+		case "alpine":
+			return pkgManager{cmd: "apk add"}
+		}
+	}
+	return pkgManager{} // unknown → full list
+}
+
+// osReleaseIDs extracts the ID plus every ID_LIKE token from an os-release body,
+// lower-cased and unquoted, ID first. ID_LIKE lets derivatives (Pop!_OS, Mint,
+// Rocky) resolve via their upstream even when the exact ID isn't listed above.
+func osReleaseIDs(body string) []string {
+	var ids []string
+	var like []string
+	for line := range strings.SplitSeq(body, "\n") {
+		k, v, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok {
+			continue
+		}
+		v = strings.ToLower(strings.Trim(v, `"'`))
+		switch k {
+		case "ID":
+			ids = append(ids, v)
+		case "ID_LIKE":
+			like = append(like, strings.Fields(v)...)
+		}
+	}
+	return append(ids, like...)
+}
+
+// tools returns the dependency set adapted to the host OS. The install hints
+// differ per platform; the *set* is the same everywhere except that `bash` and
+// `envsubst` are only meaningfully checkable where a POSIX shell exists.
+func tools(goos string) []Tool {
+	// Per-OS install hints. macOS leans on Homebrew; Linux notes the common
+	// package managers; Windows routes everything through WSL because the
+	// bash-based run step needs a POSIX userland regardless.
+	var gettext, dockerHint, bashHint string
+	switch goos {
+	case "darwin":
+		gettext = "brew install gettext && brew link --force gettext"
+		dockerHint = "install Docker Desktop (includes the compose v2 plugin)"
+		bashHint = "ships with macOS"
+	case "windows":
+		gettext = "inside WSL2/Git Bash: apt install gettext-base  (or is bundled)"
+		dockerHint = "Docker Desktop with WSL2 backend; run the wizard from WSL"
+		bashHint = "use WSL2 or Git Bash — native cmd/PowerShell has no bash"
+	default: // linux and the rest
+		pm := detectPkgManager()
+		gettext = pm.hint("gettext-base", "gettext", "gettext")
+		dockerHint = "install Docker Engine + the docker-compose-plugin package"
+		bashHint = "install via your package manager (usually preinstalled)"
+	}
+
+	return []Tool{
+		{
+			Name: "bash", Tier: Required,
+			Why:     "the render + up steps run via bash -c, and run.sh is a bash script",
+			Install: bashHint,
+		},
+		{
+			Name: "envsubst", Tier: Required,
+			Why:     "expands ${VAR} secrets from .env into the rendered router config",
+			Install: gettext,
+		},
+		{
+			Name: "docker", Tier: Required,
+			Why:     "builds and runs the smart-router stack",
+			Install: dockerHint,
+		},
+		{
+			Name: "docker compose", Probe: dockerComposeV2, Tier: Required,
+			Why:     "the run command is `docker compose … up` (the v2 plugin, not docker-compose)",
+			Install: dockerHint,
+		},
+		{
+			Name: "go", Tier: Optional,
+			Why:     "builds the smartrouter binary for endpoint health checks (skippable if build/ has one)",
+			Install: "https://go.dev/dl/  (make wizard runs `make build` first, so this is usually covered)",
+		},
+		{
+			Name: "gh", Tier: Optional,
+			Why:     "fetches chain specs via the GitHub API; falls back to a plain HTTPS download when absent",
+			Install: "https://cli.github.com/  (then `gh auth login`)",
+		},
+	}
+}
+
+// hasPOSIXShell reports whether a bash is resolvable — used to detect the
+// native-Windows-without-WSL case. On Windows-with-Git-Bash bash IS on PATH, so
+// this correctly lets that setup through.
+func hasPOSIXShell() bool {
+	_, err := lookPath("bash")
+	return err == nil
+}
+
+// Run sweeps the dependency set for the current OS and returns a Report.
+func Run() Report {
+	goos := runtime.GOOS
+	r := Report{OS: goos}
+	for _, t := range tools(goos) {
+		if !t.found() {
+			r.Missing = append(r.Missing, t)
+		}
+	}
+	if goos == "windows" && !hasPOSIXShell() {
+		r.WindowsNoShell = true
+	}
+	return r
+}
+
+// Render draws the preflight result as a wizard section. On success it prints a
+// single green line; on a miss it lists each absent tool with its reason and
+// install hint, and (on native Windows) a WSL callout. It returns whether the
+// wizard may proceed — the caller hard-stops when false.
+func Render(r Report) bool {
+	fmt.Println(ui.Section(0, "Prerequisites"))
+	fmt.Println()
+
+	if r.WindowsNoShell {
+		fmt.Println(ui.Alert("Windows: no POSIX shell",
+			"The wizard's run step needs bash + envsubst, which native Windows\n"+
+				"(cmd/PowerShell) doesn't provide. Run the wizard inside WSL2 or\n"+
+				"Git Bash. Docker Desktop's WSL2 backend still powers `docker compose`."))
+		fmt.Println()
+	}
+
+	if len(r.Missing) == 0 && !r.WindowsNoShell {
+		fmt.Println("  " + ui.Tick("all prerequisites present ("+r.OS+")"))
+		return true
+	}
+
+	for _, t := range r.Missing {
+		label := t.Name
+		if t.Tier == Required {
+			fmt.Println("  " + ui.XMark(ui.Er.Render(label)+ui.Hint.Render("  (required)")))
+		} else {
+			fmt.Println("  " + ui.Wn.Render("! ") + ui.Wn.Render(label) + ui.Hint.Render("  (optional — has a fallback)"))
+		}
+		fmt.Println("      " + ui.Hint.Render(t.Why))
+		fmt.Println("      " + ui.Subtle.Render("install: ") + ui.Accent.Render(t.Install))
+	}
+
+	fmt.Println()
+	if !r.OK() {
+		var names []string
+		for _, t := range r.Missing {
+			if t.Tier == Required {
+				names = append(names, t.Name)
+			}
+		}
+		if r.WindowsNoShell {
+			fmt.Println("  " + ui.Er.Render("✗ cannot continue on native Windows — re-run inside WSL2/Git Bash."))
+		} else {
+			fmt.Println("  " + ui.Er.Render("✗ missing required tool(s): "+strings.Join(names, ", ")+" — install and re-run."))
+		}
+		return false
+	}
+
+	// Only optional tools missing — safe to proceed with a heads-up.
+	fmt.Println("  " + ui.Wn.Render("continuing — only optional tools are missing; features above will degrade."))
+	return true
+}

--- a/tools/wizard/internal/preflight/preflight_test.go
+++ b/tools/wizard/internal/preflight/preflight_test.go
@@ -1,0 +1,225 @@
+package preflight
+
+import (
+	"os/exec"
+	"slices"
+	"testing"
+)
+
+// withStubs swaps the package-level probes for the duration of a test.
+func withStubs(t *testing.T, present map[string]bool, composeV2 bool, fn func()) {
+	t.Helper()
+	origLook, origCompose := lookPath, dockerComposeV2
+	lookPath = func(name string) (string, error) {
+		if present[name] {
+			return "/usr/bin/" + name, nil
+		}
+		return "", exec.ErrNotFound
+	}
+	dockerComposeV2 = func() bool { return composeV2 }
+	t.Cleanup(func() { lookPath, dockerComposeV2 = origLook, origCompose })
+	fn()
+}
+
+// allPresent is the set of executables for a fully-provisioned host.
+var allPresent = map[string]bool{
+	"bash": true, "envsubst": true, "docker": true, "go": true, "gh": true,
+}
+
+func TestToolsCoverEveryOS(t *testing.T) {
+	for _, goos := range []string{"darwin", "linux", "windows", "freebsd"} {
+		got := tools(goos)
+		if len(got) == 0 {
+			t.Fatalf("%s: no tools declared", goos)
+		}
+		for _, tool := range got {
+			if tool.Why == "" || tool.Install == "" {
+				t.Errorf("%s: tool %q missing Why/Install hint", goos, tool.Name)
+			}
+		}
+	}
+}
+
+func TestInstallHintsAreOSSpecific(t *testing.T) {
+	// gettext hint (envsubst) must differ between mac (brew) and linux (apt).
+	find := func(goos, name string) Tool {
+		for _, tool := range tools(goos) {
+			if tool.Name == name {
+				return tool
+			}
+		}
+		t.Fatalf("%s: tool %q not found", goos, name)
+		return Tool{}
+	}
+	mac := find("darwin", "envsubst").Install
+	lin := find("linux", "envsubst").Install
+	win := find("windows", "envsubst").Install
+	if mac == lin || mac == win || lin == win {
+		t.Errorf("envsubst install hints should be OS-specific, got mac=%q linux=%q win=%q", mac, lin, win)
+	}
+}
+
+func TestRequiredVsOptionalTiers(t *testing.T) {
+	byName := map[string]Tier{}
+	for _, tool := range tools("linux") {
+		byName[tool.Name] = tool.Tier
+	}
+	wantRequired := []string{"bash", "envsubst", "docker", "docker compose"}
+	wantOptional := []string{"go", "gh"}
+	for _, n := range wantRequired {
+		if byName[n] != Required {
+			t.Errorf("%q should be Required", n)
+		}
+	}
+	for _, n := range wantOptional {
+		if byName[n] != Optional {
+			t.Errorf("%q should be Optional", n)
+		}
+	}
+}
+
+func TestOSReleaseIDs(t *testing.T) {
+	body := `NAME="Ubuntu"
+ID=ubuntu
+ID_LIKE=debian
+VERSION_ID="22.04"`
+	got := osReleaseIDs(body)
+	if len(got) < 2 || got[0] != "ubuntu" || got[1] != "debian" {
+		t.Errorf("want [ubuntu debian ...], got %v", got)
+	}
+	// ID_LIKE can carry multiple space-separated tokens.
+	multi := osReleaseIDs(`ID=rocky` + "\n" + `ID_LIKE="rhel centos fedora"`)
+	if !slices.Contains(multi, "rocky") || !slices.Contains(multi, "fedora") {
+		t.Errorf("ID_LIKE tokens not split: %v", multi)
+	}
+	// Garbage / empty → no ids, no panic.
+	if len(osReleaseIDs("")) != 0 {
+		t.Error("empty body should yield no ids")
+	}
+}
+
+func TestDetectPkgManager(t *testing.T) {
+	tests := []struct {
+		name     string
+		release  string
+		wantHint string
+	}{
+		{"ubuntu", "ID=ubuntu\nID_LIKE=debian", "apt install gettext-base"},
+		{"debian", "ID=debian", "apt install gettext-base"},
+		{"pop via id_like", "ID=pop\nID_LIKE=\"ubuntu debian\"", "apt install gettext-base"},
+		{"fedora", "ID=fedora", "dnf install gettext"},
+		{"rocky via id_like", "ID=rocky\nID_LIKE=\"rhel centos fedora\"", "dnf install gettext"},
+		{"alpine", "ID=alpine", "apk add gettext"},
+		{"unknown falls back to full list", "ID=exoticos", "apt install gettext-base   ·   dnf install gettext   ·   apk add gettext"},
+		{"no os-release falls back", "", "apt install gettext-base   ·   dnf install gettext   ·   apk add gettext"},
+	}
+	orig := readOSRelease
+	t.Cleanup(func() { readOSRelease = orig })
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			readOSRelease = func() string { return tc.release }
+			got := detectPkgManager().hint("gettext-base", "gettext", "gettext")
+			if got != tc.wantHint {
+				t.Errorf("hint = %q, want %q", got, tc.wantHint)
+			}
+		})
+	}
+}
+
+func TestLinuxToolsUseDetectedManager(t *testing.T) {
+	orig := readOSRelease
+	t.Cleanup(func() { readOSRelease = orig })
+	readOSRelease = func() string { return "ID=fedora" }
+	for _, tool := range tools("linux") {
+		if tool.Name == "envsubst" {
+			if tool.Install != "dnf install gettext" {
+				t.Errorf("envsubst hint = %q, want dnf-narrowed", tool.Install)
+			}
+			return
+		}
+	}
+	t.Fatal("envsubst tool not found in linux set")
+}
+
+func TestReportOK(t *testing.T) {
+	tests := []struct {
+		name    string
+		missing []Tool
+		winNoSh bool
+		wantOK  bool
+	}{
+		{"clean", nil, false, true},
+		{"optional missing", []Tool{{Name: "gh", Tier: Optional}}, false, true},
+		{"required missing", []Tool{{Name: "docker", Tier: Required}}, false, false},
+		{"windows no shell", nil, true, false},
+		{"windows no shell overrides clean", nil, true, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := Report{Missing: tc.missing, WindowsNoShell: tc.winNoSh}
+			if r.OK() != tc.wantOK {
+				t.Errorf("OK()=%v want %v", r.OK(), tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestRunAllPresent(t *testing.T) {
+	withStubs(t, allPresent, true, func() {
+		r := Run()
+		if len(r.Missing) != 0 {
+			t.Errorf("expected nothing missing, got %+v", r.Missing)
+		}
+		if !r.OK() {
+			t.Error("OK() should be true when everything is present")
+		}
+	})
+}
+
+func TestRunDetectsMissingRequired(t *testing.T) {
+	present := map[string]bool{"bash": true, "envsubst": true, "go": true, "gh": true}
+	// docker absent; compose probe also fails.
+	withStubs(t, present, false, func() {
+		r := Run()
+		if r.OK() {
+			t.Fatal("OK() should be false when docker is missing")
+		}
+		var names []string
+		for _, m := range r.Missing {
+			names = append(names, m.Name)
+		}
+		if !slices.Contains(names, "docker") || !slices.Contains(names, "docker compose") {
+			t.Errorf("expected docker + docker compose missing, got %v", names)
+		}
+	})
+}
+
+func TestRunComposeV1OnlyStillMisses(t *testing.T) {
+	// docker binary present but the v2 plugin probe fails (only legacy
+	// docker-compose installed) → the `docker compose` entry must be reported.
+	withStubs(t, allPresent, false, func() {
+		r := Run()
+		var found bool
+		for _, m := range r.Missing {
+			if m.Name == "docker compose" {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("compose v2 miss should be reported even when docker binary exists")
+		}
+	})
+}
+
+func TestHasPOSIXShell(t *testing.T) {
+	withStubs(t, map[string]bool{"bash": true}, false, func() {
+		if !hasPOSIXShell() {
+			t.Error("bash present → hasPOSIXShell true")
+		}
+	})
+	withStubs(t, map[string]bool{}, false, func() {
+		if hasPOSIXShell() {
+			t.Error("no bash → hasPOSIXShell false")
+		}
+	})
+}

--- a/tools/wizard/main.go
+++ b/tools/wizard/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/magma-Devs/smart-router/tools/wizard/internal/health"
 	"github.com/magma-Devs/smart-router/tools/wizard/internal/icons"
 	"github.com/magma-Devs/smart-router/tools/wizard/internal/laststate"
+	"github.com/magma-Devs/smart-router/tools/wizard/internal/preflight"
 	"github.com/magma-Devs/smart-router/tools/wizard/internal/ui"
 )
 
@@ -32,7 +33,16 @@ func main() {
 	specsSrc := flag.String("specs", "", "spec source: remote (github) | local (specs/ dir) | auto. Empty = ask.")
 	diagnose := flag.Bool("diagnose", false, "print terminal + icon capability and exit")
 	last := flag.Bool("last", false, "reprint the run command from the most recent wizard run and exit")
+	preflightOnly := flag.Bool("preflight", false, "check required tools (docker, envsubst, bash, …) and exit")
+	skipPreflight := flag.Bool("skip-preflight", false, "skip the prerequisite tool check (advanced)")
 	flag.Parse()
+
+	if *preflightOnly {
+		if !preflight.Render(preflight.Run()) {
+			os.Exit(1)
+		}
+		return
+	}
 
 	if *diagnose {
 		icons.Diagnose(os.Stdout)
@@ -48,6 +58,17 @@ func main() {
 	specDir := filepath.Join(repoRoot, "specs")
 
 	fmt.Print(ui.Banner(100))
+
+	// Prerequisite gate: verify the external tools the run step shells out to
+	// (bash, envsubst, docker + compose v2) before walking the flow, so a
+	// missing tool surfaces here — not three screens in when the run fails. The
+	// check is OS-adaptive and steers native-Windows users to WSL. --skip-preflight
+	// is the advanced escape hatch.
+	if !*skipPreflight {
+		if !preflight.Render(preflight.Run()) {
+			os.Exit(1)
+		}
+	}
 
 	// Spec source defaults to AUTO (remote github, fall back to local specs/).
 	// An explicit --specs flag overrides; it can also be changed from inside the


### PR DESCRIPTION
## Summary

- The wizard shells out to **bash**, **envsubst**, and **docker compose (v2)** at run time, but nothing verified they were installed — a missing tool only surfaced several screens in, when the run step failed.
- Adds a **preflight gate (step 0)** that runs on launch, before the flow, so a missing dependency hard-stops up front with actionable install guidance.

## What it does

- **Tiers** tools: *Required* (`bash`, `envsubst`, `docker`, `docker compose` v2) vs *Optional* (`go`, `gh` — both have fallbacks). Hard-stops only on a required miss; warns-and-continues on optional.
- **Per-tool guidance** — for each missing tool prints what it's for + how to install it, with **OS-specific** hints. On Linux the hint is **narrowed to the detected package manager** (apt/dnf/apk, resolved from `/etc/os-release` `ID` + `ID_LIKE`), falling back to the full list on unknown distros / minimal containers.
- **Windows → WSL**: detects native Windows without a POSIX shell and steers the user to WSL2 / Git Bash, since the bash-based run step can't work there. (Detect-and-guide, not a native port.)
- The `docker compose` check runs `docker compose version`, so legacy `docker-compose` v1 alone is correctly flagged as missing.

## Wiring

- `main.go` — gate after the banner; `--preflight` (check + exit) and `--skip-preflight` (escape hatch) flags.
- `Makefile` — `make wizard` now runs `wizard-preflight` **before** `build` so a missing tool fails fast instead of after a full router compile; new `make wizard-preflight` target.
- `README` — Prerequisites section with the tool table + Windows note.

## Test plan

- `cd tools/wizard && go test ./...` — new `internal/preflight` suite covers distro detection (apt/dnf/apk incl. `ID_LIKE` derivatives + fallbacks), Required/Optional tiering, the compose-v2 probe, and the Windows-no-shell branch. Probes are indirected — no real PATH/filesystem dependency.
- `go build ./...` + `go vet ./...` clean.
- Manually verified: happy path (`✓ all prerequisites present`), failure path (stripped PATH → required tools listed with narrowed `apt install gettext-base` hint on this Ubuntu box, exit 1), and `make -n wizard` shows preflight → build → launch order.

## Breaking changes

None. New flags are additive; `--skip-preflight` bypasses the gate for advanced use.