### PR TITLE
fix(shared-state): rebuild cross-pod consistency on the guarded chain tip (T10)

### DIFF
--- a/ecosystem/cache/handlers.go
+++ b/ecosystem/cache/handlers.go
@@ -320,13 +320,13 @@ func (s *RelayerCacheServer) performInt64WriteWithValidationAndRetry(
 	}
 }
 
-func (s *RelayerCacheServer) setSeenBlockOnSharedStateMode(chainId, sharedStateId string, seenBlock int64) {
+func (s *RelayerCacheServer) setSeenBlockOnSharedStateMode(chainId, sharedStateId string, seenBlock int64, ttl time.Duration) {
 	if sharedStateId == "" {
 		return
 	}
 	key := latestBlockKey(chainId, sharedStateId)
 	set := func() {
-		s.CacheServer.finalizedCache.SetWithTTL(key, seenBlock, 0, s.CacheServer.ExpirationFinalized)
+		s.CacheServer.finalizedCache.SetWithTTL(key, seenBlock, 0, ttl)
 	}
 	get := func() int64 {
 		return s.getSeenBlockForSharedStateMode(chainId, sharedStateId)
@@ -375,7 +375,7 @@ func (s *RelayerCacheServer) SetRelay(ctx context.Context, relayCacheSet *relayt
 		cache.SetWithTTL(string(cacheKey), cacheValue, cacheValue.Cost(), s.getExpirationForChain(time.Duration(relayCacheSet.AverageBlockTime), relayCacheSet.BlockHash))
 	}
 
-	s.setSeenBlockOnSharedStateMode(relayCacheSet.ChainId, relayCacheSet.SharedStateId, latestKnownBlock)
+	s.setSeenBlockOnSharedStateMode(relayCacheSet.ChainId, relayCacheSet.SharedStateId, latestKnownBlock, s.CacheServer.SharedStateTipExpiration(time.Duration(relayCacheSet.AverageBlockTime)))
 	s.setLatestBlock(latestBlockKey(relayCacheSet.ChainId, ""), latestKnownBlock)
 	s.setBlocksHashesToHeights(relayCacheSet.ChainId, relayCacheSet.BlocksHashesToHeights)
 	return &emptypb.Empty{}, nil

--- a/ecosystem/cache/server.go
+++ b/ecosystem/cache/server.go
@@ -32,6 +32,12 @@ const (
 	ExpirationNodeErrorsOnFinalizedFlagName      = "expiration-finalized-node-errors"
 	FlagCacheSizeName                            = "max-items"
 	DefaultExpirationForNonFinalized             = 500 * time.Millisecond
+	// SharedStateTipBlockMultiplier bounds how long a pod's published chain tip lives in the
+	// shared cache: SharedStateTipBlockMultiplier * averageBlockTime. It mirrors the smart
+	// router's own tip-staleness horizon (chainstate.StalenessWindow) so a dead pod's tip
+	// evaporates on roughly the same timescale the router considers a tip stale, rather than
+	// lingering for the full finalized (~1h) TTL.
+	SharedStateTipBlockMultiplier                = 10
 	DefaultExpirationTimeFinalizedMultiplier     = 1.0
 	DefaultExpirationTimeNonFinalizedMultiplier  = 1.0
 	DefaultExpirationBlocksHashesToHeights       = 48 * time.Hour
@@ -201,6 +207,15 @@ func (cs *CacheServer) Serve(ctx context.Context, listenAddr string) {
 func (cs *CacheServer) ExpirationForChain(averageBlockTimeForChain time.Duration) time.Duration {
 	eighthBlock := averageBlockTimeForChain / 8
 	return lavaslices.Max([]time.Duration{eighthBlock, cs.ExpirationNonFinalized})
+}
+
+// SharedStateTipExpiration returns the TTL for a pod's published chain tip in shared-state
+// mode: SharedStateTipBlockMultiplier * averageBlockTime, floored at ExpirationNonFinalized so
+// a chain whose spec omits the average block time still gets a sane, non-zero TTL (a zero TTL
+// would never expire).
+func (cs *CacheServer) SharedStateTipExpiration(averageBlockTimeForChain time.Duration) time.Duration {
+	ttl := averageBlockTimeForChain * SharedStateTipBlockMultiplier
+	return lavaslices.Max([]time.Duration{ttl, cs.ExpirationNonFinalized})
 }
 
 func (cs *CacheServer) GetTotalCacheSize() int64 {

--- a/ecosystem/cache/shared_state_tip_test.go
+++ b/ecosystem/cache/shared_state_tip_test.go
@@ -1,0 +1,58 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSharedStateTipExpiration locks the shared-state tip TTL contract (T10): a pod's published
+// tip lives for SharedStateTipBlockMultiplier * averageBlockTime, floored at ExpirationNonFinalized
+// so a chain with an unknown block time still gets a sane, non-zero TTL instead of never expiring.
+func TestSharedStateTipExpiration(t *testing.T) {
+	cs := &CacheServer{ExpirationNonFinalized: 500 * time.Millisecond}
+
+	// Normal chain: 12s block → 120s TTL (well above the floor, far below the ~1h finalized TTL).
+	require.Equal(t, 120*time.Second, cs.SharedStateTipExpiration(12*time.Second))
+
+	// Fast chain: 400ms block → 4s (still above the floor).
+	require.Equal(t, 4*time.Second, cs.SharedStateTipExpiration(400*time.Millisecond))
+
+	// Unknown block time (spec omits average_block_time): 0*10 = 0 → floored so it is not eternal.
+	require.Equal(t, cs.ExpirationNonFinalized, cs.SharedStateTipExpiration(0))
+}
+
+// TestSharedStateTip_RoundTripAndKeyIsolation is the T10 fix: a tip written under one shared-state
+// id is readable only under the SAME id. The historical bug was that the write used a chain-level
+// id and the read used a per-user id, so the read never resolved the write. This test proves the
+// round-trip works when the ids match and misses when they do not, and that writes are max-merged.
+func TestSharedStateTip_RoundTripAndKeyIsolation(t *testing.T) {
+	cs := &CacheServer{
+		finalizedCache:         newRistrettoForTest(t),
+		ExpirationNonFinalized: 500 * time.Millisecond,
+	}
+	srv := &RelayerCacheServer{CacheServer: cs}
+
+	const chainID = "ETH1"
+	const writeID = "ETH1jsonrpc" // == listenEndpoint.Key(): the chain-level id both sides now use
+
+	srv.setSeenBlockOnSharedStateMode(chainID, writeID, 1000, time.Minute)
+	cs.finalizedCache.Wait()
+
+	// Aligned id → round-trips.
+	require.Equal(t, int64(1000), srv.getSeenBlockForSharedStateMode(chainID, writeID))
+
+	// Mismatched (old per-user) id → miss, returns 0. This is the pre-T10 breakage, now asserted
+	// to stay dead only for a genuinely different id.
+	require.Equal(t, int64(0), srv.getSeenBlockForSharedStateMode(chainID, "mydapp__1.2.3.4"))
+
+	// Max-merge: a lower write is ignored, a higher write wins.
+	srv.setSeenBlockOnSharedStateMode(chainID, writeID, 900, time.Minute)
+	cs.finalizedCache.Wait()
+	require.Equal(t, int64(1000), srv.getSeenBlockForSharedStateMode(chainID, writeID), "lower write must not lower the shared tip")
+
+	srv.setSeenBlockOnSharedStateMode(chainID, writeID, 1100, time.Minute)
+	cs.finalizedCache.Wait()
+	require.Equal(t, int64(1100), srv.getSeenBlockForSharedStateMode(chainID, writeID), "higher write must advance the shared tip")
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2807,6 +2807,23 @@ func isFinalizedForCacheWrite(requestedBlock, replyLatestBlock, trackedLatestBlo
 	return spectypes.IsFinalizedBlock(requestedBlock, latest, finalizationDistance)
 }
 
+// adoptSharedStateTip feeds a peer pod's chain tip — read from the shared cache under the
+// chain-level key, so it is the fleet-max of every pod's guarded tip — into this pod's
+// ChainState, but only when it is ahead of our local view. SetLatestBlock applies the same
+// outlier/Recompute guards as a local observation, so a poisoned peer value is snapped down
+// rather than trusted (T10). No-op when shared state is off or ChainState is not yet wired.
+func (rpcss *RPCSmartRouterServer) adoptSharedStateTip(ctx context.Context, peerTip, localSeenBlock int64) {
+	if !rpcss.sharedState || rpcss.chainState == nil || peerTip <= localSeenBlock {
+		return
+	}
+	utils.LavaFormatDebug("shared-state tip is newer, feeding to chain state",
+		utils.LogAttr("peer_tip", peerTip),
+		utils.LogAttr("local_seen_block", localSeenBlock),
+		utils.LogAttr("GUID", ctx),
+	)
+	rpcss.chainState.SetLatestBlock(peerTip)
+}
+
 // tryCacheWrite attempts to write a successful relay response to the cache.
 // It runs in a separate goroutine to avoid blocking the relay response.
 // Cache writes are skipped when:
@@ -3029,10 +3046,10 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 	userData := protocolMessage.GetUserData()
 	var sharedStateId string // defaults to "", if shared state is disabled then no shared state will be used.
 	if rpcss.sharedState {
-		// Per-caller shared-state id. The retired consistency store used to own this key
-		// derivation; it is now a plain function, byte-identical so entries written by an older
-		// build still resolve. Moving shared state to a chain-level key is T10.
-		sharedStateId = relaycore.UserDataKey(userData)
+		// Chain-level shared-state id (T10): matches the write key in tryCacheWrite, so the
+		// value each pod publishes (its guarded chain tip) round-trips. Must equal the write
+		// key or the read never resolves it.
+		sharedStateId = rpcss.listenEndpoint.Key()
 	}
 
 	chainId, apiInterface := rpcss.GetChainIdAndApiInterface()
@@ -3168,31 +3185,10 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 					)
 					reply := cacheReply.GetReply()
 
-					// BEHAVIOR DROPPED (Topic C C-G, consciously accepted): inter-consumer-instance
-					// consistency via the cache server's seen block. This used to raise this
-					// request's SeenBlock (and the per-user consistency cache) to a seen block
-					// reported by ANOTHER router instance, so a user whose requests were balanced
-					// across instances kept a shared read-your-writes floor.
-					//
-					// It is removed rather than repointed because there is nothing to repoint it
-					// to: the tip is per-router-instance, and adopting a cross-instance value here
-					// would reintroduce exactly the vector C-G closes — an ungated block from
-					// outside this instance's anti-lie guards flowing into request resolution and
-					// the cache key.
-					//
-					// Cost: none in practice — this path was already dead. The write and read used
-					// DIFFERENT SharedStateIds (write: listenEndpoint.Key() = chainID+apiInterface,
-					// below in tryCacheWrite; read: relaycore.UserDataKey(userData) =
-					// dappId__consumerIp), and the cache server keys the value as
-					// chainID + "_" + sharedStateId (ecosystem/cache/handlers.go:556). The two keys
-					// can never collide, so getSeenBlockForSharedStateMode missed every time and
-					// returned 0. Both lines date to the initial smart-router commit (22cbf32).
-					//
-					// The PUBLISH side is deliberately left intact (tryCacheWrite still sends
-					// SeenBlock + SharedStateId), and what it now publishes is the guarded tip.
-					// Rebuilding the adopt side properly — chain-level key, value fed through
-					// ChainState.SetLatestBlock so it passes the anti-lie guards — is tracked as
-					// follow-up task T10.
+					// Cross-pod consistency (T10): peer pods publish their guarded chain tip under
+					// the shared chain-level key; the server returns the fleet-max. Adopt it through
+					// the same anti-lie guards as a local observation.
+					rpcss.adoptSharedStateTip(ctx, cacheReply.GetSeenBlock(), localRelayData.SeenBlock)
 
 					// handle cache reply
 					if cacheError == nil && reply != nil {

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2816,12 +2816,17 @@ func (rpcss *RPCSmartRouterServer) adoptSharedStateTip(ctx context.Context, peer
 	if !rpcss.sharedState || rpcss.chainState == nil || peerTip <= localSeenBlock {
 		return
 	}
-	utils.LavaFormatDebug("shared-state tip is newer, feeding to chain state",
+	// SetLatestBlock re-guards: advanced=false means the anti-lie guard rejected/snapped down the
+	// peer tip (e.g. a lying-high value). Log the outcome so a rejected peer tip is visible rather
+	// than silent — a stream of adopted=false is the signature of a poisoned shared tip.
+	tip, _, advanced := rpcss.chainState.SetLatestBlock(peerTip)
+	utils.LavaFormatDebug("shared-state tip fed to chain state",
 		utils.LogAttr("peer_tip", peerTip),
 		utils.LogAttr("local_seen_block", localSeenBlock),
+		utils.LogAttr("adopted", advanced),
+		utils.LogAttr("chain_state_tip", tip),
 		utils.LogAttr("GUID", ctx),
 	)
-	rpcss.chainState.SetLatestBlock(peerTip)
 }
 
 // tryCacheWrite attempts to write a successful relay response to the cache.

--- a/protocol/rpcsmartrouter/shared_state_tip_adopt_test.go
+++ b/protocol/rpcsmartrouter/shared_state_tip_adopt_test.go
@@ -1,0 +1,79 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/chainstate"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/stretchr/testify/require"
+)
+
+// newAdoptTestServer builds an rpcss whose ChainState is seeded to `seed` under a fixed clock, so
+// the tip stays fresh for the whole test (no TTL flakiness). OutlierThreshold is 100.
+func newAdoptTestServer(t *testing.T, sharedState bool, seed int64) *RPCSmartRouterServer {
+	t.Helper()
+	clock := func() time.Time { return time.Unix(1700000000, 0) }
+	cs := chainstate.NewWithClock("ETH1", chainstate.Config{
+		BucketWidth:      2,
+		OutlierThreshold: 100,
+		StalenessWindow:  10 * time.Second,
+		TTL:              10 * time.Second,
+	}, clock)
+	if _, _, ok := cs.SetLatestBlock(seed); !ok {
+		t.Fatalf("seed SetLatestBlock(%d) did not take", seed)
+	}
+	return &RPCSmartRouterServer{
+		listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"},
+		chainState:     cs,
+		sharedState:    sharedState,
+	}
+}
+
+func tip(t *testing.T, rpcss *RPCSmartRouterServer) int64 {
+	t.Helper()
+	block, ok := rpcss.chainState.GetLatestBlock()
+	require.True(t, ok, "tip should be known and fresh")
+	return block
+}
+
+// TestAdoptSharedStateTip covers the T10 adopt glue: a peer pod's fleet-max tip is fed into
+// ChainState only when shared state is on and the peer is ahead, and only through the anti-lie
+// guard — so an over-threshold peer value is snapped down, never trusted raw.
+func TestAdoptSharedStateTip(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("shared state off is a no-op", func(t *testing.T) {
+		rpcss := newAdoptTestServer(t, false, 1000)
+		rpcss.adoptSharedStateTip(ctx, 1005, 1000)
+		require.Equal(t, int64(1000), tip(t, rpcss))
+	})
+
+	t.Run("peer not ahead is a no-op", func(t *testing.T) {
+		rpcss := newAdoptTestServer(t, true, 1000)
+		rpcss.adoptSharedStateTip(ctx, 1000, 1000) // equal
+		rpcss.adoptSharedStateTip(ctx, 999, 1000)  // lower
+		require.Equal(t, int64(1000), tip(t, rpcss))
+	})
+
+	t.Run("peer ahead within threshold is adopted", func(t *testing.T) {
+		rpcss := newAdoptTestServer(t, true, 1000)
+		rpcss.adoptSharedStateTip(ctx, 1050, 1000)
+		require.Equal(t, int64(1050), tip(t, rpcss), "a plausible peer tip advances the local tip")
+	})
+
+	t.Run("over-threshold peer value is snapped down by the guard", func(t *testing.T) {
+		rpcss := newAdoptTestServer(t, true, 1000)
+		rpcss.adoptSharedStateTip(ctx, 1101, 1000) // 1000 + OutlierThreshold(100) + 1
+		require.Equal(t, int64(1000), tip(t, rpcss), "a lying-high peer tip is rejected, not trusted raw")
+	})
+
+	t.Run("nil chain state does not panic", func(t *testing.T) {
+		rpcss := &RPCSmartRouterServer{
+			listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"},
+			sharedState:    true,
+		}
+		require.NotPanics(t, func() { rpcss.adoptSharedStateTip(ctx, 5000, 1) })
+	})
+}


### PR DESCRIPTION
## What

Rebuilds the cross-pod shared-state consistency mechanism on the **guarded chain tip** instead of the retired per-user seenBlock. Stacked on #226 (T4).

### The bug it fixes
Shared-state mode wrote the seen block under a **chain-level** key (`listenEndpoint.Key()` = `ChainID+ApiInterface`) but **read** it under a **per-user** key (`dappId__consumerIp`). The two never collided, so `getSeenBlockForSharedStateMode` missed every time and returned 0 — the feature has been dead since the initial commit (`22cbf32`). T2 (#225) removed the dead read half; this rebuilds it correctly.

### Changes
- **Read id → `listenEndpoint.Key()`** (matches the write; chain-level) so the round-trip closes.
- **`adoptSharedStateTip()`** feeds the fleet-max peer tip through `ChainState.SetLatestBlock` — the same outlier + Recompute anti-lie guards as a local observation — instead of raw into request resolution. A poisoned peer value is snapped down, not trusted. No-op unless shared state is on, ChainState is wired, and the peer is genuinely ahead.
- **Cache TTL**: the shared tip now expires after `SharedStateTipBlockMultiplier(10) × averageBlockTime` (`SharedStateTipExpiration`, floored at `ExpirationNonFinalized`), replacing the flat ~1h finalized TTL. Mirrors the router's own `StalenessWindow`, so a dead pod's tip evaporates on the same horizon the router considers a tip stale.
- The write side needed **zero changes** — it already publishes the guarded tip under the chain-level key.

## Verification

**Live**, on a 2-replica `base-router` + shared `router-cache` (dev cluster, `--shared-state` on):
- Reads hit the aligned key `BASE_BASEjsonrpc` at **~99.4%** (328 hits / 2 cold-start misses in 90s).
- Writes land under that same key (`Got Cache Set … latestKnownBlock` == the read value).
- Peer-ahead tips adopt through the guard on **both** replicas (`peer=local+1`), 0 crashes, 0 errors.

**Unit tests**:
- `ecosystem/cache/shared_state_tip_test.go` — TTL math (incl. zero-block-time floor); key round-trip + per-user-id isolation (encodes the bug); max-merge.
- `protocol/rpcsmartrouter/shared_state_tip_adopt_test.go` — adopt glue: no-op when off / not ahead / nil ChainState; adopts a plausible peer tip; **snaps down an over-threshold (lying-high) peer tip**.

Full `./protocol/rpcsmartrouter/...` and `./ecosystem/cache/...` suites pass; `go vet` + full build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)