### PR TITLE
refactor(endpointtip): block-monotonic per-endpoint tip with a staleness backstop (Topic C T4)

### DIFF
--- a/protocol/chainstate/chain_state.go
+++ b/protocol/chainstate/chain_state.go
@@ -122,12 +122,22 @@ func outlierThresholdForBlockTime(averageBlockTime time.Duration) int64 {
 	return blocks
 }
 
+// StalenessWindow is the ONE derivation of the "fresh/alive horizon" from a chain's average
+// block time: max(DefaultStalenessMultiplier × avgBlockTime, minStalenessWindow). It is the
+// single source of truth for the concept — the consensus window / tip TTL (DefaultConfig), the
+// probe's liveness horizon, and the per-endpoint tip's staleness backstop (endpointtip, fed via
+// the monitor) all read it, so tuning DefaultStalenessMultiplier moves every one in lockstep. A
+// non-positive block time falls back to the floor.
+func StalenessWindow(averageBlockTime time.Duration) time.Duration {
+	return max(time.Duration(DefaultStalenessMultiplier)*averageBlockTime, minStalenessWindow)
+}
+
 // DefaultConfig derives the freshness/consensus window AND the outlier threshold from a chain's
-// average block time (D6): StalenessWindow = TTL = max(DefaultStalenessMultiplier × avgBlockTime,
-// floor); OutlierThreshold = clamp(OutlierTimeBudget / avgBlockTime, floor, ceiling). BucketWidth
-// stays a block-count constant (clustering tolerance is intrinsically in blocks, not time).
+// average block time (D6): StalenessWindow = TTL = StalenessWindow(avgBlockTime); OutlierThreshold
+// = clamp(OutlierTimeBudget / avgBlockTime, floor, ceiling). BucketWidth stays a block-count
+// constant (clustering tolerance is intrinsically in blocks, not time).
 func DefaultConfig(averageBlockTime time.Duration) Config {
-	window := max(time.Duration(DefaultStalenessMultiplier)*averageBlockTime, minStalenessWindow)
+	window := StalenessWindow(averageBlockTime)
 	return Config{
 		BucketWidth:      DefaultBucketWidth,
 		OutlierThreshold: outlierThresholdForBlockTime(averageBlockTime),

--- a/protocol/chainstate/chain_state.go
+++ b/protocol/chainstate/chain_state.go
@@ -122,12 +122,14 @@ func outlierThresholdForBlockTime(averageBlockTime time.Duration) int64 {
 	return blocks
 }
 
-// StalenessWindow is the ONE derivation of the "fresh/alive horizon" from a chain's average
-// block time: max(DefaultStalenessMultiplier × avgBlockTime, minStalenessWindow). It is the
-// single source of truth for the concept — the consensus window / tip TTL (DefaultConfig), the
-// probe's liveness horizon, and the per-endpoint tip's staleness backstop (endpointtip, fed via
-// the monitor) all read it, so tuning DefaultStalenessMultiplier moves every one in lockstep. A
-// non-positive block time falls back to the floor.
+// StalenessWindow derives the "fresh/alive horizon" from a chain's average block time:
+// max(DefaultStalenessMultiplier × avgBlockTime, minStalenessWindow). The consensus window / tip
+// TTL (DefaultConfig) and the per-endpoint tip's staleness backstop (endpointtip, fed via the
+// monitor) both call it, so they move in lockstep. The shared knob across the codebase is the
+// MULTIPLIER, not this function: the probe's liveness horizon (probing.DefaultVerdictConfig)
+// re-derives with DefaultStalenessMultiplier but a deliberately different floor (minProbeStaleness),
+// so it tracks the multiplier without reading this function. A non-positive block time falls back
+// to the floor.
 func StalenessWindow(averageBlockTime time.Duration) time.Duration {
 	return max(time.Duration(DefaultStalenessMultiplier)*averageBlockTime, minStalenessWindow)
 }

--- a/protocol/chainstate/chain_state.go
+++ b/protocol/chainstate/chain_state.go
@@ -122,14 +122,13 @@ func outlierThresholdForBlockTime(averageBlockTime time.Duration) int64 {
 	return blocks
 }
 
-// StalenessWindow derives the "fresh/alive horizon" from a chain's average block time:
-// max(DefaultStalenessMultiplier × avgBlockTime, minStalenessWindow). The consensus window / tip
-// TTL (DefaultConfig) and the per-endpoint tip's staleness backstop (endpointtip, fed via the
-// monitor) both call it, so they move in lockstep. The shared knob across the codebase is the
-// MULTIPLIER, not this function: the probe's liveness horizon (probing.DefaultVerdictConfig)
-// re-derives with DefaultStalenessMultiplier but a deliberately different floor (minProbeStaleness),
-// so it tracks the multiplier without reading this function. A non-positive block time falls back
-// to the floor.
+// StalenessWindow is the ONE derivation of the "fresh/alive horizon" from a chain's average block
+// time: max(DefaultStalenessMultiplier × avgBlockTime, minStalenessWindow). Every consumer of the
+// concept reads it — the consensus window / tip TTL (DefaultConfig) and the per-endpoint tip's
+// staleness backstop (endpointtip, fed via the monitor) use it directly, and the probe's liveness
+// horizon (probing.DefaultVerdictConfig) composes it with its own wider floor (max(StalenessWindow,
+// minProbeStaleness)) — so tuning the derivation here moves all of them in lockstep. A non-positive
+// block time falls back to the floor.
 func StalenessWindow(averageBlockTime time.Duration) time.Duration {
 	return max(time.Duration(DefaultStalenessMultiplier)*averageBlockTime, minStalenessWindow)
 }

--- a/protocol/endpointstate/endpoint_monitor.go
+++ b/protocol/endpointstate/endpoint_monitor.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/magma-Devs/smart-router/protocol/chainlib"
+	"github.com/magma-Devs/smart-router/protocol/chainstate"
 	"github.com/magma-Devs/smart-router/protocol/chaintracker"
 	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/endpointtip"
@@ -87,9 +88,13 @@ type EndpointMonitor struct {
 
 	// Chain-specific timing
 	averageBlockTime time.Duration
-	blocksToSave     uint64
-	retryMinDelay    time.Duration
-	retryMaxDelay    time.Duration
+	// tipStaleAfter is the per-endpoint tip staleness horizon (T4/C-D): the shared
+	// chainstate.StalenessWindow, derived once and passed to every endpointtip.Store.Set to
+	// gate downward (reorg) moves.
+	tipStaleAfter time.Duration
+	blocksToSave  uint64
+	retryMinDelay time.Duration
+	retryMaxDelay time.Duration
 
 	// relayGateFreshness is the maximum age of a relay-harvested tip that still suppresses
 	// a dedicated poll (MAG-2159 Topic B / Pass 2 — the "gate freshness threshold"). A
@@ -176,6 +181,7 @@ func NewEndpointMonitor(ctx context.Context, config EndpointChainTrackerConfig) 
 		chainID:           config.ChainID,
 		apiInterface:      config.ApiInterface,
 		averageBlockTime:  avgBlockTime,
+		tipStaleAfter:     chainstate.StalenessWindow(avgBlockTime),
 		blocksToSave:      blocksToSave,
 		retryMinDelay:     defaultTrackerStartRetryMin,
 		retryMaxDelay:     defaultTrackerStartRetryMax,

--- a/protocol/endpointstate/endpoint_monitor.go
+++ b/protocol/endpointstate/endpoint_monitor.go
@@ -501,7 +501,7 @@ func (m *EndpointMonitor) GetLatestBlockData(endpointURL string) (latestBlock in
 // against exactly the value the reset asked to discard, defeating ResetLatestBlock's
 // "consistency sees <= 0 and skips" contract until the next poll happens to overwrite it.
 // We Remove the store entry (not Set 0): the store ignores non-positive writes and its
-// time-monotonic guard cannot represent "cleared", so removal is the only way to zero it.
+// block-monotonic guard cannot represent "cleared", so removal is the only way to zero it.
 // endpointtip's lock is a leaf that never calls back into the monitor, so taking it under
 // m.mu (read) introduces no lock-order inversion — same idiom as RemoveTracker/Stop.
 func (m *EndpointMonitor) ResetAllLatestBlocks() int {

--- a/protocol/endpointstate/endpoint_monitor_lifecycle_test.go
+++ b/protocol/endpointstate/endpoint_monitor_lifecycle_test.go
@@ -211,7 +211,7 @@ func TestEndpointMonitor_ResetAllLatestBlocks_ClearsEndpointTipStore(t *testing.
 	// Seed a stale tip in the shared store, as a prior poll/relay observation would have.
 	require.True(t, endpointtip.Default().Set(key, endpointtip.Tip{
 		Block: 1000, ObservedAt: time.Now(), Source: endpointtip.SourcePoll,
-	}))
+	}, 0))
 	require.Equal(t, int64(1000), endpointtip.Default().Block(key),
 		"precondition: the store holds the pre-reset block")
 

--- a/protocol/endpointstate/observation.go
+++ b/protocol/endpointstate/observation.go
@@ -117,16 +117,15 @@ func (m *EndpointMonitor) recordPollObservation(endpointURL string, gen uint64, 
 		o.LastPollError = ""
 		o.ConsecutivePollFailures = 0
 		// The block triple lives in the single-source-of-truth endpointtip store, not on
-		// this record. Set applies the same time-monotonic guard the record used to (a
-		// poll older than the stored observation is dropped wholesale) and reports whether
-		// it advanced the tip — only then do we feed the per-chain consensus tip. Called
-		// under obsMu: lock order is obsMu → store lock everywhere (the store has no
-		// callbacks, so this cannot deadlock).
+		// this record. Set applies the block-monotonic guard (T4) and reports whether it
+		// advanced the tip — only then do we feed the per-chain consensus tip. Called under
+		// obsMu: lock order is obsMu → store lock everywhere (the store has no callbacks, so
+		// this cannot deadlock).
 		if endpointtip.Default().Set(m.tipKey(endpointURL), endpointtip.Tip{
 			Block:      block,
 			ObservedAt: at,
 			Source:     endpointtip.SourcePoll,
-		}) {
+		}, m.tipStaleAfter) {
 			tipBlock = block // feed the per-chain tip after unlock
 		}
 	} else {
@@ -196,13 +195,13 @@ func (m *EndpointMonitor) RecordRelayObservation(endpointURL string, gen uint64,
 		m.observations[endpointURL] = EndpointObservation{}
 	}
 
-	// Set applies the time-monotonic guard (a relay older than the stored observation is
-	// dropped) and reports whether it advanced the tip. Lock order obsMu → store lock.
+	// Set applies the block-monotonic guard (T4) and reports whether it advanced the tip.
+	// Lock order obsMu → store lock.
 	if endpointtip.Default().Set(m.tipKey(endpointURL), endpointtip.Tip{
 		Block:      block,
 		ObservedAt: at,
 		Source:     endpointtip.SourceRelay,
-	}) {
+	}, m.tipStaleAfter) {
 		tipBlock = block // feed the per-chain tip after unlock
 		return true
 	}

--- a/protocol/endpointstate/observation.go
+++ b/protocol/endpointstate/observation.go
@@ -32,9 +32,11 @@ const (
 //   - The block triple (LatestBlock / ObservedAt / Source) is the single-source-of-truth
 //     tip owned by the endpointtip store, NOT stored on this record. GetObservation and
 //     SnapshotObservations populate the triple from that store at read time, so callers
-//     see a consistent value while the tip lives in exactly one place. ObservedAt is
-//     monotonic — a later write never moves it backward, and a stale observation (older
-//     than the current ObservedAt) is ignored — enforced in endpointtip.Store.Set.
+//     see a consistent value while the tip lives in exactly one place. ObservedAt only
+//     advances (a write never carries it backward), but the store's guard is
+//     block-monotonic (T4), not time-monotonic: a higher-or-equal block always applies,
+//     while a lower block is dropped as a late straggler while the stored tip is fresh and
+//     accepted only once it goes stale (a real reorg down) — enforced in endpointtip.Store.Set.
 //   - The poll-health fields (LastPollAttempt, LastSuccessfulPoll, LastPollLatency,
 //     LastPollError, ConsecutivePollFailures) are written *only* by the poll path and
 //     are the only fields physically stored in the monitor's observation map.
@@ -43,7 +45,7 @@ const (
 type EndpointObservation struct {
 	// Block observation (delegated to the endpointtip store; filled on read, never stored here):
 	LatestBlock int64             // most recent observed block for this endpoint
-	ObservedAt  time.Time         // wall-clock of the observation that set LatestBlock (monotonic)
+	ObservedAt  time.Time         // freshness stamp of the latest block observation; only advances
 	Source      ObservationSource // origin of the latest block observation
 
 	// Poll-health fields (written only by the poll path):
@@ -142,7 +144,9 @@ func (m *EndpointMonitor) recordPollObservation(endpointURL string, gen uint64, 
 
 // RecordRelayObservation records a block harvested from a served relay response. It
 // updates only the block triple (Source = Relay) — never the poll-health fields — and
-// honors the monotonic ObservedAt guard.
+// goes through the store's block-monotonic guard (T4): the harvested block is kept only
+// when it is higher than or equal to the stored tip; a lower one is treated as a late
+// straggler and dropped until the stored tip goes stale.
 //
 // gen is the observation generation the caller captured for this endpoint (see
 // ObservationGeneration / GetOrCreateTracker). Like recordPollObservation, the write is

--- a/protocol/endpointtip/store.go
+++ b/protocol/endpointtip/store.go
@@ -1,23 +1,15 @@
 // Package endpointtip holds the single, process-wide source of truth for the
 // per-endpoint observed block tip.
 //
-// Why a standalone leaf package: the tip is written by the high layer
-// (endpointstate's poll + relay-harvest observers) but also read by the low layer
-// (lavasession's per-endpoint QoS sync-block). endpointstate already imports
-// lavasession, so lavasession cannot import endpointstate to reach the observation
-// store — that would be an import cycle. A leaf package that imports only the
-// standard library can be imported by BOTH layers, so they share ONE store instead
-// of each keeping its own copy (the divergence that this package exists to remove).
+// It is a standard-library-only leaf so both the high layer (endpointstate's poll +
+// relay observers, which write it) and the low layer (lavasession's QoS sync-block,
+// which reads it) can import it without a cycle — sharing ONE store rather than each
+// keeping a divergent copy. It stores the whole {Block, ObservedAt, Source} triple so
+// the guard and the relay-freshness gate see a consistent value.
 //
-// The store holds the whole atomic tip triple {Block, ObservedAt, Source} — never a
-// bare block — because the monotonic guard needs Block and ObservedAt together and
-// the relay-freshness gate reads Source. Splitting the triple across two stores would
-// reintroduce exactly the divergence this consolidation removes.
-//
-// Generation gating (rejecting writes from a removed/replaced tracker) is NOT done
-// here: this leaf cannot know about tracker lifecycles. Callers in endpointstate
-// gate on generation FIRST and only then call Set, which applies the time-monotonic
-// guard.
+// Generation gating (rejecting writes from a removed tracker) is done by the
+// endpointstate callers before Set; this leaf only applies the block-monotonic guard
+// with a staleness backstop (T4/C-D — see Set).
 package endpointtip
 
 import (
@@ -54,9 +46,13 @@ func (s Source) String() string {
 // either advances all three or none.
 type Tip struct {
 	Block      int64     // most recent observed block (always > 0 once set)
-	ObservedAt time.Time // wall-clock of the observation that set Block (monotonic)
+	ObservedAt time.Time // wall-clock of the observation that set Block (freshness stamp)
 	Source     Source    // origin of this observation
 }
+
+// The staleness horizon is NOT defined here — this leaf is pure mechanism. The caller
+// (endpointstate's monitor) derives it from chainstate.StalenessWindow, the one source of
+// truth for the fresh/alive horizon, and passes it to Set as staleAfter.
 
 // Store is the per-endpoint tip store, keyed by the composite Key. It is safe for
 // concurrent use. The exported instance type (rather than only package globals) lets
@@ -78,27 +74,37 @@ func Key(chainID, apiInterface, url string) string {
 	return chainID + "|" + apiInterface + "|" + url
 }
 
-// Set applies a tip observation under the time-monotonic guard: a write whose
-// ObservedAt predates the stored ObservedAt is dropped wholesale so no field
-// regresses. Equal timestamps apply (last-writer-wins, the documented deterministic
-// tie-break, matching the prior observation-record semantics). A non-positive block is
-// ignored. Returns true iff the write was applied (the caller uses this to decide
-// whether to feed the per-chain consensus tip).
+// Set applies a tip observation, block-monotonic with a staleness backstop (T4/C-D):
+// higher wins, equal refreshes the stamp, lower is rejected while fresh (a late
+// straggler must not regress the tip — F2) and accepted once stale (a real reorg down).
 //
-// The guard is time-monotonic, NOT block-monotonic — it relocates the exact semantics
-// the observation record used before consolidation; it is deliberately not "improved"
-// to max-block.
-func (s *Store) Set(key string, t Tip) bool {
+// Staleness is the gap between the stored and incoming observation stamps (> staleAfter),
+// not wall-clock — deterministic, no clock. A rejected write must not refresh the stamp,
+// else a repeated straggler keeps the tip forever fresh. staleAfter<=0 is up-only.
+// Returns true iff the stored tip now reflects this block (gates the consensus feed).
+func (s *Store) Set(key string, t Tip, staleAfter time.Duration) bool {
 	if t.Block <= 0 {
 		return false
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if cur, ok := s.tips[key]; ok && t.ObservedAt.Before(cur.ObservedAt) {
-		return false
+	cur, ok := s.tips[key]
+	switch {
+	case !ok || t.Block > cur.Block:
+		s.tips[key] = t
+		return true
+	case t.Block == cur.Block:
+		if t.ObservedAt.After(cur.ObservedAt) {
+			s.tips[key] = t // advance the freshness stamp, never backwards
+		}
+		return true
+	default: // lower block
+		if staleAfter > 0 && t.ObservedAt.Sub(cur.ObservedAt) > staleAfter {
+			s.tips[key] = t // stored tip went stale → accept the reorg
+			return true
+		}
+		return false // still fresh → reject the straggler (F2)
 	}
-	s.tips[key] = t
-	return true
 }
 
 // Get returns the stored tip and whether one exists. The returned Tip is a value copy,

--- a/protocol/endpointtip/store.go
+++ b/protocol/endpointtip/store.go
@@ -80,8 +80,11 @@ func Key(chainID, apiInterface, url string) string {
 //
 // Staleness is the gap between the stored and incoming observation stamps (> staleAfter),
 // not wall-clock — deterministic, no clock. A rejected write must not refresh the stamp,
-// else a repeated straggler keeps the tip forever fresh. staleAfter<=0 is up-only.
-// Returns true iff the stored tip now reflects this block (gates the consensus feed).
+// else a repeated straggler keeps the tip forever fresh. The freshness stamp only ever
+// advances (an accepted write never carries it backwards, even when the block jumps up on
+// an earlier-stamped cross-source observation), so the staleness gap can't be widened by a
+// stamp regression. staleAfter<=0 is up-only. Returns true iff the stored tip now reflects
+// this block (gates the consensus feed).
 func (s *Store) Set(key string, t Tip, staleAfter time.Duration) bool {
 	if t.Block <= 0 {
 		return false
@@ -91,6 +94,9 @@ func (s *Store) Set(key string, t Tip, staleAfter time.Duration) bool {
 	cur, ok := s.tips[key]
 	switch {
 	case !ok || t.Block > cur.Block:
+		if ok && cur.ObservedAt.After(t.ObservedAt) {
+			t.ObservedAt = cur.ObservedAt // freshness stamp only advances, never regresses
+		}
 		s.tips[key] = t
 		return true
 	case t.Block == cur.Block:

--- a/protocol/endpointtip/store_test.go
+++ b/protocol/endpointtip/store_test.go
@@ -7,41 +7,104 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestStore_Set_TimeMonotonicGuard pins the relocated guard: a write older than the
-// stored observation is dropped wholesale (no field regresses), a newer write applies,
-// and an equal timestamp applies (last-writer-wins). This is the exact semantics the
-// observation record enforced before consolidation — it must not become block-monotonic.
-func TestStore_Set_TimeMonotonicGuard(t *testing.T) {
+// TestStore_Set_BlockMonotonic pins the T4/C-D rule: the tip orders by BLOCK, not by
+// arrival time. A higher block always wins; an equal block refreshes freshness; a
+// newer-but-LOWER straggler is rejected while the stored tip is fresh (the F2 bug). This
+// is the inverse of the old time-monotonic guard.
+func TestStore_Set_BlockMonotonic(t *testing.T) {
 	s := NewStore()
 	k := Key("ETH1", "jsonrpc", "https://a.example:443")
 	base := time.Unix(1_000, 0)
+	const ttl = 100 * time.Second
 
-	require.True(t, s.Set(k, Tip{Block: 100, ObservedAt: base, Source: SourcePoll}))
+	// First observation stores.
+	require.True(t, s.Set(k, Tip{Block: 100, ObservedAt: base, Source: SourcePoll}, ttl))
 	require.Equal(t, int64(100), s.Block(k))
 
-	// Older observation is dropped wholesale, even though its block is higher.
-	require.False(t, s.Set(k, Tip{Block: 999, ObservedAt: base.Add(-time.Second), Source: SourceRelay}))
+	// Higher block wins — even carrying an EARLIER arrival stamp (block, not time, is the
+	// comparator now; the inverse of the old guard).
+	require.True(t, s.Set(k, Tip{Block: 200, ObservedAt: base.Add(-time.Second), Source: SourceRelay}, ttl))
+	require.Equal(t, int64(200), s.Block(k))
+
+	// The F2 straggler: a LOWER block observed only slightly later is rejected (< ttl since
+	// the stored tip's observation, so the stored tip is still fresh).
+	require.False(t, s.Set(k, Tip{Block: 198, ObservedAt: base.Add(2 * time.Second), Source: SourceRelay}, ttl))
 	got, ok := s.Get(k)
 	require.True(t, ok)
-	require.Equal(t, int64(100), got.Block, "stale write must not move the block")
-	require.Equal(t, SourcePoll, got.Source, "stale write must not move the source")
-
-	// Newer observation applies even with a LOWER block (guard is time-, not block-monotonic).
-	require.True(t, s.Set(k, Tip{Block: 50, ObservedAt: base.Add(time.Second), Source: SourceRelay}))
-	require.Equal(t, int64(50), s.Block(k))
-
-	// Equal timestamp applies (last-writer-wins).
-	require.True(t, s.Set(k, Tip{Block: 77, ObservedAt: base.Add(time.Second), Source: SourcePoll}))
-	require.Equal(t, int64(77), s.Block(k))
+	require.Equal(t, int64(200), got.Block, "a newer-but-lower straggler must not regress the tip")
+	require.Equal(t, SourceRelay, got.Source, "rejected write must not move the source")
+	require.Equal(t, base.Add(-time.Second), got.ObservedAt, "rejected write must not refresh the stamp")
 }
 
-// TestStore_Set_RejectsNonPositive guards that a zero/negative block is never stored,
-// matching the upstream "block <= 0" rejection in the observation writers.
+// TestStore_Set_EqualBlockRefreshesFreshness pins that an equal block re-proves liveness:
+// it advances the freshness stamp (so a healthy endpoint sitting at a stable head keeps
+// re-confirming and never goes stale) without moving the block, and never regresses it.
+func TestStore_Set_EqualBlockRefreshesFreshness(t *testing.T) {
+	s := NewStore()
+	k := Key("ETH1", "jsonrpc", "u")
+	base := time.Unix(1_000, 0)
+	const ttl = 10 * time.Second
+
+	require.True(t, s.Set(k, Tip{Block: 100, ObservedAt: base, Source: SourcePoll}, ttl))
+
+	// Re-report the SAME block 9s later: the stamp advances to base+9s.
+	require.True(t, s.Set(k, Tip{Block: 100, ObservedAt: base.Add(9 * time.Second), Source: SourcePoll}, ttl))
+	got, _ := s.Get(k)
+	require.Equal(t, base.Add(9*time.Second), got.ObservedAt, "equal-block confirmation advances the stamp")
+
+	// A lower block observed 8s after the REFRESH (base+17s) is only 8s < ttl past the
+	// refreshed stamp → still fresh → rejected. Without the refresh it would be 17s > ttl.
+	require.False(t, s.Set(k, Tip{Block: 99, ObservedAt: base.Add(17 * time.Second), Source: SourcePoll}, ttl))
+	require.Equal(t, int64(100), s.Block(k), "the equal-block refresh kept the tip fresh")
+
+	// A delayed equal block must NOT drag the stamp backward.
+	require.True(t, s.Set(k, Tip{Block: 100, ObservedAt: base, Source: SourceRelay}, ttl))
+	got, _ = s.Get(k)
+	require.Equal(t, base.Add(9*time.Second), got.ObservedAt, "stamp only advances, never regresses")
+}
+
+// TestStore_Set_StaleBackstopAcceptsReorg is the reorg half of C-D: while the stored tip
+// is fresh a lower block is rejected; once no higher block has re-confirmed it for longer
+// than the horizon, the same lower block is accepted (the endpoint genuinely fell back).
+// No fork signal is involved — the observation-time gap is the sole downward mechanism
+// (D-FORK resolved). Staleness is measured in observation time, so this is deterministic.
+func TestStore_Set_StaleBackstopAcceptsReorg(t *testing.T) {
+	s := NewStore()
+	k := Key("ETH1", "jsonrpc", "u")
+	base := time.Unix(1_000, 0)
+	const ttl = 100 * time.Second
+
+	require.True(t, s.Set(k, Tip{Block: 1001, ObservedAt: base, Source: SourcePoll}, ttl))
+
+	// Reorg to 1000 observed 30s later → within the horizon → rejected (stale-high, bounded).
+	require.False(t, s.Set(k, Tip{Block: 1000, ObservedAt: base.Add(30 * time.Second), Source: SourcePoll}, ttl))
+	require.Equal(t, int64(1001), s.Block(k))
+
+	// The endpoint keeps reporting 1000; 101s after the (never-refreshed) stored stamp the
+	// gap exceeds the horizon → accept the downward move. Self-heals to the true head.
+	require.True(t, s.Set(k, Tip{Block: 1000, ObservedAt: base.Add(101 * time.Second), Source: SourcePoll}, ttl))
+	require.Equal(t, int64(1000), s.Block(k), "stale stored tip → accept the endpoint's true head")
+}
+
+// TestStore_Set_ZeroStaleAfterDisablesDownward: staleAfter<=0 is pure up-only (never
+// accepts a lower block). Used by never-stale test seeds, which Remove-then-Set anyway.
+func TestStore_Set_ZeroStaleAfterDisablesDownward(t *testing.T) {
+	s := NewStore()
+	k := Key("ETH1", "jsonrpc", "u")
+	base := time.Unix(1_000, 0)
+
+	require.True(t, s.Set(k, Tip{Block: 100, ObservedAt: base, Source: SourcePoll}, 0))
+	// Even a far-later lower block is rejected when staleness is disabled.
+	require.False(t, s.Set(k, Tip{Block: 50, ObservedAt: base.Add(time.Hour), Source: SourcePoll}, 0))
+	require.Equal(t, int64(100), s.Block(k))
+}
+
+// TestStore_Set_RejectsNonPositive guards that a zero/negative block is never stored.
 func TestStore_Set_RejectsNonPositive(t *testing.T) {
 	s := NewStore()
 	k := Key("ETH1", "jsonrpc", "u")
-	require.False(t, s.Set(k, Tip{Block: 0, ObservedAt: time.Unix(1, 0)}))
-	require.False(t, s.Set(k, Tip{Block: -5, ObservedAt: time.Unix(1, 0)}))
+	require.False(t, s.Set(k, Tip{Block: 0, ObservedAt: time.Unix(1, 0)}, time.Minute))
+	require.False(t, s.Set(k, Tip{Block: -5, ObservedAt: time.Unix(1, 0)}, time.Minute))
 	require.Equal(t, int64(0), s.Block(k))
 	_, ok := s.Get(k)
 	require.False(t, ok)
@@ -57,8 +120,8 @@ func TestStore_Key_NoCrossChainCollision(t *testing.T) {
 	require.NotEqual(t, kEth, kLava)
 
 	now := time.Unix(2_000, 0)
-	s.Set(kEth, Tip{Block: 111, ObservedAt: now, Source: SourcePoll})
-	s.Set(kLava, Tip{Block: 222, ObservedAt: now, Source: SourcePoll})
+	s.Set(kEth, Tip{Block: 111, ObservedAt: now, Source: SourcePoll}, time.Minute)
+	s.Set(kLava, Tip{Block: 222, ObservedAt: now, Source: SourcePoll}, time.Minute)
 	require.Equal(t, int64(111), s.Block(kEth))
 	require.Equal(t, int64(222), s.Block(kLava))
 }
@@ -68,7 +131,7 @@ func TestStore_Key_NoCrossChainCollision(t *testing.T) {
 func TestStore_RemoveAndReset(t *testing.T) {
 	s := NewStore()
 	k := Key("ETH1", "jsonrpc", "u")
-	s.Set(k, Tip{Block: 5, ObservedAt: time.Unix(1, 0), Source: SourcePoll})
+	s.Set(k, Tip{Block: 5, ObservedAt: time.Unix(1, 0), Source: SourcePoll}, time.Minute)
 	require.Equal(t, int64(5), s.Block(k))
 
 	s.Remove(k)
@@ -76,7 +139,7 @@ func TestStore_RemoveAndReset(t *testing.T) {
 	require.False(t, ok)
 	require.Equal(t, int64(0), s.Block(k))
 
-	s.Set(k, Tip{Block: 9, ObservedAt: time.Unix(2, 0), Source: SourcePoll})
+	s.Set(k, Tip{Block: 9, ObservedAt: time.Unix(2, 0), Source: SourcePoll}, time.Minute)
 	s.Reset()
 	require.Equal(t, int64(0), s.Block(k), "Reset clears the whole store")
 }

--- a/protocol/endpointtip/store_test.go
+++ b/protocol/endpointtip/store_test.go
@@ -22,9 +22,12 @@ func TestStore_Set_BlockMonotonic(t *testing.T) {
 	require.Equal(t, int64(100), s.Block(k))
 
 	// Higher block wins — even carrying an EARLIER arrival stamp (block, not time, is the
-	// comparator now; the inverse of the old guard).
+	// comparator now; the inverse of the old guard). The freshness stamp is anchored forward,
+	// though: it stays at the stored (later) base, never regressing to the earlier one.
 	require.True(t, s.Set(k, Tip{Block: 200, ObservedAt: base.Add(-time.Second), Source: SourceRelay}, ttl))
 	require.Equal(t, int64(200), s.Block(k))
+	gotHigh, _ := s.Get(k)
+	require.Equal(t, base, gotHigh.ObservedAt, "higher block accepts but the stamp only advances")
 
 	// The F2 straggler: a LOWER block observed only slightly later is rejected (< ttl since
 	// the stored tip's observation, so the stored tip is still fresh).
@@ -33,7 +36,7 @@ func TestStore_Set_BlockMonotonic(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, int64(200), got.Block, "a newer-but-lower straggler must not regress the tip")
 	require.Equal(t, SourceRelay, got.Source, "rejected write must not move the source")
-	require.Equal(t, base.Add(-time.Second), got.ObservedAt, "rejected write must not refresh the stamp")
+	require.Equal(t, base, got.ObservedAt, "rejected write must not refresh the stamp")
 }
 
 // TestStore_Set_EqualBlockRefreshesFreshness pins that an equal block re-proves liveness:
@@ -61,6 +64,35 @@ func TestStore_Set_EqualBlockRefreshesFreshness(t *testing.T) {
 	require.True(t, s.Set(k, Tip{Block: 100, ObservedAt: base, Source: SourceRelay}, ttl))
 	got, _ = s.Get(k)
 	require.Equal(t, base.Add(9*time.Second), got.ObservedAt, "stamp only advances, never regresses")
+}
+
+// TestStore_Set_HigherBlockDoesNotRegressStamp pins that the higher-block branch anchors the
+// freshness stamp forward too: a higher block carrying an EARLIER observation stamp (reachable
+// cross-source — a relay skips the poll's arrival gate) is accepted for its block but keeps the
+// stored (later) stamp, so the staleness gap can't be widened by a stamp regression. Without the
+// anchor, a subsequent lower straggler would cross the horizon sooner than intended and wrongly
+// regress the tip (a residual F2).
+func TestStore_Set_HigherBlockDoesNotRegressStamp(t *testing.T) {
+	s := NewStore()
+	k := Key("ETH1", "jsonrpc", "u")
+	base := time.Unix(1_000, 0)
+	const ttl = 100 * time.Second
+
+	// Stored: block 200 observed at base+50s (e.g. a fresh poll).
+	require.True(t, s.Set(k, Tip{Block: 200, ObservedAt: base.Add(50 * time.Second), Source: SourcePoll}, ttl))
+
+	// A higher block 201 arrives carrying an EARLIER stamp (base+0s). Block wins, but the stamp
+	// must stay at the later base+50s.
+	require.True(t, s.Set(k, Tip{Block: 201, ObservedAt: base, Source: SourceRelay}, ttl))
+	got, _ := s.Get(k)
+	require.Equal(t, int64(201), got.Block, "higher block wins")
+	require.Equal(t, base.Add(50*time.Second), got.ObservedAt, "stamp must not regress below the stored one")
+	require.Equal(t, SourceRelay, got.Source, "the accepted higher block carries its own source")
+
+	// A lower block 200 observed at base+120s is 70s past the anchored stamp (< ttl) → still fresh
+	// → rejected. Had the stamp regressed to base+0s, this would be 120s > ttl and wrongly accepted.
+	require.False(t, s.Set(k, Tip{Block: 200, ObservedAt: base.Add(120 * time.Second), Source: SourcePoll}, ttl))
+	require.Equal(t, int64(201), s.Block(k), "anchored stamp keeps the tip fresh; straggler rejected")
 }
 
 // TestStore_Set_StaleBackstopAcceptsReorg is the reorg half of C-D: while the stored tip

--- a/protocol/probing/verdict.go
+++ b/protocol/probing/verdict.go
@@ -39,14 +39,16 @@ type VerdictConfig struct {
 }
 
 // DefaultVerdictConfig derives the verdict thresholds from a chain's average block time. The
-// per-endpoint "alive" horizon (StalenessWindow) shares ONE multiplier with the chainstate
-// consensus window — chainstate.DefaultStalenessMultiplier — so the liveness horizon and the
-// consensus freshness window never silently diverge when that horizon is tuned. Only the floor
-// differs (minProbeStaleness here vs chainstate.minStalenessWindow), since a per-endpoint probe
-// tolerates a slightly wider floor than the per-chain consensus.
+// per-endpoint "alive" horizon is chainstate.StalenessWindow raised to this package's own floor:
+// StalenessWindow already applies the shared DefaultStalenessMultiplier (so the liveness horizon
+// and the consensus freshness window never silently diverge when that derivation is tuned), and
+// the outer max lifts it to minProbeStaleness, a slightly wider floor than the per-chain consensus
+// (chainstate.minStalenessWindow) because a per-endpoint probe must not flip to "dead" on one slow
+// poll. Since minProbeStaleness > chainstate.minStalenessWindow the result is identical to deriving
+// the multiplier term inline; calling StalenessWindow just keeps the derivation in one place.
 func DefaultVerdictConfig(averageBlockTime time.Duration) VerdictConfig {
 	return VerdictConfig{
-		StalenessWindow:    max(time.Duration(chainstate.DefaultStalenessMultiplier)*averageBlockTime, minProbeStaleness),
+		StalenessWindow:    max(chainstate.StalenessWindow(averageBlockTime), minProbeStaleness),
 		LagToleranceBlocks: DefaultLagToleranceBlocks,
 		ReEnableHysteresis: DefaultProbeReEnableHysteresis,
 	}

--- a/protocol/rpcsmartrouter/chainstate_glue_test.go
+++ b/protocol/rpcsmartrouter/chainstate_glue_test.go
@@ -365,15 +365,25 @@ func TestHarvest_BootstrapAtomicGatedOnChainStateVerdict(t *testing.T) {
 	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1000}, gen, "provider1")
 	require.Equal(t, uint64(1000), rpcss.latestBlockHeight.Load(), "an accepted harvest seeds the bootstrap atomic")
 
-	// A lying-high harvest passes the per-endpoint store guard (higher + newer) but ChainState
-	// rejects it (fresh-tip anti-lie guard) → the atomic must NOT ratchet.
+	// A plausible advance ratchets the atomic (ChainState accepts; the store accepts a higher
+	// block). Ordered BEFORE the lie so the block-monotonic store does not retain a higher value
+	// that would reject it — see the T4 note below.
+	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1050}, gen, "provider1")
+	require.Equal(t, uint64(1050), rpcss.latestBlockHeight.Load(), "a plausible advance ratchets the atomic")
+
+	// A lying-high harvest passes the per-endpoint store guard (higher block, no anti-lie at that
+	// layer) but ChainState rejects it (fresh-tip anti-lie guard) → the atomic must NOT ratchet.
 	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1_000_000}, gen, "provider1")
-	require.Equal(t, uint64(1000), rpcss.latestBlockHeight.Load(),
+	require.Equal(t, uint64(1050), rpcss.latestBlockHeight.Load(),
 		"a harvest ChainState rejects as an outlier must not ratchet the monotonic atomic")
 
-	// A plausible advance flows normally again.
-	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1050}, gen, "provider1")
-	require.Equal(t, uint64(1050), rpcss.latestBlockHeight.Load(), "a plausible advance still ratchets the atomic")
+	// T4 consequence: the block-monotonic store RETAINS the lying-high 1_000_000 until it goes
+	// stale, so a subsequent honest-but-lower harvest is rejected and the harvest bails before the
+	// atomic. This is the conscious trade for fixing F2 — only a liar's own tip is inflated (F19,
+	// accepted); the global tip stays protected by ChainState's guard.
+	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1051}, gen, "provider1")
+	require.Equal(t, uint64(1050), rpcss.latestBlockHeight.Load(),
+		"a lower harvest is rejected while the higher lie is still fresh")
 }
 
 // TestSiteC_SyncReferenceIsChainTip documents the Topic C T1/D4 contract that REPLACED the

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2541,8 +2541,9 @@ func (rpcss *RPCSmartRouterServer) harvestAndUpdateTipFromRelay(
 	}
 	// The router-wide bootstrap atomic is monotonic-max with NO downward correction, so it may
 	// only follow blocks the CHAIN-level anti-lie guard accepted — the per-endpoint store's
-	// time-monotonic acceptance above is the wrong scope (a lying-high endpoint passes its own
-	// per-endpoint guard). By the time recordRelayBlockObservation returns, the monitor's
+	// block-monotonic acceptance above is the wrong scope: that guard has no anti-lie check, so a
+	// lying-high endpoint clears its own per-endpoint guard trivially (any higher block wins).
+	// By the time recordRelayBlockObservation returns, the monitor's
 	// OnTipObservation hook has already driven ChainState.SetLatestBlock with this very block
 	// (synchronously, after obsMu release — see RecordRelayObservation's deferred callback), so
 	// the ChainState tip reflects the verdict: an accepted block reads back as tip >= block, a

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -2643,9 +2643,14 @@ func TestSmartRouterSessionLeakPrevention_SingleProvider(t *testing.T) {
 // chain|apiInterface|url. ObservedAt = time.Now() keeps the time-monotonic guard happy for
 // successive seeds within a test.
 func seedEndpointTip(chainID, apiInterface, url string, block int64) {
+	key := endpointtip.Key(chainID, apiInterface, url)
+	// T4: the store is block-monotonic, so a re-seed to a lower block would be rejected.
+	// Tests want an exact value, so drop any prior entry first (staleAfter=0 = up-only).
+	endpointtip.Default().Remove(key)
 	endpointtip.Default().Set(
-		endpointtip.Key(chainID, apiInterface, url),
+		key,
 		endpointtip.Tip{Block: block, ObservedAt: time.Now(), Source: endpointtip.SourcePoll},
+		0,
 	)
 }
 

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -2640,8 +2640,8 @@ func TestSmartRouterSessionLeakPrevention_SingleProvider(t *testing.T) {
 // seedEndpointTip writes a poll-sourced tip into the shared single-source-of-truth
 // endpointtip store so the consistency/syncGap readers (which now read that store instead
 // of a per-Endpoint atomic) observe the block under test. It keys exactly as production:
-// chain|apiInterface|url. ObservedAt = time.Now() keeps the time-monotonic guard happy for
-// successive seeds within a test.
+// chain|apiInterface|url. The store is block-monotonic (T4), so a re-seed to a lower block
+// would be rejected; the helper drops any prior entry first and seeds up-only (staleAfter=0).
 func seedEndpointTip(chainID, apiInterface, url string, block int64) {
 	key := endpointtip.Key(chainID, apiInterface, url)
 	// T4: the store is block-monotonic, so a re-seed to a lower block would be rejected.

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -2666,11 +2666,13 @@ func seedChainTip(block int64) *chainstate.ChainState {
 
 // TestEndpointTipPreferStore locks the MAG-2160 Finding 6 fix + follow-up review: consistency
 // pre-validation prefers the endpointtip store (the single source of truth) and falls back to the
-// poll-tracker atomic ONLY when the store is empty. The store is fed by both poll and relay under a
-// time-monotonic guard, so it reflects the newest observation — including a newer LOWER block after
-// a reorg. A naive max() would keep a STALE-HIGH atomic winning there, making a rolled-back endpoint
-// look caught up; prefer-store fixes that while still winning the traffic-gate-frozen case (where
-// the store is the fresher/higher value).
+// poll-tracker atomic ONLY when the store is empty. The store is fed by both poll and relay; under
+// the T4 block-monotonic guard it self-heals a reorg DOWN — a newer lower block is held off while
+// the old higher tip is still fresh and adopted once that tip goes stale, so the downward correction
+// is delayed by up to the staleness window, not immediate. Either way the store eventually reflects
+// the true head, while the monotonic-max atomic never corrects downward at all — so a naive max()
+// would keep a STALE-HIGH atomic winning and make a rolled-back endpoint look caught up; prefer-store
+// fixes that while still winning the traffic-gate-frozen case (where the store is the fresher/higher value).
 func TestEndpointTipPreferStore(t *testing.T) {
 	cases := []struct {
 		name       string


### PR DESCRIPTION
## What

Topic C **T4 / C-D**. Makes the per-endpoint tip store order by **block**, not by arrival time.

> **Stacked on #225 (T1+T2).** Targets `unify-seenBlock-chainTip`; will auto-retarget to `main` when #225 merges. Review #225 first.

## Root cause (F2)

The per-endpoint store dropped any write whose `ObservedAt` predated the stored one. So a newer-but-**lower** straggler (a relay observed earlier but delivered late) overwrote a higher poll block, **regressing an honest endpoint's tip** for no real reason. That per-endpoint value is the operand consistency measures, an input to sync scoring, and a vote in consensus — so a wrong value leaks widely.

## The change

`endpointtip.Store.Set` is now block-monotonic with a staleness backstop (mirrors `ChainState.SetLatestBlock`):
- a **higher** block always wins;
- an **equal** block advances the freshness stamp;
- a **lower** block is rejected while the stored tip is fresh (kills F2) and accepted once stale (a real reorg down).

Staleness is measured between the stored and incoming **observation stamps** (`> staleAfter`), not wall-clock — deterministic, no clock injection. Resolves **D-FORK** as *staleness-only* (no fork signal), dropping the cross-package `chaintracker→store` wiring the original plan needed.

The horizon reuses the shared **`chainstate.StalenessWindow`** — the same derivation the consensus window / tip TTL uses. `endpointtip` defines no staleness constants of its own; the monitor derives and passes it in. (Note: the probe's liveness horizon shares the same **multiplier** — `DefaultStalenessMultiplier` — but re-derives with its own floor rather than calling `StalenessWindow`, so the shared knob across the codebase is the multiplier, not the function.)

## Accepted trade-off

With no anti-lie guard at the per-endpoint layer (that lives in `ChainState`), a transient lying-**HIGH** observation is now retained until it goes stale, where arrival-time overwrote it instantly. This is **asymmetric in our favour**: F2 harmed *honest* endpoints (wrongly filtered → availability loss); the new cost only inflates a *liar's* own tip (F19, already accepted), and the global tip + consensus stay protected by ChainState's guard and clustering. `TestHarvest_BootstrapAtomicGatedOnChainStateVerdict` documents this.

## Testing

- `go build ./...` + full `go test ./...` green (34 packages).
- New `endpointtip` unit tests cover the straggler rejection, equal-block refresh, and the stale-backstop reorg acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
