### PR TITLE
fix(rpcsmartrouter): wire /debug/time-warp into ChainState TTL/staleness (MAG-2307)

### DIFF
--- a/protocol/chainstate/chain_state.go
+++ b/protocol/chainstate/chain_state.go
@@ -20,6 +20,7 @@ package chainstate
 import (
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -135,9 +136,16 @@ func DefaultConfig(averageBlockTime time.Duration) Config {
 type ChainState struct {
 	chainID string
 	cfg     Config
-	// now is the clock; time.Now in production, overridable in tests for deterministic TTL /
+	// now is the BASE clock; time.Now in production, overridable in tests for deterministic TTL /
 	// staleness. Set once at construction and never reassigned, so it is read without the lock.
 	now func() time.Time
+	// warpOffset is a debug-only forward shift added on top of `now` (see effectiveNow). It exists
+	// so the /debug/time-warp HTTP hook can age this chain's TTL/staleness/consensus windows the
+	// same way it ages the provider-optimizer clock (MAG-2307) — without it the warp never reached
+	// ChainState and per-chain expiry could only be exercised by waiting real time. Atomic, so it is
+	// read lock-free in effectiveNow and written lock-free by SetDebugClockOffset. Zero in production
+	// (only the debug handler ever stores a non-zero value), so it is a no-op on the relay hot path.
+	warpOffset atomic.Int64 // nanoseconds
 
 	mu          sync.RWMutex
 	latestBlock int64 // observed tip; raised by SetLatestBlock, lowered only by Recompute's realign or SetLatestBlock's stale-tip re-adoption
@@ -190,6 +198,24 @@ func NewWithClock(chainID string, cfg Config, clock func() time.Time) *ChainStat
 	return &ChainState{chainID: chainID, cfg: cfg, now: clock}
 }
 
+// effectiveNow is the clock every TTL/staleness/consensus read uses: the base clock plus the
+// debug warp offset. In production the offset is always zero, so this is exactly the base clock;
+// under /debug/time-warp it shifts forward so a warp ages this chain's windows just like it ages
+// the provider-optimizer clock (MAG-2307). The atomic load is lock-free, matching the base clock's
+// no-lock read contract.
+func (cs *ChainState) effectiveNow() time.Time {
+	return cs.now().Add(time.Duration(cs.warpOffset.Load()))
+}
+
+// SetDebugClockOffset shifts this chain's effective clock forward by d, aging its TTL/staleness/
+// consensus windows without waiting real time. Debug-only: the /debug/time-warp and /debug/reset-all
+// handlers call it (with d and 0 respectively), mirroring how they set/clear the optimizer's NowFunc.
+// It is NOT reachable from any relay path. The write is atomic and takes no lock, so it is safe to
+// call concurrently with live reads.
+func (cs *ChainState) SetDebugClockOffset(d time.Duration) {
+	cs.warpOffset.Store(int64(d))
+}
+
 // SetLatestBlock is the cheap per-observation write the relay-harvest and poll paths call. It
 // raises the tip monotonically and guards against an anti-lie outlier:
 //   - a block below a FRESH tip is ignored (monotonic; a live tip only goes DOWN via Recompute's
@@ -228,7 +254,7 @@ func (cs *ChainState) SetLatestBlock(block int64) (latest int64, at time.Time, a
 	if block <= 0 {
 		return cs.latestBlock, cs.lastObservedAt, false
 	}
-	now := cs.now()
+	now := cs.effectiveNow()
 	_, tipFresh := cs.freshLatestLocked(now)
 	if cs.initialized {
 		if block < cs.latestBlock {
@@ -266,7 +292,7 @@ func (cs *ChainState) SetLatestBlock(block int64) (latest int64, at time.Time, a
 func (cs *ChainState) GetLatestBlock() (int64, bool) {
 	cs.mu.RLock()
 	defer cs.mu.RUnlock()
-	return cs.freshLatestLocked(cs.now())
+	return cs.freshLatestLocked(cs.effectiveNow())
 }
 
 // GetConsensusBaseline returns the strict-majority CONSENSUS baseline and whether it is known
@@ -287,10 +313,18 @@ func (cs *ChainState) GetConsensusBaseline() (int64, bool) {
 func (cs *ChainState) GetConsensusBaselineWithTime() (block int64, at time.Time, ok bool) {
 	cs.mu.RLock()
 	defer cs.mu.RUnlock()
+	return cs.freshBaselineLocked(cs.effectiveNow())
+}
+
+// freshBaselineLocked returns the consensus baseline, its establishment time (baselineSince), and
+// whether a fresh (TTL) strict-majority baseline currently exists, evaluated against the supplied
+// clock. It mirrors freshLatestLocked for the consensus baseline; the caller holds cs.mu. Sharing
+// it keeps GetConsensusBaselineWithTime and DebugSnapshot's BaselineFresh from drifting apart.
+func (cs *ChainState) freshBaselineLocked(now time.Time) (int64, time.Time, bool) {
 	if !cs.hasBaseline || cs.baseline <= 0 {
 		return 0, time.Time{}, false
 	}
-	if cs.cfg.TTL > 0 && cs.now().Sub(cs.baselineAt) > cs.cfg.TTL {
+	if cs.cfg.TTL > 0 && now.Sub(cs.baselineAt) > cs.cfg.TTL {
 		return 0, time.Time{}, false
 	}
 	return cs.baseline, cs.baselineSince, true
@@ -339,7 +373,7 @@ func (cs *ChainState) freshLatestLocked(now time.Time) (int64, bool) {
 // snapshots (no lock), and only the final tip/baseline update takes the ChainState lock — so
 // the monitor lock (released before this call) and the ChainState lock never nest.
 func (cs *ChainState) Recompute(snapshots []BlockObservation) {
-	now := cs.now()
+	now := cs.effectiveNow()
 	baseline, ok := computeMajorityBaseline(snapshots, now, cs.cfg)
 
 	cs.mu.Lock()
@@ -372,6 +406,12 @@ func (cs *ChainState) Recompute(snapshots []BlockObservation) {
 // baseline clearing from the raw (block, timestamp) pairs — a gated getter would hide exactly those
 // transitions by collapsing to (0, false). BaselineSince is the establishment time (distinct from
 // the TTL-freshness baselineAt that GetConsensusBaselineWithTime exposes).
+//
+// TipFresh / BaselineFresh are the ONE computed exception: the TTL-gated verdicts (what
+// GetLatestBlock / GetConsensusBaseline would report) evaluated against the effective clock. They
+// exist so a /debug/time-warp forward shift is observable IMMEDIATELY — the raw ObservedTip /
+// HasBaseline fields only change on the next Recompute tick, and never at all in a fixture with no
+// recompute loop running (MAG-2307). Assert on these, not the raw fields, to see warp-driven expiry.
 type ChainStateSnapshot struct {
 	ObservedTip       int64
 	LastObservedAt    time.Time
@@ -379,6 +419,8 @@ type ChainStateSnapshot struct {
 	HasBaseline       bool
 	BaselineSince     time.Time
 	Initialized       bool
+	TipFresh          bool // GetLatestBlock would return (ObservedTip, true) right now
+	BaselineFresh     bool // GetConsensusBaseline would return (ConsensusBaseline, true) right now
 }
 
 // DebugSnapshot returns the raw ChainState fields under one read lock, without the TTL gate the
@@ -386,6 +428,9 @@ type ChainStateSnapshot struct {
 func (cs *ChainState) DebugSnapshot() ChainStateSnapshot {
 	cs.mu.RLock()
 	defer cs.mu.RUnlock()
+	now := cs.effectiveNow()
+	_, tipFresh := cs.freshLatestLocked(now)
+	_, _, baselineFresh := cs.freshBaselineLocked(now)
 	return ChainStateSnapshot{
 		ObservedTip:       cs.latestBlock,
 		LastObservedAt:    cs.lastObservedAt,
@@ -393,6 +438,8 @@ func (cs *ChainState) DebugSnapshot() ChainStateSnapshot {
 		HasBaseline:       cs.hasBaseline,
 		BaselineSince:     cs.baselineSince,
 		Initialized:       cs.initialized,
+		TipFresh:          tipFresh,
+		BaselineFresh:     baselineFresh,
 	}
 }
 

--- a/protocol/chainstate/chain_state_test.go
+++ b/protocol/chainstate/chain_state_test.go
@@ -262,6 +262,61 @@ func TestGetConsensusBaseline_HonorsTTL(t *testing.T) {
 	base, has := snap.ConsensusBaseline, snap.HasBaseline
 	require.True(t, has)
 	require.Equal(t, int64(1000), base)
+	// ...but the gated BaselineFresh verdict DOES reflect the TTL lapse (MAG-2307): this is the field
+	// /debug/chain-state exposes so a warp-driven expiry is observable without a Recompute.
+	require.False(t, snap.BaselineFresh, "BaselineFresh is the TTL-gated verdict, false once past TTL")
+}
+
+// TestSetDebugClockOffset_AgesTTLLikeRealTime is the MAG-2307 fix: a debug clock offset ages the
+// TTL/staleness/consensus windows exactly as advancing real time would, WITHOUT touching the base
+// clock — this is what lets /debug/time-warp expire ChainState. It also pins the raw-vs-gated
+// snapshot split (TipFresh/BaselineFresh flip immediately; the raw ObservedTip/HasBaseline stay put
+// until a Recompute) and that clearing the offset restores freshness.
+func TestSetDebugClockOffset_AgesTTLLikeRealTime(t *testing.T) {
+	cs, clk := newTestState(t) // TTL = StalenessWindow = 10s; base clock stays frozen at clk
+	cs.SetLatestBlock(1000)
+	cs.Recompute([]BlockObservation{
+		{URL: "a", Block: 1000, ObservedAt: clk.now()},
+		{URL: "b", Block: 1000, ObservedAt: clk.now()},
+	})
+
+	// Baseline established, everything fresh.
+	_, ok := cs.GetLatestBlock()
+	require.True(t, ok)
+	_, ok = cs.GetConsensusBaseline()
+	require.True(t, ok)
+	snap := cs.DebugSnapshot()
+	require.True(t, snap.TipFresh)
+	require.True(t, snap.BaselineFresh)
+
+	// Warp the effective clock past TTL without advancing the base clock — the fix under test.
+	cs.SetDebugClockOffset(20 * time.Second) // > 10s TTL
+	_, ok = cs.GetLatestBlock()
+	require.False(t, ok, "a forward warp expires the observed tip just like real time")
+	_, ok = cs.GetConsensusBaseline()
+	require.False(t, ok, "a forward warp expires the consensus baseline just like real time")
+	snap = cs.DebugSnapshot()
+	require.False(t, snap.TipFresh, "TipFresh (gated) flips immediately under the warp")
+	require.False(t, snap.BaselineFresh, "BaselineFresh (gated) flips immediately under the warp")
+	// Raw fields are unchanged until a Recompute runs — the /debug/chain-state suite must assert on
+	// the *Fresh verdicts, not these, to see a warp take effect.
+	require.Equal(t, int64(1000), snap.ObservedTip, "raw observed tip is untouched by the warp")
+	require.True(t, snap.HasBaseline, "raw HasBaseline is untouched until the next Recompute")
+
+	// A Recompute under the warp sees the (real-time-stamped) observations as stale and clears the
+	// raw baseline — mirroring what the live recompute tick does after a real-time TTL lapse.
+	cs.Recompute([]BlockObservation{
+		{URL: "a", Block: 1000, ObservedAt: clk.now()},
+		{URL: "b", Block: 1000, ObservedAt: clk.now()},
+	})
+	require.False(t, cs.DebugSnapshot().HasBaseline, "stale-under-warp observations clear the raw baseline")
+
+	// Clearing the offset restores real-time behavior: the tip's lastObservedAt is still within TTL
+	// of the un-warped base clock, so it is fresh again.
+	cs.SetDebugClockOffset(0)
+	_, ok = cs.GetLatestBlock()
+	require.True(t, ok, "clearing the warp restores the un-aged tip")
+	require.True(t, cs.DebugSnapshot().TipFresh)
 }
 
 // --- Consensus cardinality (computeMajorityBaseline) ------------------------------------

--- a/protocol/rpcsmartrouter/debug_server_test.go
+++ b/protocol/rpcsmartrouter/debug_server_test.go
@@ -379,6 +379,64 @@ func TestDebugChainState_ReportsRawSnapshot(t *testing.T) {
 	require.NotEmpty(t, row["BaselineSince"], "established baseline carries an RFC3339 timestamp")
 }
 
+// TestDebugTimeWarp_AgesChainState is the MAG-2307 end-to-end check at the HTTP layer: POST
+// /debug/time-warp forward past the TTL must age every per-chain ChainState so /debug/chain-state
+// reports the tip/baseline as no longer fresh, and resetting the offset to 0 must restore them.
+// Before the fix the warp only moved the optimizer clock, so these verdicts never changed.
+func TestDebugTimeWarp_AgesChainState(t *testing.T) {
+	var offsetNano atomic.Int64
+	cs := chainstate.New("ETH1", chainstate.Config{
+		BucketWidth: 2, OutlierThreshold: 100, StalenessWindow: 10 * time.Second, TTL: 10 * time.Second,
+	})
+	cs.SetLatestBlock(1000)
+	now := time.Now()
+	cs.Recompute([]chainstate.BlockObservation{
+		{URL: "a", Block: 1000, ObservedAt: now},
+		{URL: "b", Block: 1000, ObservedAt: now},
+	})
+	router := &RPCSmartRouter{
+		rpcServers: map[string]*RPCSmartRouterServer{
+			"ETH1-jsonrpc": {chainState: cs, listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"}},
+		},
+	}
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano, router: router})
+
+	chainStateRow := func() map[string]any {
+		t.Helper()
+		rr := getDebugRouter(mux, "/debug/chain-state")
+		require.Equal(t, http.StatusOK, rr.Code)
+		var rows []map[string]any
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &rows))
+		require.Len(t, rows, 1)
+		return rows[0]
+	}
+
+	// Freshly established → both gated verdicts true.
+	row := chainStateRow()
+	require.Equal(t, true, row["TipFresh"], "tip is fresh right after establishment")
+	require.Equal(t, true, row["BaselineFresh"], "baseline is fresh right after establishment")
+
+	// Warp +200s (>> 10s TTL). Before MAG-2307 this reached only the optimizer clock.
+	rr := postTimeWarpRouter(mux, `{"offset_seconds":200}`)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"applied_to_chains":true`)
+
+	row = chainStateRow()
+	require.Equal(t, false, row["TipFresh"], "a forward warp ages the tip out of its TTL window")
+	require.Equal(t, false, row["BaselineFresh"], "a forward warp ages the baseline out of its TTL window")
+	// The raw fields are intentionally untouched by the warp (no Recompute ran): the suite asserts
+	// on the *Fresh verdicts, not these.
+	require.Equal(t, float64(1000), row["ObservedTip"], "raw observed tip is unchanged by the warp")
+	require.Equal(t, true, row["HasBaseline"], "raw HasBaseline is unchanged until a Recompute")
+
+	// Reset the warp → verdicts fresh again (observations are still within TTL of real time).
+	rr = postTimeWarpRouter(mux, `{"offset_seconds":0}`)
+	require.Equal(t, http.StatusOK, rr.Code)
+	row = chainStateRow()
+	require.Equal(t, true, row["TipFresh"], "clearing the warp restores tip freshness")
+	require.Equal(t, true, row["BaselineFresh"], "clearing the warp restores baseline freshness")
+}
+
 // TestDebugProviderRouting_ReportsPerCSMShape verifies the handler keys output per session manager and
 // emits the three address fields as JSON arrays (non-null) even when empty, and skips a nil CSM.
 func TestDebugProviderRouting_ReportsPerCSMShape(t *testing.T) {

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -592,6 +592,27 @@ func reregisterChainTrackerRows(deps debugMuxDeps) (ensured, created int) {
 	return ensured, created
 }
 
+// setAllChainStateDebugOffset shifts every per-server ChainState's effective clock by offset,
+// mirroring how /debug/time-warp sets each optimizer's NowFunc. A forward offset ages the per-chain
+// TTL/staleness/consensus windows; offset 0 clears the warp. Nil-safe at every level so test
+// fixtures without a fully-wired router are a no-op. Only the ChainState READ clock is warped —
+// observation write timestamps (relay/poll) stay on real time — so this reliably ages state when
+// endpoints are quiesced (the debug age-out use case) without perturbing the live relay-gate
+// freshness path (MAG-2307).
+func setAllChainStateDebugOffset(deps debugMuxDeps, offset time.Duration) {
+	if deps.router == nil {
+		return
+	}
+	deps.router.mu.Lock()
+	defer deps.router.mu.Unlock()
+	for _, server := range deps.router.rpcServers {
+		if server == nil || server.chainState == nil {
+			continue
+		}
+		server.chainState.SetDebugClockOffset(offset)
+	}
+}
+
 // resetAllConsistencies flushes every per-chain seen-block cache that
 // implements consistencyResetter. Why this is necessary: SetSeenBlockFromKey
 // only writes monotonically (consistency.go: `block >= blockSeen → return`),
@@ -801,6 +822,12 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 			}
 			return true
 		})
+		// Mirror the warp onto every per-chain ChainState clock so a forward shift ages its
+		// TTL/staleness/consensus windows exactly as it ages the optimizer above (MAG-2307).
+		// offset==0 clears it. Only the READ clock is warped: observation write-stamps (relay/poll)
+		// stay on real time, so a warp reliably ages state when endpoints are quiesced without
+		// skewing the live relay-gate freshness path.
+		setAllChainStateDebugOffset(deps, offset)
 		// Gated on needsReset (same as opt.ResetState above) because the
 		// documented move-clock recovery sets offset_seconds back to 0 — that's
 		// the moment we also want to flush the per-chain seen-block cache. See
@@ -877,6 +904,8 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 			opt.ResetState()
 			return true
 		})
+		// Clear any ChainState warp too, mirroring opt.NowFunc = nil above (MAG-2307).
+		setAllChainStateDebugOffset(deps, 0)
 
 		// 2. Per-chain seen-block consistency caches. Must be flushed here too,
 		//    not just in /debug/reset-scores: a poisoned huge seenBlock value
@@ -1156,6 +1185,8 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 					"HasBaseline":       s.HasBaseline,
 					"BaselineSince":     debugTimeRFC3339(s.BaselineSince),
 					"Initialized":       s.Initialized,
+					"TipFresh":          s.TipFresh,
+					"BaselineFresh":     s.BaselineFresh,
 				})
 			}
 			deps.router.mu.Unlock()
@@ -2539,7 +2570,7 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	cmdRPCSmartRouter.Flags().Uint64Var(&lavasession.MaximumStreamsOverASingleConnection, lavasession.MaximumStreamsOverASingleConnectionFlag, lavasession.DefaultMaximumStreamsOverASingleConnection, "maximum number of parallel streams over a single provider connection")
 	cmdRPCSmartRouter.Flags().Bool(common.TestModeFlagName, false, "test mode sends dummy data and prints all metadata in listeners")
 	cmdRPCSmartRouter.Flags().String(performance.PprofAddressFlagName, "", "pprof server address, used for code profiling")
-	cmdRPCSmartRouter.Flags().String("debug-address", "", "debug HTTP server for integration tests, e.g. :9999 — exposes /debug/time-warp to shift QoS clock")
+	cmdRPCSmartRouter.Flags().String("debug-address", "", "debug HTTP server for integration tests, e.g. :9999 — exposes /debug/time-warp to shift the QoS clock and age per-chain ChainState TTL/staleness")
 	if err := viper.BindPFlag("debug-address", cmdRPCSmartRouter.Flags().Lookup("debug-address")); err != nil {
 		utils.LavaFormatFatal("failed binding debug-address flag", err)
 	}


### PR DESCRIPTION
## What & why

`POST /debug/time-warp` is meant to age out stale router state without waiting real time. It moved the provider-optimizer clock but **not** the per-chain `ChainState` clock, so ChainState's TTL / staleness / consensus windows could only be exercised by waiting *real* time — 130 s on ETH (10× average block time), ~4 s on Solana. The warp never reached ChainState because it was built with a hard-wired `time.Now` (`chainstate.New` → `NewWithClock(..., time.Now)`).

Fixes **[MAG-2307](https://magmadevs.atlassian.net/browse/MAG-2307)**. Per the reporter's own investigation this is a new debug-surface gap, not a regression.

## Approach

- **ChainState gets a debug-only warp offset** (`warpOffset atomic.Int64`) added on top of the base clock in a new `effectiveNow()`. The four clock reads (`SetLatestBlock`, `GetLatestBlock`, `GetConsensusBaseline` TTL, `Recompute` staleness) now go through `effectiveNow()`.
- **The `/debug/time-warp` and `/debug/reset-all` handlers set the offset per chain** (`setAllChainStateDebugOffset`), mirroring how they already set/clear each optimizer's `NowFunc`. `/debug/reset-scores` deliberately does **not** touch it — it documents itself as leaving the clock alone.
- **Read-clock-only, by design.** Only ChainState's own clock is warped; the external endpoint-observation write stamps (relay/poll) stay on real time. That's exactly what ages observations out under a forward warp when endpoints are quiesced (the age-out use case), without perturbing the live relay-gate freshness path.

## Production is inert

`warpOffset` defaults to 0, so `effectiveNow() == now()` on every relay path — byte-for-byte unchanged behavior. Only the debug handler ever stores a non-zero offset. Concurrency is safe by construction (atomic offset; the base `now` func is still never reassigned).

## ⚠️ Note on `observed_tip` (avoids a ticket bounce)

The ticket flagged both `has_baseline` staying `true` **and** `observed_tip` unchanged. This fix clears the former, but **raw `observed_tip` / `has_baseline` in `/debug/chain-state` are intentionally the non-TTL-gated view** (so black-box tests can still assert raw transitions). Warp-driven expiry is exposed through two **new computed fields, `TipFresh` / `BaselineFresh`**, which flip immediately on a warp (the raw fields only change on the next `Recompute`). **Assert `TipFresh` / `BaselineFresh`** (or poll `has_baseline` against the live router) to observe the warp taking effect.

## Testing

- `chainstate` unit test: a warp offset ages TTL exactly like real time; pins the raw-vs-gated snapshot split; resetting the offset restores freshness.
- rpcsmartrouter HTTP end-to-end test: `POST /debug/time-warp {offset_seconds:200}` → `/debug/chain-state` `TipFresh`/`BaselineFresh` flip to `false` → `offset_seconds:0` restores them.
- `go build ./...`, full `chainstate` + `rpcsmartrouter` suites, and `-race` on `chainstate` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MAG-2307]: https://magmadevs.atlassian.net/browse/MAG-2307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ