### PR TITLE
fix(lavasession): give each router key its own unwanted set (MAG-2442)

### DIFF
--- a/protocol/lavasession/used_providers.go
+++ b/protocol/lavasession/used_providers.go
@@ -2,6 +2,7 @@ package lavasession
 
 import (
 	"context"
+	"maps"
 	"sync"
 	"time"
 
@@ -16,27 +17,20 @@ type BlockedProvidersInf interface {
 }
 
 func NewUsedProviders(blockedProviders BlockedProvidersInf) *UsedProviders {
-	unwantedProviders := map[string]struct{}{}
-	originalUnwantedProviders := map[string]struct{}{} // we need a new map as map changes are changed by pointer
+	// originalUnwantedProviders holds ONLY the user's blocklist. Each router key is seeded from a
+	// COPY of it (see newSeededUniqueUsedProviders), never a reference — sharing one reference let a
+	// write under one key mutate the user's blocklist and every other key seeded from it (MAG-2442).
+	originalUnwantedProviders := map[string]struct{}{}
 	if blockedProviders != nil {
-		providerAddressesToBlock := blockedProviders.GetBlockedProviders()
-		if len(providerAddressesToBlock) > 0 {
-			for _, providerAddress := range providerAddressesToBlock {
-				unwantedProviders[providerAddress] = struct{}{}
-				originalUnwantedProviders[providerAddress] = struct{}{}
-			}
+		for _, providerAddress := range blockedProviders.GetBlockedProviders() {
+			originalUnwantedProviders[providerAddress] = struct{}{}
 		}
 	}
 
 	return &UsedProviders{
-		uniqueUsedProviders: map[string]*UniqueUsedProviders{GetEmptyRouterKey().String(): {
-			providers:         map[string]struct{}{},
-			unwantedProviders: unwantedProviders,
-			blockOnSyncLoss:   map[string]struct{}{},
-			erroredProviders:  map[string]struct{}{},
-		}},
-		// we keep the original unwanted providers so when we create more unique used providers
-		// we can reuse it as its the user's instructions.
+		uniqueUsedProviders: map[string]*UniqueUsedProviders{
+			GetEmptyRouterKey().String(): newSeededUniqueUsedProviders(originalUnwantedProviders),
+		},
 		originalUnwantedProviders: originalUnwantedProviders,
 		eligibilityFunc:           common.DecideEligibility, // default; overridden via SetEligibilityFunc
 	}
@@ -155,13 +149,38 @@ func (up *UsedProviders) AllUnwantedAddresses() []string {
 	}
 	up.lock.RLock()
 	defer up.lock.RUnlock()
-	addresses := []string{}
+	// Dedup across router keys: the same provider is commonly unwanted under several keys
+	// (every key is seeded from the user blocklist), and callers expect a set, not a bag.
+	unwantedSet := map[string]struct{}{}
 	for _, uniqueUsedProviders := range up.uniqueUsedProviders {
 		for addr := range uniqueUsedProviders.unwantedProviders {
-			addresses = append(addresses, addr)
+			unwantedSet[addr] = struct{}{}
 		}
 	}
+	addresses := make([]string, 0, len(unwantedSet))
+	for addr := range unwantedSet {
+		addresses = append(addresses, addr)
+	}
 	return addresses
+}
+
+// newSeededUniqueUsedProviders builds a fresh per-router-key exclusion set whose unwanted map is a
+// COPY of the user's original blocklist. Each router key must own its unwanted map: seeding it with a
+// reference to originalUnwantedProviders (as this code once did) let a write under one key
+// (AddUnwantedAddresses, setUnwanted via RemoveUsed/ReleaseFromLatestBatch, MigrateUnwantedProviders)
+// mutate the user's blocklist and, through it, every other key seeded from the same reference
+// (MAG-2442). maps.Clone(nil) returns nil, so fall back to an empty map to keep writes safe.
+func newSeededUniqueUsedProviders(originalUnwantedProviders map[string]struct{}) *UniqueUsedProviders {
+	seededUnwanted := maps.Clone(originalUnwantedProviders)
+	if seededUnwanted == nil {
+		seededUnwanted = map[string]struct{}{}
+	}
+	return &UniqueUsedProviders{
+		providers:         map[string]struct{}{},
+		unwantedProviders: seededUnwanted,
+		blockOnSyncLoss:   map[string]struct{}{},
+		erroredProviders:  map[string]struct{}{},
+	}
 }
 
 // Use when locked. Checking wether a router key exists in unique used providers,
@@ -171,12 +190,8 @@ func (up *UsedProviders) createOrUseUniqueUsedProvidersForKey(key RouterKey) *Un
 	keyString := key.String()
 	uniqueUsedProviders, ok := up.uniqueUsedProviders[keyString]
 	if !ok {
-		uniqueUsedProviders = &UniqueUsedProviders{
-			providers:         map[string]struct{}{},
-			unwantedProviders: up.originalUnwantedProviders,
-			blockOnSyncLoss:   map[string]struct{}{},
-			erroredProviders:  map[string]struct{}{},
-		}
+		// Seed from a COPY of the user blocklist so this key's writes stay local to it (MAG-2442).
+		uniqueUsedProviders = newSeededUniqueUsedProviders(up.originalUnwantedProviders)
 		up.uniqueUsedProviders[keyString] = uniqueUsedProviders
 	}
 	return uniqueUsedProviders

--- a/protocol/lavasession/used_providers_mag2442_test.go
+++ b/protocol/lavasession/used_providers_mag2442_test.go
@@ -1,0 +1,83 @@
+package lavasession
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mag2442BlockedProviders is a minimal BlockedProvidersInf that seeds a user blocklist.
+type mag2442BlockedProviders struct{ addresses []string }
+
+func (m mag2442BlockedProviders) GetBlockedProviders() []string { return m.addresses }
+
+// TestUnwantedProvidersDoNotLeakAcrossRouterKeys covers MAG-2442: every router key must own
+// its unwanted set. Before the fix, createOrUseUniqueUsedProvidersForKey seeded each new key
+// with the SAME map reference as originalUnwantedProviders, so a write under one key mutated
+// the user's original blocklist and leaked into every other key (over-excluding providers).
+func TestUnwantedProvidersDoNotLeakAcrossRouterKeys(t *testing.T) {
+	archiveKey := NewRouterKey([]string{"archive"})
+	debugKey := NewRouterKey([]string{"debug"})
+
+	// The bug-pinning case: a provider marked unwanted under one non-default key must NOT
+	// appear under a different key first materialized afterward. Under the aliasing bug it
+	// does, because both keys share the one originalUnwantedProviders map.
+	t.Run("write under one key does not leak into a key created afterward", func(t *testing.T) {
+		up := NewUsedProviders(nil)
+
+		up.AddUnwantedAddresses("providerX", archiveKey)
+
+		unwantedUnderDebug := up.GetUnwantedProvidersToSend(debugKey)
+		require.NotContains(t, unwantedUnderDebug, "providerX",
+			"unwanted set leaked across router keys via the shared original map (MAG-2442)")
+
+		// The default key must also be untouched by the archive-key write.
+		unwantedUnderDefault := up.GetUnwantedProvidersToSend(GetEmptyRouterKey())
+		require.NotContains(t, unwantedUnderDefault, "providerX")
+
+		// ...but the key it was actually added under must still exclude it.
+		unwantedUnderArchive := up.GetUnwantedProvidersToSend(archiveKey)
+		require.Contains(t, unwantedUnderArchive, "providerX")
+	})
+
+	// MigrateUnwantedProviders is the other write path into a non-default key's unwanted set;
+	// it must not leak into the original blocklist / later keys either.
+	t.Run("migrate into a non-default key does not leak into a later key", func(t *testing.T) {
+		up := NewUsedProviders(nil)
+		up.AddUnwantedAddresses("providerY", GetEmptyRouterKey())
+		up.MigrateUnwantedProviders(GetEmptyRouterKey(), archiveKey)
+
+		unwantedUnderDebug := up.GetUnwantedProvidersToSend(debugKey)
+		require.NotContains(t, unwantedUnderDebug, "providerY",
+			"migrated provider leaked into a later router key via the shared original map (MAG-2442)")
+	})
+
+	// The user's real blocklist must still seed every router key — from a copy, not by aliasing.
+	t.Run("user blocklist still seeds every router key", func(t *testing.T) {
+		up := NewUsedProviders(mag2442BlockedProviders{addresses: []string{"userBlocked"}})
+
+		up.AddUnwantedAddresses("providerX", archiveKey)
+
+		unwantedUnderDebug := up.GetUnwantedProvidersToSend(debugKey)
+		require.Contains(t, unwantedUnderDebug, "userBlocked",
+			"user blocklist must seed every router key (from a copy)")
+		require.NotContains(t, unwantedUnderDebug, "providerX")
+	})
+
+	// AllUnwantedAddresses must dedup across router keys.
+	t.Run("AllUnwantedAddresses dedups across router keys", func(t *testing.T) {
+		up := NewUsedProviders(mag2442BlockedProviders{addresses: []string{"userBlocked"}})
+		up.AddUnwantedAddresses("providerX", archiveKey)
+		up.AddUnwantedAddresses("providerX", debugKey)
+
+		counts := map[string]int{}
+		for _, addr := range up.AllUnwantedAddresses() {
+			counts[addr]++
+		}
+		for addr, c := range counts {
+			require.Equalf(t, 1, c, "AllUnwantedAddresses returned %q %d times; must dedup across router keys", addr, c)
+		}
+		require.Contains(t, counts, "userBlocked")
+		require.Contains(t, counts, "providerX")
+	})
+}


### PR DESCRIPTION
## Summary

Fixes [MAG-2442](https://magmadevs.atlassian.net/browse/MAG-2442): `UsedProviders.createOrUseUniqueUsedProvidersForKey` seeded every newly created router key's `unwantedProviders` with the **same map reference** as `up.originalUnwantedProviders` (the user blocklist):

```go
unwantedProviders: up.originalUnwantedProviders,   // reference, not a copy
```

Go maps are reference types, so this made `originalUnwantedProviders` and the `unwantedProviders` of **every non-default router key** one shared map. Consequences:

1. **State corruption / over-exclusion.** A write under any extension/retry key — `AddUnwantedAddresses`, `setUnwanted` (via `RemoveUsed`/`ReleaseFromLatestBatch`), or `MigrateUnwantedProviders` — mutated the user's original blocklist in place, and that mutation then leaked into every router key seeded from it (including keys created later). A provider marked unwanted under one lane could become permanently/globally excluded from selection.
2. **`AllUnwantedAddresses` over-reported.** It flattened the per-key sets with no cross-key dedup (compounded by the aliasing, which made several keys iterate the same map), so the same provider appeared multiple times.

The constructor comment at `NewUsedProviders` already warned about exactly this hazard ("we need a new map as map changes are changed by pointer") for the default key; the per-key factory reintroduced it for every other key.

Split out of MAG-2351 / PR #213 review as an independent latent bug.

## Fix

- **Single seeding path.** New `newSeededUniqueUsedProviders(original)` helper seeds each router key's `unwantedProviders` from `maps.Clone(original)` (Go 1.26 stdlib; nil-guarded). Both `NewUsedProviders` (default key) and `createOrUseUniqueUsedProvidersForKey` (per-key factory) now go through it, so they can't drift.
- **Invariant established.** `originalUnwantedProviders` is now a pristine, read-only seed template: nothing writes it after construction, and its only reader is the seeding helper. Per-key writes stay local to the key.
- **Dedup `AllUnwantedAddresses`** across router keys (via a set); still returns a non-nil slice to preserve the prior contract.

## Interaction with MAG-2392 (`RemoveUnwantedAddresses`) — reviewer note

MAG-2392's all-stale consistency fallback (`RemoveUnwantedAddresses`, already on `main`) is the one place this fix interacts with, and it is **deliberately left unchanged**. Verified:

- The fallback iterates every existing router key and deletes the reopened addresses from each key's own (now-cloned) set, and its retry reuses the **same** router key (a consistency failure does not toggle extensions), so it still re-enables providers correctly.
- Keeping `originalUnwantedProviders` pristine is the correct invariant — deleting from it would make the fallback override the user's explicit blocklist for future keys, a MAG-2392 semantic call out of scope here.
- `TestSendRelayTaskWithConsistencyFallback`, `TestPromoteConsistencyFallback`, `TestFilterEndpointsByConsistency*`, and `TestRemoveUnwantedAddresses` all pass under `-race`.

MAG-2228's `MigrateUnwantedProviders` (intentional cross-key carry on an archive toggle) is likewise preserved and covered by `TestMigrateUnwantedProviders`.

## Tests

`protocol/lavasession/used_providers_mag2442_test.go` (written test-first, **verified failing before the fix**):

- a provider marked unwanted under one router key must be **absent** from a different key materialized afterward (the bug-pinning cross-key-leak assertion);
- the same for a `MigrateUnwantedProviders` write;
- the user blocklist still seeds every router key (from a copy);
- `AllUnwantedAddresses` dedups across keys.

## Verification

- New regression test passes (failed pre-fix); `TestMigrateUnwantedProviders` (MAG-2228) + `TestRemoveUnwantedAddresses` + the consistency-fallback suite (MAG-2392) pass.
- Full `protocol/lavasession` and `protocol/relaycore` suites pass with `-race`.
- `go build ./...` clean; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MAG-2442]: https://magmadevs.atlassian.net/browse/MAG-2442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ