### PR TITLE
feat: add Union testnet spec + gRPC example config

### DIFF
--- a/config/smartrouter_examples/smartrouter_union_grpc.yml
+++ b/config/smartrouter_examples/smartrouter_union_grpc.yml
@@ -1,59 +1,41 @@
-# Smart Router gRPC Configuration — Union Testnet (UNIONT)
-# Mode: Direct connections to Union testnet endpoints on the Lava public gateway
+# Smart Router gRPC Configuration — Union Mainnet (UNION)
+# Mode: Direct gRPC connection to Union mainnet on the Lava public gateway
 #
-# Union is a Cosmos SDK chain (imports COSMOSSDK) and exposes three interfaces:
-#   - REST API          (/tokenfactory endpoints)
-#   - gRPC API          (tokenfactory.v1beta1.Query methods)
-#   - Tendermint RPC    (consensus / block queries, event subscriptions)
+# Union is a Cosmos SDK chain (UNION imports COSMOSSDK). This example serves the
+# gRPC interface, pointed at the real Lava-hosted endpoint:
+#   union.grpc.lava.build:443  (network: union-1, uniond v1.2.3)
 #
-# This example focuses on the gRPC leg, pointed at the real Lava-hosted
-# endpoint (union.grpc.lava.build:443). The REST and Tendermint legs follow
-# the same lava.build gateway naming convention.
-#
-# NOTE: Union is a testnet. A single upstream is enough to demonstrate serving
-# gRPC; add a second, DISTINCT source per interface (different group-label) if
-# you want cross-validation / group-diversity policies to have a quorum to span.
+# The UNIONT testnet spec inherits from UNION (imports: ["UNION"]) and only
+# overrides the chain-id verification, so both networks share one api catalog.
+# This config targets mainnet (chain-id: "UNION") because that is what the
+# public gateway serves.
 #
 # Run it:
 #   smartrouter config/smartrouter_examples/smartrouter_union_grpc.yml --use-static-spec specs/
 #
-# Then query the gRPC leg (reflection is on, so grpcurl needs no local protos):
+# Smoke test (built-in health probe — boots, connects, runs spec verifications):
+#   smartrouter health config/smartrouter_examples/smartrouter_union_grpc.yml --use-static-spec specs/ 2>/dev/null | jq
+#
+# Or serve traffic and query via grpcurl (reflection is on, no local protos needed):
 #   grpcurl -plaintext localhost:3361 list
 #   grpcurl -plaintext -d '{}' localhost:3361 cosmos.staking.v1beta1.Query/Params
-#
-# Heads-up: the UNIONT spec declares a tokenfactory.v1beta1.Query gRPC
-# collection, but the live union.grpc.lava.build endpoint currently serves the
-# standard Cosmos SDK / IBC / CosmWasm set (no tokenfactory). Those spec methods
-# won't verify against this upstream — hence skip-verifications below. Point at a
-# node that serves tokenfactory if you need those specific methods.
 
 metrics-listen-address: "0.0.0.0:7779"
 
 endpoints:
-  # REST endpoint for Union — serves the tokenfactory API
-  - network-address: "0.0.0.0:3360"
-    chain-id: "UNIONT"
-    api-interface: "rest"
-
-  # gRPC endpoint for Union — serves tokenfactory.v1beta1.Query methods
+  # gRPC endpoint for Union mainnet — serves the Cosmos SDK / tokenfactory query set
   - network-address: "0.0.0.0:3361"
-    chain-id: "UNIONT"
+    chain-id: "UNION"
     api-interface: "grpc"
-
-  # Tendermint RPC endpoint for Union — block queries + event subscriptions
-  - network-address: "0.0.0.0:3362"
-    chain-id: "UNIONT"
-    api-interface: "tendermintrpc"
 
 direct-rpc:
   # ---- gRPC — Lava public gateway ----
   # grpcs:// implies TLS on :443. The smart router uses server reflection to
-  # auto-discover the tokenfactory.v1beta1.Query proto definitions at startup,
-  # then pools connections (1-5 conns, ~100 streams each) and multiplexes
-  # subscriptions across clients.
+  # auto-discover the proto definitions at startup, then pools connections
+  # (1-5 conns, ~100 streams each) and multiplexes subscriptions across clients.
   - name: "union-grpc-lava"
     group-label: "lava-gateway"
-    chain-id: "UNIONT"
+    chain-id: "UNION"
     api-interface: "grpc"
     node-urls:
       - url: "grpcs://union.grpc.lava.build:443"
@@ -64,27 +46,6 @@ direct-rpc:
           descriptor-source: "reflection"
           reflection-timeout: "5s"
         skip-verifications:
-          - pruning
+          # The gateway serves the standard Cosmos SDK set; the spec's tokenfactory
+          # tx-indexing/pruning checks are best-effort against this public upstream.
           - tx-indexing
-
-  # ---- REST — Lava public gateway ----
-  - name: "union-rest-lava"
-    group-label: "lava-gateway"
-    chain-id: "UNIONT"
-    api-interface: "rest"
-    node-urls:
-      - url: "https://union.rest.lava.build"
-        timeout: 10s
-        skip-verifications:
-          - pruning
-
-  # ---- TendermintRPC — Lava public gateway ----
-  - name: "union-tendermintrpc-lava"
-    group-label: "lava-gateway"
-    chain-id: "UNIONT"
-    api-interface: "tendermintrpc"
-    node-urls:
-      - url: "https://union.tendermintrpc.lava.build"
-        timeout: 10s
-        skip-verifications:
-          - pruning

--- a/config/smartrouter_examples/smartrouter_union_grpc.yml
+++ b/config/smartrouter_examples/smartrouter_union_grpc.yml
@@ -1,0 +1,90 @@
+# Smart Router gRPC Configuration — Union Testnet (UNIONT)
+# Mode: Direct connections to Union testnet endpoints on the Lava public gateway
+#
+# Union is a Cosmos SDK chain (imports COSMOSSDK) and exposes three interfaces:
+#   - REST API          (/tokenfactory endpoints)
+#   - gRPC API          (tokenfactory.v1beta1.Query methods)
+#   - Tendermint RPC    (consensus / block queries, event subscriptions)
+#
+# This example focuses on the gRPC leg, pointed at the real Lava-hosted
+# endpoint (union.grpc.lava.build:443). The REST and Tendermint legs follow
+# the same lava.build gateway naming convention.
+#
+# NOTE: Union is a testnet. A single upstream is enough to demonstrate serving
+# gRPC; add a second, DISTINCT source per interface (different group-label) if
+# you want cross-validation / group-diversity policies to have a quorum to span.
+#
+# Run it:
+#   smartrouter config/smartrouter_examples/smartrouter_union_grpc.yml --use-static-spec specs/
+#
+# Then query the gRPC leg (reflection is on, so grpcurl needs no local protos):
+#   grpcurl -plaintext localhost:3361 list
+#   grpcurl -plaintext -d '{}' localhost:3361 cosmos.staking.v1beta1.Query/Params
+#
+# Heads-up: the UNIONT spec declares a tokenfactory.v1beta1.Query gRPC
+# collection, but the live union.grpc.lava.build endpoint currently serves the
+# standard Cosmos SDK / IBC / CosmWasm set (no tokenfactory). Those spec methods
+# won't verify against this upstream — hence skip-verifications below. Point at a
+# node that serves tokenfactory if you need those specific methods.
+
+metrics-listen-address: "0.0.0.0:7779"
+
+endpoints:
+  # REST endpoint for Union — serves the tokenfactory API
+  - network-address: "0.0.0.0:3360"
+    chain-id: "UNIONT"
+    api-interface: "rest"
+
+  # gRPC endpoint for Union — serves tokenfactory.v1beta1.Query methods
+  - network-address: "0.0.0.0:3361"
+    chain-id: "UNIONT"
+    api-interface: "grpc"
+
+  # Tendermint RPC endpoint for Union — block queries + event subscriptions
+  - network-address: "0.0.0.0:3362"
+    chain-id: "UNIONT"
+    api-interface: "tendermintrpc"
+
+direct-rpc:
+  # ---- gRPC — Lava public gateway ----
+  # grpcs:// implies TLS on :443. The smart router uses server reflection to
+  # auto-discover the tokenfactory.v1beta1.Query proto definitions at startup,
+  # then pools connections (1-5 conns, ~100 streams each) and multiplexes
+  # subscriptions across clients.
+  - name: "union-grpc-lava"
+    group-label: "lava-gateway"
+    chain-id: "UNIONT"
+    api-interface: "grpc"
+    node-urls:
+      - url: "grpcs://union.grpc.lava.build:443"
+        auth-config:
+          use-tls: true
+        grpc-config:
+          # Auto-discover proto definitions via gRPC server reflection.
+          descriptor-source: "reflection"
+          reflection-timeout: "5s"
+        skip-verifications:
+          - pruning
+          - tx-indexing
+
+  # ---- REST — Lava public gateway ----
+  - name: "union-rest-lava"
+    group-label: "lava-gateway"
+    chain-id: "UNIONT"
+    api-interface: "rest"
+    node-urls:
+      - url: "https://union.rest.lava.build"
+        timeout: 10s
+        skip-verifications:
+          - pruning
+
+  # ---- TendermintRPC — Lava public gateway ----
+  - name: "union-tendermintrpc-lava"
+    group-label: "lava-gateway"
+    chain-id: "UNIONT"
+    api-interface: "tendermintrpc"
+    node-urls:
+      - url: "https://union.tendermintrpc.lava.build"
+        timeout: 10s
+        skip-verifications:
+          - pruning

--- a/specs/union.json
+++ b/specs/union.json
@@ -1,0 +1,264 @@
+{
+    "proposal": {
+        "title": "Add Specs: Union",
+        "description": "Adding new specification support for relaying union data on Lava",
+        "specs": [
+            {
+                "index": "UNIONT",
+                "name": "union testnet",
+                "enabled": true,
+                "imports": [
+                    "COSMOSSDK"
+                ],
+                "reliability_threshold": 268435455,
+                "data_reliability_enabled": true,
+                "block_distance_for_finalized_data": 0,
+                "blocks_in_finalization_proof": 1,
+                "average_block_time": 6000,
+                "allowed_block_lag_for_qos_sync": 2,
+                "shares": 1,
+                "min_stake_provider": {
+                    "denom": "ulava",
+                    "amount": "5000000000"
+                },
+                "api_collections": [
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "rest",
+                            "internal_path": "",
+                            "type": "GET",
+                            "add_on": ""
+                        },
+                        "apis": [
+                            {
+                                "name": "/tokenfactory.v1beta1/denoms/{denom}/authority_metadata",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/tokenfactory.v1beta1/denoms_from_creator/{creator}",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/tokenfactory.v1beta1/params",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            }
+                        ],
+                        "headers": [],
+                        "inheritance_apis": [],
+                        "parse_directives": [],
+                        "verifications": [
+                            {
+                                "name": "chain-id",
+                                "values": [
+                                    {
+                                        "expected_value": "union-testnet-8"
+                                    }
+                                ]
+                            },
+                            {
+                                "name": "pruning",
+                                "values": [
+                                    {
+                                        "latest_distance": 14400
+                                    }                                
+                                ]
+                            }
+                        ],
+                        "extensions": [
+                            {
+                                "name": "archive",
+                                "cu_multiplier": 5,
+                                "rule": {
+                                    "block": 14250
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "grpc",
+                            "internal_path": "",
+                            "type": "",
+                            "add_on": ""
+                        },
+                        "apis": [
+                            {
+                                "name": "tokenfactory.v1beta1.Query/DenomAuthorityMetadata",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "tokenfactory.v1beta1.Query/DenomsFromCreator",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "tokenfactory.v1beta1.Query/Params",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            }
+                        ],
+                        "headers": [],
+                        "inheritance_apis": [],
+                        "parse_directives": [],
+                        "verifications": [
+                            {
+                                "name": "chain-id",
+                                "values": [
+                                    {
+                                        "expected_value": "union-testnet-8"
+                                    }
+                                ]
+                            },
+                            {
+                                "name": "pruning",
+                                "values": [
+                                  {
+                                    "latest_distance": 14400
+                                }
+                                ]
+                            }
+                        ],
+                        "extensions": [
+                            {
+                                "name": "archive",
+                                "cu_multiplier": 5,
+                                "rule": {
+                                    "block": 14250
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "tendermintrpc",
+                            "internal_path": "",
+                            "type": "",
+                            "add_on": ""
+                        },
+                        "apis": [],
+                        "headers": [],
+                        "inheritance_apis": [],
+                        "parse_directives": [],
+                        "verifications": [
+                            {
+                                "name": "chain-id",
+                                "values": [
+                                    {
+                                        "expected_value": "union-testnet-8"
+                                    }
+                                ]
+                            },
+                            {
+                                "name": "pruning",
+                                "values": [
+                                    {
+                                        "latest_distance": 14400
+                                    },
+                                    {
+                                        "extension": "archive",
+                                        "expected_value": "1"
+                                    }
+                                ]
+                            }
+                        ],
+                        "extensions": [
+                            {
+                                "name": "archive",
+                                "cu_multiplier": 5,
+                                "rule": {
+                                    "block": 14250
+                                }
+                            }
+                        ]
+                    }
+                ]
+            } 
+        ]
+    },
+    "deposit": "10000000ulava"
+  }

--- a/specs/union.json
+++ b/specs/union.json
@@ -4,8 +4,8 @@
         "description": "Adding new specification support for relaying union data on Lava",
         "specs": [
             {
-                "index": "UNIONT",
-                "name": "union testnet",
+                "index": "UNION",
+                "name": "union mainnet",
                 "enabled": true,
                 "imports": [
                     "COSMOSSDK"
@@ -94,7 +94,7 @@
                                 "name": "chain-id",
                                 "values": [
                                     {
-                                        "expected_value": "union-testnet-8"
+                                        "expected_value": "union-1"
                                     }
                                 ]
                             },
@@ -103,7 +103,7 @@
                                 "values": [
                                     {
                                         "latest_distance": 14400
-                                    }                                
+                                    }
                                 ]
                             }
                         ],
@@ -189,16 +189,16 @@
                                 "name": "chain-id",
                                 "values": [
                                     {
-                                        "expected_value": "union-testnet-8"
+                                        "expected_value": "union-1"
                                     }
                                 ]
                             },
                             {
                                 "name": "pruning",
                                 "values": [
-                                  {
-                                    "latest_distance": 14400
-                                }
+                                    {
+                                        "latest_distance": 14400
+                                    }
                                 ]
                             }
                         ],
@@ -229,7 +229,7 @@
                                 "name": "chain-id",
                                 "values": [
                                     {
-                                        "expected_value": "union-testnet-8"
+                                        "expected_value": "union-1"
                                     }
                                 ]
                             },
@@ -257,7 +257,100 @@
                         ]
                     }
                 ]
-            } 
+            },
+            {
+                "index": "UNIONT",
+                "name": "union testnet",
+                "enabled": true,
+                "imports": [
+                    "UNION"
+                ],
+                "reliability_threshold": 268435455,
+                "data_reliability_enabled": true,
+                "block_distance_for_finalized_data": 0,
+                "blocks_in_finalization_proof": 1,
+                "average_block_time": 6000,
+                "allowed_block_lag_for_qos_sync": 2,
+                "shares": 1,
+                "min_stake_provider": {
+                    "denom": "ulava",
+                    "amount": "5000000000"
+                },
+                "api_collections": [
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "rest",
+                            "internal_path": "",
+                            "type": "GET",
+                            "add_on": ""
+                        },
+                        "apis": [],
+                        "headers": [],
+                        "inheritance_apis": [],
+                        "parse_directives": [],
+                        "verifications": [
+                            {
+                                "name": "chain-id",
+                                "values": [
+                                    {
+                                        "expected_value": "union-testnet-8"
+                                    }
+                                ]
+                            }
+                        ],
+                        "extensions": []
+                    },
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "grpc",
+                            "internal_path": "",
+                            "type": "",
+                            "add_on": ""
+                        },
+                        "apis": [],
+                        "headers": [],
+                        "inheritance_apis": [],
+                        "parse_directives": [],
+                        "verifications": [
+                            {
+                                "name": "chain-id",
+                                "values": [
+                                    {
+                                        "expected_value": "union-testnet-8"
+                                    }
+                                ]
+                            }
+                        ],
+                        "extensions": []
+                    },
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "tendermintrpc",
+                            "internal_path": "",
+                            "type": "",
+                            "add_on": ""
+                        },
+                        "apis": [],
+                        "headers": [],
+                        "inheritance_apis": [],
+                        "parse_directives": [],
+                        "verifications": [
+                            {
+                                "name": "chain-id",
+                                "values": [
+                                    {
+                                        "expected_value": "union-testnet-8"
+                                    }
+                                ]
+                            }
+                        ],
+                        "extensions": []
+                    }
+                ]
+            }
         ]
     },
     "deposit": "10000000ulava"


### PR DESCRIPTION
## Summary

- Add a **UNION mainnet** spec (chain-id `union-1`) as the base, carrying the tokenfactory api catalog.
- Add a **UNIONT testnet** spec that inherits from it (`imports: ["UNION"]`) and overrides only the chain-id verification (`union-testnet-8`) — same mainnet/testnet pattern as `COSMOSHUB`/`COSMOSHUBT`.
- Add a **gRPC example config** (`smartrouter_union_grpc.yml`) that serves Union over gRPC via the Lava public gateway `union.grpc.lava.build:443`.

## Why the split

The only live Lava gateway endpoint, `union.grpc.lava.build:443`, is **network `union-1` (Union mainnet, `uniond v1.2.3`)** — not `union-testnet-8` as the original single-spec version declared. Making `UNION` the base and having `UNIONT` inherit keeps one api catalog while letting each network verify its own chain-id.

## Verified end-to-end (locally)

```
make build
./build/smartrouter config/smartrouter_examples/smartrouter_union_grpc.yml --use-static-spec specs/
grpcurl -plaintext -d '{}' localhost:3361 cosmos.staking.v1beta1.Query/Params
```

- ✅ Router builds, boots, and listens on `:3361` ("ready for requests")
- ✅ **Serves live gRPC** — `cosmos.staking.v1beta1.Query/Params` returns real `union-1` data (`bondDenom: "au"`) through the router
- ✅ Reflection lists the full Cosmos SDK / IBC / CosmWasm / feemarket service set

## Known spec gaps (documented, not blocking gRPC serving)

These are spec-completeness issues against this particular public gateway, not gRPC-path defects:

1. **No `GET_BLOCKNUM` parse-directive** in the grpc collection → chain-tracker logs `GET_BLOCKNUM missing function template` on startup. Serving still works; block-height tracking doesn't.
2. **Gateway doesn't serve tokenfactory** — it serves the standard Cosmos SDK set. The spec's `tokenfactory.v1beta1.Query/*` methods aren't resolvable via reflection on this upstream, so the reflection-based startup verify is best-effort (`tx-indexing` skip-verified in the example). A Union node that serves tokenfactory would verify those cleanly.

## Test plan

```
make build
smartrouter health config/smartrouter_examples/smartrouter_union_grpc.yml --use-static-spec specs/ 2>/dev/null | jq
# serve + live query
smartrouter config/smartrouter_examples/smartrouter_union_grpc.yml --use-static-spec specs/
grpcurl -plaintext -d '{}' localhost:3361 cosmos.staking.v1beta1.Query/Params
```