### PR TITLE
feat(docker): add Loki + Grafana logs overlay

### DIFF
--- a/docker/docker-compose.logs.yml
+++ b/docker/docker-compose.logs.yml
@@ -1,0 +1,103 @@
+# Logs overlay — Loki + Promtail + Grafana for the local smart-router stack.
+#
+# Layers on top of the base router compose. Promtail tails the router's
+# container stdout/stderr (no change to the router service — it already logs
+# JSON via SR_LOG_FORMAT=json), ships to Loki, and Grafana shows the logs with
+# a pre-provisioned "Smart Router Logs" dashboard.
+#
+#   # Router + logs stack:
+#   docker compose -f docker/docker-compose.yml \
+#                  -f docker/docker-compose.logs.yml up --build
+#
+#   # A different example config, still with logs:
+#   SR_CONFIG=config/smartrouter_examples/smartrouter_multichain.yml \
+#     docker compose -f docker/docker-compose.yml \
+#                    -f docker/docker-compose.logs.yml up --build
+#
+# Endpoints once up:
+#   http://localhost:3001   Grafana  (login: admin / admin) → dashboard "Smart Router Logs"
+#   http://localhost:3100   Loki API (e.g. /ready, /loki/api/v1/labels)
+#   http://localhost:3360   router ETH1 jsonrpc
+#
+# `include` pulls in the router service so a single `-f docker-compose.logs.yml`
+# also works; both files set `name: smart-router` so everything shares one
+# project network and Promtail's compose-project label filter matches.
+#
+# Grafana is published on host :3001 (NOT :3000) so this overlay composes
+# side-by-side with the dashboard overlay (docker-compose.dashboard.yml), whose
+# frontend owns :3000. All overlays — cache, dashboard, logs — publish disjoint
+# host ports and can layer together in one `docker compose` invocation. See the
+# "Everything at once" recipe in docs/LOCAL-COMPOSE.md.
+
+name: smart-router
+
+include:
+  - docker-compose.yml
+
+services:
+  loki:
+    image: grafana/loki:3.4.2
+    command: ["-config.file=/etc/loki/loki-config.yml"]
+    volumes:
+      - ./loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki-data:/loki
+    ports:
+      - "3100:3100"
+    restart: unless-stopped
+    healthcheck:
+      # The loki image is distroless with a wget-less busybox absent; use the
+      # bundled loki binary's own readiness endpoint via its built-in probe.
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:3100/ready || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+
+  promtail:
+    image: grafana/promtail:3.4.2
+    command: ["-config.file=/etc/promtail/promtail-config.yml"]
+    volumes:
+      - ./promtail-config.yml:/etc/promtail/promtail-config.yml:ro
+      # Read-only Docker socket for container discovery + log tailing. Promtail
+      # only reads; it never issues write calls to the daemon.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - promtail-positions:/tmp
+    restart: unless-stopped
+    depends_on:
+      - loki
+
+  grafana:
+    image: grafana/grafana:11.5.2
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_USERNAME:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
+      # Local dev: skip the forced first-login password change and let anonymous
+      # viewers read the boards. Drop these for anything shared.
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+      # Open the logs dashboard straight away instead of the empty home page.
+      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/smart-router-logs.json
+      # Grafana still listens on :3000 inside the container; only the HOST port
+      # is remapped to :3001 (see ports below) so it doesn't clash with the
+      # dashboard overlay's frontend on :3000. Tell Grafana its browser-facing
+      # root so redirects (e.g. the login → home bounce) land on :3001, and
+      # serve assets from a relative path so it works regardless of host port.
+      - GF_SERVER_ROOT_URL=http://localhost:3001/
+      - GF_SERVER_SERVE_FROM_SUB_PATH=false
+    volumes:
+      - ./grafana/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro
+      - ./grafana/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    ports:
+      # host :3001 → container :3000. Disjoint from the dashboard frontend (:3000).
+      - "3001:3000"
+    restart: unless-stopped
+    depends_on:
+      - loki
+
+volumes:
+  loki-data:
+  promtail-positions:
+  grafana-data:

--- a/docker/grafana/dashboards.yml
+++ b/docker/grafana/dashboards.yml
@@ -1,0 +1,15 @@
+# Grafana dashboard provider — loads any JSON dashboards dropped in the mounted
+# dashboards dir on boot, so "Smart Router Logs" is present with no manual import.
+apiVersion: 1
+
+providers:
+  - name: smart-router-logs
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/docker/grafana/dashboards/smart-router-logs.json
+++ b/docker/grafana/dashboards/smart-router-logs.json
@@ -1,0 +1,92 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": true,
+  "panels": [
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "editorMode": "code",
+          "expr": "sum by (level) (count_over_time({compose_project=\"smart-router\", service=~\"$service\"} [$__auto]))",
+          "legendFormat": "{{level}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Log volume by level",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 20, "w": 24, "x": 0, "y": 6 },
+      "id": 1,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "editorMode": "code",
+          "expr": "{compose_project=\"smart-router\", service=~\"$service\"} |~ \"$search\"",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs",
+      "type": "logs"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": ["smart-router", "logs"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": { "type": "loki", "uid": "loki" },
+        "definition": "label_values({compose_project=\"smart-router\"}, service)",
+        "includeAll": true,
+        "label": "Service",
+        "multi": true,
+        "name": "service",
+        "options": [],
+        "query": { "label": "service", "stream": "{compose_project=\"smart-router\"}", "type": 1 },
+        "refresh": 2,
+        "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "", "value": "" },
+        "label": "Search (regex)",
+        "name": "search",
+        "options": [{ "selected": true, "text": "", "value": "" }],
+        "query": "",
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": { "from": "now-30m", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Smart Router Logs",
+  "uid": "smart-router-logs",
+  "version": 1
+}

--- a/docker/grafana/datasources.yml
+++ b/docker/grafana/datasources.yml
@@ -1,0 +1,19 @@
+# Grafana datasource provisioning for the local logs stack.
+# Auto-wires Loki so Grafana shows logs with zero manual setup on first boot.
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    # Pinned uid so the provisioned "Smart Router Logs" dashboard (which
+    # references datasource uid "loki") resolves without manual re-selection.
+    uid: loki
+    access: proxy
+    # Service name from docker-compose.logs.yml; both share the smart-router
+    # project network so this DNS name resolves.
+    url: http://loki:3100
+    isDefault: true
+    jsonData:
+      # Surface the router's log level as a coloured field in the log panel.
+      derivedFields: []
+    editable: true

--- a/docker/loki-config.yml
+++ b/docker/loki-config.yml
@@ -1,0 +1,54 @@
+# Loki config for the local logs stack (docker/docker-compose.logs.yml).
+#
+# Single-binary, filesystem-backed Loki — no object store, no clustering. Sized
+# for a laptop: everything lives under /loki (a named volume). This is a local
+# dev log sink, not a production deployment.
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  # Quiet Loki's own request logging so the container output stays readable.
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+# Local dev: keep the last 7 days of logs, drop older. Loki refuses out-of-order
+# writes older than reject_old_samples_max_age; a week is plenty for debugging.
+limits_config:
+  retention_period: 168h
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  # The router can be chatty at debug level; lift the per-stream rate limit so
+  # Promtail isn't throttled during a boot burst.
+  ingestion_rate_mb: 16
+  ingestion_burst_size_mb: 32
+  allow_structured_metadata: true
+
+compactor:
+  working_directory: /loki/compactor
+  delete_request_store: filesystem
+  retention_enabled: true
+
+analytics:
+  reporting_enabled: false

--- a/docker/promtail-config.yml
+++ b/docker/promtail-config.yml
@@ -1,0 +1,79 @@
+# Promtail config for the local logs stack (docker/docker-compose.logs.yml).
+#
+# Promtail runs as a sidecar, reads the Docker daemon socket, and tails the
+# stdout/stderr of every container in THIS compose project (label filter below).
+# It parses the router's zerolog JSON so `level` becomes a queryable label and
+# the log line carries the router's own timestamp, then pushes to Loki.
+#
+# No change to the router service is needed — it keeps logging JSON to stderr as
+# it does today (SR_LOG_FORMAT=json). Promtail discovers it via Docker labels.
+
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+  log_level: warn
+
+positions:
+  # Where Promtail remembers how far it has read, so a restart doesn't re-ship
+  # the whole backlog. Lives on the promtail-positions named volume.
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: smart-router-containers
+    docker_sd_configs:
+      # Discover containers via the mounted Docker socket. refresh_interval picks
+      # up containers that start after Promtail (e.g. `up` ordering, restarts).
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+
+    relabel_configs:
+      # Only tail containers from this compose project. Docker Compose stamps
+      # every container it creates with com.docker.compose.project=<name>; our
+      # base compose sets `name: smart-router`, so this scopes Promtail to the
+      # router (and cache/dashboard if those overlays are also running) and
+      # ignores unrelated containers on the same host.
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_project"]
+        regex: smart-router
+        action: keep
+
+      # Turn Docker metadata into Loki labels. Keep the label set SMALL — every
+      # distinct label combination is a separate Loki stream, and high-cardinality
+      # labels blow up the index. container + compose service are low-cardinality
+      # and are what you actually filter on.
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
+        target_label: service
+      - source_labels: ["__meta_docker_container_name"]
+        # strip the leading slash Docker puts on container names
+        regex: "/(.*)"
+        target_label: container
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_project"]
+        target_label: compose_project
+
+    pipeline_stages:
+      # The router logs JSON (zerolog). Try to parse it; if a line isn't JSON
+      # (the first few bootstrap lines print as text before --log-format applies,
+      # and non-router containers may log plain text), the json stage is a no-op
+      # and the raw line is shipped as-is.
+      - json:
+          expressions:
+            level: level
+            # zerolog writes the event timestamp under "time" as a Unix-nanosecond
+            # number (the router sets zerolog.TimeFieldFormat = TimeFormatUnixNano).
+            ts: time
+            msg: message
+
+      # Promote the parsed log level to a label so `{service="router"} | level="error"`
+      # works and Grafana's level colouring lights up. Low cardinality (5 values).
+      - labels:
+          level:
+
+      # Use the router's own timestamp for the log entry instead of Promtail's
+      # ingest time. UnixNs matches zerolog's TimeFormatUnixNano. If `ts` is empty
+      # (non-JSON line), this stage is skipped and ingest time is used.
+      - timestamp:
+          source: ts
+          format: UnixNs
+          action_on_failure: skip

--- a/docs/LOCAL-COMPOSE.md
+++ b/docs/LOCAL-COMPOSE.md
@@ -167,3 +167,87 @@ curl -s http://localhost:7779/metrics | head
 
 Set `metrics-listen-address: disabled` in the config to turn it off, or
 override with the `--metrics-listen-address` flag.
+
+## Logs (Loki + Grafana)
+
+An optional overlay (`docker/docker-compose.logs.yml`) adds a **Loki + Promtail
++ Grafana** stack that captures the router's logs and shows them in a Grafana
+board — no change to the router service, it keeps logging JSON to stdout as it
+does today. Layer it on the base compose like the cache overlay:
+
+```bash
+docker compose -f docker/docker-compose.yml \
+               -f docker/docker-compose.logs.yml up --build
+```
+
+Then open Grafana and it lands on the **Smart Router Logs** dashboard:
+
+| URL                     | What                                              |
+|-------------------------|---------------------------------------------------|
+| http://localhost:3001   | Grafana (`admin` / `admin`) → "Smart Router Logs" |
+| http://localhost:3100   | Loki API (`/ready`, `/loki/api/v1/labels`)        |
+
+Grafana is on **:3001** (not the usual :3000) on purpose — the dashboard
+overlay's frontend owns :3000, and this overlay is designed to run *alongside*
+it (see [Everything at once](#everything-at-once) below).
+
+How it fits together:
+
+- **Promtail** tails the Docker socket, keeps only containers in this compose
+  project (`com.docker.compose.project=smart-router`), parses the router's
+  zerolog JSON, and pushes to **Loki**. Parsing promotes the log `level` to a
+  Loki label and uses the router's own nanosecond `time` field as the entry
+  timestamp.
+- **Grafana** auto-provisions the Loki datasource and the logs dashboard — a
+  log-volume-by-level graph, a live log panel, and `Service` / `Search (regex)`
+  variables. It works whether you run just the router or the full multichain
+  fleet.
+
+Query logs directly with LogQL, e.g. only errors from the router:
+
+```bash
+curl -s -G http://localhost:3100/loki/api/v1/query_range \
+  --data-urlencode 'query={service="router", level="error"}' | head -c 400
+```
+
+Tune verbosity with the same `SR_LOG_LEVEL` env var above (e.g.
+`SR_LOG_LEVEL=debug`); `SR_LOG_FORMAT` must stay `json` (the default) for the
+level/timestamp parsing to apply — plain-text lines still ship, just without the
+`level` label.
+
+Override credentials with `GRAFANA_USERNAME` / `GRAFANA_PASSWORD`. Tear down and
+drop the stored logs with `down -v` (the `loki-data` / `grafana-data` volumes).
+
+## Everything at once
+
+The base router + all three overlays (cache, dashboard, logs) publish **disjoint
+host ports**, so they compose into a single stack in one command — a multichain
+router with the cache in path, Prometheus + the dashboard UI, and the Loki/Grafana
+log pipeline, all together:
+
+```bash
+SR_CONFIG=config/smartrouter_examples/smartrouter_multichain_cached.yml \
+  docker compose \
+    -f docker/docker-compose.yml \
+    -f docker/docker-compose.cache.yml \
+    -f docker/docker-compose.dashboard.yml \
+    -f docker/docker-compose.logs.yml \
+    up --build
+```
+
+The full port map (all unique):
+
+| Port        | Service                                   | Overlay    |
+|-------------|-------------------------------------------|------------|
+| `3360`–`3367` | router RPC listeners (per chain)        | base       |
+| `7779`      | router Prometheus metrics                 | base       |
+| `5555`      | cache Prometheus metrics                  | cache      |
+| `9090`      | Prometheus                                | dashboard  |
+| `8000`      | dashboard backend (FastAPI)               | dashboard  |
+| `3000`      | dashboard frontend (Next.js)              | dashboard  |
+| `3100`      | Loki API                                  | logs       |
+| `3001`      | Grafana → "Smart Router Logs"             | logs       |
+
+Drop any overlay you don't want (e.g. omit `-f docker-compose.dashboard.yml` for
+router + cache + logs only). The cache still needs a `*_cached.yml` config that
+declares `cache-be:` — see [Enabling the cache](#enabling-the-cache).


### PR DESCRIPTION
## Summary

- Adds a local **Loki + Promtail + Grafana** logs overlay (`docker/docker-compose.logs.yml`) that captures the router's logs and shows them in a pre-provisioned Grafana dashboard.
- The **router service is unchanged** — it keeps logging JSON to stdout as today. Promtail discovers it via Docker labels, so nothing about the router config or command changes.
- Grafana is published on host **:3001** (not :3000) so this overlay runs **side-by-side with the dashboard overlay**. Base + cache + dashboard + logs all publish disjoint host ports and layer together in one `docker compose` invocation.

## How it works

- **Promtail** tails the Docker socket, keeps only containers in this compose project (`com.docker.compose.project=smart-router`), parses the router's zerolog JSON — promoting `level` to a Loki label and using the router's own nanosecond `time` field as the entry timestamp — and pushes to **Loki**.
- **Loki** is single-binary, filesystem-backed, 7-day retention (a local dev sink, not a prod deployment).
- **Grafana** auto-provisions the Loki datasource and a "Smart Router Logs" dashboard: a log-volume-by-level graph, a live log panel, and `Service` / `Search (regex)` variables.

## Usage

Router + logs only:

```bash
docker compose -f docker/docker-compose.yml -f docker/docker-compose.logs.yml up --build
# → http://localhost:3001  Grafana (admin/admin), lands on "Smart Router Logs"
```

Everything at once (multichain + cache + dashboard + Prometheus + logs):

```bash
SR_CONFIG=config/smartrouter_examples/smartrouter_multichain_cached.yml \
  docker compose \
    -f docker/docker-compose.yml \
    -f docker/docker-compose.cache.yml \
    -f docker/docker-compose.dashboard.yml \
    -f docker/docker-compose.logs.yml \
    up --build
```

| Port | Service | Overlay |
|------|---------|---------|
| 3360–3367 | router RPC listeners | base |
| 7779 | router metrics | base |
| 5555 | cache metrics | cache |
| 9090 | Prometheus | dashboard |
| 8000 | dashboard backend | dashboard |
| 3000 | dashboard frontend | dashboard |
| 3100 | Loki API | logs |
| 3001 | Grafana | logs |

## Test plan

Brought up the full combined stack (`multichain_cached` config + all 4 overlays) and verified end-to-end:

- All 8 services healthy; **every host port unique** (no collisions across overlays).
- Multichain router logs land in Loki with chains **COSMOSHUB, ETH1, SOLANA** all present.
- zerolog JSON parsed correctly — `level` label values `error`/`info`/`warn`; entry timestamps match the router's own ns `time` field.
- Prometheus target `smart-router → up (http://router:7779/metrics)`.
- Grafana on **:3001** healthy, Loki datasource + "Smart Router Logs" dashboard auto-provisioned; the dashboard's exact panel query returns router logs through Grafana's datasource proxy.

## Notes

- Docs: new **Logs (Loki + Grafana)** and **Everything at once** sections in `docs/LOCAL-COMPOSE.md`.
- No source/code changes — compose + config + docs only.
