### PR TITLE
feat(smart-router/debug): add /debug/reset-probe-backoff + /debug/reset-chaintracker-rows (MAG-2395)

### DIFF
--- a/protocol/chaintracker/chain_tracker.go
+++ b/protocol/chaintracker/chain_tracker.go
@@ -38,6 +38,15 @@ type IChainTracker interface {
 	// repopulates the value on its next successful fetch.
 	ResetLatestBlock()
 
+	// ResetBackoff clears the failure backoff so the next dedicated poll fires at base cadence
+	// (debug recovery for /debug/reset-probe-backoff, MAG-2395).
+	ResetBackoff()
+
+	// CurrentPollInterval returns the poll interval most recently scheduled — base cadence when
+	// healthy, exponentialBackoff-stretched when the endpoint has been failing. Debug telemetry
+	// only (MAG-2395).
+	CurrentPollInterval() time.Duration
+
 	// StartAndServe starts the chain tracker and serves gRPC if configured
 	StartAndServe(ctx context.Context) error
 
@@ -137,6 +146,17 @@ type ChainTracker struct {
 
 	// allows us to mock the chain fetcher for different use cases for example: Solana needs slot to block number
 	iChainFetcherWrapper IChainFetcherWrapper
+
+	// currentPollIntervalNanos publishes the interval updateTimer most recently scheduled: base
+	// cadence when healthy, stretched by exponentialBackoff when fetchFails > 0. fetchFails is
+	// goroutine-local, so this atomic is the only lock-free window into the live backoff state,
+	// surfaced by /debug/endpoint-state as PollIntervalMs (MAG-2395). Written only by the poll
+	// goroutine (updateTimer), read by any goroutine.
+	currentPollIntervalNanos atomic.Int64
+	// resetBackoffCh signals the poll goroutine to clear the failure backoff — zero fetchFails and
+	// reschedule the next poll at base cadence. Buffered(1) with a non-blocking send in
+	// ResetBackoff, so /debug/reset-probe-backoff never blocks on the poll goroutine (MAG-2395).
+	resetBackoffCh chan struct{}
 }
 
 func (cs *ChainTracker) IsDummy() bool {
@@ -583,6 +603,16 @@ func (cs *ChainTracker) start(ctx context.Context, pollingTime time.Duration) er
 				if enoughSamples {
 					blockGapTicker.Reset(pollingTime * 10)
 				}
+			case <-cs.resetBackoffCh:
+				// /debug/reset-probe-backoff (MAG-2395): clear the failure backoff and reschedule the
+				// next poll at base cadence. Cadence only — block data, observations, and the
+				// traffic-gate skip counter (relaySkipsSinceRealPoll) are untouched. Stop the old
+				// (possibly minutes-out) timer before updateTimer reassigns cs.timer so it does not leak.
+				fetchFails = 0
+				if cs.timer != nil {
+					cs.timer.Stop()
+				}
+				cs.updateTimer(pollingTime, fetchFails)
 			case <-ctx.Done():
 				cs.timer.Stop()
 				return
@@ -593,7 +623,30 @@ func (cs *ChainTracker) start(ctx context.Context, pollingTime time.Duration) er
 }
 
 func (cs *ChainTracker) updateTimer(tickerBaseTime time.Duration, fetchFails uint64) {
-	cs.timer = time.NewTimer(cs.computePollInterval(tickerBaseTime, fetchFails))
+	interval := cs.computePollInterval(tickerBaseTime, fetchFails)
+	cs.currentPollIntervalNanos.Store(int64(interval)) // publish live cadence for /debug/endpoint-state (MAG-2395)
+	cs.timer = time.NewTimer(interval)
+}
+
+// ResetBackoff clears the failure backoff so the next dedicated poll fires at base cadence. It is
+// the debug recovery for /debug/reset-probe-backoff (MAG-2395): a provider that failed before a
+// reset otherwise keeps its stretched poll schedule (up to BACKOFF_MAX_TIME) afterwards. The send
+// is non-blocking on a buffered(1) channel, so the caller never waits on the poll goroutine and a
+// second request coalesces harmlessly with a pending one. Cadence only — block data, observations,
+// and the traffic-gate skip counter (relaySkipsSinceRealPoll) are untouched. A no-op until the poll
+// goroutine is running (the buffered slot is drained on the first loop iteration).
+func (cs *ChainTracker) ResetBackoff() {
+	select {
+	case cs.resetBackoffCh <- struct{}{}:
+	default:
+	}
+}
+
+// CurrentPollInterval returns the dedicated-poll interval most recently scheduled: base cadence when
+// healthy, exponentialBackoff-stretched when the endpoint has been failing. Debug telemetry only
+// (surfaced by /debug/endpoint-state as PollIntervalMs, MAG-2395) — never a decision-plane signal.
+func (cs *ChainTracker) CurrentPollInterval() time.Duration {
+	return time.Duration(cs.currentPollIntervalNanos.Load())
 }
 
 // computePollInterval returns the next dedicated-poll interval.
@@ -779,7 +832,12 @@ func newCustomChainTracker(chainFetcher ChainFetcher, config ChainTrackerConfig)
 		relayTipFresh:           config.RelayTipFresh,
 		maxRelaySkipsBeforePoll: maxRelaySkips,
 		endpoint:                endpoint,
+		resetBackoffCh:          make(chan struct{}, 1),
 	}
+	// Publish the base cadence up front so /debug/endpoint-state reports a sensible PollIntervalMs
+	// before the first poll reschedules it (0 for the legacy global tracker, which is not a
+	// per-endpoint row). See CurrentPollInterval / updateTimer (MAG-2395).
+	chainTracker.currentPollIntervalNanos.Store(int64(config.FlatPollInterval))
 
 	switch config.ChainId {
 	// TODO: we can do it better by creating a spec fields for custom trackers.

--- a/protocol/chaintracker/dummy_chain_tracker.go
+++ b/protocol/chaintracker/dummy_chain_tracker.go
@@ -31,6 +31,12 @@ func (dct *DummyChainTracker) GetAtomicLatestBlockNum() int64 {
 // ResetLatestBlock is a no-op for the dummy tracker; it has no cached state to clear.
 func (dct *DummyChainTracker) ResetLatestBlock() {}
 
+// ResetBackoff is a no-op for the dummy tracker; it has no poll loop or backoff to clear.
+func (dct *DummyChainTracker) ResetBackoff() {}
+
+// CurrentPollInterval is 0 for the dummy tracker; it schedules no polls.
+func (dct *DummyChainTracker) CurrentPollInterval() time.Duration { return 0 }
+
 // StartAndServe starts the chain tracker and serves gRPC if configured
 func (dct *DummyChainTracker) StartAndServe(ctx context.Context) error {
 	return nil

--- a/protocol/chaintracker/reset_backoff_external_test.go
+++ b/protocol/chaintracker/reset_backoff_external_test.go
@@ -1,0 +1,71 @@
+package chaintracker_test
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/chaintracker"
+	"github.com/stretchr/testify/require"
+)
+
+// togglableFailFetcher wraps MockChainFetcher and starts failing its fetches once fail is set, so a
+// tracker can be driven into failure backoff after a successful init.
+type togglableFailFetcher struct {
+	*MockChainFetcher
+	fail atomic.Bool
+}
+
+func (f *togglableFailFetcher) FetchLatestBlockNum(ctx context.Context) (int64, error) {
+	if f.fail.Load() {
+		return 0, fmt.Errorf("injected poll failure")
+	}
+	return f.MockChainFetcher.FetchLatestBlockNum(ctx)
+}
+
+func (f *togglableFailFetcher) FetchBlockHashByNum(ctx context.Context, blockNum int64) (string, error) {
+	if f.fail.Load() {
+		return "", fmt.Errorf("injected poll failure")
+	}
+	return f.MockChainFetcher.FetchBlockHashByNum(ctx, blockNum)
+}
+
+// TestChainTracker_ResetBackoff_ReturnsToBaseCadence is the end-to-end MAG-2395 check: a per-endpoint
+// tracker driven into failure backoff (its poll interval stretched beyond base) returns to base
+// cadence once ResetBackoff fires — the poll goroutine clears fetchFails and reschedules immediately
+// instead of waiting out the stretched delay. Mirrors the ticket flow: fail, heal, reset.
+func TestChainTracker_ResetBackoff_ReturnsToBaseCadence(t *testing.T) {
+	base := 40 * time.Millisecond
+	// Blocks 1000..1019 with hashes, so init (FetchLatestBlockNum + recent hashes) succeeds.
+	f := &togglableFailFetcher{MockChainFetcher: NewMockChainFetcher(1000, 20, nil)}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tracker, err := chaintracker.NewChainTracker(ctx, f, chaintracker.ChainTrackerConfig{
+		BlocksToSave:          10,
+		AverageBlockTime:      2 * base,
+		ServerBlockMemory:     20,
+		ParseDirectiveEnabled: true, // required: else newCustomChainTracker returns a DummyChainTracker
+		FlatPollInterval:      base, // flat per-endpoint cadence, subject to failure backoff
+	})
+	require.NoError(t, err)
+	require.NoError(t, tracker.StartAndServe(ctx))
+
+	require.Equal(t, base, tracker.CurrentPollInterval(), "a healthy tracker polls at base cadence")
+
+	// Break polling → the failure backoff stretches the interval beyond base.
+	f.fail.Store(true)
+	require.Eventually(t, func() bool { return tracker.CurrentPollInterval() > base },
+		3*time.Second, 5*time.Millisecond, "failing polls must stretch the poll interval via backoff")
+
+	// Heal + reset (the ticket flow). ResetBackoff clears the backoff and reschedules the next poll
+	// at base immediately, rather than waiting out the stretched delay; the healed poll then keeps it
+	// at base.
+	f.fail.Store(false)
+	tracker.ResetBackoff()
+	require.Eventually(t, func() bool { return tracker.CurrentPollInterval() == base },
+		3*time.Second, 5*time.Millisecond, "reset-probe-backoff must return the cadence to base")
+}

--- a/protocol/chaintracker/reset_backoff_internal_test.go
+++ b/protocol/chaintracker/reset_backoff_internal_test.go
@@ -1,0 +1,45 @@
+package chaintracker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestChainTracker_CurrentPollInterval_ReflectsBackoff verifies updateTimer publishes the live
+// dedicated-poll interval to the atomic that CurrentPollInterval reads (MAG-2395): base cadence
+// when healthy (fetchFails == 0), exponentialBackoff-stretched when failing. This is the value
+// /debug/endpoint-state surfaces as PollIntervalMs — the observable the reset returns to base.
+func TestChainTracker_CurrentPollInterval_ReflectsBackoff(t *testing.T) {
+	flat := 6 * time.Second
+	ct := &ChainTracker{flatPollInterval: flat}
+
+	// Healthy → base cadence. computePollInterval ignores the tickerBaseTime arg for flat trackers.
+	ct.updateTimer(flat, 0)
+	require.Equal(t, flat, ct.CurrentPollInterval())
+
+	// Backed off → base * 2^fetchFails.
+	ct.updateTimer(flat, 3)
+	require.Equal(t, flat*8, ct.CurrentPollInterval())
+
+	ct.timer.Stop()
+}
+
+// TestChainTracker_ResetBackoff_NonBlockingCoalesces verifies ResetBackoff never blocks on the poll
+// goroutine and coalesces repeated requests on its buffered(1) channel (MAG-2395), so the
+// /debug/reset-probe-backoff handler is always fast even while a reset is already pending.
+func TestChainTracker_ResetBackoff_NonBlockingCoalesces(t *testing.T) {
+	ct := &ChainTracker{resetBackoffCh: make(chan struct{}, 1)}
+
+	ct.ResetBackoff()
+	ct.ResetBackoff()
+	ct.ResetBackoff()
+	require.Len(t, ct.resetBackoffCh, 1, "repeated resets coalesce into one buffered signal")
+
+	<-ct.resetBackoffCh // the poll goroutine drains one signal per loop iteration
+	require.Empty(t, ct.resetBackoffCh)
+
+	ct.ResetBackoff()
+	require.Len(t, ct.resetBackoffCh, 1, "reset works again once the pending signal is drained")
+}

--- a/protocol/endpointstate/endpoint_monitor.go
+++ b/protocol/endpointstate/endpoint_monitor.go
@@ -510,6 +510,35 @@ func (m *EndpointMonitor) ResetAllLatestBlocks() int {
 	return count
 }
 
+// ResetAllBackoff clears the failure backoff on every registered tracker so each endpoint returns
+// to its base poll cadence, without restarting the poll goroutines. Debug recovery for
+// /debug/reset-probe-backoff (MAG-2395): probe back-off is otherwise unreachable by any reset, so a
+// provider that failed before a reset keeps its stretched schedule (up to BACKOFF_MAX_TIME) after
+// it. Returns the number of trackers signalled. Same RLock idiom as ResetAllLatestBlocks.
+func (m *EndpointMonitor) ResetAllBackoff() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	count := 0
+	for _, t := range m.trackers {
+		t.ResetBackoff()
+		count++
+	}
+	return count
+}
+
+// BackoffSnapshot returns the current dedicated-poll interval per endpoint URL, so
+// /debug/endpoint-state can surface the live backoff as PollIntervalMs — base cadence when healthy,
+// exponentialBackoff-stretched when failing (MAG-2395). Read-only telemetry.
+func (m *EndpointMonitor) BackoffSnapshot() map[string]time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make(map[string]time.Duration, len(m.trackers))
+	for url, t := range m.trackers {
+		out[url] = t.CurrentPollInterval()
+	}
+	return out
+}
+
 // RemoveTracker removes and stops a ChainTracker for an endpoint.
 // It cancels the tracker's context first, which signals the goroutine to exit cleanly.
 func (m *EndpointMonitor) RemoveTracker(endpointURL string) {

--- a/protocol/endpointstate/endpoint_monitor_lifecycle_test.go
+++ b/protocol/endpointstate/endpoint_monitor_lifecycle_test.go
@@ -130,11 +130,23 @@ func TestEndpointMonitor_RemoveTrackerCallsCancel(t *testing.T) {
 // RLock while iterating.
 type recordingChainTracker struct {
 	*chaintracker.DummyChainTracker
-	resetCalls atomic.Int32
+	resetCalls        atomic.Int32
+	resetBackoffCalls atomic.Int32
+	pollInterval      time.Duration
 }
 
 func (r *recordingChainTracker) ResetLatestBlock() {
 	r.resetCalls.Add(1)
+}
+
+// ResetBackoff / CurrentPollInterval shadow the embedded dummy so ResetAllBackoff and
+// BackoffSnapshot can be exercised without spinning real ChainTracker poll goroutines (MAG-2395).
+func (r *recordingChainTracker) ResetBackoff() {
+	r.resetBackoffCalls.Add(1)
+}
+
+func (r *recordingChainTracker) CurrentPollInterval() time.Duration {
+	return r.pollInterval
 }
 
 // TestEndpointMonitor_ResetAllLatestBlocks verifies that ResetAllLatestBlocks

--- a/protocol/endpointstate/reset_backoff_test.go
+++ b/protocol/endpointstate/reset_backoff_test.go
@@ -1,0 +1,66 @@
+package endpointstate
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEndpointMonitor_ResetAllBackoff verifies ResetAllBackoff signals ResetBackoff on every
+// registered tracker exactly once and returns the count (MAG-2395) — the /debug/reset-probe-backoff
+// dispatch. Uses injected fakes (in-package) so no real poll goroutines are spun; the per-tracker
+// backoff-clear behavior itself is covered in chaintracker's reset_backoff_internal_test.go.
+func TestEndpointMonitor_ResetAllBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := NewEndpointMonitor(ctx, EndpointChainTrackerConfig{
+		ChainID:          "ETH",
+		ApiInterface:     "jsonrpc",
+		AverageBlockTime: 12 * time.Second,
+		BlocksToSave:     10,
+	})
+	require.NotNil(t, m)
+	defer m.Stop()
+
+	fakes := []*recordingChainTracker{{}, {}, {}, {}}
+	for i, f := range fakes {
+		m.trackers["http://endpoint-"+strconv.Itoa(i)+":8545"] = f
+	}
+
+	count := m.ResetAllBackoff()
+
+	require.Equal(t, len(fakes), count, "ResetAllBackoff should report every tracker signalled")
+	for i, f := range fakes {
+		require.Equal(t, int32(1), f.resetBackoffCalls.Load(),
+			"tracker %d should have had ResetBackoff called exactly once", i)
+	}
+}
+
+// TestEndpointMonitor_BackoffSnapshot verifies BackoffSnapshot reports each tracker's current poll
+// interval keyed by URL — the data /debug/endpoint-state emits as PollIntervalMs (MAG-2395).
+func TestEndpointMonitor_BackoffSnapshot(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := NewEndpointMonitor(ctx, EndpointChainTrackerConfig{
+		ChainID:          "ETH",
+		ApiInterface:     "jsonrpc",
+		AverageBlockTime: 12 * time.Second,
+		BlocksToSave:     10,
+	})
+	require.NotNil(t, m)
+	defer m.Stop()
+
+	m.trackers["http://healthy:8545"] = &recordingChainTracker{pollInterval: 6 * time.Second}
+	m.trackers["http://backed-off:8545"] = &recordingChainTracker{pollInterval: 48 * time.Second}
+
+	snap := m.BackoffSnapshot()
+
+	require.Len(t, snap, 2)
+	require.Equal(t, 6*time.Second, snap["http://healthy:8545"], "healthy endpoint reports base cadence")
+	require.Equal(t, 48*time.Second, snap["http://backed-off:8545"], "backed-off endpoint reports the stretched interval")
+}

--- a/protocol/rpcsmartrouter/debug_reset_backoff_test.go
+++ b/protocol/rpcsmartrouter/debug_reset_backoff_test.go
@@ -1,0 +1,67 @@
+package rpcsmartrouter
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// postDebugRouter POSTs to a debug path and returns the recorder (MAG-2395 handlers).
+func postDebugRouter(mux http.Handler, path string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, path, nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	return rr
+}
+
+// TestDebugResetProbeBackoff_ReturnsJSON covers the /debug/reset-probe-backoff HTTP contract
+// (MAG-2395). The per-tracker clear + return-to-base-cadence behavior is proven at the lower layers
+// (chaintracker.TestChainTracker_* and endpointstate.TestEndpointMonitor_ResetAllBackoff); here we
+// pin the handler shape. With no router wired the count is 0, but the field must still appear so
+// the suite can rely on the shape regardless of fixture wiring.
+func TestDebugResetProbeBackoff_ReturnsJSON(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano})
+
+	rr := postDebugRouter(mux, "/debug/reset-probe-backoff")
+	require.Equal(t, http.StatusOK, rr.Code, "body=%q", rr.Body.String())
+	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	body := rr.Body.String()
+	require.Contains(t, body, `"reset":true`)
+	require.Contains(t, body, `"endpoints_reset":0`)
+}
+
+func TestDebugResetProbeBackoff_MethodNotAllowed(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano})
+
+	rr := getDebugRouter(mux, "/debug/reset-probe-backoff") // GET on a POST-only endpoint
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}
+
+// TestDebugResetChainTrackerRows_ReturnsJSON covers the /debug/reset-chaintracker-rows HTTP contract
+// (MAG-2395): re-register every configured endpoint that lost its ChainTracker row. With no router
+// wired both counts are 0, but the shape (reset + rows_ensured + rows_created) must be stable.
+func TestDebugResetChainTrackerRows_ReturnsJSON(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano})
+
+	rr := postDebugRouter(mux, "/debug/reset-chaintracker-rows")
+	require.Equal(t, http.StatusOK, rr.Code, "body=%q", rr.Body.String())
+	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	body := rr.Body.String()
+	require.Contains(t, body, `"reset":true`)
+	require.Contains(t, body, `"rows_ensured":0`)
+	require.Contains(t, body, `"rows_created":0`)
+}
+
+func TestDebugResetChainTrackerRows_MethodNotAllowed(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano})
+
+	rr := getDebugRouter(mux, "/debug/reset-chaintracker-rows") // GET on a POST-only endpoint
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -544,6 +544,11 @@ func resetAllProbeBackoff(deps debugMuxDeps) int {
 // restored while a genuinely config-removed one is correctly left out. GetOrCreateTracker is
 // idempotent (no-op for a live row) and non-blocking (it registers synchronously and starts the poll
 // goroutine via startTrackerWithRetry), so the handler never blocks on a down endpoint's init fetch.
+//
+// Holding router.mu does NOT exclude the epoch cleanup: cleanupStaleTrackers deliberately runs
+// outside that lock, so a cleanup pass that already built its keep-set can delete a row this handler
+// just recreated. Acceptable for a recovery tool — the operator re-POSTs, and MAG-2445 is the root
+// fix — but do not assume the lock provides that exclusion.
 // Returns (ensured, created): endpoints processed, and rows that did not previously exist.
 func reregisterChainTrackerRows(deps debugMuxDeps) (ensured, created int) {
 	if deps.router == nil {
@@ -559,7 +564,13 @@ func reregisterChainTrackerRows(deps debugMuxDeps) (ensured, created int) {
 		if csm == nil {
 			continue
 		}
-		before := server.endpointChainTrackerManager.GetEndpointCount()
+		// Count creations against a snapshot of the pre-existing rows rather than a
+		// GetEndpointCount before/after delta: a concurrent cleanupStaleTrackers removal between
+		// the two reads would skew the delta (even negative).
+		existing := make(map[string]bool)
+		for _, url := range server.endpointChainTrackerManager.GetAllEndpoints() {
+			existing[url] = true
+		}
 		for _, ep := range csm.GetAllDirectRPCEndpoints() {
 			if ep == nil || ep.Endpoint == nil {
 				continue
@@ -570,9 +581,13 @@ func reregisterChainTrackerRows(deps debugMuxDeps) (ensured, created int) {
 					utils.LogAttr("endpoint", ep.Endpoint.NetworkAddress),
 					utils.LogAttr("chainKey", chainKey),
 				)
+				continue
+			}
+			if !existing[ep.Endpoint.NetworkAddress] {
+				created++
+				existing[ep.Endpoint.NetworkAddress] = true
 			}
 		}
-		created += server.endpointChainTrackerManager.GetEndpointCount() - before
 	}
 	return ensured, created
 }

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -514,6 +514,69 @@ func resetAllChainTrackers(deps debugMuxDeps) int {
 	return count
 }
 
+// resetAllProbeBackoff walks every server's EndpointMonitor and clears the per-endpoint poll
+// back-off so each provider returns to its base poll cadence (MAG-2395). Probe back-off (the
+// fetchFails streak) is otherwise unreachable by any reset endpoint, so a provider that failed
+// before a reset keeps its stretched schedule (up to BACKOFF_MAX_TIME) after it. Nil-safe at every
+// level; returns the total number of trackers signalled across all servers.
+func resetAllProbeBackoff(deps debugMuxDeps) int {
+	if deps.router == nil {
+		return 0
+	}
+	deps.router.mu.Lock()
+	defer deps.router.mu.Unlock()
+	count := 0
+	for _, server := range deps.router.rpcServers {
+		if server == nil || server.endpointChainTrackerManager == nil {
+			continue
+		}
+		count += server.endpointChainTrackerManager.ResetAllBackoff()
+	}
+	return count
+}
+
+// reregisterChainTrackerRows re-registers every currently-configured direct-RPC endpoint that lost
+// its ChainTracker row — the recovery tool for MAG-2445, where the epoch cleanup (cleanupStaleTrackers)
+// can delete the row of a provider that was only briefly unhealthy, after which no reset recreates it
+// and the provider returns only on a later ~15-minute rebuild. The source is the config/pairing set
+// (GetAllDirectRPCEndpoints, the same source initializeChainTrackers uses at startup), NOT the live
+// health-filtered set cleanupStaleTrackers deletes from — so a temporarily-disabled provider is
+// restored while a genuinely config-removed one is correctly left out. GetOrCreateTracker is
+// idempotent (no-op for a live row) and non-blocking (it registers synchronously and starts the poll
+// goroutine via startTrackerWithRetry), so the handler never blocks on a down endpoint's init fetch.
+// Returns (ensured, created): endpoints processed, and rows that did not previously exist.
+func reregisterChainTrackerRows(deps debugMuxDeps) (ensured, created int) {
+	if deps.router == nil {
+		return 0, 0
+	}
+	deps.router.mu.Lock()
+	defer deps.router.mu.Unlock()
+	for chainKey, server := range deps.router.rpcServers {
+		if server == nil || server.endpointChainTrackerManager == nil {
+			continue
+		}
+		csm := deps.router.sessionManagers[chainKey]
+		if csm == nil {
+			continue
+		}
+		before := server.endpointChainTrackerManager.GetEndpointCount()
+		for _, ep := range csm.GetAllDirectRPCEndpoints() {
+			if ep == nil || ep.Endpoint == nil {
+				continue
+			}
+			ensured++
+			if _, err := server.endpointChainTrackerManager.GetOrCreateTracker(ep.Endpoint, ep.DirectConnection); err != nil {
+				utils.LavaFormatWarning("reset-chaintracker-rows: failed to re-register endpoint", err,
+					utils.LogAttr("endpoint", ep.Endpoint.NetworkAddress),
+					utils.LogAttr("chainKey", chainKey),
+				)
+			}
+		}
+		created += server.endpointChainTrackerManager.GetEndpointCount() - before
+	}
+	return ensured, created
+}
+
 // resetAllConsistencies flushes every per-chain seen-block cache that
 // implements consistencyResetter. Why this is necessary: SetSeenBlockFromKey
 // only writes monotonically (consistency.go: `block >= blockSeen → return`),
@@ -1018,6 +1081,7 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 					continue
 				}
 				observations := server.endpointChainTrackerManager.SnapshotObservations()
+				backoffByURL := server.endpointChainTrackerManager.BackoffSnapshot()
 				for _, ep := range csm.GetAllDirectRPCEndpoints() {
 					if ep == nil || ep.Endpoint == nil {
 						continue
@@ -1037,6 +1101,10 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 						"LatestBlock":              obs.LatestBlock,
 						"ObservedAt":               debugTimeRFC3339(obs.ObservedAt),
 						"Source":                   obs.Source.String(),
+						// PollIntervalMs is the live dedicated-poll cadence: base when healthy,
+						// exponentialBackoff-stretched when the endpoint has been failing. This is the
+						// observable /debug/reset-probe-backoff returns to base (MAG-2395).
+						"PollIntervalMs": backoffByURL[url].Milliseconds(),
 					})
 				}
 			}
@@ -1159,6 +1227,38 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 		reenabled := resetEndpointHealthAndGauge(deps)
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"reset":true,"endpoints_reenabled":%d}`, reenabled)
+	})
+
+	// POST /debug/reset-probe-backoff — clear the ChainTracker probe back-off on every endpoint so
+	// each provider's poll schedule returns to base cadence (MAG-2395). The back-off (fetchFails
+	// streak) is unreachable by reset-all / reset-scores / reset-endpoint-health / reset-pairing, so
+	// a provider that failed before a reset otherwise keeps its stretched schedule (up to
+	// BACKOFF_MAX_TIME = 10m) after it. Cadence only — nothing else is touched. The effect is
+	// observable as PollIntervalMs returning to base in /debug/endpoint-state.
+	mux.HandleFunc("/debug/reset-probe-backoff", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST only", http.StatusMethodNotAllowed)
+			return
+		}
+		reset := resetAllProbeBackoff(deps)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"reset":true,"endpoints_reset":%d}`, reset)
+	})
+
+	// POST /debug/reset-chaintracker-rows — re-register every configured endpoint that lost its
+	// ChainTracker row (MAG-2395). The epoch cleanup can delete a briefly-unhealthy provider's row
+	// (MAG-2445); no other reset recreates it, so it returns only on a later ~15-minute rebuild or a
+	// pod restart. This re-adds any missing row from the config/pairing set and is a no-op for rows
+	// that already exist. "rows_ensured" is the number of configured endpoints checked;
+	// "rows_created" is how many rows were actually (re)created.
+	mux.HandleFunc("/debug/reset-chaintracker-rows", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST only", http.StatusMethodNotAllowed)
+			return
+		}
+		ensured, created := reregisterChainTrackerRows(deps)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"reset":true,"rows_ensured":%d,"rows_created":%d}`, ensured, created)
 	})
 
 	// GET /debug/runtime-config — expose the router's live tuning values as JSON so the


### PR DESCRIPTION
## What & why

Two pieces of per-endpoint ChainTracker state cannot be cleared by any debug endpoint today, so tests that reset the router and then measure poll timing or provider health start from a dirty state and can silently give a wrong result. This adds two focused reset endpoints. **reset-all and reset-scores are unchanged** (the ticket's explicit requirement).

Implements **[MAG-2395](https://magmadevs.atlassian.net/browse/MAG-2395)**.

### Architecture note
The ticket's pointers reference the pre-redesign `protocol/chaintracker/chain_tracker.go`; on current `main` the old ChainTracker is still live but owned **per-endpoint** by `endpointstate.EndpointMonitor` (one `ChainTracker` per URL). The two capabilities are mapped onto that current structure.

## `POST /debug/reset-probe-backoff`
Clears the per-endpoint failure backoff so each provider returns to base poll cadence. Nothing else.
- `fetchFails` is goroutine-local and the poll timer can be stretched up to `BACKOFF_MAX_TIME` (10m); neither is safely resettable from outside the poll goroutine. So `ChainTracker` gets a buffered `resetBackoffCh`; a new `select` case zeroes `fetchFails` and reschedules the next poll at base cadence. `ResetBackoff()` is a non-blocking send, so the handler never waits on the poll goroutine.
- **Observability:** `/debug/endpoint-state` had no interval/backoff field, so the ticket's acceptance ("poll interval visibly stretches … next poll on the BASE interval") wasn't observable. `updateTimer` now publishes the live interval to an atomic, exposed as **`PollIntervalMs`** — it goes base → stretched under failures and back to base after the reset.

## `POST /debug/reset-chaintracker-rows`
Re-registers every configured endpoint that lost its ChainTracker row. Nothing else.
- The epoch cleanup (`cleanupStaleTrackers`) can delete a briefly-unhealthy provider's row (MAG-2445); no reset recreates it, so it returns only on a ~15-minute rebuild or a pod restart.
- Re-registration reuses `GetOrCreateTracker` over `GetAllDirectRPCEndpoints()` — the **config/pairing** set startup registers from, **not** the health-filtered live set the cleanup deletes from — so a temporarily-disabled provider is restored while a genuinely config-removed one is correctly left out. `GetOrCreateTracker` is idempotent and non-blocking, so a still-down provider's row reappears immediately and the handler never blocks on init fetch.

## Relationship to MAG-2445
This is the **recovery tool**; MAG-2445 is the complementary root fix (stop deleting the rows). They ship independently.

## Testing
- **chaintracker:** interval-publish, non-blocking-coalesce, and an **end-to-end reset-returns-to-base-cadence** test (run 3× under `-race`, no flakiness).
- **endpointstate:** `ResetAllBackoff` dispatch + `BackoffSnapshot`.
- **rpcsmartrouter:** handler contracts (POST-only → 405, JSON shape).
- `go build ./...`, `rpcsmartrouter` full suite, `endpointstate` `-race`, and `chaintracker` all pass.
- Pre-existing/unrelated: `TestChainTrackerCallbacks/one_long_test` trips `-race` on clean `main` too (reproduced with these changes stashed) — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MAG-2395]: https://magmadevs.atlassian.net/browse/MAG-2395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ