### PR TITLE
feat(cors): add --cors-expose-headers to expose response headers to browsers

### DIFF
--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -623,6 +623,13 @@ func createAndSetupBaseAppListener(cmdFlags common.ConsumerCmdFlags, healthCheck
 	app.Use(func(c *fiber.Ctx) error {
 		// we set up wild card by default.
 		c.Set("Access-Control-Allow-Origin", cmdFlags.OriginFlag)
+		// Expose selected response headers to browser JS. Access-Control-Expose-
+		// Headers must be present on the ACTUAL response (not just the preflight)
+		// for fetch() to read a non-simple header like Lava-Provider-Address.
+		// Empty flag => header omitted (only simple response headers readable).
+		if cmdFlags.ExposeHeadersFlag != "" {
+			c.Set("Access-Control-Expose-Headers", cmdFlags.ExposeHeadersFlag)
+		}
 		// Handle preflight requests directly
 		if c.Method() == "OPTIONS" {
 			// set up all allowed methods.

--- a/protocol/common/cobra_common.go
+++ b/protocol/common/cobra_common.go
@@ -24,6 +24,7 @@ const (
 	CorsCredentialsFlag     = "cors-credentials"       // comma separated list of headers, or * for all, default simple cors specification headers
 	CorsOriginFlag          = "cors-origin"            // comma separated list of origins, or * for all, default enabled completely
 	CorsMethodsFlag         = "cors-methods"           // comma separated list of methods, default "GET,POST,PUT,DELETE,OPTIONS"
+	CorsExposeHeadersFlag   = "cors-expose-headers"    // comma separated list of response headers to expose to the browser (Access-Control-Expose-Headers), or * for all. Empty = none exposed (browsers can then only read simple response headers).
 	CDNCacheDurationFlag    = "cdn-cache-duration"     // how long to cache the preflight response default 24 hours (in seconds) "86400"
 	RelaysHealthEnableFlag  = "relays-health-enable"   // enable relays health check, default true
 	RelayHealthIntervalFlag = "relays-health-interval" // interval between each relay health check, default 5m
@@ -137,6 +138,7 @@ type ConsumerCmdFlags struct {
 	CredentialsFlag          string        // access-control-allow-credentials, defaults to "true"
 	OriginFlag               string        // comma separated list of origins, or * for all, default enabled completely
 	MethodsFlag              string        // whether to allow access control headers *, most proxies have their own access control so its not required
+	ExposeHeadersFlag        string        // Access-Control-Expose-Headers — response headers the browser is allowed to read (e.g. Lava-Provider-Address). Empty = none.
 	CDNCacheDuration         string        // how long to cache the preflight response defaults 24 hours (in seconds) "86400"
 	RelaysHealthEnableFlag   bool          // enables relay health check
 	RelaysHealthIntervalFlag time.Duration // interval for relay health check

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -2245,6 +2245,7 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 				CredentialsFlag:          viper.GetString(common.CorsCredentialsFlag),
 				OriginFlag:               viper.GetString(common.CorsOriginFlag),
 				MethodsFlag:              viper.GetString(common.CorsMethodsFlag),
+				ExposeHeadersFlag:        viper.GetString(common.CorsExposeHeadersFlag),
 				CDNCacheDuration:         viper.GetString(common.CDNCacheDurationFlag),
 				RelaysHealthEnableFlag:   viper.GetBool(common.RelaysHealthEnableFlag),
 				RelaysHealthIntervalFlag: viper.GetDuration(common.RelayHealthIntervalFlag),
@@ -2362,6 +2363,7 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	cmdRPCSmartRouter.Flags().String(common.CorsHeadersFlag, "", "Set up CORS allowed headers, * for all, default simple cors specification headers")
 	cmdRPCSmartRouter.Flags().String(common.CorsOriginFlag, "*", "Set up CORS allowed origin, enabled * by default")
 	cmdRPCSmartRouter.Flags().String(common.CorsMethodsFlag, "GET,POST,PUT,DELETE,OPTIONS", "set up Allowed OPTIONS methods, defaults to: \"GET,POST,PUT,DELETE,OPTIONS\"")
+	cmdRPCSmartRouter.Flags().String(common.CorsExposeHeadersFlag, "", "Set up CORS Access-Control-Expose-Headers — response headers a browser may read (e.g. \"Lava-Provider-Address\", or \"*\" for all). Empty by default (only simple response headers are readable from JS).")
 	cmdRPCSmartRouter.Flags().String(common.CDNCacheDurationFlag, "86400", "set up preflight options response cache duration, default 86400 (24h in seconds)")
 	cmdRPCSmartRouter.Flags().Bool(common.SharedStateFlag, false, "Share the consumer consistency state with the cache service. this should be used with cache backend enabled if you want to state sync multiple rpc consumers")
 	// relays health check related flags


### PR DESCRIPTION
# Description

Adds a `--cors-expose-headers` flag so the router can set
`Access-Control-Expose-Headers` on its responses, letting browser JS read
non-simple response headers (most usefully **`Lava-Provider-Address`**,
which carries the upstream that served a relay, or `Cached` on a cache hit).

## Why

The client-facing CORS middleware (`protocol/chainlib/common.go`) sets
`Access-Control-Allow-Origin` / `-Allow-Methods` / `-Allow-Headers`, but
**never** `Access-Control-Expose-Headers`. Per the Fetch spec, a browser
`fetch()` can only read *simple* response headers (`Content-Type`,
`Content-Length`, …) unless the server explicitly exposes others. So even
though the router already emits `Lava-Provider-Address`, a browser client
(e.g. the Smart Router Dashboard's Live-test console) gets `null` when it
tries to read it — it can't show which upstream served the request or
whether the response came from cache.

## What

- New `--cors-expose-headers` flag (mirrors the existing `--cors-*` flags):
  a comma-separated header list, or `*` for all.
- When set, the middleware adds `Access-Control-Expose-Headers` to the
  **actual** response (not just the preflight — the header must be present
  on the real response for `fetch()` to read it).
- **Empty by default → behaviour unchanged** (header omitted) unless a
  deployment opts in, e.g. `--cors-expose-headers "Lava-Provider-Address"`.

## Verification

- `go build ./cmd/smartrouter` — clean.
- `smartrouter rpcsmartrouter --help` lists `--cors-expose-headers` alongside
  the other `cors-*` flags.
- With the flag set, `Access-Control-Expose-Headers: Lava-Provider-Address`
  appears on relay responses and the header becomes readable from browser JS.

---

## Author Checklist

* [x] included the correct type prefix in the PR title (`feat:`)
* [x] targeted the `main` branch
* [x] no breaking change (flag is opt-in; default preserves current behaviour)
