### PR TITLE
fix(rpcsmartrouter): dedicated ChainState time-warp endpoint + real-clock timestamps (MAG-2307 review)

### DIFF
--- a/protocol/chainstate/chain_state.go
+++ b/protocol/chainstate/chain_state.go
@@ -198,20 +198,30 @@ func NewWithClock(chainID string, cfg Config, clock func() time.Time) *ChainStat
 	return &ChainState{chainID: chainID, cfg: cfg, now: clock}
 }
 
-// effectiveNow is the clock every TTL/staleness/consensus read uses: the base clock plus the
+// warpOffsetDuration is the current debug warp offset as a Duration (0 in production). Split out so
+// effectiveNow and the "store real / compare warped" split in SetLatestBlock and Recompute read the
+// same lock-free value.
+func (cs *ChainState) warpOffsetDuration() time.Duration {
+	return time.Duration(cs.warpOffset.Load())
+}
+
+// effectiveNow is the clock every TTL/staleness/consensus COMPARISON uses: the base clock plus the
 // debug warp offset. In production the offset is always zero, so this is exactly the base clock;
-// under /debug/time-warp it shifts forward so a warp ages this chain's windows just like it ages
-// the provider-optimizer clock (MAG-2307). The atomic load is lock-free, matching the base clock's
-// no-lock read contract.
+// under the debug ChainState time-warp it shifts forward so a warp ages this chain's windows without
+// waiting real time (MAG-2307). It is used ONLY to EVALUATE freshness — stored timestamps
+// (lastObservedAt / baselineAt / baselineSince) always use the real base clock cs.now(), so clearing
+// the warp can never leave a future-dated timestamp that reads as artificially fresh (MAG-2307
+// review). The atomic load is lock-free, matching the base clock's no-lock read contract.
 func (cs *ChainState) effectiveNow() time.Time {
-	return cs.now().Add(time.Duration(cs.warpOffset.Load()))
+	return cs.now().Add(cs.warpOffsetDuration())
 }
 
 // SetDebugClockOffset shifts this chain's effective clock forward by d, aging its TTL/staleness/
-// consensus windows without waiting real time. Debug-only: the /debug/time-warp and /debug/reset-all
-// handlers call it (with d and 0 respectively), mirroring how they set/clear the optimizer's NowFunc.
-// It is NOT reachable from any relay path. The write is atomic and takes no lock, so it is safe to
-// call concurrently with live reads.
+// consensus windows without waiting real time. Debug-only: driven by the dedicated
+// /debug/chain-state-time-warp endpoint, which is INDEPENDENT of /debug/time-warp (the optimizer/QoS
+// clock) so a routine QoS warp-then-reset never disturbs ChainState. It changes only freshness
+// EVALUATION (effectiveNow), never a stored timestamp. Not reachable from any relay path. The write
+// is atomic and takes no lock, so it is safe to call concurrently with live reads.
 func (cs *ChainState) SetDebugClockOffset(d time.Duration) {
 	cs.warpOffset.Store(int64(d))
 }
@@ -254,8 +264,11 @@ func (cs *ChainState) SetLatestBlock(block int64) (latest int64, at time.Time, a
 	if block <= 0 {
 		return cs.latestBlock, cs.lastObservedAt, false
 	}
-	now := cs.effectiveNow()
-	_, tipFresh := cs.freshLatestLocked(now)
+	// Freshness is EVALUATED against the warped clock, but the stored lastObservedAt uses the real
+	// base clock — a debug warp must never write a future-dated timestamp that reads as artificially
+	// fresh once the warp is cleared (real - future = negative age; MAG-2307 review).
+	nowReal := cs.now()
+	_, tipFresh := cs.freshLatestLocked(nowReal.Add(cs.warpOffsetDuration()))
 	if cs.initialized {
 		if block < cs.latestBlock {
 			if tipFresh {
@@ -263,11 +276,11 @@ func (cs *ChainState) SetLatestBlock(block int64) (latest int64, at time.Time, a
 			}
 			// Stale-tip downward re-adoption (self-heal from a poisoned/frozen tip).
 			cs.latestBlock = block
-			cs.lastObservedAt = now
+			cs.lastObservedAt = nowReal
 			return cs.latestBlock, cs.lastObservedAt, false
 		}
 		if block == cs.latestBlock {
-			cs.lastObservedAt = now // equal-block confirmation refreshes freshness (Finding 4)
+			cs.lastObservedAt = nowReal // equal-block confirmation refreshes freshness (Finding 4)
 			return cs.latestBlock, cs.lastObservedAt, false
 		}
 	}
@@ -281,7 +294,7 @@ func (cs *ChainState) SetLatestBlock(block int64) (latest int64, at time.Time, a
 		return cs.latestBlock, cs.lastObservedAt, false
 	}
 	cs.latestBlock = block
-	cs.lastObservedAt = now
+	cs.lastObservedAt = nowReal
 	cs.initialized = true
 	return cs.latestBlock, cs.lastObservedAt, true
 }
@@ -373,8 +386,12 @@ func (cs *ChainState) freshLatestLocked(now time.Time) (int64, bool) {
 // snapshots (no lock), and only the final tip/baseline update takes the ChainState lock — so
 // the monitor lock (released before this call) and the ChainState lock never nest.
 func (cs *ChainState) Recompute(snapshots []BlockObservation) {
-	now := cs.effectiveNow()
-	baseline, ok := computeMajorityBaseline(snapshots, now, cs.cfg)
+	// Staleness is EVALUATED against the warped clock (so a debug warp ages observations out of the
+	// consensus window), but the stored baseline/tip timestamps use the real base clock — never a
+	// warped, possibly-future value that would distort freshness / sync-lag once the warp is cleared
+	// (MAG-2307 review).
+	nowReal := cs.now()
+	baseline, ok := computeMajorityBaseline(snapshots, nowReal.Add(cs.warpOffsetDuration()), cs.cfg)
 
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
@@ -385,17 +402,17 @@ func (cs *ChainState) Recompute(snapshots []BlockObservation) {
 	if ok {
 		// TTL freshness: every confirming Recompute re-proves consensus is live (mirrors
 		// lastObservedAt for the optimistic tip), so a stable-but-reconfirmed baseline never expires.
-		cs.baselineAt = now
+		cs.baselineAt = nowReal
 		// Establishment time: reset ONLY when the baseline block changes — a forward advance, a
 		// downward reorg/realign, or re-establishment after a consensus gap (prevHasBaseline false).
 		// When the block is unchanged we PRESERVE baselineSince so sync-lag reflects the baseline's
 		// true age (Finding 3); resetting it here is the bug that made an old baseline look new.
 		if !prevHasBaseline || prevBaseline != baseline {
-			cs.baselineSince = now
+			cs.baselineSince = nowReal
 		}
 		if cs.latestBlock > baseline+cs.cfg.OutlierThreshold {
 			cs.latestBlock = baseline
-			cs.lastObservedAt = now
+			cs.lastObservedAt = nowReal
 		}
 	}
 }
@@ -404,14 +421,15 @@ func (cs *ChainState) Recompute(snapshots []BlockObservation) {
 // (MAG-2202 /debug/chain-state). Unlike GetLatestBlock / GetConsensusBaseline it never applies the
 // TTL freshness gate: black-box tests assert TTL expiry, downward realignment, and empty-snapshot
 // baseline clearing from the raw (block, timestamp) pairs — a gated getter would hide exactly those
-// transitions by collapsing to (0, false). BaselineSince is the establishment time (distinct from
-// the TTL-freshness baselineAt that GetConsensusBaselineWithTime exposes).
+// transitions by collapsing to (0, false). BaselineSince is the establishment time — the same value
+// GetConsensusBaselineWithTime returns — distinct from the internal TTL-freshness timestamp baselineAt
+// (which drives the freshness gate but is never exposed).
 //
 // TipFresh / BaselineFresh are the ONE computed exception: the TTL-gated verdicts (what
 // GetLatestBlock / GetConsensusBaseline would report) evaluated against the effective clock. They
-// exist so a /debug/time-warp forward shift is observable IMMEDIATELY — the raw ObservedTip /
-// HasBaseline fields only change on the next Recompute tick, and never at all in a fixture with no
-// recompute loop running (MAG-2307). Assert on these, not the raw fields, to see warp-driven expiry.
+// exist so a debug ChainState warp is observable IMMEDIATELY — the raw ObservedTip / HasBaseline
+// fields only change on the next Recompute tick, and never at all in a fixture with no recompute loop
+// running (MAG-2307). Assert on these, not the raw fields, to see warp-driven expiry.
 type ChainStateSnapshot struct {
 	ObservedTip       int64
 	LastObservedAt    time.Time

--- a/protocol/chainstate/chain_state_test.go
+++ b/protocol/chainstate/chain_state_test.go
@@ -319,6 +319,57 @@ func TestSetDebugClockOffset_AgesTTLLikeRealTime(t *testing.T) {
 	require.True(t, cs.DebugSnapshot().TipFresh)
 }
 
+// TestSetLatestBlock_TimestampStaysOnRealClockUnderWarp pins the MAG-2307-review fix: SetLatestBlock
+// evaluates freshness against the warped clock but STORES lastObservedAt on the REAL clock. A block
+// accepted while a warp is active must not get a future-dated timestamp — otherwise clearing the warp
+// leaves real - future = negative age, which reads as "fresh forever" until real time catches up.
+func TestSetLatestBlock_TimestampStaysOnRealClockUnderWarp(t *testing.T) {
+	cs, clk := newTestState(t) // TTL = 10s; base clock frozen at clk
+	realWriteTime := clk.now()
+
+	cs.SetDebugClockOffset(200 * time.Second) // warp forward, THEN accept a block
+	cs.SetLatestBlock(1000)
+
+	require.Equal(t, realWriteTime, cs.DebugSnapshot().LastObservedAt,
+		"lastObservedAt must be stamped on the real clock, not the warped +200s future")
+
+	cs.SetDebugClockOffset(0) // clear the warp
+	_, ok := cs.GetLatestBlock()
+	require.True(t, ok, "a block just written is legitimately fresh")
+
+	clk.advance(11 * time.Second) // real time crosses the 10s TTL
+	_, ok = cs.GetLatestBlock()
+	require.False(t, ok,
+		"a tip written under a warp must still expire on real time once the warp is cleared (no negative-age freshness)")
+}
+
+// TestRecompute_TimestampsStayOnRealClockUnderWarp is the Recompute companion: baselineAt/baselineSince
+// are stored on the real clock. A SMALL warp (< TTL) keeps observations fresh under the warped clock,
+// so a baseline forms and its timestamps are written while the warp is active — those must be real.
+func TestRecompute_TimestampsStayOnRealClockUnderWarp(t *testing.T) {
+	cs, clk := newTestState(t) // TTL = staleness = 10s
+	realWriteTime := clk.now()
+
+	cs.SetDebugClockOffset(5 * time.Second) // < TTL, so the observations still count as fresh
+	cs.SetLatestBlock(1000)
+	cs.Recompute([]BlockObservation{
+		{URL: "a", Block: 1000, ObservedAt: realWriteTime},
+		{URL: "b", Block: 1000, ObservedAt: realWriteTime},
+	})
+
+	require.Equal(t, realWriteTime, cs.DebugSnapshot().BaselineSince,
+		"baselineSince must be the real write time, not the warped future (MAG-2307 review)")
+
+	cs.SetDebugClockOffset(0)
+	_, ok := cs.GetConsensusBaseline()
+	require.True(t, ok, "a baseline just established is fresh")
+
+	clk.advance(11 * time.Second) // real time crosses the TTL
+	_, ok = cs.GetConsensusBaseline()
+	require.False(t, ok,
+		"a baseline established under a warp must still expire on real time once the warp is cleared")
+}
+
 // --- Consensus cardinality (computeMajorityBaseline) ------------------------------------
 
 func TestComputeMajorityBaseline_Cardinality(t *testing.T) {

--- a/protocol/rpcsmartrouter/debug_server_test.go
+++ b/protocol/rpcsmartrouter/debug_server_test.go
@@ -434,7 +434,7 @@ func TestDebugChainStateTimeWarp_AgesChainState(t *testing.T) {
 	// Warp +200s (>> 10s TTL) via the dedicated endpoint → both verdicts flip to false.
 	rr := postChainStateTimeWarp(mux, `{"offset_seconds":200}`)
 	require.Equal(t, http.StatusOK, rr.Code)
-	require.Contains(t, rr.Body.String(), `"applied_to_chains":1`, "the one wired ChainState was warped")
+	require.Contains(t, rr.Body.String(), `"chain_states_warped":1`, "the one wired ChainState was warped")
 
 	row = chainStateRow()
 	require.Equal(t, false, row["TipFresh"], "a forward warp ages the tip out of its TTL window")
@@ -469,6 +469,31 @@ func TestDebugTimeWarp_DoesNotTouchChainState(t *testing.T) {
 	rr = postTimeWarpRouter(mux, `{"offset_seconds":0}`)
 	require.Equal(t, http.StatusOK, rr.Code)
 	require.Equal(t, true, chainStateRow()["TipFresh"], "resetting the QoS warp must not touch ChainState")
+}
+
+// TestDebugResetAll_DoesNotTouchChainStateWarp pins the other half of the MAG-2307-review decoupling:
+// /debug/reset-all resets optimizer/QoS + related state but must NOT clear ChainState's debug warp —
+// that is exclusively the /debug/chain-state-time-warp endpoint's job. A regression re-adding the
+// removed setAllChainStateDebugOffset(deps, 0) call inside reset-all would fail this test.
+func TestDebugResetAll_DoesNotTouchChainStateWarp(t *testing.T) {
+	mux, chainStateRow := newAgedChainStateRouter(t)
+
+	// Warp ChainState past its TTL via the dedicated endpoint.
+	rr := postChainStateTimeWarp(mux, `{"offset_seconds":200}`)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, false, chainStateRow()["TipFresh"], "the ChainState warp is active")
+
+	// A full /debug/reset-all must leave that warp intact.
+	req := httptest.NewRequest(http.MethodPost, "/debug/reset-all", nil)
+	resetRR := httptest.NewRecorder()
+	mux.ServeHTTP(resetRR, req)
+	require.Equal(t, http.StatusOK, resetRR.Code, "body=%q", resetRR.Body.String())
+	require.Equal(t, false, chainStateRow()["TipFresh"], "/debug/reset-all must NOT clear the ChainState warp")
+
+	// The warp is still cleared only via its own endpoint.
+	rr = postChainStateTimeWarp(mux, `{"offset_seconds":0}`)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, true, chainStateRow()["TipFresh"], "clearing via the dedicated endpoint restores freshness")
 }
 
 // TestDebugProviderRouting_ReportsPerCSMShape verifies the handler keys output per session manager and

--- a/protocol/rpcsmartrouter/debug_server_test.go
+++ b/protocol/rpcsmartrouter/debug_server_test.go
@@ -379,12 +379,20 @@ func TestDebugChainState_ReportsRawSnapshot(t *testing.T) {
 	require.NotEmpty(t, row["BaselineSince"], "established baseline carries an RFC3339 timestamp")
 }
 
-// TestDebugTimeWarp_AgesChainState is the MAG-2307 end-to-end check at the HTTP layer: POST
-// /debug/time-warp forward past the TTL must age every per-chain ChainState so /debug/chain-state
-// reports the tip/baseline as no longer fresh, and resetting the offset to 0 must restore them.
-// Before the fix the warp only moved the optimizer clock, so these verdicts never changed.
-func TestDebugTimeWarp_AgesChainState(t *testing.T) {
-	var offsetNano atomic.Int64
+// postChainStateTimeWarp POSTs an offset to the dedicated ChainState time-warp endpoint.
+func postChainStateTimeWarp(mux http.Handler, rawBody string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/debug/chain-state-time-warp", strings.NewReader(rawBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	return rr
+}
+
+// newAgedChainStateRouter wires one ETH1 ChainState with a just-established baseline (10s TTL) into a
+// router + debug mux, and returns the mux plus a helper reading the single /debug/chain-state row.
+func newAgedChainStateRouter(t *testing.T) (http.Handler, func() map[string]any) {
+	t.Helper()
+	offsetNano := new(atomic.Int64)
 	cs := chainstate.New("ETH1", chainstate.Config{
 		BucketWidth: 2, OutlierThreshold: 100, StalenessWindow: 10 * time.Second, TTL: 10 * time.Second,
 	})
@@ -399,8 +407,7 @@ func TestDebugTimeWarp_AgesChainState(t *testing.T) {
 			"ETH1-jsonrpc": {chainState: cs, listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"}},
 		},
 	}
-	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano, router: router})
-
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: offsetNano, router: router})
 	chainStateRow := func() map[string]any {
 		t.Helper()
 		rr := getDebugRouter(mux, "/debug/chain-state")
@@ -410,31 +417,58 @@ func TestDebugTimeWarp_AgesChainState(t *testing.T) {
 		require.Len(t, rows, 1)
 		return rows[0]
 	}
+	return mux, chainStateRow
+}
+
+// TestDebugChainStateTimeWarp_AgesChainState is the MAG-2307 end-to-end check at the HTTP layer: the
+// dedicated /debug/chain-state-time-warp endpoint ages every per-chain ChainState so /debug/chain-state
+// reports the tip/baseline as no longer fresh, and resetting the offset to 0 restores them.
+func TestDebugChainStateTimeWarp_AgesChainState(t *testing.T) {
+	mux, chainStateRow := newAgedChainStateRouter(t)
 
 	// Freshly established → both gated verdicts true.
 	row := chainStateRow()
 	require.Equal(t, true, row["TipFresh"], "tip is fresh right after establishment")
 	require.Equal(t, true, row["BaselineFresh"], "baseline is fresh right after establishment")
 
-	// Warp +200s (>> 10s TTL). Before MAG-2307 this reached only the optimizer clock.
-	rr := postTimeWarpRouter(mux, `{"offset_seconds":200}`)
+	// Warp +200s (>> 10s TTL) via the dedicated endpoint → both verdicts flip to false.
+	rr := postChainStateTimeWarp(mux, `{"offset_seconds":200}`)
 	require.Equal(t, http.StatusOK, rr.Code)
-	require.Contains(t, rr.Body.String(), `"applied_to_chains":true`)
+	require.Contains(t, rr.Body.String(), `"applied_to_chains":1`, "the one wired ChainState was warped")
 
 	row = chainStateRow()
 	require.Equal(t, false, row["TipFresh"], "a forward warp ages the tip out of its TTL window")
 	require.Equal(t, false, row["BaselineFresh"], "a forward warp ages the baseline out of its TTL window")
-	// The raw fields are intentionally untouched by the warp (no Recompute ran): the suite asserts
-	// on the *Fresh verdicts, not these.
+	// Raw fields are intentionally untouched by the warp (no Recompute ran): assert on the *Fresh verdicts.
 	require.Equal(t, float64(1000), row["ObservedTip"], "raw observed tip is unchanged by the warp")
 	require.Equal(t, true, row["HasBaseline"], "raw HasBaseline is unchanged until a Recompute")
 
-	// Reset the warp → verdicts fresh again (observations are still within TTL of real time).
-	rr = postTimeWarpRouter(mux, `{"offset_seconds":0}`)
+	// Reset the warp → verdicts fresh again.
+	rr = postChainStateTimeWarp(mux, `{"offset_seconds":0}`)
 	require.Equal(t, http.StatusOK, rr.Code)
 	row = chainStateRow()
 	require.Equal(t, true, row["TipFresh"], "clearing the warp restores tip freshness")
 	require.Equal(t, true, row["BaselineFresh"], "clearing the warp restores baseline freshness")
+}
+
+// TestDebugTimeWarp_DoesNotTouchChainState pins the MAG-2307-review decoupling: /debug/time-warp is
+// the optimizer/QoS clock ONLY. Both a forward warp and the reset-to-0 there must leave ChainState
+// untouched, so the routine QoS warp-then-reset can never accidentally disturb ChainState.
+func TestDebugTimeWarp_DoesNotTouchChainState(t *testing.T) {
+	mux, chainStateRow := newAgedChainStateRouter(t)
+	require.Equal(t, true, chainStateRow()["TipFresh"])
+
+	// A QoS time-warp forward past ChainState's TTL must NOT age ChainState.
+	rr := postTimeWarpRouter(mux, `{"offset_seconds":200}`)
+	require.Equal(t, http.StatusOK, rr.Code)
+	row := chainStateRow()
+	require.Equal(t, true, row["TipFresh"], "/debug/time-warp must not age the ChainState tip")
+	require.Equal(t, true, row["BaselineFresh"], "/debug/time-warp must not age the ChainState baseline")
+
+	// The QoS reset-to-0 must also leave ChainState untouched.
+	rr = postTimeWarpRouter(mux, `{"offset_seconds":0}`)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, true, chainStateRow()["TipFresh"], "resetting the QoS warp must not touch ChainState")
 }
 
 // TestDebugProviderRouting_ReportsPerCSMShape verifies the handler keys output per session manager and

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -845,7 +845,15 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 	// Deliberately SEPARATE from /debug/time-warp (the optimizer/QoS clock): a routine QoS
 	// warp-then-reset must never disturb ChainState (MAG-2307 review). offset_seconds is relative to
 	// real time; 0 returns ChainState to real time. Same validation as /debug/time-warp (finite, >= 0,
-	// <= 24 h). The effect is observable via TipFresh / BaselineFresh in /debug/chain-state.
+	// <= 24 h). Responds with chain_states_warped (a count) — a distinct key from /debug/time-warp's
+	// boolean applied_to_chains, so the two responses never collide on JSON type. The effect is
+	// observable via TipFresh / BaselineFresh in /debug/chain-state.
+	//
+	// Semantic note: because stored observation timestamps use the real clock while freshness is
+	// evaluated against the warp (see ChainState.effectiveNow), a block/consensus write that arrives
+	// DURING an active >TTL warp reads as already aged — live traffic cannot refresh TipFresh while the
+	// warp is held. That is the intended "age out state while endpoints are quiesced" behavior; for a
+	// clean result, warp with the target endpoints quiesced.
 	mux.HandleFunc("/debug/chain-state-time-warp", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "POST only", http.StatusMethodNotAllowed)
@@ -874,7 +882,7 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 		offset := time.Duration(int64(body.OffsetSeconds * float64(time.Second)))
 		applied := setAllChainStateDebugOffset(deps, offset)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"offset_seconds":%v,"applied_to_chains":%d}`, body.OffsetSeconds, applied)
+		fmt.Fprintf(w, `{"offset_seconds":%v,"chain_states_warped":%d}`, body.OffsetSeconds, applied)
 	})
 
 	// GET /debug/time — returns real and effective time so callers can verify the clock moved.

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -592,25 +592,29 @@ func reregisterChainTrackerRows(deps debugMuxDeps) (ensured, created int) {
 	return ensured, created
 }
 
-// setAllChainStateDebugOffset shifts every per-server ChainState's effective clock by offset,
-// mirroring how /debug/time-warp sets each optimizer's NowFunc. A forward offset ages the per-chain
-// TTL/staleness/consensus windows; offset 0 clears the warp. Nil-safe at every level so test
-// fixtures without a fully-wired router are a no-op. Only the ChainState READ clock is warped —
-// observation write timestamps (relay/poll) stay on real time — so this reliably ages state when
-// endpoints are quiesced (the debug age-out use case) without perturbing the live relay-gate
-// freshness path (MAG-2307).
-func setAllChainStateDebugOffset(deps debugMuxDeps, offset time.Duration) {
+// setAllChainStateDebugOffset shifts every per-server ChainState's effective clock by offset, aging
+// its TTL/staleness/consensus windows without waiting real time; offset 0 clears the warp. It backs
+// /debug/chain-state-time-warp — deliberately SEPARATE from /debug/time-warp (the optimizer/QoS
+// clock) so a routine QoS warp-then-reset never disturbs ChainState (MAG-2307 review). Only freshness
+// EVALUATION is warped; stored observation timestamps stay on the real clock (see
+// ChainState.effectiveNow), so the warp ages state without leaving future-dated timestamps. Nil-safe
+// at every level (test fixtures without a wired router are a no-op). Returns the number of
+// ChainStates the offset was applied to.
+func setAllChainStateDebugOffset(deps debugMuxDeps, offset time.Duration) int {
 	if deps.router == nil {
-		return
+		return 0
 	}
 	deps.router.mu.Lock()
 	defer deps.router.mu.Unlock()
+	count := 0
 	for _, server := range deps.router.rpcServers {
 		if server == nil || server.chainState == nil {
 			continue
 		}
 		server.chainState.SetDebugClockOffset(offset)
+		count++
 	}
+	return count
 }
 
 // resetAllConsistencies flushes every per-chain seen-block cache that
@@ -822,12 +826,9 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 			}
 			return true
 		})
-		// Mirror the warp onto every per-chain ChainState clock so a forward shift ages its
-		// TTL/staleness/consensus windows exactly as it ages the optimizer above (MAG-2307).
-		// offset==0 clears it. Only the READ clock is warped: observation write-stamps (relay/poll)
-		// stay on real time, so a warp reliably ages state when endpoints are quiesced without
-		// skewing the live relay-gate freshness path.
-		setAllChainStateDebugOffset(deps, offset)
+		// /debug/time-warp is the optimizer/QoS clock ONLY. ChainState's TTL/staleness clock is driven
+		// by the separate /debug/chain-state-time-warp endpoint, so a routine QoS warp-then-reset here
+		// never disturbs ChainState (MAG-2307 review).
 		// Gated on needsReset (same as opt.ResetState above) because the
 		// documented move-clock recovery sets offset_seconds back to 0 — that's
 		// the moment we also want to flush the per-chain seen-block cache. See
@@ -837,6 +838,43 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"offset_seconds":%v,"applied_to_chains":true}`, body.OffsetSeconds)
+	})
+
+	// POST /debug/chain-state-time-warp — ages the per-chain ChainState TTL/staleness/consensus clock
+	// WITHOUT waiting real time, so black-box tests can cross a ~130 s ETH staleness window in seconds.
+	// Deliberately SEPARATE from /debug/time-warp (the optimizer/QoS clock): a routine QoS
+	// warp-then-reset must never disturb ChainState (MAG-2307 review). offset_seconds is relative to
+	// real time; 0 returns ChainState to real time. Same validation as /debug/time-warp (finite, >= 0,
+	// <= 24 h). The effect is observable via TipFresh / BaselineFresh in /debug/chain-state.
+	mux.HandleFunc("/debug/chain-state-time-warp", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST only", http.StatusMethodNotAllowed)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 1024)
+		var body struct {
+			OffsetSeconds float64 `json:"offset_seconds"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid JSON", http.StatusBadRequest)
+			return
+		}
+		if math.IsNaN(body.OffsetSeconds) || math.IsInf(body.OffsetSeconds, 0) {
+			http.Error(w, "offset_seconds must be a finite number", http.StatusBadRequest)
+			return
+		}
+		if body.OffsetSeconds < 0 {
+			http.Error(w, "offset_seconds must be >= 0 (no travel to the past)", http.StatusBadRequest)
+			return
+		}
+		if body.OffsetSeconds > maxDebugOffsetSeconds {
+			http.Error(w, fmt.Sprintf("offset_seconds must be <= %g (24h)", maxDebugOffsetSeconds), http.StatusBadRequest)
+			return
+		}
+		offset := time.Duration(int64(body.OffsetSeconds * float64(time.Second)))
+		applied := setAllChainStateDebugOffset(deps, offset)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"offset_seconds":%v,"applied_to_chains":%d}`, body.OffsetSeconds, applied)
 	})
 
 	// GET /debug/time — returns real and effective time so callers can verify the clock moved.
@@ -904,8 +942,10 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 			opt.ResetState()
 			return true
 		})
-		// Clear any ChainState warp too, mirroring opt.NowFunc = nil above (MAG-2307).
-		setAllChainStateDebugOffset(deps, 0)
+		// ChainState's debug warp is intentionally NOT cleared here: it is independent of the
+		// optimizer/QoS state this endpoint resets, and is cleared only via its own
+		// /debug/chain-state-time-warp endpoint (offset 0), so a QoS reset never disturbs ChainState
+		// (MAG-2307 review).
 
 		// 2. Per-chain seen-block consistency caches. Must be flushed here too,
 		//    not just in /debug/reset-scores: a poisoned huge seenBlock value
@@ -2570,7 +2610,7 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	cmdRPCSmartRouter.Flags().Uint64Var(&lavasession.MaximumStreamsOverASingleConnection, lavasession.MaximumStreamsOverASingleConnectionFlag, lavasession.DefaultMaximumStreamsOverASingleConnection, "maximum number of parallel streams over a single provider connection")
 	cmdRPCSmartRouter.Flags().Bool(common.TestModeFlagName, false, "test mode sends dummy data and prints all metadata in listeners")
 	cmdRPCSmartRouter.Flags().String(performance.PprofAddressFlagName, "", "pprof server address, used for code profiling")
-	cmdRPCSmartRouter.Flags().String("debug-address", "", "debug HTTP server for integration tests, e.g. :9999 — exposes /debug/time-warp to shift the QoS clock and age per-chain ChainState TTL/staleness")
+	cmdRPCSmartRouter.Flags().String("debug-address", "", "debug HTTP server for integration tests, e.g. :9999 — exposes /debug/time-warp (QoS clock) and /debug/chain-state-time-warp (per-chain ChainState TTL/staleness)")
 	if err := viper.BindPFlag("debug-address", cmdRPCSmartRouter.Flags().Lookup("debug-address")); err != nil {
 		utils.LavaFormatFatal("failed binding debug-address flag", err)
 	}


### PR DESCRIPTION
## What & why

Review follow-up to **PR #222** (MAG-2307, merged as `c011a80`) — addresses @VicSheCodes's two required changes and all three Copilot comments. Since #222 is already merged, this is a new PR against `main`.

### 1. Dedicated ChainState endpoint, decoupled from `/debug/time-warp` (VicSheCodes #1)
`/debug/time-warp` is the optimizer/QoS clock, and the black-box suite runs `warp → reset-to-0` routinely to reset QoS state. #222 coupled ChainState's warp to it, so a routine QoS reset would disturb ChainState.
- **New `POST /debug/chain-state-time-warp`** drives *only* ChainState's TTL/staleness clock (`offset_seconds` relative to real time, `0` = real; same finite / `>= 0` / `<= 24h` validation). Effect is observable via `TipFresh` / `BaselineFresh` in `/debug/chain-state`.
- `/debug/time-warp` and `/debug/reset-all` **no longer touch ChainState** — fully independent, so a QoS reset can never disturb it.

### 2. Store timestamps on the real clock (VicSheCodes #2 = Copilot `chain_state.go:258`, `:377`)
`SetLatestBlock` / `Recompute` stored `lastObservedAt` / `baselineAt` / `baselineSince` using the **warped** clock. A write while a warp is active stamped a *future* time → clearing the warp gave `real − future = negative age` → the entry read as fresh forever until real time caught up. Fix: **freshness is evaluated against the warped clock, but stored timestamps always use the real base clock** (`cs.now()`). (I'd flagged this skew as a "limitation" in #222 — the reviewers are right that it should be fixed.)

### 3. Doc fix (Copilot `chain_state.go:408`)
Corrected the `ChainStateSnapshot` comment: `GetConsensusBaselineWithTime` returns `baselineSince` (establishment time), not `baselineAt` (the internal TTL-freshness stamp, never exposed).

## Copilot assessment
All three comments are valid — `:258` / `:377` are the same real issue as VicSheCodes #2 (fixed), and `:408` is a genuine (pre-existing) doc inaccuracy (fixed).

## Testing
- `TestDebugChainStateTimeWarp_AgesChainState` — the new endpoint ages ChainState (`TipFresh`/`BaselineFresh` → false), reset restores them.
- `TestDebugTimeWarp_DoesNotTouchChainState` — `/debug/time-warp` (forward warp **and** reset-to-0) leaves ChainState untouched.
- `TestSetLatestBlock_TimestampStaysOnRealClockUnderWarp` / `TestRecompute_TimestampsStayOnRealClockUnderWarp` — a write under a warp stamps the real clock, and the entry still expires on real time once the warp is cleared (no negative-age freshness).
- Full `chainstate` (`-race`) and `rpcsmartrouter` suites pass; `go build ./...` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
