### PR TITLE
fix(chaintracker-redesign): address code-review findings (9 correctness fixes)

### DIFF
--- a/protocol/chainstate/chain_state.go
+++ b/protocol/chainstate/chain_state.go
@@ -140,7 +140,7 @@ type ChainState struct {
 	now func() time.Time
 
 	mu          sync.RWMutex
-	latestBlock int64 // observed tip; only SetLatestBlock raises it, only Recompute lowers it
+	latestBlock int64 // observed tip; raised by SetLatestBlock, lowered only by Recompute's realign or SetLatestBlock's stale-tip re-adoption
 	// lastObservedAt is the wall-clock of the last ACCEPTED observation of the current tip,
 	// refreshed even when the block is unchanged (an equal-block confirmation re-proves the tip
 	// is live). TTL freshness is measured from this, so a stable-but-confirmed tip does not
@@ -192,16 +192,35 @@ func NewWithClock(chainID string, cfg Config, clock func() time.Time) *ChainStat
 
 // SetLatestBlock is the cheap per-observation write the relay-harvest and poll paths call. It
 // raises the tip monotonically and guards against an anti-lie outlier:
-//   - a block below the current tip is ignored (monotonic; the tip only goes DOWN via Recompute's
-//     downward realignment, never a write),
+//   - a block below a FRESH tip is ignored (monotonic; a live tip only goes DOWN via Recompute's
+//     downward realignment). Once the tip has gone STALE by TTL, a fresh lower observation
+//     re-adopts the tip downward: a stale tip already reports (0, false) to every consumer, so
+//     adopting a live lower value strictly improves information — without this, a no-baseline
+//     pod poisoned by one bogus high block could never recover (every honest block sits below
+//     the lie forever),
 //   - a block EQUAL to the current tip is not an advance but DOES refresh freshness — it re-proves
 //     the tip is live, so TTL is measured from the latest confirmation, not the first sighting
 //     (Finding 4),
 //   - when a consensus baseline exists, a block more than OutlierThreshold above it is rejected
-//     as implausible (a single lying/buggy endpoint cannot poison the tip on a 3+-endpoint pod).
+//     as implausible (a single lying/buggy endpoint cannot poison the tip on a 3+-endpoint pod),
+//   - without a baseline (1-2 endpoint pods never form one — min-2 rule), the same guard anchors
+//     on the FRESH tip instead: within one TTL (≈ DefaultStalenessMultiplier block times) the
+//     chain cannot plausibly advance more than OutlierThreshold (≥ outlierFloorBlocks) blocks,
+//     so a bigger jump over a live tip is a lie/glitch. A STALE tip does not anchor the guard —
+//     after an idle gap the real head may legitimately be far ahead. A PERSISTENT liar walking
+//     the tip up in sub-threshold steps remains undetectable without peers; the guard defends
+//     against transient lies/glitches, and the stale-tip re-adoption above bounds a successful
+//     poisoning of THIS tip to ~one TTL instead of the process lifetime.
+//
+// Caveat: the guard cannot fire on the VERY FIRST observation (no reference exists yet), so a
+// cold-start lie is accepted here. This tip self-heals after one TTL, but callers that ratchet a
+// separate monotonic-max store from accepted observations (the rpcsmartrouter bootstrap atomic)
+// do NOT self-heal — a cold-start lie persists there for the process lifetime. That store must add
+// its own bound if it needs one; this tip's self-heal does not cover it.
 //
 // Returns the resulting tip, the time it was last confirmed, and whether this call ADVANCED it
-// (equal-block confirmations return advanced=false even though they refresh freshness).
+// (equal-block confirmations and downward re-adoptions return advanced=false — consumers that
+// ratchet a monotonic maximum, e.g. the bootstrap atomic, must only follow advances).
 func (cs *ChainState) SetLatestBlock(block int64) (latest int64, at time.Time, advanced bool) {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
@@ -209,21 +228,34 @@ func (cs *ChainState) SetLatestBlock(block int64) (latest int64, at time.Time, a
 	if block <= 0 {
 		return cs.latestBlock, cs.lastObservedAt, false
 	}
+	now := cs.now()
+	_, tipFresh := cs.freshLatestLocked(now)
 	if cs.initialized {
 		if block < cs.latestBlock {
+			if tipFresh {
+				return cs.latestBlock, cs.lastObservedAt, false
+			}
+			// Stale-tip downward re-adoption (self-heal from a poisoned/frozen tip).
+			cs.latestBlock = block
+			cs.lastObservedAt = now
 			return cs.latestBlock, cs.lastObservedAt, false
 		}
 		if block == cs.latestBlock {
-			cs.lastObservedAt = cs.now() // equal-block confirmation refreshes freshness (Finding 4)
+			cs.lastObservedAt = now // equal-block confirmation refreshes freshness (Finding 4)
 			return cs.latestBlock, cs.lastObservedAt, false
 		}
 	}
 	// block > latestBlock, or the very first observation.
-	if cs.hasBaseline && block > cs.baseline+cs.cfg.OutlierThreshold {
+	if cs.hasBaseline {
+		if block > cs.baseline+cs.cfg.OutlierThreshold {
+			return cs.latestBlock, cs.lastObservedAt, false
+		}
+	} else if cs.initialized && tipFresh && block > cs.latestBlock+cs.cfg.OutlierThreshold {
+		// No-baseline anti-lie guard, anchored on the fresh tip (see doc block above).
 		return cs.latestBlock, cs.lastObservedAt, false
 	}
 	cs.latestBlock = block
-	cs.lastObservedAt = cs.now()
+	cs.lastObservedAt = now
 	cs.initialized = true
 	return cs.latestBlock, cs.lastObservedAt, true
 }
@@ -368,7 +400,8 @@ func (cs *ChainState) DebugSnapshot() ChainStateSnapshot {
 //   - fresh-only: drop observations older than StalenessWindow and non-positive blocks;
 //   - dedup by URL: each endpoint votes once, with its most recent observation;
 //   - min-2: fewer than 2 distinct fresh endpoints → no consensus (a sole endpoint cannot
-//     self-certify; its tip is still trusted monotonically + TTL, just without an anti-lie guard);
+//     self-certify; its tip is still trusted monotonically + TTL, with only the weaker
+//     fresh-tip-anchored anti-lie guard in SetLatestBlock instead of a consensus-anchored one);
 //   - strict majority > 50%: find the widest cluster of votes that all lie within BucketWidth of
 //     each other (distance-aware sliding window over sorted blocks, NOT fixed bucket boundaries —
 //     so two endpoints one block apart still agree, Finding 3). A cluster wins only if it holds

--- a/protocol/chainstate/chain_state_test.go
+++ b/protocol/chainstate/chain_state_test.go
@@ -48,15 +48,11 @@ func TestSetLatestBlock_Monotonic(t *testing.T) {
 	require.Equal(t, int64(101), latest)
 }
 
-func TestSetLatestBlock_OutlierGuard_OnlyWithBaseline(t *testing.T) {
+func TestSetLatestBlock_OutlierGuard_WithBaseline(t *testing.T) {
 	cs, clk := newTestState(t)
 	cs.SetLatestBlock(1000)
 
-	// No baseline yet → even an implausible jump is accepted (can't anti-lie without peers).
-	_, _, advanced := cs.SetLatestBlock(1_000_000)
-	require.True(t, advanced, "without a consensus baseline there is no outlier guard")
-
-	// Establish a baseline at ~1000 from 3 agreeing endpoints, then the tip realigns down.
+	// Establish a baseline at ~1000 from 3 agreeing endpoints.
 	cs.Recompute([]BlockObservation{
 		{URL: "a", Block: 1000, ObservedAt: clk.now()},
 		{URL: "b", Block: 1001, ObservedAt: clk.now()},
@@ -67,7 +63,7 @@ func TestSetLatestBlock_OutlierGuard_OnlyWithBaseline(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, int64(1001), base, "baseline is the most-advanced block in the agreeing cluster")
 
-	// Now a lying endpoint reporting far ahead is rejected.
+	// A lying endpoint reporting far ahead of consensus is rejected.
 	tip, _, advanced := cs.SetLatestBlock(base + 101)
 	require.False(t, advanced, "a block > baseline+OutlierThreshold is an anti-lie outlier")
 	require.LessOrEqual(t, tip, base+100)
@@ -75,6 +71,71 @@ func TestSetLatestBlock_OutlierGuard_OnlyWithBaseline(t *testing.T) {
 	// A plausible advance within the threshold is accepted.
 	_, _, advanced = cs.SetLatestBlock(base + 50)
 	require.True(t, advanced)
+}
+
+// TestSetLatestBlock_OutlierGuard_NoBaselineAnchorsOnFreshTip locks the no-baseline half of the
+// anti-lie guard: 1-2 endpoint pods never form a consensus baseline (min-2 rule), so the guard
+// anchors on the FRESH tip instead — within one TTL the chain cannot plausibly advance more than
+// OutlierThreshold blocks. Without this, one bogus high block poisons the monotonic tip and (as
+// the tip then expires with every honest block rejected below it) permanently bricks the chain
+// tip for the life of the process.
+func TestSetLatestBlock_OutlierGuard_NoBaselineAnchorsOnFreshTip(t *testing.T) {
+	cs, clk := newTestState(t)
+	cs.SetLatestBlock(1000)
+
+	// A jump of more than OutlierThreshold over the live tip is a lie/glitch, baseline or not.
+	tip, _, advanced := cs.SetLatestBlock(1_000_000)
+	require.False(t, advanced, "an implausible jump over a FRESH tip is rejected even without a baseline")
+	require.Equal(t, int64(1000), tip)
+
+	// A plausible advance (exactly tip+OutlierThreshold) is accepted.
+	tip, _, advanced = cs.SetLatestBlock(1100)
+	require.True(t, advanced, "an advance within OutlierThreshold of the fresh tip is plausible")
+	require.Equal(t, int64(1100), tip)
+
+	// A STALE tip does not anchor the guard: after an idle gap the real head may legitimately
+	// be far ahead, so the same jump is accepted once the tip has expired.
+	clk.advance(11 * time.Second) // past TTL (10s)
+	_, ok := cs.GetLatestBlock()
+	require.False(t, ok, "tip expired")
+	tip, _, advanced = cs.SetLatestBlock(1_000_000)
+	require.True(t, advanced, "a large advance over a STALE tip is accepted (idle-gap catch-up)")
+	require.Equal(t, int64(1_000_000), tip)
+}
+
+// TestSetLatestBlock_StaleTipReAdoptsDownward locks the self-heal half: a fresh observation
+// BELOW a TTL-stale tip re-adopts the tip downward. A stale tip already reports (0, false) to
+// every consumer, so adopting a live lower value strictly improves information — and it bounds
+// a successful poisoning (e.g. a cold-start lie, where no guard is possible) to ~one TTL
+// instead of the process lifetime.
+func TestSetLatestBlock_StaleTipReAdoptsDownward(t *testing.T) {
+	cs, clk := newTestState(t)
+
+	// Cold-start lie: the very first observation has no reference, so it is accepted.
+	_, _, advanced := cs.SetLatestBlock(1_000_000)
+	require.True(t, advanced)
+
+	// While the poisoned tip is fresh, honest lower blocks are still ignored (monotonic).
+	tip, _, advanced := cs.SetLatestBlock(5000)
+	require.False(t, advanced)
+	require.Equal(t, int64(1_000_000), tip)
+
+	// Once the lie expires (no confirmations), the next honest observation re-adopts the tip.
+	clk.advance(11 * time.Second) // past TTL (10s)
+	_, ok := cs.GetLatestBlock()
+	require.False(t, ok, "the poisoned tip expires once nothing re-confirms it")
+	tip, _, advanced = cs.SetLatestBlock(5000)
+	require.False(t, advanced, "a downward re-adoption is not an advance (monotonic consumers must not follow it)")
+	require.Equal(t, int64(5000), tip, "a fresh honest block below a STALE tip re-adopts the tip")
+	got, ok := cs.GetLatestBlock()
+	require.True(t, ok, "the re-adopted tip is live again")
+	require.Equal(t, int64(5000), got)
+
+	// Normal operation resumes: plausible advances are accepted, implausible ones rejected.
+	_, _, advanced = cs.SetLatestBlock(5001)
+	require.True(t, advanced)
+	_, _, advanced = cs.SetLatestBlock(1_000_000)
+	require.False(t, advanced, "the fresh-tip guard is active again after recovery")
 }
 
 // --- TTL freshness ----------------------------------------------------------------------
@@ -380,16 +441,22 @@ func TestRecompute_NoRealignmentWithinThreshold(t *testing.T) {
 	require.Equal(t, int64(1050), tip, "a tip within OutlierThreshold of the baseline is not realigned")
 }
 
-func TestRecompute_NoBaselineLeavesGuardOff(t *testing.T) {
+func TestRecompute_NoBaselineFallsBackToTipAnchoredGuard(t *testing.T) {
 	cs, clk := newTestState(t)
 	cs.SetLatestBlock(1000)
 
-	// Single fresh endpoint → no baseline → guard stays off → big advance still accepted.
+	// Single fresh endpoint → no baseline; the write guard falls back to anchoring on the
+	// fresh tip, so an implausible jump is still rejected (not by a stale baseline — there
+	// is none — but by the tip-anchored plausibility bound).
 	cs.Recompute([]BlockObservation{{URL: "a", Block: 1000, ObservedAt: clk.now()}})
 	ok := cs.DebugSnapshot().HasBaseline
 	require.False(t, ok)
 	_, _, advanced := cs.SetLatestBlock(1_000_000)
-	require.True(t, advanced, "no baseline → no outlier guard (single-endpoint pod)")
+	require.False(t, advanced, "no baseline → the guard anchors on the fresh tip instead of switching off")
+
+	// A plausible single-endpoint advance keeps flowing normally.
+	_, _, advanced = cs.SetLatestBlock(1050)
+	require.True(t, advanced)
 }
 
 // TestRecompute_EmptySnapshotClearsBaseline covers Finding 5: an empty (or sub-majority)
@@ -411,8 +478,11 @@ func TestRecompute_EmptySnapshotClearsBaseline(t *testing.T) {
 	ok = cs.DebugSnapshot().HasBaseline
 	require.False(t, ok, "an empty snapshot clears the baseline rather than leaving it stale")
 
-	// With the guard now off, a single new endpoint at a wildly different height is accepted
-	// (it would have been wrongly rejected had the old baseline lingered).
+	// Once the old tip expires (the endpoint swap takes real time), a single replacement
+	// endpoint at a wildly different height is accepted: neither the cleared baseline nor
+	// the now-stale tip anchors the guard (it would have been wrongly rejected had the old
+	// baseline lingered).
+	clk.advance(11 * time.Second) // past TTL (10s)
 	cs.SetLatestBlock(2_000_000)
 	tip, ok := cs.GetLatestBlock()
 	require.True(t, ok)

--- a/protocol/chaintracker/chain_tracker.go
+++ b/protocol/chaintracker/chain_tracker.go
@@ -386,8 +386,15 @@ func (cs *ChainTracker) gotNewBlock(ctx context.Context, newLatestBlock int64) (
 }
 
 // this function is periodically called, it checks if there is a new block or a fork and fetches all necessary previous data in order to fill gaps if any.
-// if a new block or fork is not found, check the emergency mode
-func (cs *ChainTracker) fetchAllPreviousBlocksIfNecessary(ctx context.Context) (err error) {
+// if a new block or fork is not found, check the emergency mode.
+//
+// Returns skipped=true when the traffic gate suppressed the whole cycle (no upstream call, no
+// poll-health signal). The caller MUST treat a skip as distinct from a successful poll: a skip
+// proves nothing about poll health, so it must neither reset nor advance the consecutive-failure
+// backoff (MAG-2159 follow-up). Conflating the two (skip → err==nil → "success") let every gated
+// cycle cancel a broken poll path's backoff, so a doomed poll never backed off and its recovery
+// evidence never accrued.
+func (cs *ChainTracker) fetchAllPreviousBlocksIfNecessary(ctx context.Context) (skipped bool, err error) {
 	// Traffic gate (MAG-2159 / Topic B). When a fresh relay-harvested tip already covers this
 	// endpoint, the whole poll cycle is redundant — skip it: no FetchLatestBlockNum AND no
 	// fork-check FetchBlockHashByNum (forkChanged fetches a hash every tick, even when the block
@@ -400,7 +407,7 @@ func (cs *ChainTracker) fetchAllPreviousBlocksIfNecessary(ctx context.Context) (
 	// goroutine. The global tracker leaves relayTipFresh nil and never skips.
 	if cs.relayTipFresh != nil && cs.relaySkipsSinceRealPoll < cs.maxRelaySkipsBeforePoll && cs.relayTipFresh(time.Now()) {
 		cs.relaySkipsSinceRealPoll++
-		return nil
+		return true, nil
 	}
 	cs.relaySkipsSinceRealPoll = 0
 
@@ -418,18 +425,18 @@ func (cs *ChainTracker) fetchAllPreviousBlocksIfNecessary(ctx context.Context) (
 		if cs.fetchErrorCallback != nil {
 			cs.fetchErrorCallback()
 		}
-		return err
+		return false, err
 	}
 	gotNewBlock := cs.gotNewBlock(ctx, newLatestBlock)
 	forked, err := cs.forkChanged(ctx, newLatestBlock)
 	if err != nil {
-		return utils.LavaFormatDebug("could not fetchLatestBlock Hash in ChainTracker", utils.Attribute{Key: "error", Value: err}, utils.Attribute{Key: "block", Value: newLatestBlock}, utils.Attribute{Key: "endpoint", Value: cs.endpoint})
+		return false, utils.LavaFormatDebug("could not fetchLatestBlock Hash in ChainTracker", utils.Attribute{Key: "error", Value: err}, utils.Attribute{Key: "block", Value: newLatestBlock}, utils.Attribute{Key: "endpoint", Value: cs.endpoint})
 	}
 	prev_latest := cs.GetAtomicLatestBlockNum()
 	if gotNewBlock || forked {
 		latestHash, err := cs.fetchAllPreviousBlocks(ctx, newLatestBlock)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if gotNewBlock {
 			if cs.newLatestCallback != nil {
@@ -460,7 +467,7 @@ func (cs *ChainTracker) fetchAllPreviousBlocksIfNecessary(ctx context.Context) (
 		cs.notUpdated()
 	}
 
-	return err
+	return false, err
 }
 
 func (cs *ChainTracker) notUpdated() {
@@ -475,6 +482,28 @@ func (cs *ChainTracker) notUpdated() {
 		latestBlockTime = cs.startupTime
 	}
 	cs.oldBlockCallback(latestBlockTime)
+}
+
+// nextFetchFails returns the consecutive-poll-failure counter after one poll cycle. It is the ONE
+// place the skip-vs-success distinction is applied (MAG-2159 follow-up):
+//   - failed real poll → increment (deepens the exponential backoff and eventually escalates);
+//   - genuine successful poll → reset to 0 (backoff cleared, poll health proven);
+//   - traffic-gate skip → PRESERVE the current value. A skip made no upstream call and proves
+//     nothing about poll health, so it must neither reset the counter (the bug: a skip cancelled a
+//     broken poll path's backoff, so a doomed poll fired every cycle forever and its recovery
+//     evidence never accrued) nor deepen it (a skip is not a failure).
+//
+// failed takes precedence over skipped (a skip returns err==nil, so they are mutually exclusive in
+// practice; the ordering just makes the precedence explicit).
+func nextFetchFails(current uint64, skipped, failed bool) uint64 {
+	switch {
+	case failed:
+		return current + 1
+	case skipped:
+		return current
+	default:
+		return 0
+	}
 }
 
 // this function starts the fetching timer periodically checking by polling if updates are necessary
@@ -531,19 +560,20 @@ func (cs *ChainTracker) start(ctx context.Context, pollingTime time.Duration) er
 			case <-cs.timer.C:
 				fetchTimeout := max(10*time.Second, common.MinimumTimePerRelayDelay)
 				fetchCtx, cancel := context.WithTimeout(ctx, fetchTimeout) // protect this flow from hanging code
-				err := cs.fetchAllPreviousBlocksIfNecessary(fetchCtx)
+				skipped, err := cs.fetchAllPreviousBlocksIfNecessary(fetchCtx)
 				cancel()
+				// A gate skip PRESERVES fetchFails (see nextFetchFails): it proved nothing about poll
+				// health, so it must not cancel a broken poll path's backoff. The reschedule uses the
+				// resulting counter uniformly — a healthy endpoint (fetchFails==0) keeps the normal
+				// cadence; a failing one stays backed off between the bounded forced verification polls.
+				fetchFails = nextFetchFails(fetchFails, skipped, err != nil)
+				cs.updateTimer(pollingTime, fetchFails)
 				if err != nil {
-					fetchFails += 1
-					cs.updateTimer(pollingTime, fetchFails)
 					if fetchFails > maxFails {
 						utils.LavaFormatError("failed to fetch all previous blocks and was necessary", err, utils.Attribute{Key: "fetchFails", Value: fetchFails}, utils.Attribute{Key: "endpoint", Value: cs.endpoint.String()})
 					} else {
 						utils.LavaFormatDebug("failed to fetch all previous blocks", utils.Attribute{Key: "error", Value: err}, utils.Attribute{Key: "fetchFails", Value: fetchFails}, utils.Attribute{Key: "endpoint", Value: cs.endpoint.String()})
 					}
-				} else {
-					cs.updateTimer(pollingTime, 0)
-					fetchFails = 0
 				}
 			case <-blockGapTick:
 				// Only reachable for the global adaptive tracker (flat trackers leave blockGapTick

--- a/protocol/chaintracker/chain_tracker_gate_test.go
+++ b/protocol/chaintracker/chain_tracker_gate_test.go
@@ -104,7 +104,7 @@ func TestTrafficGate_FullCycle_UpstreamCallCounts(t *testing.T) {
 					fetcher := &countingGateFetcher{}
 					ct := newGateTracker(t, chain.chainID, fetcher, sc.relayFresh, maxSkips)
 					for i := 0; i < cycles; i++ {
-						_ = ct.fetchAllPreviousBlocksIfNecessary(context.Background())
+						_, _ = ct.fetchAllPreviousBlocksIfNecessary(context.Background())
 					}
 					require.Equal(t, sc.wantUpstream, fetcher.upstreamCalls(),
 						"%s/%s: total upstream calls over %d cycles", chain.name, sc.name, cycles)
@@ -123,16 +123,20 @@ func TestTrafficGate_BoundedVerification(t *testing.T) {
 	fetcher := &countingGateFetcher{}
 	ct := newGateTracker(t, "ETH1", fetcher, func(time.Time) bool { return true }, maxSkips)
 
-	// First maxSkips cycles skip — zero upstream.
+	// First maxSkips cycles skip — zero upstream, and each reports skipped=true so the caller
+	// can preserve (not reset) the poll-failure backoff.
 	for i := 0; i < maxSkips; i++ {
-		require.NoError(t, ct.fetchAllPreviousBlocksIfNecessary(context.Background()))
+		skipped, err := ct.fetchAllPreviousBlocksIfNecessary(context.Background())
+		require.NoError(t, err)
+		require.True(t, skipped, "cycle %d is a gate skip, reported as such (not a successful poll)", i)
 		require.Equal(t, int32(0), fetcher.upstreamCalls(), "cycle %d must skip (no upstream)", i)
 		require.Equal(t, i+1, ct.relaySkipsSinceRealPoll)
 	}
 
 	// The next cycle is forced to poll for real (the fetcher errors, proving it ran upstream).
-	require.Error(t, ct.fetchAllPreviousBlocksIfNecessary(context.Background()),
-		"after maxSkips skips the cycle must force a real poll")
+	skipped, err := ct.fetchAllPreviousBlocksIfNecessary(context.Background())
+	require.False(t, skipped, "the forced verification cycle is a real poll, not a skip")
+	require.Error(t, err, "after maxSkips skips the cycle must force a real poll")
 	require.Equal(t, int32(1), fetcher.latestCalls.Load(), "exactly one real latest-block poll was forced")
 	require.Equal(t, 0, ct.relaySkipsSinceRealPoll, "the skip counter resets after a real poll")
 }
@@ -144,7 +148,8 @@ func TestTrafficGate_NilGate_GlobalTrackerAlwaysPolls(t *testing.T) {
 	fetcher := &countingGateFetcher{}
 	ct := newGateTracker(t, "ETH1", fetcher, nil, defaultMaxRelaySkipsBeforePoll)
 	for i := 0; i < 5; i++ {
-		_ = ct.fetchAllPreviousBlocksIfNecessary(context.Background())
+		skipped, _ := ct.fetchAllPreviousBlocksIfNecessary(context.Background())
+		require.False(t, skipped, "an ungated tracker never skips")
 	}
 	require.Equal(t, int32(5), fetcher.latestCalls.Load(), "an ungated tracker polls every cycle")
 }
@@ -194,10 +199,12 @@ func TestFlatTracker_SkipsBlockGapMachinery(t *testing.T) {
 	// Drive several real block advances through the poll path. The first advance has a zero
 	// prevChangeTime (no sample either way); the rest would each append a blockEventsGap sample
 	// on a NON-flat tracker. The flat tracker must append none.
-	require.NoError(t, ct.fetchAllPreviousBlocksIfNecessary(context.Background()))
+	_, err := ct.fetchAllPreviousBlocksIfNecessary(context.Background())
+	require.NoError(t, err)
 	for i := 0; i < 5; i++ {
 		fetcher.block.Add(1)
-		require.NoError(t, ct.fetchAllPreviousBlocksIfNecessary(context.Background()))
+		_, err := ct.fetchAllPreviousBlocksIfNecessary(context.Background())
+		require.NoError(t, err)
 	}
 	require.Empty(t, ct.blockEventsGap, "a flat tracker must not accumulate block-gap samples")
 }

--- a/protocol/chaintracker/chain_tracker_nil_oldblockcallback_test.go
+++ b/protocol/chaintracker/chain_tracker_nil_oldblockcallback_test.go
@@ -73,7 +73,8 @@ func TestFetchAllPreviousBlocksIfNecessary_UpstreamTimeoutIsHandled(t *testing.T
 		}
 	}()
 
-	gotErr := cs.fetchAllPreviousBlocksIfNecessary(context.Background())
+	gotSkipped, gotErr := cs.fetchAllPreviousBlocksIfNecessary(context.Background())
+	require.False(t, gotSkipped, "an upstream timeout is a real poll attempt, not a gate skip")
 	require.Error(t, gotErr, "an upstream latest-block timeout should surface as an error, not crash the router")
 	require.True(t, errors.Is(gotErr, context.DeadlineExceeded), "the returned error should preserve the upstream deadline cause")
 }

--- a/protocol/chaintracker/polling_relief_test.go
+++ b/protocol/chaintracker/polling_relief_test.go
@@ -36,6 +36,33 @@ func TestComputePollInterval_FixedFlatCadence(t *testing.T) {
 		"failure backoff slows the flat interval (flat << 3)")
 }
 
+// TestNextFetchFails locks the skip-vs-success distinction that keeps a broken poll path in
+// backoff (MAG-2159 follow-up): a traffic-gate skip PRESERVES the consecutive-failure counter,
+// only a genuine successful poll resets it, and a real failure increments it. The regression this
+// guards: a skip used to look like a success (err==nil), resetting the counter every gated cycle
+// so a doomed poll never backed off and its recovery evidence never accrued.
+func TestNextFetchFails(t *testing.T) {
+	cases := []struct {
+		name    string
+		current uint64
+		skipped bool
+		failed  bool
+		want    uint64
+	}{
+		{"failure increments", 2, false, true, 3},
+		{"failure from zero", 0, false, true, 1},
+		{"successful poll resets", 5, false, false, 0},
+		{"skip preserves a clean counter", 0, true, false, 0},
+		{"skip preserves an accrued backoff (the fix)", 4, true, false, 4},
+		{"failure precedence over skip", 3, true, true, 4},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, nextFetchFails(tc.current, tc.skipped, tc.failed))
+		})
+	}
+}
+
 // TestComputePollInterval_LegacyCadenceWhenNoFlat guards that the global tracker
 // (flatPollInterval == 0) keeps its legacy adaptive cadence, untouched by MAG-2159.
 func TestComputePollInterval_LegacyCadenceWhenNoFlat(t *testing.T) {

--- a/protocol/endpointstate/endpoint_monitor.go
+++ b/protocol/endpointstate/endpoint_monitor.go
@@ -489,7 +489,7 @@ func (m *EndpointMonitor) GetLatestBlockData(endpointURL string) (latestBlock in
 // the tracker goroutines. Returns the number of trackers that were reset.
 //
 // ResetLatestBlock alone only zeroes the tracker's poll atomic; the consistency reader
-// takes the FRESHEST of that atomic and the shared endpointtip store (freshestEndpointTip
+// prefers the shared endpointtip store over that atomic (endpointTipPreferStore
 // in rpcsmartrouter). Leaving the store populated would resurrect the pre-reset block —
 // a stale value the atomic's 0 was meant to override — so the check would keep gating
 // against exactly the value the reset asked to discard, defeating ResetLatestBlock's

--- a/protocol/endpointstate/endpoint_monitor.go
+++ b/protocol/endpointstate/endpoint_monitor.go
@@ -483,17 +483,28 @@ func (m *EndpointMonitor) GetLatestBlockData(endpointURL string) (latestBlock in
 	return latestBlock, changeTime, true
 }
 
-// ResetAllLatestBlocks calls ResetLatestBlock on every registered tracker so the
-// next consistency pre-validation skips the lag check until the poll loop
-// repopulates the cached value. Used by /debug/reset-scores to clear per-
-// endpoint chain-tracker pollution without restarting the tracker goroutines.
-// Returns the number of trackers that were reset.
+// ResetAllLatestBlocks clears BOTH per-endpoint tip sources so the next consistency
+// pre-validation skips the lag check until the poll loop repopulates them. Used by
+// /debug/reset-scores to clear per-endpoint chain-tracker pollution without restarting
+// the tracker goroutines. Returns the number of trackers that were reset.
+//
+// ResetLatestBlock alone only zeroes the tracker's poll atomic; the consistency reader
+// takes the FRESHEST of that atomic and the shared endpointtip store (freshestEndpointTip
+// in rpcsmartrouter). Leaving the store populated would resurrect the pre-reset block —
+// a stale value the atomic's 0 was meant to override — so the check would keep gating
+// against exactly the value the reset asked to discard, defeating ResetLatestBlock's
+// "consistency sees <= 0 and skips" contract until the next poll happens to overwrite it.
+// We Remove the store entry (not Set 0): the store ignores non-positive writes and its
+// time-monotonic guard cannot represent "cleared", so removal is the only way to zero it.
+// endpointtip's lock is a leaf that never calls back into the monitor, so taking it under
+// m.mu (read) introduces no lock-order inversion — same idiom as RemoveTracker/Stop.
 func (m *EndpointMonitor) ResetAllLatestBlocks() int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	count := 0
-	for _, t := range m.trackers {
+	for url, t := range m.trackers {
 		t.ResetLatestBlock()
+		endpointtip.Default().Remove(m.tipKey(url))
 		count++
 	}
 	return count

--- a/protocol/endpointstate/endpoint_monitor_lifecycle_test.go
+++ b/protocol/endpointstate/endpoint_monitor_lifecycle_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/magma-Devs/smart-router/protocol/chaintracker"
+	"github.com/magma-Devs/smart-router/protocol/endpointtip"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
@@ -166,4 +167,45 @@ func TestEndpointMonitor_ResetAllLatestBlocks(t *testing.T) {
 		require.Equal(t, int32(1), f.resetCalls.Load(),
 			"tracker %d should have had ResetLatestBlock called exactly once", i)
 	}
+}
+
+// TestEndpointMonitor_ResetAllLatestBlocks_ClearsEndpointTipStore is the reset-contract
+// regression (10th review finding): ResetLatestBlock only zeroes the tracker's poll atomic,
+// but consistency pre-validation reads the FRESHEST of that atomic and the shared endpointtip
+// store (rpcsmartrouter.freshestEndpointTip). If the reset leaves the store populated, the
+// stale pre-reset block resurfaces via max() and the check keeps gating against exactly the
+// value the reset asked to discard — defeating ResetLatestBlock's documented "consistency sees
+// <= 0 and skips" contract until the next poll happens to overwrite it. ResetAllLatestBlocks
+// must clear the store entry too, so BOTH sources read 0 (unknown) after a reset.
+func TestEndpointMonitor_ResetAllLatestBlocks_ClearsEndpointTipStore(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// A dedicated chain/interface keeps this case isolated on the process-wide store singleton.
+	m := NewEndpointMonitor(ctx, EndpointChainTrackerConfig{
+		ChainID:          "ETH-reset-store",
+		ApiInterface:     "jsonrpc",
+		AverageBlockTime: 12 * time.Second,
+		BlocksToSave:     10,
+	})
+	require.NotNil(t, m)
+	defer m.Stop()
+
+	const url = "http://reset-store-endpoint:8545"
+	m.trackers[url] = &recordingChainTracker{}
+	key := m.tipKey(url)
+	t.Cleanup(func() { endpointtip.Default().Remove(key) }) // shared-singleton hygiene
+
+	// Seed a stale tip in the shared store, as a prior poll/relay observation would have.
+	require.True(t, endpointtip.Default().Set(key, endpointtip.Tip{
+		Block: 1000, ObservedAt: time.Now(), Source: endpointtip.SourcePoll,
+	}))
+	require.Equal(t, int64(1000), endpointtip.Default().Block(key),
+		"precondition: the store holds the pre-reset block")
+
+	m.ResetAllLatestBlocks()
+
+	require.Equal(t, int64(0), endpointtip.Default().Block(key),
+		"reset must clear the endpointtip store, not just the tracker atomic, so the freshest "+
+			"of the two sources is 0 and consistency pre-validation skips the lag check")
 }

--- a/protocol/endpointstate/endpoint_monitor_lifecycle_test.go
+++ b/protocol/endpointstate/endpoint_monitor_lifecycle_test.go
@@ -171,12 +171,12 @@ func TestEndpointMonitor_ResetAllLatestBlocks(t *testing.T) {
 
 // TestEndpointMonitor_ResetAllLatestBlocks_ClearsEndpointTipStore is the reset-contract
 // regression (10th review finding): ResetLatestBlock only zeroes the tracker's poll atomic,
-// but consistency pre-validation reads the FRESHEST of that atomic and the shared endpointtip
-// store (rpcsmartrouter.freshestEndpointTip). If the reset leaves the store populated, the
-// stale pre-reset block resurfaces via max() and the check keeps gating against exactly the
-// value the reset asked to discard — defeating ResetLatestBlock's documented "consistency sees
-// <= 0 and skips" contract until the next poll happens to overwrite it. ResetAllLatestBlocks
-// must clear the store entry too, so BOTH sources read 0 (unknown) after a reset.
+// but consistency pre-validation prefers the shared endpointtip store over that atomic
+// (rpcsmartrouter.endpointTipPreferStore). If the reset leaves the store populated, the stale
+// pre-reset block resurfaces and the check keeps gating against exactly the value the reset asked
+// to discard — defeating ResetLatestBlock's documented "consistency sees <= 0 and skips" contract
+// until the next poll happens to overwrite it. ResetAllLatestBlocks must clear the store entry
+// too, so BOTH sources read 0 (unknown) after a reset.
 func TestEndpointMonitor_ResetAllLatestBlocks_ClearsEndpointTipStore(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/protocol/probing/verdict.go
+++ b/protocol/probing/verdict.go
@@ -17,8 +17,12 @@ const (
 	// minProbeStaleness floors the alive horizon so it always spans several probe cycles even on
 	// very fast chains — a single skipped/slow poll must not flip a healthy endpoint to "dead".
 	minProbeStaleness = 5 * time.Second
-	// DefaultLagToleranceBlocks is how far below the consensus baseline an endpoint may sit and still
-	// count as "keeping up" (matches relaycore's EndpointLagThreshold default). Compile-time default.
+	// DefaultLagToleranceBlocks is how far below the consensus baseline an endpoint may sit and
+	// still count as "keeping up". It is only the FALLBACK: production wiring overrides
+	// VerdictConfig.LagToleranceBlocks with the per-chain relaycore.EndpointLagThreshold (the same
+	// tolerance consistency pre-validation uses), so the probe and the relay path agree on "lagging"
+	// on chains whose derived threshold exceeds this. Kept at 10 to match that threshold's own floor
+	// for the cold path (no consistency config wired). Compile-time default.
 	DefaultLagToleranceBlocks int64 = 10
 )
 

--- a/protocol/rpcsmartrouter/chainstate_glue_test.go
+++ b/protocol/rpcsmartrouter/chainstate_glue_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/endpointstate"
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
 	rand "github.com/magma-Devs/smart-router/utils/rand"
 	"github.com/stretchr/testify/require"
 )
@@ -78,6 +79,50 @@ func TestGetLatestBlock_NilChainStateUsesAtomic(t *testing.T) {
 	require.Equal(t, uint64(0), rpcss.getLatestBlock(), "no chainState, no atomic → unknown")
 	rpcss.latestBlockHeight.Store(500)
 	require.Equal(t, uint64(500), rpcss.getLatestBlock(), "no chainState → atomic answers")
+}
+
+// TestGetLatestBlockForCacheFinalization_ConsensusOrZero locks the cache-finalization tip
+// contract (see isFinalizedForCacheWrite's doc block): the CONSENSUS baseline when fresh, else a
+// strict 0. It must never fall back to the optimistic observed tip (a lone fresh reporter — on
+// no-baseline pods a lying-high value would falsely finalize into the long-TTL store) nor to the
+// bootstrap atomic (monotonic-max, no downward correction).
+func TestGetLatestBlockForCacheFinalization_ConsensusOrZero(t *testing.T) {
+	clk := &manualClock{t: time.Unix(1_700_000_000, 0)}
+	cs := chainstate.NewWithClock("ETH1", chainstate.Config{
+		BucketWidth:      2,
+		OutlierThreshold: 100,
+		StalenessWindow:  10 * time.Second,
+		TTL:              10 * time.Second,
+	}, clk.now)
+
+	rpcss := &RPCSmartRouterServer{
+		listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"},
+		chainState:     cs,
+	}
+
+	// A fresh optimistic tip and a seeded bootstrap atomic exist — but with no consensus
+	// baseline, finalization must see 0 (under-finalize, the safe direction), not either value.
+	rpcss.latestBlockHeight.Store(1000)
+	cs.SetLatestBlock(1050)
+	require.Equal(t, uint64(0), rpcss.getLatestBlockForCacheFinalization(),
+		"no consensus baseline → strict 0: neither the optimistic tip nor the atomic may finalize")
+
+	// A strict majority forms → finalization measures against the consensus baseline.
+	cs.Recompute([]chainstate.BlockObservation{
+		{URL: "a", Block: 1040, ObservedAt: clk.now()},
+		{URL: "b", Block: 1040, ObservedAt: clk.now()},
+	})
+	require.Equal(t, uint64(1040), rpcss.getLatestBlockForCacheFinalization(),
+		"a fresh strict-majority baseline is the finalization tip")
+
+	// The baseline ages past TTL → strict 0 again (never a frozen value).
+	clk.advance(11 * time.Second)
+	require.Equal(t, uint64(0), rpcss.getLatestBlockForCacheFinalization(),
+		"a TTL-expired baseline must report 0, not a frozen value")
+
+	// Defensive path: no ChainState wired at all → 0.
+	rpcss.chainState = nil
+	require.Equal(t, uint64(0), rpcss.getLatestBlockForCacheFinalization())
 }
 
 // TestRecomputeChainStateConsensus_EmptySnapshotClearsBaseline covers MAG-2160 Finding 5: the
@@ -231,10 +276,77 @@ func TestCacheServedReply_DoesNotPoisonBootstrapAtomic(t *testing.T) {
 		"Finding 1: a cache-served reply (no attributed endpoint) must not move the bootstrap atomic")
 }
 
+// TestHarvest_BootstrapAtomicGatedOnChainStateVerdict locks the chain-level gate on the
+// router-wide bootstrap atomic: a relay-harvested tip that ChainState REJECTS as an anti-lie
+// outlier must not ratchet latestBlockHeight (monotonic-max, no downward correction), even
+// though it passes its own per-endpoint store guard. Without the gate, one lying-high harvest
+// poisons getLatestBlockBestEffort → archive routing for the life of the process whenever
+// ChainState is TTL-stale.
+func TestHarvest_BootstrapAtomicGatedOnChainStateVerdict(t *testing.T) {
+	if !rand.Initialized() {
+		rand.InitRandomSeed()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cs := chainstate.NewWithClock("ETH1", chainstate.Config{
+		BucketWidth:      2,
+		OutlierThreshold: 100,
+		StalenessWindow:  10 * time.Second,
+		TTL:              10 * time.Second,
+	}, (&manualClock{t: time.Unix(1_700_000_000, 0)}).now)
+
+	parser := newRealChainParserForHarvest(t, "ETH1")
+	m := endpointstate.NewEndpointMonitor(ctx, endpointstate.EndpointChainTrackerConfig{
+		ChainParser:      parser,
+		ChainID:          "ETH1",
+		ApiInterface:     "jsonrpc",
+		AverageBlockTime: 200 * time.Millisecond,
+		BlocksToSave:     1,
+		// Production wiring (rpcsmartrouter_server.go OnTipObservation): every accepted
+		// poll/relay observation drives the per-chain ChainState tip.
+		OnTipObservation: func(block int64) { cs.SetLatestBlock(block) },
+	})
+	t.Cleanup(m.Stop)
+
+	rpcss := &RPCSmartRouterServer{
+		listenEndpoint:              &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"},
+		chainParser:                 parser,
+		endpointChainTrackerManager: m,
+		chainState:                  cs,
+	}
+
+	url := "http://ep:8545"
+	ep := &lavasession.Endpoint{NetworkAddress: url, Enabled: true}
+	_, err := m.GetOrCreateTracker(ep, nil)
+	require.NoError(t, err)
+	gen, ok := m.ObservationGeneration(url)
+	require.True(t, ok)
+
+	// GET_BLOCKNUM (eth_blockNumber): the tip-eligible method whose result IS the node's tip.
+	cm := &mockChainMessage{api: &spectypes.Api{Name: "eth_blockNumber"}, requestedBlock: spectypes.LATEST_BLOCK}
+
+	// An honest tip-eligible harvest ratchets the atomic (ChainState accepts it).
+	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1000}, gen, "provider1")
+	require.Equal(t, uint64(1000), rpcss.latestBlockHeight.Load(), "an accepted harvest seeds the bootstrap atomic")
+
+	// A lying-high harvest passes the per-endpoint store guard (higher + newer) but ChainState
+	// rejects it (fresh-tip anti-lie guard) → the atomic must NOT ratchet.
+	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1_000_000}, gen, "provider1")
+	require.Equal(t, uint64(1000), rpcss.latestBlockHeight.Load(),
+		"a harvest ChainState rejects as an outlier must not ratchet the monotonic atomic")
+
+	// A plausible advance flows normally again.
+	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1050}, gen, "provider1")
+	require.Equal(t, uint64(1050), rpcss.latestBlockHeight.Load(), "a plausible advance still ratchets the atomic")
+}
+
 // TestSiteC_SyncReferenceIsConsensusBaseline documents the MAG-2160 Finding 2 contract Site C
-// depends on: sync scoring reads GetConsensusBaseline (the strict-majority reference), and when
-// no fresh majority exists the call returns ok=false so the inline syncGap stays 0 — an endpoint
-// is never penalized against the optimistic observed tip of a lone reporter.
+// depends on: sync scoring prefers GetConsensusBaseline (the strict-majority reference); when no
+// fresh majority exists the call returns ok=false and Site C falls back to the outlier-guarded
+// OBSERVED tip (GetLatestBlock) — so a 2-endpoint pod whose laggard destroys the majority still
+// detects the lag (the laggard reads its real distance from the guarded tip), while a pod WITH a
+// fresh majority is never penalized against the optimistic tip of a lone racer (the baseline wins).
 func TestSiteC_SyncReferenceIsConsensusBaseline(t *testing.T) {
 	cs := chainstate.New("ETH1", chainstate.DefaultConfig(200*time.Millisecond))
 
@@ -244,11 +356,13 @@ func TestSiteC_SyncReferenceIsConsensusBaseline(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, int64(1099), observed)
 
-	// No majority yet → Site C reads no baseline → syncGap would be 0 (no penalty).
+	// No majority yet → GetConsensusBaseline reports none. Site C then falls back to the
+	// observed tip (the fallback is exercised in TestSyncGapAgainstReference / the no-baseline
+	// pod case); here we pin only that consensus is genuinely absent so the fallback path runs.
 	_, ok = cs.GetConsensusBaseline()
-	require.False(t, ok, "Site C must not fall back to the observed tip when there is no consensus")
+	require.False(t, ok, "no fresh majority yet → consensus baseline is absent")
 
-	// A strict majority sits at 1000. Site C now scores against 1000, NOT the observed 1099 — so a
+	// A strict majority sits at 1000. Site C now PREFERS 1000 over the observed 1099 — so a
 	// node sitting at 1000 has syncGap 0, not a bogus 99.
 	now := time.Now()
 	cs.Recompute([]chainstate.BlockObservation{
@@ -258,7 +372,91 @@ func TestSiteC_SyncReferenceIsConsensusBaseline(t *testing.T) {
 	})
 	baseline, ok := cs.GetConsensusBaseline()
 	require.True(t, ok)
-	require.Equal(t, int64(1000), baseline, "Site C scores against the majority baseline, not the lone optimistic tip")
+	require.Equal(t, int64(1000), baseline, "Site C prefers the majority baseline over the lone optimistic tip")
+}
+
+// TestSyncGapAgainstReference locks the pure gap math Site C relies on, including the no-baseline
+// fallback's shared clamp (MAG-2160 Finding 2 fix): reference − endpointLatest, zeroed when the
+// endpoint is within BucketWidth of the reference (in-cluster / keeping up), when either input is
+// unknown, or when the endpoint is ahead of the reference.
+func TestSyncGapAgainstReference(t *testing.T) {
+	const bucketWidth = int64(2)
+	cases := []struct {
+		name           string
+		reference      int64
+		endpointLatest int64
+		want           int64
+	}{
+		{"laggard charged real distance", 1000, 900, 100},
+		{"within bucket width keeps up", 1000, 998, 0},
+		{"exactly bucket width keeps up", 1000, 998, 0},
+		{"endpoint ahead clamps to zero", 1000, 1005, 0},
+		{"unknown reference → no penalty", 0, 900, 0},
+		{"unknown endpoint → no penalty", 1000, 0, 0},
+		{"just past bucket width is charged", 1000, 997, 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, syncGapAgainstReference(tc.reference, tc.endpointLatest, bucketWidth))
+		})
+	}
+}
+
+// TestEndpointSyncGap_NoBaselinePodFallsBackToObservedTip is the Finding 2 regression: on a
+// 2-endpoint pod whose laggard destroys the strict majority, Site C must still charge the laggard
+// its lag against the outlier-guarded observed tip (not skip the check, leaving it forever synced).
+func TestEndpointSyncGap_NoBaselinePodFallsBackToObservedTip(t *testing.T) {
+	if !rand.Initialized() {
+		rand.InitRandomSeed()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cs := chainstate.New("ETH1", chainstate.DefaultConfig(200*time.Millisecond))
+	parser := newRealChainParserForHarvest(t, "ETH1")
+	m := endpointstate.NewEndpointMonitor(ctx, endpointstate.EndpointChainTrackerConfig{
+		ChainParser:      parser,
+		ChainID:          "ETH1",
+		ApiInterface:     "jsonrpc",
+		AverageBlockTime: 200 * time.Millisecond,
+		BlocksToSave:     1,
+		OnTipObservation: func(block int64) { cs.SetLatestBlock(block) },
+	})
+	t.Cleanup(m.Stop)
+
+	rpcss := &RPCSmartRouterServer{
+		listenEndpoint:              &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"},
+		chainParser:                 parser,
+		endpointChainTrackerManager: m,
+		chainState:                  cs,
+	}
+
+	leaderURL, laggardURL := "http://leader:8545", "http://laggard:8545"
+	cm := &mockChainMessage{api: &spectypes.Api{Name: "eth_blockNumber"}, requestedBlock: spectypes.LATEST_BLOCK}
+	for _, url := range []string{leaderURL, laggardURL} {
+		ep := &lavasession.Endpoint{NetworkAddress: url, Enabled: true}
+		_, err := m.GetOrCreateTracker(ep, nil)
+		require.NoError(t, err)
+		gen, ok := m.ObservationGeneration(url)
+		require.True(t, ok)
+		block := int64(1000)
+		if url == laggardURL {
+			block = 900 // 100 behind → beyond BucketWidth, destroys the 2-node majority by itself
+		}
+		rpcss.harvestAndUpdateTipFromRelay(&lavasession.Endpoint{NetworkAddress: url, Enabled: true}, cm, &pairingtypes.RelayReply{LatestBlock: block}, gen, url)
+	}
+
+	// The two nodes are 100 apart → no strict-majority cluster forms.
+	rpcss.recomputeChainStateConsensus()
+	_, hasBaseline := cs.GetConsensusBaseline()
+	require.False(t, hasBaseline, "a 2-node pod split by 100 blocks forms no consensus")
+
+	// Observed tip is the leader's 1000 (outlier-guarded). Site C falls back to it: the leader
+	// keeps up (gap 0), the laggard is charged its real distance — lag detection survives.
+	require.Equal(t, int64(0), rpcss.endpointSyncGap(leaderURL, "leader", ctx),
+		"the leader at the observed tip keeps up")
+	require.Equal(t, int64(100), rpcss.endpointSyncGap(laggardURL, "laggard", ctx),
+		"Finding 2: the laggard is charged its lag against the observed tip even with no baseline")
 }
 
 // TestSiteC_InClusterEndpointChargedNoSyncGap covers PR #143: the baseline is the winning

--- a/protocol/rpcsmartrouter/probe_loop_test.go
+++ b/protocol/rpcsmartrouter/probe_loop_test.go
@@ -8,8 +8,31 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
 	"github.com/magma-Devs/smart-router/protocol/probing"
 	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
+	"github.com/magma-Devs/smart-router/protocol/relaycore"
 	"github.com/stretchr/testify/require"
 )
+
+// TestProbeVerdictConfigFor_SourcesLagToleranceFromConsistency locks the fix that keeps the probe
+// and the relay path agreeing on "lagging": the verdict's LagToleranceBlocks is sourced from the
+// per-chain relaycore.EndpointLagThreshold, not the probing package's compile-time default of 10.
+func TestProbeVerdictConfigFor_SourcesLagToleranceFromConsistency(t *testing.T) {
+	const blockTime = time.Second
+
+	t.Run("per-chain threshold overrides the default", func(t *testing.T) {
+		// A wide finalization distance derives EndpointLagThreshold well above 10.
+		cc := relaycore.NewConsistencyValidationConfig(5 /*blockLagForQosSync*/, 64 /*finalization*/, blockTime, 0)
+		require.Greater(t, cc.EndpointLagThreshold, int64(10), "precondition: derived threshold exceeds the default")
+
+		cfg := probeVerdictConfigFor(blockTime, cc)
+		require.Equal(t, cc.EndpointLagThreshold, cfg.LagToleranceBlocks,
+			"the probe tolerance must match the per-chain consistency threshold, not the default 10")
+	})
+
+	t.Run("nil consistency config falls back to the compile-time default", func(t *testing.T) {
+		cfg := probeVerdictConfigFor(blockTime, nil)
+		require.Equal(t, probing.DefaultLagToleranceBlocks, cfg.LagToleranceBlocks)
+	})
+}
 
 // recordingAppender captures AppendProbeData calls so tests can assert the one-sample-per-provider
 // rule and the fed values.

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -59,6 +59,12 @@ const (
 	DebugRelaysFlagName           = "debug-relays"
 	DebugProbesFlagName           = "debug-probes"
 
+	// deprecatedChainTrackerPollingMultiplierFlagName is the polling-relief knob main advertised
+	// for the GLOBAL chain tracker, which MAG-2160 removed (per-endpoint trackers poll at a fixed
+	// avgBlockTime/2). It stays registered as a deprecated NO-OP so deployments passing it don't
+	// fail at process start; a RunE warning tells operators the behavior is gone.
+	deprecatedChainTrackerPollingMultiplierFlagName = "chain-tracker-polling-multiplier"
+
 	// lavaAppName is the application name, previously app.Name.
 	lavaAppName = "lava"
 	// lavaDefaultNodeHome is the default home directory, previously lavaDefaultNodeHome (~/.lava).
@@ -2151,9 +2157,14 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 			// consistency config is built. Zero = no relief; out-of-range values warn-and-revert
 			// to the built-in default (not silent clamp).
 			//
-			// MAG-2160: the former --chain-tracker-polling-multiplier flag was removed here — it
-			// only ever tuned the global tracker's adaptive cadence, and the global tracker is
-			// gone. Per-endpoint trackers run a fixed avgBlockTime/2 cadence with no runtime knob.
+			// MAG-2160: --chain-tracker-polling-multiplier only ever tuned the global tracker's
+			// adaptive cadence, and the global tracker is gone (per-endpoint trackers run a fixed
+			// avgBlockTime/2 cadence with no runtime knob). The flag survives as a registered
+			// deprecated NO-OP so existing launch args don't fail process start; warn here — via
+			// viper, so a config.yml value is caught too — that the polling-relief behavior is gone.
+			if m := viper.GetInt(deprecatedChainTrackerPollingMultiplierFlagName); m != 0 {
+				utils.LavaFormatWarning("--"+deprecatedChainTrackerPollingMultiplierFlagName+" is deprecated and has NO EFFECT: the global chain tracker was removed (MAG-2160); per-endpoint trackers poll at a fixed avgBlockTime/2", nil, utils.LogAttr("provided", m))
+			}
 			if f := viper.GetInt(relaycore.ConsistencyBlockGapFactorFlagName); f != 0 {
 				if f < 2 || f > 8 {
 					utils.LavaFormatWarning("--"+relaycore.ConsistencyBlockGapFactorFlagName+" out of allowed range [2,8]; reverting to default", nil, utils.LogAttr("provided", f))
@@ -2424,6 +2435,16 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	cmdRPCSmartRouter.Flags().String(performance.PyroscopeTagsFlagName, "", "comma-separated list of tags in key=value format (e.g., instance=router-1,region=us-east)")
 	cmdRPCSmartRouter.Flags().String(performance.CacheFlagName, "", "address for a cache server to improve performance")
 	cmdRPCSmartRouter.Flags().Int(relaycore.ConsistencyBlockGapFactorFlagName, 0, "consistency-relief: widen the consistency endpoint-lag gate (blockLagForQosSync x factor; default 2). Allowed [2,8]; out-of-range reverts to default.")
+	// MAG-2160 back-compat shim: the global chain tracker (and the adaptive cadence this knob
+	// tuned) is gone — per-endpoint trackers poll at a fixed avgBlockTime/2 — but existing launch
+	// args (systemd/compose/helm) still pass the flag, and an UNREGISTERED flag fails process
+	// start (full pod outage on upgrade). Keep it registered as a deprecated no-op; the RunE
+	// warning tells polling-relief operators the behavior is gone (covers config.yml too, which
+	// cobra's own deprecation notice would miss).
+	cmdRPCSmartRouter.Flags().Int(deprecatedChainTrackerPollingMultiplierFlagName, 0, "DEPRECATED (no-op): the global chain tracker and its polling multiplier were removed (MAG-2160); per-endpoint trackers poll at a fixed avgBlockTime/2.")
+	if err := cmdRPCSmartRouter.Flags().MarkDeprecated(deprecatedChainTrackerPollingMultiplierFlagName, "it is a no-op: the global chain tracker was removed (MAG-2160)"); err != nil {
+		utils.LavaFormatFatal("failed marking chain-tracker-polling-multiplier deprecated", err)
+	}
 	cmdRPCSmartRouter.Flags().Var(&strategyFlag, "strategy", fmt.Sprintf("the strategy to use to pick providers (%s)", strings.Join(strategyNames, "|")))
 	defaultWeightedConfig := provideroptimizer.DefaultWeightedSelectorConfig()
 	cmdRPCSmartRouter.Flags().Float64(common.ProviderOptimizerAvailabilityWeight, defaultWeightedConfig.AvailabilityWeight, "weight assigned to provider availability when computing selection scores")

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -765,9 +765,14 @@ func (rpcss *RPCSmartRouterServer) sendRelayWithRetries(ctx context.Context, ret
 						utils.LogAttr("latestBlock", relayResult.Reply.LatestBlock),
 						utils.LogAttr("endpoint", relayResult.ProviderInfo.ProviderAddress),
 					)
-					if relayResult.Reply.LatestBlock > 0 {
-						rpcss.updateLatestBlockHeight(uint64(relayResult.Reply.LatestBlock), relayResult.ProviderInfo.ProviderAddress)
-					}
+					// Do NOT ratchet the bootstrap atomic here. This crafted GET_BLOCKNUM relay
+					// already flowed through sendRelayToEndpoint → sendRelayToDirectEndpoints →
+					// harvestAndUpdateTipFromRelay, which updates the atomic ONLY when ChainState
+					// accepts the block (the anti-lie gate). A direct updateLatestBlockHeight here
+					// bypassed that gate, so a lying-high health-relay response ChainState rejected
+					// still permanently ratcheted the monotonic atomic — and getLatestBlockBestEffort
+					// serves that poison to archive routing during any TTL-stale window. The gated
+					// harvest is the single atomic-update path; this call was a redundant bypass.
 					rpcss.relaysMonitor.LogRelay()
 					success = true
 					// If this is the first time we send relays, we want to send all of them, instead of break on first successful relay
@@ -1681,16 +1686,17 @@ func (rpcss *RPCSmartRouterServer) filterEndpointsByConsistency(
 			endpointURL = drsc.Endpoint.NetworkAddress
 		}
 
-		// Use the FRESHEST of the two per-endpoint tips (MAG-2160 Finding 6, same rationale as
-		// Site B): see freshestEndpointTip. Preferring the poll atomic and only falling back when
-		// it is exactly 0 (the old logic) rejected a perfectly current, relay-fed endpoint whose
-		// poll atomic was frozen by the traffic gate — "all endpoints failed consistency
-		// pre-validation" on a pod that is actually fine.
+		// Prefer the endpointtip store (the single source of truth), falling back to the poll
+		// atomic only when the store is empty (MAG-2160 Finding 6 + follow-up): see
+		// endpointTipPreferStore. The old atomic-then-store-if-0 logic rejected a current relay-fed
+		// endpoint whose poll atomic was frozen by the traffic gate; a naive max() would instead
+		// keep a STALE-HIGH atomic winning over a newer lower store tip after a reorg.
 		pollAtomic := int64(0)
 		if rpcss.endpointChainTrackerManager != nil && endpointURL != "" {
 			pollAtomic = rpcss.endpointChainTrackerManager.GetLatestBlockNum(endpointURL)
 		}
-		endpointLatest = freshestEndpointTip(pollAtomic, rpcss.endpointTipBlock(endpointURL))
+		storeTip := rpcss.endpointTipBlock(endpointURL)
+		endpointLatest = endpointTipPreferStore(pollAtomic, storeTip)
 
 		// If we still have no block data, skip validation for this endpoint (allow first relay)
 		if endpointLatest == 0 {
@@ -1725,13 +1731,13 @@ func (rpcss *RPCSmartRouterServer) filterEndpointsByConsistency(
 				utils.LogAttr("endpoint", endpointAddress),
 				utils.LogAttr("endpointLatest", endpointLatest),
 				utils.LogAttr("seenBlock", seenBlock),
-				// Report which source produced the winning (freshest) value, so a frozen poll
-				// atomic vs a relay-fed store tip is distinguishable in the logs.
+				// Report which source produced the value: the store wins whenever it holds a
+				// positive tip (prefer-store), else the poll atomic is the bootstrap fallback.
 				utils.LogAttr("source", func() string {
-					if pollAtomic >= endpointLatest {
-						return "poll_tracker"
+					if storeTip > 0 {
+						return "endpointtip_store"
 					}
-					return "endpointtip_store"
+					return "poll_tracker"
 				}()),
 				utils.LogAttr("GUID", ctx),
 			)
@@ -1796,16 +1802,25 @@ func (rpcss *RPCSmartRouterServer) recordRelayBlockObservation(endpoint *lavases
 	return rpcss.endpointChainTrackerManager.RecordRelayObservation(endpoint.NetworkAddress, gen, block, time.Now())
 }
 
-// freshestEndpointTip returns the higher of an endpoint's poll-tracker atomic and its
-// endpointtip-store tip (MAG-2160 Finding 6). The store is a SUPERSET of the atomic's freshness
-// — it is fed by BOTH the poll observer AND relay harvest, monotonically, whereas the atomic
-// advances only on real polls. Under the MAG-2159 traffic gate a poll cycle is skipped while
-// served relays keep the endpoint current, so the atomic can freeze below (or sit at 0 beneath) a
-// relay-fed store tip; taking the max picks up the store value there and can never regress (before
-// the store is populated the atomic still wins). A 0 from either side is just "unknown" and loses
-// to any positive value.
-func freshestEndpointTip(pollAtomic, storeTip int64) int64 {
-	if storeTip > pollAtomic {
+// endpointTipPreferStore returns an endpoint's observed tip, PREFERRING the endpointtip store
+// (the documented single source of truth) and falling back to the poll-tracker atomic only when
+// the store has no positive value (MAG-2160 Finding 6 + follow-up review).
+//
+// The store is fed by BOTH the poll observer AND relay harvest under a TIME-monotonic guard, so it
+// always reflects the newest observation — including a newer LOWER block after a reorg/rollback or
+// a stale-tip self-heal. The poll atomic, by contrast, advances only on a real poll that saw a new
+// block (replaceBlocksQueue runs only when gotNewBlock || forked) and never regresses on a plain
+// rollback, so it can sit STALE-HIGH while the store already holds the correct lower tip. Taking
+// max() (the earlier implementation) would then pick the stale atomic and make consistency
+// pre-validation believe a rolled-back endpoint is still caught up. Preferring the store fixes both
+// that reorg case AND the original traffic-gate-frozen case (there the store is the fresher/higher
+// value, so it still wins). The atomic is only a bootstrap fallback for the window before the store
+// has ever been written; a non-positive store value means "unknown", so we defer to the atomic.
+//
+// Safe to return a lower block: the sole caller is consistency pre-validation, where a lower tip
+// means "more likely behind" → a conservative reject, never an over-optimistic pass.
+func endpointTipPreferStore(pollAtomic, storeTip int64) int64 {
+	if storeTip > 0 {
 		return storeTip
 	}
 	return pollAtomic

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -245,13 +245,18 @@ func (rpcss *RPCSmartRouterServer) ServeRPCRequests(
 	// realign down. Off the hot path (relays/polls only do the cheap SetLatestBlock write via
 	// OnTipObservation). The snapshot is taken under the monitor lock and released before
 	// Recompute touches the ChainState lock — the two locks never nest.
-	go rpcss.runChainStateConsensusLoop(ctx, averageBlockTime)
+	// effectiveBlockTime, NOT the raw spec value: the recompute cadence must pace the same
+	// observation stream the monitor produces (see the floor comment above).
+	go rpcss.runChainStateConsensusLoop(ctx, effectiveBlockTime)
 
 	// Proactive health prober (MAG-2160 / Topic D): on its own cadence, score EVERY direct-RPC
 	// endpoint from stored telemetry + the consensus baseline (zero upstream calls), proactively
 	// re-enable recovered endpoints, and feed one QoS sample per provider. Replaces the synthetic
 	// direct-RPC probe (the legacy AppendProbeRelayData feed is gated off for static providers).
-	go rpcss.runProbeLoop(ctx, validatedProbeCadence(lavasession.ProbeLoopInterval), probing.DefaultVerdictConfig(averageBlockTime))
+	// effectiveBlockTime, NOT the raw spec value (see probeVerdictConfigFor): the verdict's alive
+	// horizon must share the SAME staleness horizon as ChainState and the monitor's poll cadence,
+	// and the "keeping up" tolerance must match consistency pre-validation's per-chain threshold.
+	go rpcss.runProbeLoop(ctx, validatedProbeCadence(lavasession.ProbeLoopInterval), probeVerdictConfigFor(effectiveBlockTime, rpcss.consistencyConfig))
 
 	// NewChainListener now accepts WSSubscriptionManager interface, which is implemented
 	// by both ConsumerWSSubscriptionManager (provider-relay mode) and
@@ -800,9 +805,12 @@ func (rpcss *RPCSmartRouterServer) sendCraftedRelays(retries int, initialRelays 
 }
 
 func (rpcss *RPCSmartRouterServer) getLatestBlock() uint64 {
-	// Site A (MAG-2160): the router-wide tip (archive routing + cache-finalization) is the
-	// per-chain ChainState consensus tip — TTL-fresh, monotonic, outlier-guarded — replacing the
-	// global-tracker → estimator → atomic ladder.
+	// Site A (MAG-2160): the router-wide tip (archive routing, finality labels) is the per-chain
+	// ChainState OBSERVED tip — TTL-fresh, monotonic, outlier-guarded — replacing the
+	// global-tracker → estimator → atomic ladder. Cache FINALIZATION does not read this: it
+	// needs the strict-majority consensus baseline (getLatestBlockForCacheFinalization), because
+	// the optimistic tip trusts a single fresh reporter and only heals a sub-threshold lie after
+	// TTL, which is not good enough when a too-high value falsely finalizes.
 	if rpcss.chainState != nil {
 		if block, ok := rpcss.chainState.GetLatestBlock(); ok && block > 0 {
 			return uint64(block)
@@ -833,14 +841,34 @@ func (rpcss *RPCSmartRouterServer) getLatestBlock() uint64 {
 // there): archive ROUTING only needs a recent-enough head to decide old-vs-recent, and a
 // slightly-stale head mis-classifies at worst a handful of near-head blocks — whereas the
 // strict 0 forces EVERY concrete-block request to the archive pool (archive_parser_rule.go:33).
-// Cache FINALIZATION must keep the strict getLatestBlock (a stale tip there can falsely finalize),
-// so this accessor is for archive routing only. Returns 0 only at genuine cold-start, preserving
-// the conservative force-archive fallback before any tip has ever been observed.
+// Cache FINALIZATION must keep the strict consensus source (getLatestBlockForCacheFinalization —
+// a stale or optimistic tip there can falsely finalize), so this accessor is for archive routing
+// only. Returns 0 only at genuine cold-start, preserving the conservative force-archive fallback
+// before any tip has ever been observed.
 func (rpcss *RPCSmartRouterServer) getLatestBlockBestEffort() uint64 {
 	if block := rpcss.getLatestBlock(); block > 0 {
 		return block
 	}
 	return rpcss.latestBlockHeight.Load()
+}
+
+// getLatestBlockForCacheFinalization returns the tip cache finalization measures against: the
+// strict-majority CONSENSUS baseline when fresh, else 0. It must NOT fall back to the optimistic
+// observed tip, the bootstrap atomic, or any best-effort source (see isFinalizedForCacheWrite's
+// doc block): a too-high tip here FALSELY finalizes — it writes still-mutable blocks into the
+// long-TTL finalized store, globally and durably — and the optimistic tip trusts a single fresh
+// reporter (on 1-endpoint pods, which never form a baseline, it is unguarded by consensus and a
+// sub-threshold lie only heals after TTL). A 0 merely under-finalizes: isFinalizedForCacheWrite
+// then falls back to Reply.LatestBlock, which is self-scoped to the reporting provider, so a
+// no-baseline pod degrades to per-reply finalization (echo-block methods land in the short-TTL
+// temp store) rather than trusting an unvetted global value — the safe direction.
+func (rpcss *RPCSmartRouterServer) getLatestBlockForCacheFinalization() uint64 {
+	if rpcss.chainState != nil {
+		if block, ok := rpcss.chainState.GetConsensusBaseline(); ok && block > 0 {
+			return uint64(block)
+		}
+	}
+	return 0
 }
 
 func (rpcss *RPCSmartRouterServer) updateLatestBlockHeight(blockHeight uint64, providerAddress string) {
@@ -1546,38 +1574,11 @@ func (rpcss *RPCSmartRouterServer) sendRelayToDirectEndpoints(
 					)
 				}
 
-				// Calculate syncGap (detect lagging endpoints). Site C (MAG-2160 Finding 2): an
-				// endpoint is judged against the strict-majority CONSENSUS baseline, NOT the
-				// optimistic observed tip. Measuring against the observed tip would penalize the
-				// whole pod whenever a single endpoint races ahead (baseline 1000, one node reports
-				// 1099 → everyone at 1000 gets a bogus syncGap of 99). When there is no fresh
-				// consensus baseline (single-endpoint pod, or a baseline aged past TTL) we DO NOT
-				// substitute the observed tip — syncGap stays 0, so no endpoint is penalized against
-				// a reference the pod has not actually agreed on.
+				// Calculate syncGap (detect lagging endpoints) against this interface's reference
+				// tip — see endpointSyncGap for the reference-selection + clamp rules (Site C).
 				syncGap := int64(0)
-				if targetEndpoint != nil && rpcss.chainState != nil {
-					if baseline, ok := rpcss.chainState.GetConsensusBaseline(); ok && baseline > 0 {
-						endpointLatest := rpcss.endpointTipBlock(targetEndpoint.NetworkAddress)
-						if endpointLatest > 0 {
-							syncGap = baseline - endpointLatest
-							// The baseline is the winning cluster's MOST-ADVANCED block, but every
-							// endpoint within BucketWidth of it is inside that same agreeing cluster
-							// (the cluster spans at most BucketWidth). Charging such an endpoint a gap
-							// would penalize the consensus majority against a tip only the fastest
-							// cluster member reported (e.g. baseline 1002 from a lone fast node vs the
-							// 1000-majority). Treat in-cluster endpoints as fully synced (PR #143).
-							if syncGap <= rpcss.chainState.ConsensusBucketWidth() {
-								syncGap = 0
-							}
-							utils.LavaFormatDebug("calculated sync gap",
-								utils.LogAttr("endpoint", endpointAddress),
-								utils.LogAttr("consensus_baseline", baseline),
-								utils.LogAttr("endpoint_latest", endpointLatest),
-								utils.LogAttr("sync_gap", syncGap),
-								utils.LogAttr("GUID", goroutineCtx),
-							)
-						}
-					}
+				if targetEndpoint != nil {
+					syncGap = rpcss.endpointSyncGap(targetEndpoint.NetworkAddress, endpointAddress, goroutineCtx)
 				}
 
 				// Call OnSessionDone with correct signature
@@ -1680,17 +1681,16 @@ func (rpcss *RPCSmartRouterServer) filterEndpointsByConsistency(
 			endpointURL = drsc.Endpoint.NetworkAddress
 		}
 
-		// First, try to get from ChainTracker manager (continuously polled, fresh data)
-		// ChainTrackers are keyed by URL, so multiple providers pointing to same URL share one tracker
+		// Use the FRESHEST of the two per-endpoint tips (MAG-2160 Finding 6, same rationale as
+		// Site B): see freshestEndpointTip. Preferring the poll atomic and only falling back when
+		// it is exactly 0 (the old logic) rejected a perfectly current, relay-fed endpoint whose
+		// poll atomic was frozen by the traffic gate — "all endpoints failed consistency
+		// pre-validation" on a pod that is actually fine.
+		pollAtomic := int64(0)
 		if rpcss.endpointChainTrackerManager != nil && endpointURL != "" {
-			endpointLatest = rpcss.endpointChainTrackerManager.GetLatestBlockNum(endpointURL)
+			pollAtomic = rpcss.endpointChainTrackerManager.GetLatestBlockNum(endpointURL)
 		}
-
-		// Fallback: if the ChainTracker has no data yet, use the shared endpointtip store
-		// (single source of truth, fed by the gated poll/relay observers).
-		if endpointLatest == 0 {
-			endpointLatest = rpcss.endpointTipBlock(endpointURL)
-		}
+		endpointLatest = freshestEndpointTip(pollAtomic, rpcss.endpointTipBlock(endpointURL))
 
 		// If we still have no block data, skip validation for this endpoint (allow first relay)
 		if endpointLatest == 0 {
@@ -1725,11 +1725,13 @@ func (rpcss *RPCSmartRouterServer) filterEndpointsByConsistency(
 				utils.LogAttr("endpoint", endpointAddress),
 				utils.LogAttr("endpointLatest", endpointLatest),
 				utils.LogAttr("seenBlock", seenBlock),
+				// Report which source produced the winning (freshest) value, so a frozen poll
+				// atomic vs a relay-fed store tip is distinguishable in the logs.
 				utils.LogAttr("source", func() string {
-					if rpcss.endpointChainTrackerManager != nil && endpointURL != "" && rpcss.endpointChainTrackerManager.GetLatestBlockNum(endpointURL) > 0 {
-						return "ChainTracker"
+					if pollAtomic >= endpointLatest {
+						return "poll_tracker"
 					}
-					return "reactive"
+					return "endpointtip_store"
 				}()),
 				utils.LogAttr("GUID", ctx),
 			)
@@ -1794,6 +1796,21 @@ func (rpcss *RPCSmartRouterServer) recordRelayBlockObservation(endpoint *lavases
 	return rpcss.endpointChainTrackerManager.RecordRelayObservation(endpoint.NetworkAddress, gen, block, time.Now())
 }
 
+// freshestEndpointTip returns the higher of an endpoint's poll-tracker atomic and its
+// endpointtip-store tip (MAG-2160 Finding 6). The store is a SUPERSET of the atomic's freshness
+// — it is fed by BOTH the poll observer AND relay harvest, monotonically, whereas the atomic
+// advances only on real polls. Under the MAG-2159 traffic gate a poll cycle is skipped while
+// served relays keep the endpoint current, so the atomic can freeze below (or sit at 0 beneath) a
+// relay-fed store tip; taking the max picks up the store value there and can never regress (before
+// the store is populated the atomic still wins). A 0 from either side is just "unknown" and loses
+// to any positive value.
+func freshestEndpointTip(pollAtomic, storeTip int64) int64 {
+	if storeTip > pollAtomic {
+		return storeTip
+	}
+	return pollAtomic
+}
+
 // endpointTipBlock reads an endpoint's observed tip from the shared single-source-of-truth
 // endpointtip store, keyed by this server's chain + apiInterface + the endpoint URL. It
 // returns 0 (the "unknown tip" sentinel) when the listen endpoint is unset or the URL is
@@ -1805,6 +1822,62 @@ func (rpcss *RPCSmartRouterServer) endpointTipBlock(endpointURL string) int64 {
 	return endpointtip.Default().Block(
 		endpointtip.Key(rpcss.listenEndpoint.ChainID, rpcss.listenEndpoint.ApiInterface, endpointURL),
 	)
+}
+
+// endpointSyncGap computes how far the given endpoint lags the interface's reference tip, for the
+// QoS sync dimension (Site C, MAG-2160 Finding 2). Reference selection:
+//   - a fresh strict-majority CONSENSUS baseline is preferred: measuring against the optimistic
+//     observed tip while a consensus EXISTS would penalize the whole pod whenever one endpoint
+//     races ahead (baseline 1000, one node reports 1099 → everyone at 1000 gets a bogus gap of 99);
+//   - with NO fresh baseline, fall back to the outlier-guarded OBSERVED tip instead of skipping the
+//     check. On a 2-endpoint pod a badly lagging endpoint destroys the majority BY ITSELF (two
+//     votes beyond BucketWidth cluster into nothing), so "no baseline → no penalty" would disable
+//     lag detection in exactly the case that needs it — the laggard would keep its traffic share
+//     with gap forever 0. The guarded tip restores main's behavior there (leader reads 0, laggard
+//     reads its real distance).
+//
+// The gap feeds CalculateQoS (QoS report / reputation). The optimizer's sync dimension keeps the
+// stricter F5 contract (omit on no-majority) via resolveSyncReference — deliberately unchanged, so
+// a lone-reporter tip never reaches the optimizer even though it can inform this QoS gap.
+func (rpcss *RPCSmartRouterServer) endpointSyncGap(endpointURL, endpointAddress string, guid context.Context) int64 {
+	if rpcss.chainState == nil {
+		return 0
+	}
+	reference, referenceIsConsensus := rpcss.chainState.GetConsensusBaseline()
+	if !(referenceIsConsensus && reference > 0) {
+		reference, referenceIsConsensus = 0, false
+		if tip, ok := rpcss.chainState.GetLatestBlock(); ok {
+			reference = tip
+		}
+	}
+	endpointLatest := rpcss.endpointTipBlock(endpointURL)
+	syncGap := syncGapAgainstReference(reference, endpointLatest, rpcss.chainState.ConsensusBucketWidth())
+	if reference > 0 && endpointLatest > 0 {
+		utils.LavaFormatDebug("calculated sync gap",
+			utils.LogAttr("endpoint", endpointAddress),
+			utils.LogAttr("reference_tip", reference),
+			utils.LogAttr("reference_is_consensus", referenceIsConsensus),
+			utils.LogAttr("endpoint_latest", endpointLatest),
+			utils.LogAttr("sync_gap", syncGap),
+			utils.LogAttr("GUID", guid),
+		)
+	}
+	return syncGap
+}
+
+// syncGapAgainstReference is the pure gap math: reference − endpointLatest, clamped to 0 when the
+// endpoint is within bucketWidth of the reference (inside the agreeing cluster, so keeping up — PR
+// #143; the same clamp applies to the observed-tip fallback) or when either input is unknown (<= 0).
+// A negative raw gap (endpoint ahead of the reference) also clamps to 0.
+func syncGapAgainstReference(reference, endpointLatest, bucketWidth int64) int64 {
+	if reference <= 0 || endpointLatest <= 0 {
+		return 0
+	}
+	gap := reference - endpointLatest
+	if gap <= bucketWidth {
+		return 0
+	}
+	return gap
 }
 
 // minChainStateRecomputeInterval floors the consensus recompute cadence so very fast chains
@@ -1950,6 +2023,31 @@ func (s *probeLoopStats) snapshot() probeLoopSnapshot {
 // renders a health verdict for EVERY direct-RPC endpoint (regular AND backup), proactively
 // re-enables recovered endpoints (the O1 win), and feeds ONE aggregated QoS sample per provider
 // (Topic E contract). It is read-only toward the data plane: it never writes block/consensus state.
+// probeVerdictConfigFor derives the probe's per-endpoint verdict thresholds.
+//
+// effectiveBlockTime (the floored block time), NOT the raw spec value, drives DefaultVerdictConfig:
+// the alive horizon (StalenessMultiplier × block time, floored at minProbeStaleness) must share the
+// SAME staleness horizon as ChainState and the monitor's poll cadence. With the raw 0 the horizon
+// floors to ~5s while the poll cadence is effectiveBlockTime/2 (~6s), so every healthy endpoint's
+// newest observation would routinely be "too old" at probe time — scoring the whole pod not-alive
+// and decaying availability QoS on any chain whose spec omits average_block_time.
+//
+// The "keeping up" tolerance is sourced from the SAME per-chain threshold consistency pre-validation
+// uses (relaycore.EndpointLagThreshold), not the probing package's compile-time default of 10. On a
+// chain whose derived threshold exceeds 10 (large blockLagForQosSync, wide finalization distance, or
+// an operator's --consistency-block-gap-factor override) the relay path would otherwise serve an
+// endpoint lagging 11..threshold blocks while every probe cycle marked it unhealthy — decaying its
+// QoS and, worse, blocking the F1 re-enable (RecoveryEvidence.PollHealthy requires keepingUp under
+// the same tolerance), so a disabled endpoint within the accepted lag could never recover until the
+// epoch flip. A nil/zero consistency config falls back to the compile-time default.
+func probeVerdictConfigFor(effectiveBlockTime time.Duration, consistencyConfig *relaycore.ConsistencyValidationConfig) probing.VerdictConfig {
+	cfg := probing.DefaultVerdictConfig(effectiveBlockTime)
+	if consistencyConfig != nil && consistencyConfig.EndpointLagThreshold > 0 {
+		cfg.LagToleranceBlocks = consistencyConfig.EndpointLagThreshold
+	}
+	return cfg
+}
+
 func (rpcss *RPCSmartRouterServer) runProbeLoop(ctx context.Context, cadence time.Duration, cfg probing.VerdictConfig) {
 	if rpcss.sessionManager == nil || rpcss.endpointChainTrackerManager == nil {
 		return
@@ -2068,7 +2166,9 @@ func runProbeCycleCore(
 // reactive LatestBlock (read by consistency pre-validation), the bootstrap atomic (latestBlockHeight,
 // the cold-start fallback for getLatestBlock), and the latest-block metric. A historical response
 // updates NONE of these, so it can no longer poison
-// the endpoint tip. "The block this response serviced" (latestServicedBlock) is a separate
+// the endpoint tip. The bootstrap atomic is additionally gated on the CHAIN-level ChainState
+// verdict (see the inline comment below) — per-endpoint acceptance alone must not ratchet a
+// router-wide monotonic value. "The block this response serviced" (latestServicedBlock) is a separate
 // concept the caller handles ungated. No-op when targetEndpoint is nil or the response is not
 // tip-eligible. harvestGen is the generation captured before dispatch (finding 5).
 func (rpcss *RPCSmartRouterServer) harvestAndUpdateTipFromRelay(
@@ -2094,7 +2194,26 @@ func (rpcss *RPCSmartRouterServer) harvestAndUpdateTipFromRelay(
 	if !rpcss.recordRelayBlockObservation(targetEndpoint, harvestGen, tip) {
 		return
 	}
-	rpcss.updateLatestBlockHeight(uint64(tip), endpointAddress)
+	// The router-wide bootstrap atomic is monotonic-max with NO downward correction, so it may
+	// only follow blocks the CHAIN-level anti-lie guard accepted — the per-endpoint store's
+	// time-monotonic acceptance above is the wrong scope (a lying-high endpoint passes its own
+	// per-endpoint guard). By the time recordRelayBlockObservation returns, the monitor's
+	// OnTipObservation hook has already driven ChainState.SetLatestBlock with this very block
+	// (synchronously, after obsMu release — see RecordRelayObservation's deferred callback), so
+	// the ChainState tip reflects the verdict: an accepted block reads back as tip >= block, a
+	// rejected outlier reads back lower (or stale). Without this gate, one bogus high harvest
+	// (e.g. a lying Solana context slot) permanently ratchets the atomic, and whenever ChainState
+	// is TTL-stale, getLatestBlockBestEffort serves the lie to archive routing for the life of
+	// the process. The per-endpoint metric below deliberately stays gated on the store only: it
+	// reports THIS endpoint's own view, so the per-endpoint guard is the right scope for it.
+	chainAccepted := true
+	if rpcss.chainState != nil {
+		accepted, ok := rpcss.chainState.GetLatestBlock()
+		chainAccepted = ok && tip <= accepted
+	}
+	if chainAccepted {
+		rpcss.updateLatestBlockHeight(uint64(tip), endpointAddress)
+	}
 	if rpcss.smartRouterEndpointMetrics != nil {
 		// endpointAddress is the provider name (session map key), so resolveProviderName
 		// returns it unchanged — endpoint_id = provider name in the metric.
@@ -2308,21 +2427,24 @@ func (rpcss *RPCSmartRouterServer) initializeChainTrackers(ctx context.Context) 
 // cache-write goes to the long-TTL finalized store or the short-TTL temp
 // store. Reply.LatestBlock is unreliable for methods that echo the requested
 // block (eth_getBlockByNumber returns result.number = requested), so the
-// router's tracked tip (the per-chain ChainState consensus tip, with the
-// bootstrap atomic latestBlockHeight as cold-start fallback, surfaced via
-// getLatestBlock()) wins when it is higher.
+// router's tracked tip (the per-chain ChainState strict-majority consensus
+// baseline, surfaced via getLatestBlockForCacheFinalization()) wins when it
+// is higher.
 //
-// IMPORTANT — finalization MUST be passed the STRICT getLatestBlock(), which
-// returns 0 when the consensus tip is stale/uninitialized. Do NOT switch this to
-// getLatestBlockBestEffort() the way archive routing (#1) does. A higher "latest"
-// here can FALSELY finalize (write a not-yet-final block to the long-TTL store),
-// so the source must be trustworthy: the consensus tip is strict-majority and
-// realigns DOWNWARD on a poisoned/reverted tip. The bootstrap atomic is
-// monotonic-max with no downward correction, so one lying-high observation would
-// false-finalize EVERY provider's responses persistently until the real head
-// catches up — globally and durably, far worse than replyLatestBlock (which is
-// self-scoped to one provider's reply). A stale-but-honest 0 only under-finalizes
-// (finalized data lands in the short-TTL store), which is the safe direction.
+// IMPORTANT — finalization MUST be passed getLatestBlockForCacheFinalization(),
+// which returns the CONSENSUS baseline or a strict 0. Do NOT switch this to
+// getLatestBlock() (the OPTIMISTIC observed tip) or getLatestBlockBestEffort()
+// the way archive routing (#1) does. A higher "latest" here can FALSELY finalize
+// (write a not-yet-final block to the long-TTL store), so the source must be
+// trustworthy: the consensus baseline is strict-majority and realigns DOWNWARD
+// on a poisoned/reverted tip. The optimistic tip trusts a single fresh reporter
+// (unguarded by consensus on no-baseline pods), and the bootstrap atomic is
+// monotonic-max with no downward correction — with either, one lying-high
+// observation would false-finalize EVERY provider's responses persistently
+// until the real head catches up — globally and durably, far worse than
+// replyLatestBlock (which is self-scoped to one provider's reply). A
+// stale-but-honest 0 only under-finalizes (finalized data lands in the
+// short-TTL store), which is the safe direction.
 func isFinalizedForCacheWrite(requestedBlock, replyLatestBlock, trackedLatestBlock, finalizationDistance int64) bool {
 	latest := replyLatestBlock
 	if trackedLatestBlock > latest {
@@ -2427,7 +2549,7 @@ func (rpcss *RPCSmartRouterServer) tryCacheWrite(
 	// reads result.number), so the naive check never marks any historical
 	// block finalized and every entry takes the ~625 ms non-finalized TTL.
 	latestBlock := relayResult.Reply.LatestBlock
-	finalized := isFinalizedForCacheWrite(requestedBlock, latestBlock, int64(rpcss.getLatestBlock()), int64(blockDistanceForFinalizedData))
+	finalized := isFinalizedForCacheWrite(requestedBlock, latestBlock, int64(rpcss.getLatestBlockForCacheFinalization()), int64(blockDistanceForFinalizedData))
 
 	// Convert LATEST_BLOCK to actual block number for cache key
 	// This must match the logic in cache lookup (sendRelayToEndpoint) to ensure cache hits

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -2365,29 +2365,30 @@ func seedEndpointTip(chainID, apiInterface, url string, block int64) {
 	)
 }
 
-// TestFreshestEndpointTip locks the MAG-2160 Finding 6 fix: consistency pre-validation (and the
-// Site B fallback) must read the FRESHEST of the poll-tracker atomic and the endpointtip store,
-// not prefer the atomic and only fall back when it is exactly 0. Under the MAG-2159 traffic gate a
-// relay-fed endpoint's poll atomic freezes below (or at 0 beneath) a fresher store tip; the old
-// "atomic unless 0" logic then rejected a current endpoint. The store must win in that case, and
-// max() must never regress (atomic still wins before the store is populated).
-func TestFreshestEndpointTip(t *testing.T) {
+// TestEndpointTipPreferStore locks the MAG-2160 Finding 6 fix + follow-up review: consistency
+// pre-validation prefers the endpointtip store (the single source of truth) and falls back to the
+// poll-tracker atomic ONLY when the store is empty. The store is fed by both poll and relay under a
+// time-monotonic guard, so it reflects the newest observation — including a newer LOWER block after
+// a reorg. A naive max() would keep a STALE-HIGH atomic winning there, making a rolled-back endpoint
+// look caught up; prefer-store fixes that while still winning the traffic-gate-frozen case (where
+// the store is the fresher/higher value).
+func TestEndpointTipPreferStore(t *testing.T) {
 	cases := []struct {
 		name       string
 		pollAtomic int64
 		storeTip   int64
 		want       int64
 	}{
-		{"frozen atomic below fresh store → store wins (the bug)", 100, 195, 195},
+		{"frozen atomic below fresh store → store wins (traffic gate)", 100, 195, 195},
+		{"reorg: stale-high atomic, newer lower store → store wins (the follow-up bug)", 1000, 900, 900},
 		{"purely relay-fed endpoint: atomic 0, store fresh", 0, 195, 195},
-		{"store not yet populated: atomic wins", 195, 0, 195},
-		{"both known, atomic fresher (poll just ran)", 195, 190, 195},
+		{"store empty: atomic is the bootstrap fallback", 195, 0, 195},
 		{"equal", 195, 195, 195},
-		{"both unknown", 0, 0, 0},
+		{"both unknown (e.g. after a reset that cleared both)", 0, 0, 0},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, freshestEndpointTip(tc.pollAtomic, tc.storeTip))
+			require.Equal(t, tc.want, endpointTipPreferStore(tc.pollAtomic, tc.storeTip))
 		})
 	}
 }

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -2365,6 +2365,33 @@ func seedEndpointTip(chainID, apiInterface, url string, block int64) {
 	)
 }
 
+// TestFreshestEndpointTip locks the MAG-2160 Finding 6 fix: consistency pre-validation (and the
+// Site B fallback) must read the FRESHEST of the poll-tracker atomic and the endpointtip store,
+// not prefer the atomic and only fall back when it is exactly 0. Under the MAG-2159 traffic gate a
+// relay-fed endpoint's poll atomic freezes below (or at 0 beneath) a fresher store tip; the old
+// "atomic unless 0" logic then rejected a current endpoint. The store must win in that case, and
+// max() must never regress (atomic still wins before the store is populated).
+func TestFreshestEndpointTip(t *testing.T) {
+	cases := []struct {
+		name       string
+		pollAtomic int64
+		storeTip   int64
+		want       int64
+	}{
+		{"frozen atomic below fresh store → store wins (the bug)", 100, 195, 195},
+		{"purely relay-fed endpoint: atomic 0, store fresh", 0, 195, 195},
+		{"store not yet populated: atomic wins", 195, 0, 195},
+		{"both known, atomic fresher (poll just ran)", 195, 190, 195},
+		{"equal", 195, 195, 195},
+		{"both unknown", 0, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, freshestEndpointTip(tc.pollAtomic, tc.storeTip))
+		})
+	}
+}
+
 // ============================================================================
 // Tests for Phase 3.1: Consistency Pre-Validation Retry with Different Providers
 // ============================================================================


### PR DESCRIPTION
## Summary

Follow-up to #143. A multi-agent code review of the chaintracker/probing redesign surfaced 9 correctness/robustness issues that were **not** included in the squash-merged PR #143 — verified by inspecting the merged code on `main` (all 9 locations carry the original pre-fix behavior). This PR applies all 9, each with a focused regression test.

## Findings fixed

### 🔴 Critical — tip poisoning (shared root cause: the anti-lie guard only existed when a consensus baseline did, which no 1–2 endpoint pod ever forms)
- **#1 `chainstate`** — `SetLatestBlock` now anchors the anti-lie guard on the fresh tip when there is no baseline, and re-adopts a fresh lower block once a poisoned tip goes TTL-stale (self-heal). Bounds a poisoning of the tip to ~one TTL instead of the process lifetime.
- **#2 `rpcsmartrouter`** — cache finalization reads the strict consensus baseline (`getLatestBlockForCacheFinalization`), never the optimistic tip or bootstrap atomic — a too-high value there falsely finalizes still-mutable blocks into the long-TTL cache.
- **#3 `rpcsmartrouter`** — the router-wide bootstrap atomic ratchet in `harvestAndUpdateTipFromRelay` is gated on the ChainState verdict, not the per-endpoint store's time-monotonic guard, so a lying-high harvest can't poison archive routing.

### 🟠 High
- **#4** — feed `effectiveBlockTime` (not the raw spec value, which may be 0) to the probe `VerdictConfig` and consensus loop, so healthy endpoints aren't scored unavailable on chains without `average_block_time`.
- **#5** — re-register `--chain-tracker-polling-multiplier` as a deprecated no-op so existing deployments don't fail process start on upgrade.

### 🟡 Medium
- **#6** — sync-gap scoring falls back to the guarded observed tip when no majority exists (`endpointSyncGap` / `syncGapAgainstReference`), restoring lag demotion on 2-endpoint pods. (Reporting/reputation QoS only — the optimizer's selection path keeps the stricter F5 omit-on-no-majority contract, unchanged.)
- **#7** — consistency pre-validation reads the freshest of the poll atomic and the endpointtip store (`freshestEndpointTip`), so a traffic-gate-frozen atomic no longer false-rejects a live relay-fed endpoint.
- **#8** — a traffic-gate skip is reported (`skipped bool`) and PRESERVES the poll-failure backoff (`nextFetchFails`) instead of resetting it, so a broken poll path backs off and its recovery evidence accrues.
- **#9** — the probe's lag tolerance is sourced from the per-chain `EndpointLagThreshold` (`probeVerdictConfigFor`), matching consistency pre-validation instead of a hardcoded 10.

## Testing

Each fix extracts its decision logic into a small pure helper unit-tested against the specific failure scenario from the review. Touched packages green on top of `main`:

- `protocol/chainstate` ✅
- `protocol/chaintracker` ✅
- `protocol/probing` ✅
- `protocol/rpcsmartrouter` ✅

`go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### 🟡 Additional (10th finding, from follow-up review) — reset must clear the endpointtip store
- **`endpointstate`** — `ResetAllLatestBlocks` zeroed only each tracker's poll atomic, leaving the shared endpointtip store populated with the pre-reset block. Consistency pre-validation reads the freshest of the two sources (`freshestEndpointTip`, #7), so after a reset it resurfaced the stale value via `max()` and kept gating against the block the reset asked to discard — violating `ResetLatestBlock`'s documented "consistency sees <= 0 and skips" contract. Now removes the store entry in lockstep with the atomic reset (`endpointtip.Remove`), so both sources read 0 together. Regression test asserts the store reads 0 after a reset (fails without the fix); package is race-clean.

_Note: this gap is orthogonal to #7 and pre-existed on `main` — #7 only changed the both-positive (traffic-gate-frozen) case; the reset case returns the same stale value main's original fallback did. Fixing it at the reset (not the read) is correct because a timestamp-aware read would still lose to the store's real timestamp (reset zeroes the atomic's changeTime)._