### PR TITLE
ci: make public readiness smoke non-blocking in PR gate

### DIFF
--- a/.github/workflows/pr-gate-build-artifact.yml
+++ b/.github/workflows/pr-gate-build-artifact.yml
@@ -1310,9 +1310,31 @@ jobs:
         run: |
           set -euo pipefail
           echo "Automation target: https://eth-sim-jsonrpc.${CLUSTER_HOST}"
+
+          set +e
           python -m src.config.build_defaults
+          build_defaults_status=$?
           python -m src.config.build_deployment
+          build_deployment_status=$?
           python -m pytest tests/ -m cluster_readiness_smoke_public -v --no-cov
+          pytest_status=$?
+          set -e
+
+          if [ "$build_defaults_status" -eq 0 ] && [ "$build_deployment_status" -eq 0 ] && [ "$pytest_status" -eq 0 ]; then
+            echo "smart-router-automation public readiness smoke passed"
+            {
+              echo "### smart-router-automation public readiness"
+              echo ""
+              echo "- Checkout path: \`smart-router-automation\`"
+              echo "- Target host: \`${CLUSTER_HOST}\`"
+              echo "- Target URL: \`https://eth-sim-jsonrpc.${CLUSTER_HOST}\`"
+              echo "- Pytest command: \`python -m pytest tests/ -m cluster_readiness_smoke_public -v --no-cov\`"
+              echo "- Result: \`passed\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "::warning::smart-router-automation public readiness smoke failed but is non-blocking (build_defaults=${build_defaults_status}, build_deployment=${build_deployment_status}, pytest=${pytest_status})"
           {
             echo "### smart-router-automation public readiness"
             echo ""
@@ -1320,8 +1342,12 @@ jobs:
             echo "- Target host: \`${CLUSTER_HOST}\`"
             echo "- Target URL: \`https://eth-sim-jsonrpc.${CLUSTER_HOST}\`"
             echo "- Pytest command: \`python -m pytest tests/ -m cluster_readiness_smoke_public -v --no-cov\`"
-            echo "- Result: \`passed\`"
+            echo "- Command exit codes: build_defaults=\`${build_defaults_status}\`, build_deployment=\`${build_deployment_status}\`, pytest=\`${pytest_status}\`"
+            echo "- Result: \`warning-only / failed but non-blocking\`"
+            echo ""
+            echo "This smoke covers broad prtests public readiness and is not the blocking Smart Router PR artifact gate."
           } >> "$GITHUB_STEP_SUMMARY"
+          exit 0
 
   preflight-status:
     name: Publish PR Validation Status


### PR DESCRIPTION
Makes the broad smart-router-automation public readiness smoke warning-only in the PR Gate. The real blocking validation remains the PR image rollout, health/RPC smoke, and Helm compatibility gate.