### PR TITLE
fix: serve stale data when all providers fail consistency validation (MAG-2392)

### DIFF
--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -1928,6 +1928,24 @@ func (csm *ConsumerSessionManager) blockProvider(ctx context.Context, address st
 	return nil
 }
 
+// OnSessionDiscarded releases a session that was selected but intentionally
+// dropped before any relay was dispatched. It returns the reserved compute
+// units and unlocks the session without recording a QoS failure or adding a
+// consecutive provider error: no upstream request was made, so availability
+// was not actually tested.
+func (csm *ConsumerSessionManager) OnSessionDiscarded(consumerSession *SingleConsumerSession, reason error) error {
+	if err := consumerSession.VerifyLock(); err != nil {
+		return fmt.Errorf("OnSessionDiscarded, consumerSession.lock must be locked before accessing this method: %w", err)
+	}
+
+	cuToDecrease := consumerSession.LatestRelayCu
+	parentConsumerSessionsWithProvider := consumerSession.Parent
+	consumerSession.LatestRelayCu = 0
+	consumerSession.Free(reason)
+
+	return parentConsumerSessionsWithProvider.decreaseUsedComputeUnits(cuToDecrease)
+}
+
 // Report session failure, mark it as blocked from future usages, report if timeout happened.
 func (csm *ConsumerSessionManager) OnSessionFailure(consumerSession *SingleConsumerSession, errorReceived error) error {
 	// consumerSession must be locked when getting here.

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -887,6 +887,41 @@ func runOnSessionFailureForConsumerSessionMap(t *testing.T, css ConsumerSessions
 	}
 }
 
+func TestOnSessionDiscardedReleasesReservationWithoutProviderFailure(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+	usedProviders := NewUsedProviders(nil)
+	parent := &ConsumerSessionsWithProvider{
+		PublicLavaAddress: "provider-stale",
+		MaxComputeUnits:   100,
+		UsedComputeUnits:  10,
+	}
+	session := &SingleConsumerSession{Parent: parent}
+	blocked, ok := session.TryUseSession()
+	require.False(t, blocked)
+	require.True(t, ok)
+
+	routerKey := NewRouterKey(nil)
+	require.NoError(t, session.SetUsageForSession(10, nil, usedProviders, routerKey))
+	usedProviders.AddUsed(ConsumerSessionsMap{
+		"provider-stale": &SessionInfo{Session: session},
+	}, nil)
+	usedProviders.ReleaseFromLatestBatch("provider-stale", routerKey, ConsistencyPreValidationError)
+
+	require.NoError(t, csm.OnSessionDiscarded(session, ConsistencyPreValidationError))
+	require.Zero(t, parent.atomicReadUsedComputeUnits(), "reserved CU must be returned")
+	require.Zero(t, session.LatestRelayCu)
+	require.Empty(t, session.ConsecutiveErrors, "a request that was never sent must not count as a provider failure")
+	require.Zero(t, usedProviders.CurrentlyUsed())
+	require.Zero(t, usedProviders.SessionsLatestBatch())
+	require.Contains(t, usedProviders.GetUnwantedProvidersToSend(routerKey), "provider-stale")
+
+	// The discard must unlock the session without blocklisting it.
+	blocked, ok = session.TryUseSession()
+	require.False(t, blocked)
+	require.True(t, ok)
+	session.Free(nil)
+}
+
 func TestHappyFlowVirtualEpoch(t *testing.T) {
 	ctx := context.Background()
 	csm := CreateConsumerSessionManager()

--- a/protocol/lavasession/used_providers.go
+++ b/protocol/lavasession/used_providers.go
@@ -276,6 +276,31 @@ func (up *UsedProviders) ClearUnwanted() {
 	}
 }
 
+// RemoveUnwantedAddresses makes only the supplied providers eligible for
+// selection again, across every router key used by this request. Unlike
+// ClearUnwanted, it preserves exclusions for providers that failed for other
+// reasons. This is used by the smart router's all-stale consistency fallback:
+// once every selectable provider has failed pre-dispatch consistency
+// validation, only those consistency-rejected providers may be retried.
+func (up *UsedProviders) RemoveUnwantedAddresses(addresses []string) {
+	if up == nil || len(addresses) == 0 {
+		return
+	}
+
+	addressesToRemove := make(map[string]struct{}, len(addresses))
+	for _, address := range addresses {
+		addressesToRemove[address] = struct{}{}
+	}
+
+	up.lock.Lock()
+	defer up.lock.Unlock()
+	for _, uniqueUsedProviders := range up.uniqueUsedProviders {
+		for address := range addressesToRemove {
+			delete(uniqueUsedProviders.unwantedProviders, address)
+		}
+	}
+}
+
 func (up *UsedProviders) AddUsed(sessions ConsumerSessionsMap, err error) {
 	if up == nil {
 		return

--- a/protocol/lavasession/used_providers_test.go
+++ b/protocol/lavasession/used_providers_test.go
@@ -113,6 +113,28 @@ func TestReleaseFromLatestBatch(t *testing.T) {
 	})
 }
 
+func TestRemoveUnwantedAddresses(t *testing.T) {
+	usedProviders := NewUsedProviders(nil)
+	emptyKey := NewRouterKey(nil)
+	archiveKey := NewRouterKey([]string{"archive"})
+
+	for _, key := range []RouterKey{emptyKey, archiveKey} {
+		usedProviders.AddUnwantedAddresses("stale-1", key)
+		usedProviders.AddUnwantedAddresses("stale-2", key)
+		usedProviders.AddUnwantedAddresses("transport-failure", key)
+	}
+
+	usedProviders.RemoveUnwantedAddresses([]string{"stale-1", "stale-2"})
+
+	for _, key := range []RouterKey{emptyKey, archiveKey} {
+		unwanted := usedProviders.GetUnwantedProvidersToSend(key)
+		require.NotContains(t, unwanted, "stale-1")
+		require.NotContains(t, unwanted, "stale-2")
+		require.Contains(t, unwanted, "transport-failure",
+			"the consistency fallback must preserve providers excluded for other reasons")
+	}
+}
+
 func TestUsedProvidersAsync(t *testing.T) {
 	t.Run("concurrency", func(t *testing.T) {
 		usedProviders := NewUsedProviders(nil)

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -775,11 +775,11 @@ func (rpcss *RPCSmartRouterServer) sendRelayWithRetries(ctx context.Context, ret
 			usedEndpointsResets++
 			relayProcessor.GetUsedProviders().ClearUnwanted()
 		}
-		err = rpcss.sendRelayToEndpoint(ctx, 1, relaycore.GetEmptyRelayState(ctx, protocolMessage), relayProcessor, nil)
+		err = rpcss.sendRelayToEndpoint(ctx, 1, relaycore.GetEmptyRelayState(ctx, protocolMessage), relayProcessor, nil, nil)
 		if errors.Is(err, lavasession.PairingListEmptyError) {
 			// we don't have pairings anymore, could be related to unwanted endpoints
 			relayProcessor.GetUsedProviders().ClearUnwanted()
-			err = rpcss.sendRelayToEndpoint(ctx, 1, relaycore.GetEmptyRelayState(ctx, protocolMessage), relayProcessor, nil)
+			err = rpcss.sendRelayToEndpoint(ctx, 1, relaycore.GetEmptyRelayState(ctx, protocolMessage), relayProcessor, nil, nil)
 		}
 		if err != nil {
 			utils.LavaFormatError("[-] failed sending init relay", err, []utils.Attribute{{Key: "GUID", Value: ctx}, {Key: "chainID", Value: rpcss.listenEndpoint.ChainID}, {Key: "APIInterface", Value: rpcss.listenEndpoint.ApiInterface}, {Key: "relayProcessor", Value: relayProcessor}}...)
@@ -1180,6 +1180,14 @@ func (rpcss *RPCSmartRouterServer) ProcessRelaySend(ctx context.Context, protoco
 		rpcss.relayRetriesManager,
 		stateMachine,
 	)
+	// Cross-validation remains strict: accepting stale participants would change
+	// the caller's requested validation contract. Stateless/stateful requests get
+	// a request-local fallback that is activated only after normal selection has
+	// exhausted every non-rejected candidate.
+	var consistencyFallback *consistencyFallbackState
+	if stateMachine.GetSelection() != relaycore.CrossValidation {
+		consistencyFallback = newConsistencyFallbackState()
+	}
 
 	if reason, err := rpcss.validateCrossValidationCapacity(ctx, stateMachine.GetSelection(), crossValidationParams, chainlib.GetAddon(protocolMessage), common.GetExtensionNames(protocolMessage.GetExtensions())); err != nil {
 		if reason != "" {
@@ -1220,7 +1228,15 @@ func (rpcss *RPCSmartRouterServer) ProcessRelaySend(ctx context.Context, protoco
 			return relayProcessor, task.Err
 		}
 		utils.LavaFormatTrace("[RPCSmartRouterServer] ProcessRelaySend - task", utils.LogAttr("GUID", ctx), utils.LogAttr("numOfEndpoints", task.NumOfProviders))
-		err := rpcss.sendRelayToEndpoint(ctx, task.NumOfProviders, task.RelayState, relayProcessor, task.Analytics)
+		err := sendRelayTaskWithConsistencyFallback(
+			ctx,
+			stateMachine.GetSelection(),
+			consistencyFallback,
+			relayProcessor.GetUsedProviders(),
+			func() error {
+				return rpcss.sendRelayToEndpoint(ctx, task.NumOfProviders, task.RelayState, relayProcessor, consistencyFallback, task.Analytics)
+			},
+		)
 
 		utils.LavaFormatInfo("UPDATING BATCH",
 			utils.LogAttr("error", err),
@@ -1324,12 +1340,149 @@ func deepCopyRelayPrivateData(original *pairingtypes.RelayPrivateData) *pairingt
 	}
 }
 
+// consistencyFallbackState tracks the providers rejected by pre-dispatch
+// consistency validation during one client request. The normal path keeps
+// those providers excluded while the router searches for a fresh alternative.
+// Once selection reports PairingListEmpty, activate re-enables exactly this set
+// for a single all-stale fallback pass.
+type consistencyFallbackState struct {
+	mu                sync.RWMutex
+	rejectedProviders map[string]struct{}
+	active            bool
+	attempted         bool
+}
+
+func newConsistencyFallbackState() *consistencyFallbackState {
+	return &consistencyFallbackState{rejectedProviders: make(map[string]struct{})}
+}
+
+func (state *consistencyFallbackState) recordRejected(sessions lavasession.ConsumerSessionsMap) {
+	if state == nil || len(sessions) == 0 {
+		return
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	for providerAddress := range sessions {
+		state.rejectedProviders[providerAddress] = struct{}{}
+	}
+}
+
+func (state *consistencyFallbackState) allows(providerAddress string) bool {
+	if state == nil {
+		return false
+	}
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+	if !state.active {
+		return false
+	}
+	_, rejected := state.rejectedProviders[providerAddress]
+	return rejected
+}
+
+func (state *consistencyFallbackState) activate(usedProviders *lavasession.UsedProviders) ([]string, bool) {
+	if state == nil || usedProviders == nil {
+		return nil, false
+	}
+
+	state.mu.Lock()
+	if state.attempted || len(state.rejectedProviders) == 0 {
+		state.mu.Unlock()
+		return nil, false
+	}
+	state.attempted = true
+	state.active = true
+	providers := make([]string, 0, len(state.rejectedProviders))
+	for providerAddress := range state.rejectedProviders {
+		providers = append(providers, providerAddress)
+	}
+	state.mu.Unlock()
+
+	sort.Strings(providers)
+	usedProviders.RemoveUnwantedAddresses(providers)
+	return providers, true
+}
+
+// sendRelayTaskWithConsistencyFallback consumes consistency-only
+// pre-dispatch failures inside one state-machine task. These checks make no
+// network request, so they should not consume the generic three-send error
+// budget. A PairingListEmpty result proves normal selection is exhausted; at
+// that point the helper reopens only the consistency-rejected providers and
+// makes one fallback pass that may serve stale data instead of returning 500.
+func sendRelayTaskWithConsistencyFallback(
+	ctx context.Context,
+	selection relaycore.Selection,
+	state *consistencyFallbackState,
+	usedProviders *lavasession.UsedProviders,
+	attempt func() error,
+) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		err := attempt()
+		if state == nil || selection == relaycore.CrossValidation {
+			return err
+		}
+		if errors.Is(err, lavasession.ConsistencyPreValidationError) {
+			// The selected batch was stale and has been excluded. Keep selecting
+			// within this task so larger fleets are not cut off by the generic
+			// consecutive-send-error limit.
+			continue
+		}
+		if errors.Is(err, lavasession.PairingListEmptyError) {
+			if providers, activated := state.activate(usedProviders); activated {
+				utils.LavaFormatWarning("all selectable providers failed consistency validation; serving from stale fallback",
+					nil,
+					utils.LogAttr("fallbackProviders", providers),
+					utils.LogAttr("GUID", ctx),
+				)
+				continue
+			}
+		}
+		return err
+	}
+}
+
+// promoteConsistencyFallback moves previously consistency-rejected sessions
+// back into the valid set only while the one-shot fallback is active. Unknown
+// stale providers remain failed, so activation cannot broaden eligibility past
+// the exact providers whose exclusions were reopened.
+func promoteConsistencyFallback(
+	validSessions lavasession.ConsumerSessionsMap,
+	failedSessions lavasession.ConsumerSessionsMap,
+	filterErr error,
+	state *consistencyFallbackState,
+) (lavasession.ConsumerSessionsMap, lavasession.ConsumerSessionsMap, error, int) {
+	if state == nil || !errors.Is(filterErr, lavasession.ConsistencyPreValidationError) {
+		return validSessions, failedSessions, filterErr, 0
+	}
+
+	if validSessions == nil {
+		validSessions = make(lavasession.ConsumerSessionsMap)
+	}
+	promoted := 0
+	for providerAddress, sessionInfo := range failedSessions {
+		if state.allows(providerAddress) {
+			validSessions[providerAddress] = sessionInfo
+			delete(failedSessions, providerAddress)
+			promoted++
+		}
+	}
+	if promoted > 0 {
+		filterErr = nil
+	}
+	return validSessions, failedSessions, filterErr, promoted
+}
+
 // sendRelayToDirectEndpoints handles relay for direct RPC sessions (smart router direct mode)
 func (rpcss *RPCSmartRouterServer) sendRelayToDirectEndpoints(
 	ctx context.Context,
 	sessions lavasession.ConsumerSessionsMap,
 	protocolMessage chainlib.ProtocolMessage,
 	relayProcessor *relaycore.RelayProcessor,
+	consistencyFallback *consistencyFallbackState,
 	analytics *metrics.RelayMetrics,
 ) error {
 	chainMessage := protocolMessage
@@ -1350,25 +1503,50 @@ func (rpcss *RPCSmartRouterServer) sendRelayToDirectEndpoints(
 
 	// Pre-request consistency validation: filter out endpoints that are too far behind
 	validSessions, failedSessions, filterErr := rpcss.filterEndpointsByConsistency(ctx, sessions, protocolMessage)
+	validSessions, failedSessions, filterErr, promotedFallbacks := promoteConsistencyFallback(
+		validSessions,
+		failedSessions,
+		filterErr,
+		consistencyFallback,
+	)
+	if promotedFallbacks > 0 {
+		utils.LavaFormatWarning("consistency fallback accepted stale endpoint batch",
+			nil,
+			utils.LogAttr("promotedEndpoints", promotedFallbacks),
+			utils.LogAttr("GUID", ctx),
+		)
+	}
+	// Record only sessions that remain rejected. During the active fallback,
+	// promotion runs first so a newly encountered stale provider cannot grant
+	// itself fallback eligibility.
+	if consistencyFallback != nil {
+		consistencyFallback.recordRejected(failedSessions)
+	}
 
 	// Release failed sessions:
 	// - ReleaseFromLatestBatch decrements UsedProviders.sessionsLatestBatch so
 	//   RelayProcessor.checkEndProcessing matches the goroutines we will
 	//   actually launch. Without this the CV path can wait the full
 	//   processingTimeout (~30s) for responses that never arrive.
-	// - OnSessionFailure provides QoS punishment, unlocks the session, and
-	//   marks the provider unwanted for retry exclusion.
+	// - OnSessionDiscarded returns reserved CU and unlocks the session without
+	//   QoS punishment. No request reached the upstream, so this is a routing
+	//   exclusion rather than an availability failure.
 	usedProviders := relayProcessor.GetUsedProviders()
 	releaseRouterKey := lavasession.NewRouterKeyFromExtensions(protocolMessage.GetExtensions())
 	for endpointAddress, sessionInfo := range failedSessions {
 		if sessionInfo != nil && sessionInfo.Session != nil {
-			utils.LavaFormatDebug("releasing stale session via OnSessionFailure",
+			utils.LavaFormatDebug("discarding stale session before relay dispatch",
 				utils.LogAttr("endpoint", endpointAddress),
 				utils.LogAttr("error", lavasession.ConsistencyPreValidationError),
 				utils.LogAttr("GUID", ctx),
 			)
 			usedProviders.ReleaseFromLatestBatch(endpointAddress, releaseRouterKey, lavasession.ConsistencyPreValidationError)
-			rpcss.sessionManager.OnSessionFailure(sessionInfo.Session, lavasession.ConsistencyPreValidationError)
+			if err := rpcss.sessionManager.OnSessionDiscarded(sessionInfo.Session, lavasession.ConsistencyPreValidationError); err != nil {
+				utils.LavaFormatError("failed discarding consistency-rejected session", err,
+					utils.LogAttr("endpoint", endpointAddress),
+					utils.LogAttr("GUID", ctx),
+				)
+			}
 		}
 	}
 
@@ -2807,6 +2985,7 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 	numOfEndpoints int,
 	relayState *relaycore.RelayState,
 	relayProcessor *relaycore.RelayProcessor,
+	consistencyFallback *consistencyFallbackState,
 	analytics *metrics.RelayMetrics,
 ) (errRet error) {
 	// Send relay to direct RPC endpoints:
@@ -3167,7 +3346,7 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 		utils.LogAttr("num_sessions", len(sessions)),
 		utils.LogAttr("GUID", ctx),
 	)
-	return rpcss.sendRelayToDirectEndpoints(ctx, sessions, protocolMessage, relayProcessor, analytics)
+	return rpcss.sendRelayToDirectEndpoints(ctx, sessions, protocolMessage, relayProcessor, consistencyFallback, analytics)
 }
 
 // relayInnerDirect handles relay requests using direct RPC connections (smart router mode)

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -3000,6 +3000,152 @@ func TestFilterEndpointsByConsistency_ReturnsFailedSessions(t *testing.T) {
 	})
 }
 
+func TestSendRelayTaskWithConsistencyFallback(t *testing.T) {
+	t.Run("all stale exhausts normal selection then serves one fallback pass", func(t *testing.T) {
+		state := newConsistencyFallbackState()
+		usedProviders := lavasession.NewUsedProviders(nil)
+		routerKey := lavasession.NewRouterKey(nil)
+		usedProviders.AddUnwantedAddresses("transport-failure", routerKey)
+
+		reject := func(provider string) {
+			state.recordRejected(lavasession.ConsumerSessionsMap{
+				provider: &lavasession.SessionInfo{},
+			})
+			usedProviders.AddUnwantedAddresses(provider, routerKey)
+		}
+
+		attempts := 0
+		err := sendRelayTaskWithConsistencyFallback(
+			context.Background(),
+			relaycore.Stateless,
+			state,
+			usedProviders,
+			func() error {
+				attempts++
+				switch attempts {
+				case 1:
+					reject("stale-1")
+					return lavasession.ConsistencyPreValidationError
+				case 2:
+					reject("stale-2")
+					return fmt.Errorf("second stale candidate: %w", lavasession.ConsistencyPreValidationError)
+				case 3:
+					return lavasession.PairingListEmptyError
+				case 4:
+					require.True(t, state.allows("stale-1"))
+					require.True(t, state.allows("stale-2"))
+					unwanted := usedProviders.GetUnwantedProvidersToSend(routerKey)
+					require.NotContains(t, unwanted, "stale-1")
+					require.NotContains(t, unwanted, "stale-2")
+					require.Contains(t, unwanted, "transport-failure",
+						"fallback must not reopen providers excluded for other failures")
+					return nil
+				default:
+					t.Fatalf("unexpected extra attempt %d", attempts)
+					return nil
+				}
+			},
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, 4, attempts)
+	})
+
+	t.Run("fresh alternative wins without activating stale fallback", func(t *testing.T) {
+		state := newConsistencyFallbackState()
+		usedProviders := lavasession.NewUsedProviders(nil)
+		routerKey := lavasession.NewRouterKey(nil)
+		attempts := 0
+
+		err := sendRelayTaskWithConsistencyFallback(
+			context.Background(), relaycore.Stateless, state, usedProviders,
+			func() error {
+				attempts++
+				if attempts == 1 {
+					state.recordRejected(lavasession.ConsumerSessionsMap{"stale": &lavasession.SessionInfo{}})
+					usedProviders.AddUnwantedAddresses("stale", routerKey)
+					return lavasession.ConsistencyPreValidationError
+				}
+				return nil
+			},
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, 2, attempts)
+		require.False(t, state.allows("stale"), "fallback must stay inactive when a fresh provider is available")
+		require.Contains(t, usedProviders.GetUnwantedProvidersToSend(routerKey), "stale")
+	})
+
+	t.Run("fallback activation is one shot", func(t *testing.T) {
+		state := newConsistencyFallbackState()
+		usedProviders := lavasession.NewUsedProviders(nil)
+		routerKey := lavasession.NewRouterKey(nil)
+		attempts := 0
+
+		err := sendRelayTaskWithConsistencyFallback(
+			context.Background(), relaycore.Stateless, state, usedProviders,
+			func() error {
+				attempts++
+				if attempts == 1 {
+					state.recordRejected(lavasession.ConsumerSessionsMap{"stale": &lavasession.SessionInfo{}})
+					usedProviders.AddUnwantedAddresses("stale", routerKey)
+					return lavasession.ConsistencyPreValidationError
+				}
+				return lavasession.PairingListEmptyError
+			},
+		)
+
+		require.ErrorIs(t, err, lavasession.PairingListEmptyError)
+		require.Equal(t, 3, attempts, "a failed fallback pass must not reopen providers indefinitely")
+	})
+
+	t.Run("cross-validation remains strict", func(t *testing.T) {
+		state := newConsistencyFallbackState()
+		usedProviders := lavasession.NewUsedProviders(nil)
+		attempts := 0
+
+		err := sendRelayTaskWithConsistencyFallback(
+			context.Background(), relaycore.CrossValidation, state, usedProviders,
+			func() error {
+				attempts++
+				return lavasession.ConsistencyPreValidationError
+			},
+		)
+
+		require.ErrorIs(t, err, lavasession.ConsistencyPreValidationError)
+		require.Equal(t, 1, attempts)
+	})
+}
+
+func TestPromoteConsistencyFallback(t *testing.T) {
+	state := newConsistencyFallbackState()
+	usedProviders := lavasession.NewUsedProviders(nil)
+	state.recordRejected(lavasession.ConsumerSessionsMap{
+		"previously-rejected": &lavasession.SessionInfo{},
+	})
+	usedProviders.AddUnwantedAddresses("previously-rejected", lavasession.NewRouterKey(nil))
+	_, activated := state.activate(usedProviders)
+	require.True(t, activated)
+
+	failed := lavasession.ConsumerSessionsMap{
+		"previously-rejected": &lavasession.SessionInfo{},
+		"new-stale-provider":  &lavasession.SessionInfo{},
+	}
+	valid, remainingFailed, err, promoted := promoteConsistencyFallback(
+		nil,
+		failed,
+		lavasession.ConsistencyPreValidationError,
+		state,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, promoted)
+	require.Contains(t, valid, "previously-rejected")
+	require.NotContains(t, valid, "new-stale-provider")
+	require.Contains(t, remainingFailed, "new-stale-provider",
+		"an endpoint first encountered after activation must not grant itself fallback eligibility")
+}
+
 // TestConsistencyPreValidationError_NotRetryable verifies that ConsistencyPreValidationError
 // is NOT treated as a retryable sync loss error (unlike SessionOutOfSyncError).
 // This ensures immediate blocking via unwantedProviders rather than "allow one retry".
@@ -3161,7 +3307,7 @@ func TestSendRelayToDirectEndpoints_CrossValidationGuardReleasesAllSessions(t *t
 	defer cancel()
 
 	start := time.Now()
-	sendErr := rpcss.sendRelayToDirectEndpoints(callCtx, sessionsMap, protocolMsg, relayProcessor, nil)
+	sendErr := rpcss.sendRelayToDirectEndpoints(callCtx, sessionsMap, protocolMsg, relayProcessor, nil, nil)
 	elapsed := time.Since(start)
 
 	require.Less(t, elapsed, time.Second,


### PR DESCRIPTION
## What changed

- keep consistency-only pre-dispatch retries inside a single relay task so the router can inspect the full candidate set
- when normal selection is exhausted, reopen only providers rejected by consistency validation and allow one stale fallback pass
- preserve fresh-provider preference and keep providers excluded for unrelated failures out of the fallback
- release pre-dispatch sessions and CU reservations without recording false QoS/provider failures
- keep cross-validation strict; it does not use the stale fallback
- add regression coverage for mixed fleets, all-stale fleets, one-shot activation, provider exclusion, and session accounting

## Why

MAG-2392 occurs when the consumer's seen block is ahead of every available endpoint. Pre-request consistency validation rejects each selected endpoint, marks it unwanted, and eventually returns `No pairings available`, causing an HTTP 500 even though the endpoints can still serve data.

The new request-local exhaustion fallback continues preferring a fresh endpoint, but serves from a previously consistency-rejected endpoint once the router has established that normal selection has no candidates left.

## Impact

Requests no longer fail solely because every available provider is behind the consumer's seen block. The fallback is one-shot and limited to the exact consistency-rejected provider set, preventing retry loops or accidental reopening of transport-failed providers.

## Validation

- `go test ./protocol/rpcsmartrouter -count=1`
- `go test ./protocol/lavasession -count=1`
- targeted race-detector tests for both changed packages
- `go vet ./protocol/rpcsmartrouter ./protocol/lavasession`
- `git diff --check`

## Issue

[MAG-2392](https://magmadevs.atlassian.net/browse/MAG-2392)

## Deployment verification

Re-run the production simulator's all-stale Solana consistency scenario after deploying an image containing this commit.

[MAG-2392]: https://magmadevs.atlassian.net/browse/MAG-2392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ