### PR TITLE
refactor(chainstate): delete the bootstrap atomic; readers take the self-healing tip (T3)

### DIFF
--- a/protocol/chainstate/chain_state.go
+++ b/protocol/chainstate/chain_state.go
@@ -315,12 +315,12 @@ func (cs *ChainState) Reset() {
 // turned a cold-start lie into a process-lifetime one, is retired (T3); every reader goes through
 // this tip. Do not reintroduce a ratcheting mirror of it without its own downward path.
 //
-// Returns the resulting tip, the time it was last confirmed, and whether this call ADVANCED it
-// (equal-block confirmations and downward re-adoptions return advanced=false). advanced is the
-// accept/reject signal for a caller that needs to know whether its observation actually moved the
-// tip: the OnTipObservation hook discards it, adoptSharedStateTip LOGS it (as `adopted`) so a
-// rejected peer tip is visible rather than silent, and the package tests assert guard behaviour
-// through it.
+// Returns the resulting tip, the time it was last confirmed, and whether this call moved the tip
+// UP. advanced is not an accept/reject signal: equal-block confirmations, downward re-adoptions,
+// and rejected observations all return false. The OnTipObservation hook discards it;
+// adoptSharedStateTip logs it as `tip_advanced` and separately compares the resulting tip with the
+// positive peer input to determine whether that value was taken; package tests assert guard
+// behaviour through it.
 func (cs *ChainState) SetLatestBlock(block int64) (latest int64, at time.Time, advanced bool) {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()

--- a/protocol/chainstate/chain_state.go
+++ b/protocol/chainstate/chain_state.go
@@ -181,8 +181,11 @@ type ChainState struct {
 	// would report ~0 lag forever, since every confirming observation refreshes it.
 	latestSince time.Time
 	// initialized is a STICKY flag: true once any positive observation has ever been accepted.
-	// It distinguishes a genuine cold start (no observation yet → bootstrap fallback is allowed)
-	// from a tip that has merely gone stale by TTL (Finding 1). It never resets to false.
+	// SetLatestBlock reads it to know whether a REFERENCE exists to guard the next observation
+	// against — the very first observation has none, which is why no anti-lie check can fire on it.
+	// It also separates a genuine cold start from a tip that has merely gone stale by TTL (Finding
+	// 1): both report (0, false) to readers, but only the latter has a value worth healing. Ordinary
+	// staleness never reverts it; only Reset() clears it back to false.
 	initialized bool
 	baseline    int64 // last computed strict-majority consensus baseline (valid iff hasBaseline)
 	hasBaseline bool  // whether a fresh majority existed at the last Recompute
@@ -264,6 +267,11 @@ func (cs *ChainState) SetDebugClockOffset(d time.Duration) {
 // any peer forms a baseline. Reset is the only way to drop such a value immediately rather than
 // waiting for the liar to stop and a TTL to expire. Debug-only: reached from /debug/reset-all and
 // /debug/reset-scores, never from a relay path.
+//
+// Know one consequence before pulling it: clearing the tip also blanks GetLatestBlockAllowStale, so
+// archive routing loses its last-known head and force-archives EVERY concrete-block request (the
+// conservative answer to an unknown head, archive_parser_rule.go) until the next observation lands —
+// roughly half a block time on a polling pod. Correct, but briefly expensive on the archive pool.
 func (cs *ChainState) Reset() {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
@@ -300,14 +308,17 @@ func (cs *ChainState) Reset() {
 //     poisoning of THIS tip to ~one TTL instead of the process lifetime.
 //
 // Caveat: the guard cannot fire on the VERY FIRST observation (no reference exists yet), so a
-// cold-start lie is accepted here. This tip self-heals after one TTL, but callers that ratchet a
-// separate monotonic-max store from accepted observations (the rpcsmartrouter bootstrap atomic)
-// do NOT self-heal — a cold-start lie persists there for the process lifetime. That store must add
-// its own bound if it needs one; this tip's self-heal does not cover it.
+// cold-start lie is accepted here. It is bounded, not permanent: the stale-tip re-adoption above
+// drops it within one TTL, and on a pod that forms a baseline Recompute snaps it back sooner. That
+// self-heal is now the WHOLE bound, and it suffices — no consumer keeps a separate monotonic-max
+// copy of this value any more. The rpcsmartrouter bootstrap atomic, which was the one such copy and
+// turned a cold-start lie into a process-lifetime one, is retired (T3); every reader goes through
+// this tip. Do not reintroduce a ratcheting mirror of it without its own downward path.
 //
 // Returns the resulting tip, the time it was last confirmed, and whether this call ADVANCED it
-// (equal-block confirmations and downward re-adoptions return advanced=false — consumers that
-// ratchet a monotonic maximum, e.g. the bootstrap atomic, must only follow advances).
+// (equal-block confirmations and downward re-adoptions return advanced=false). advanced is the
+// accept/reject signal for a caller that needs to know whether its observation actually moved the
+// tip; the production hooks discard it, and the package tests assert guard behaviour through it.
 func (cs *ChainState) SetLatestBlock(block int64) (latest int64, at time.Time, advanced bool) {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
@@ -440,9 +451,14 @@ func (cs *ChainState) ConsensusBucketWidth() int64 {
 }
 
 // Initialized reports whether ChainState has ever accepted a positive observation. It is sticky
-// — once true it never reverts — so callers can distinguish a genuine cold start (allow a
-// bootstrap fallback) from a tip that has merely gone stale by TTL (do NOT revive a frozen
-// value, Finding 1).
+// within a lifetime — ordinary staleness never reverts it, only Reset() clears it — so a caller can
+// distinguish a genuine cold start (no value has ever existed) from a tip that has merely gone stale
+// by TTL (a real value exists but must not be served frozen, Finding 1).
+//
+// NOTE: no production reader consults this any more. It existed so getLatestBlock could allow a
+// bootstrap fallback on cold start while refusing to revive a frozen value once stale; that fallback
+// (the bootstrap atomic) is retired (T3) and every reader now takes the tip or 0. Retained for tests
+// and diagnostics — delete it if no future consumer appears.
 func (cs *ChainState) Initialized() bool {
 	cs.mu.RLock()
 	defer cs.mu.RUnlock()

--- a/protocol/chainstate/chain_state.go
+++ b/protocol/chainstate/chain_state.go
@@ -318,7 +318,9 @@ func (cs *ChainState) Reset() {
 // Returns the resulting tip, the time it was last confirmed, and whether this call ADVANCED it
 // (equal-block confirmations and downward re-adoptions return advanced=false). advanced is the
 // accept/reject signal for a caller that needs to know whether its observation actually moved the
-// tip; the production hooks discard it, and the package tests assert guard behaviour through it.
+// tip: the OnTipObservation hook discards it, adoptSharedStateTip LOGS it (as `adopted`) so a
+// rejected peer tip is visible rather than silent, and the package tests assert guard behaviour
+// through it.
 func (cs *ChainState) SetLatestBlock(block int64) (latest int64, at time.Time, advanced bool) {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()

--- a/protocol/chainstate/chain_state.go
+++ b/protocol/chainstate/chain_state.go
@@ -9,9 +9,13 @@
 // touches QoS or endpoint.Enabled, and nothing external writes its consensus — there is no
 // SetMajorityBaseline API (T2, inverted: ChainState owns consensus; the probe is read-only).
 //
-// It exposes ONE read API for "what block is the chain at" (Topic C governing decision, D1/D4):
-//   - GetLatestBlock / GetLatestBlockWithTime — the tip. Every consumer reads this: archive
-//     routing, cache finalization, sync scoring, and consistency.
+// It exposes the read API for "what block is the chain at" (Topic C governing decision, D1/D4):
+//   - GetLatestBlock / GetLatestBlockWithTime — the tip when TTL-fresh, else not-found (never a
+//     stale value). Cache finalization, sync scoring, consistency, and the request seenBlock read this.
+//   - GetLatestBlockAllowStale — the same tip but TTL-ignored (0 only if never observed), for archive
+//     routing, which prefers a slightly-stale head to "unknown". Both self-heal via SetLatestBlock /
+//     Recompute (grow under the outlier guard, re-adopt a lower block once stale), so neither can stay
+//     stuck on a lie the way the retired bootstrap atomic could.
 //
 // Consensus is NOT a readable value — it is background machinery that corrects the tip at the
 // band edges only (see Recompute): snap DOWN when the tip leads consensus by more than
@@ -357,6 +361,18 @@ func (cs *ChainState) GetLatestBlock() (int64, bool) {
 	cs.mu.RLock()
 	defer cs.mu.RUnlock()
 	return cs.freshLatestLocked(cs.effectiveNow())
+}
+
+// GetLatestBlockAllowStale returns the current tip value IGNORING TTL freshness — the last accepted,
+// self-healing observation (0 if none yet). It is for lenient readers (archive routing) that
+// prefer a slightly-stale head over an "unknown" that would force every request to the archive
+// pool. The tip still self-heals: SetLatestBlock grows it under the outlier guard and re-adopts a
+// lower block once stale, so this can lag but cannot stay stuck on a lie (unlike the retired
+// bootstrap atomic). Freshness-sensitive readers (cache finalization) use GetLatestBlock instead.
+func (cs *ChainState) GetLatestBlockAllowStale() int64 {
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	return cs.latestBlock
 }
 
 // GetLatestBlockWithTime is GetLatestBlock plus the wall-clock at which the current tip BLOCK was

--- a/protocol/chainstate/chain_state_test.go
+++ b/protocol/chainstate/chain_state_test.go
@@ -28,6 +28,28 @@ func newTestState(t *testing.T) (*ChainState, *fakeClock) {
 	return cs, clk
 }
 
+// TestGetLatestBlockAllowStale covers the raw (TTL-ignoring) getter T3's archive routing relies on: it
+// returns the current tip value regardless of freshness (0 before any observation) and reflects the
+// tip's downward self-heal once stale — the property the retired bootstrap atomic lacked.
+func TestGetLatestBlockAllowStale(t *testing.T) {
+	cs, clk := newTestState(t)
+
+	require.Equal(t, int64(0), cs.GetLatestBlockAllowStale(), "no tip yet → 0")
+
+	cs.SetLatestBlock(1000)
+	require.Equal(t, int64(1000), cs.GetLatestBlockAllowStale(), "fresh tip returned raw")
+
+	// Past TTL: GetLatestBlock reports unknown, but GetLatestBlockAllowStale still returns the last value.
+	clk.advance(11 * time.Second)
+	_, fresh := cs.GetLatestBlock()
+	require.False(t, fresh, "tip is stale past TTL")
+	require.Equal(t, int64(1000), cs.GetLatestBlockAllowStale(), "stale tip still returned raw (last-known)")
+
+	// Self-heal: once stale, a LOWER observation is re-adopted (the atomic could never move down).
+	cs.SetLatestBlock(900)
+	require.Equal(t, int64(900), cs.GetLatestBlockAllowStale(), "stale tip heals DOWN to a lower observation")
+}
+
 // --- SetLatestBlock: monotonic + outlier guard -----------------------------------------
 
 func TestSetLatestBlock_Monotonic(t *testing.T) {

--- a/protocol/endpointstate/observation.go
+++ b/protocol/endpointstate/observation.go
@@ -161,8 +161,10 @@ func (m *EndpointMonitor) recordPollObservation(endpointURL string, gen uint64, 
 //
 // Returns true iff the write was accepted (passed the generation + monotonic guards and
 // advanced the stored tip). The caller uses this to gate the remaining ungated tip-state
-// writes (router bootstrap atomic, per-endpoint metric) so a stale/replaced-tracker relay
-// that this method correctly drops cannot still poison them.
+// writes (the router-wide and per-endpoint latest-block metrics) so a stale/replaced-tracker
+// relay that this method correctly drops cannot still poison them. The router bootstrap atomic
+// used to be gated here too; it is retired (T3) and the router-wide value is now the guarded
+// ChainState tip.
 func (m *EndpointMonitor) RecordRelayObservation(endpointURL string, gen uint64, block int64, at time.Time) bool {
 	if block <= 0 {
 		return false

--- a/protocol/rpcsmartrouter/chainstate_glue_test.go
+++ b/protocol/rpcsmartrouter/chainstate_glue_test.go
@@ -35,10 +35,11 @@ func (c *manualClock) advance(d time.Duration) {
 	c.t = c.t.Add(d)
 }
 
-// TestGetLatestBlock_BootstrapOnlyFallback covers MAG-2160 Finding 1: the monotonic atomic is a
-// COLD-START fallback only. Once ChainState has ever observed a tip, a TTL-expired tip must
-// report "unknown" rather than being revived from a frozen atomic value.
-func TestGetLatestBlock_BootstrapOnlyFallback(t *testing.T) {
+// TestGetLatestBlock_ColdStartAndStale covers MAG-2160 Finding 1 after the bootstrap atomic is
+// retired (T3): getLatestBlock reports "unknown" (0) at cold-start (no tip yet) and again once a
+// tip has aged past TTL — never a frozen value. The tip is seeded by the first observation, so no
+// atomic fallback is needed.
+func TestGetLatestBlock_ColdStartAndStale(t *testing.T) {
 	clk := &manualClock{t: time.Unix(1_700_000_000, 0)}
 	cs := chainstate.NewWithClock("ETH1", chainstate.Config{
 		BucketWidth:      2,
@@ -52,38 +53,66 @@ func TestGetLatestBlock_BootstrapOnlyFallback(t *testing.T) {
 		chainState:     cs,
 	}
 
-	// Cold start: ChainState has never observed a tip (Initialized()==false). The init-relay-seeded
-	// atomic is the legitimate bootstrap fallback.
-	rpcss.latestBlockHeight.Store(1000)
-	require.Equal(t, uint64(1000), rpcss.getLatestBlock(), "cold start falls back to the bootstrap atomic")
+	// Cold start: ChainState has never observed a tip → unknown (0). No atomic to revive.
+	require.Equal(t, uint64(0), rpcss.getLatestBlock(), "cold start with no tip → 0")
 
 	// First observation initializes ChainState; from now on it is the authority.
 	cs.SetLatestBlock(2000)
-	require.Equal(t, uint64(2000), rpcss.getLatestBlock(), "once initialized, ChainState's fresh tip wins over the atomic")
+	require.Equal(t, uint64(2000), rpcss.getLatestBlock(), "a fresh tip answers")
 
-	// Age the ChainState tip past TTL. The atomic still holds 1000 (monotonic, never expires), but
-	// an initialized-but-stale ChainState must report unknown — NOT revive the frozen atomic.
+	// Age the ChainState tip past TTL. An initialized-but-stale tip must report unknown.
 	clk.advance(11 * time.Second)
 	require.Equal(t, uint64(0), rpcss.getLatestBlock(),
-		"Finding 1: a TTL-expired tip must report unknown, never be revived from the stale atomic")
+		"Finding 1: a TTL-expired tip must report unknown, never a frozen value")
 
-	// A fresh observation revives the tip through ChainState (the atomic is never consulted again).
+	// A fresh observation revives the tip.
 	cs.SetLatestBlock(2001)
-	require.Equal(t, uint64(2001), rpcss.getLatestBlock(), "a fresh observation revives the tip via ChainState")
+	require.Equal(t, uint64(2001), rpcss.getLatestBlock(), "a fresh observation revives the tip")
 }
 
-// TestGetLatestBlock_NilChainStateUsesAtomic is the defensive path: before ChainState is wired
-// (or in components that never construct it) getLatestBlock still answers from the atomic.
-func TestGetLatestBlock_NilChainStateUsesAtomic(t *testing.T) {
+// TestGetLatestBlock_NilChainState is the defensive path: with no ChainState wired, getLatestBlock
+// reports unknown (0). The bootstrap atomic that used to answer here is retired (T3).
+func TestGetLatestBlock_NilChainState(t *testing.T) {
 	rpcss := &RPCSmartRouterServer{listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"}}
-	require.Equal(t, uint64(0), rpcss.getLatestBlock(), "no chainState, no atomic → unknown")
-	rpcss.latestBlockHeight.Store(500)
-	require.Equal(t, uint64(500), rpcss.getLatestBlock(), "no chainState → atomic answers")
+	require.Equal(t, uint64(0), rpcss.getLatestBlock(), "no chainState → unknown")
 }
 
-// TestGetLatestBlockForCacheFinalization_TipOrZero locks the cache-finalization tip contract
-// AFTER Topic C T1/D4 (single reader): the ChainState TIP when fresh, else a strict 0. It must
-// still never fall back to the bootstrap atomic (monotonic-max, no downward correction).
+// TestGetLatestBlockAllowStale_ServesStaleAndHeals locks the T3 archive-routing contract:
+// getLatestBlockAllowStale serves the last-known tip even when stale (0 before any tip), and — the
+// whole point of retiring the monotonic atomic — it HEALS DOWN when the stale tip re-adopts a lower
+// block, where the atomic would have stayed stuck on the high value for the life of the process.
+func TestGetLatestBlockAllowStale_ServesStaleAndHeals(t *testing.T) {
+	clk := &manualClock{t: time.Unix(1_700_000_000, 0)}
+	cs := chainstate.NewWithClock("ETH1", chainstate.Config{
+		BucketWidth:      2,
+		OutlierThreshold: 100,
+		StalenessWindow:  10 * time.Second,
+		TTL:              10 * time.Second,
+	}, clk.now)
+	rpcss := &RPCSmartRouterServer{
+		listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"},
+		chainState:     cs,
+	}
+
+	// Before any tip: 0 (conservative force-archive fallback).
+	require.Equal(t, uint64(0), rpcss.getLatestBlockAllowStale(), "no tip → 0")
+
+	// A tip is served whether fresh or stale (lenient, unlike strict getLatestBlock).
+	cs.SetLatestBlock(1000)
+	require.Equal(t, uint64(1000), rpcss.getLatestBlockAllowStale(), "fresh tip served")
+	clk.advance(11 * time.Second)
+	require.Equal(t, uint64(1000), rpcss.getLatestBlockAllowStale(), "stale tip still served")
+
+	// Heal down: a lower observation after staleness is re-adopted — the retired atomic could not.
+	cs.SetLatestBlock(900)
+	require.Equal(t, uint64(900), rpcss.getLatestBlockAllowStale(),
+		"archive routing heals DOWN; no stuck-high poison the atomic would have kept")
+}
+
+// TestGetLatestBlock_GatedTipForFinalization locks the cache-finalization tip contract AFTER Topic
+// C T1/D4 (single reader) and T3 (getter consolidation): finalization reads the GATED getLatestBlock
+// — the ChainState TIP when fresh, else a strict 0. It never serves a stale value (the retired
+// bootstrap atomic, monotonic-max with no downward correction, was disqualified for exactly that).
 //
 // BEHAVIOR CHANGE: this read the strict-majority CONSENSUS baseline until T1, so a pod with no
 // majority finalized nothing (strict 0, the safe under-finalizing direction). It now finalizes
@@ -91,7 +120,7 @@ func TestGetLatestBlock_NilChainStateUsesAtomic(t *testing.T) {
 // forms a majority (1-2 endpoints) there is no baseline to bound against, so a sub-threshold
 // lying-high value can reach finalization and only heals after TTL. That is a deliberate,
 // documented loosening of a safety property, accepted as the cost of the single-reader model.
-func TestGetLatestBlockForCacheFinalization_TipOrZero(t *testing.T) {
+func TestGetLatestBlock_GatedTipForFinalization(t *testing.T) {
 	clk := &manualClock{t: time.Unix(1_700_000_000, 0)}
 	cs := chainstate.NewWithClock("ETH1", chainstate.Config{
 		BucketWidth:      2,
@@ -105,12 +134,10 @@ func TestGetLatestBlockForCacheFinalization_TipOrZero(t *testing.T) {
 		chainState:     cs,
 	}
 
-	// A fresh tip and a seeded bootstrap atomic both exist. Finalization reads the TIP (1050) —
-	// never the atomic, which is monotonic-max with no downward correction.
-	rpcss.latestBlockHeight.Store(1000)
+	// Finalization reads the TIP (1050).
 	cs.SetLatestBlock(1050)
-	require.Equal(t, uint64(1050), rpcss.getLatestBlockForCacheFinalization(),
-		"T1/D4: finalization measures against the one tip, not the atomic")
+	require.Equal(t, uint64(1050), rpcss.getLatestBlock(),
+		"T1/D4: finalization measures against the one tip")
 
 	// A strict majority at 1040 forms. The tip's 10-block lead is within OutlierThreshold (100),
 	// so the edge correction leaves it alone and finalization keeps reading 1050. Under the old
@@ -119,7 +146,7 @@ func TestGetLatestBlockForCacheFinalization_TipOrZero(t *testing.T) {
 		{URL: "a", Block: 1040, ObservedAt: clk.now()},
 		{URL: "b", Block: 1040, ObservedAt: clk.now()},
 	})
-	require.Equal(t, uint64(1050), rpcss.getLatestBlockForCacheFinalization(),
+	require.Equal(t, uint64(1050), rpcss.getLatestBlock(),
 		"a within-threshold optimistic lead survives the edge correction and is what finalization sees")
 
 	// An over-band tip IS corrected down to the baseline, which bounds how far finalization can be
@@ -141,23 +168,23 @@ func TestGetLatestBlockForCacheFinalization_TipOrZero(t *testing.T) {
 		chainState:     csSnap,
 	}
 	csSnap.SetLatestBlock(1200) // accepted raw: first observation, no reference to reject against
-	require.Equal(t, uint64(1200), rpcssSnap.getLatestBlockForCacheFinalization(),
+	require.Equal(t, uint64(1200), rpcssSnap.getLatestBlock(),
 		"a cold-start over-band tip is accepted raw and finalization sees it — the documented residual")
 	csSnap.Recompute([]chainstate.BlockObservation{
 		{URL: "a", Block: 1060, ObservedAt: clkSnap.now()},
 		{URL: "b", Block: 1060, ObservedAt: clkSnap.now()},
 	})
-	require.Equal(t, uint64(1060), rpcssSnap.getLatestBlockForCacheFinalization(),
+	require.Equal(t, uint64(1060), rpcssSnap.getLatestBlock(),
 		"a tip leading consensus by more than OutlierThreshold is snapped down before finalization reads it")
 
 	// The tip ages past TTL → strict 0 (never a frozen value).
 	clk.advance(11 * time.Second)
-	require.Equal(t, uint64(0), rpcss.getLatestBlockForCacheFinalization(),
+	require.Equal(t, uint64(0), rpcss.getLatestBlock(),
 		"a TTL-expired tip must report 0, not a frozen value")
 
 	// Defensive path: no ChainState wired at all → 0.
 	rpcss.chainState = nil
-	require.Equal(t, uint64(0), rpcss.getLatestBlockForCacheFinalization())
+	require.Equal(t, uint64(0), rpcss.getLatestBlock())
 }
 
 // TestRecomputeChainStateConsensus_EmptySnapshotClearsBaseline covers MAG-2160 Finding 5: the
@@ -289,7 +316,7 @@ func TestSiteB_ObservationFresherThanTrackerAtomic(t *testing.T) {
 // + full protocolMessage to drive end-to-end; that behavioral path is not reconstructed here. This
 // test pins the structural invariant the deletion relies on (cache shape ⇒ no tip write) at the
 // reachable tip-harvest seam.
-func TestCacheServedReply_DoesNotPoisonBootstrapAtomic(t *testing.T) {
+func TestCacheServedReply_DoesNotMoveTip(t *testing.T) {
 	if !rand.Initialized() {
 		rand.InitRandomSeed()
 	}
@@ -298,26 +325,30 @@ func TestCacheServedReply_DoesNotPoisonBootstrapAtomic(t *testing.T) {
 	cm, perr := chainParser.ParseMsg("", []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}`), "POST", nil, extensionslib.ExtensionInfo{LatestBlock: 0})
 	require.NoError(t, perr)
 
-	rpcss := &RPCSmartRouterServer{listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"}}
-	require.Equal(t, uint64(0), rpcss.latestBlockHeight.Load(), "fresh atomic starts at 0")
+	cs := chainstate.New("ETH1", chainstate.DefaultConfig(200*time.Millisecond))
+	rpcss := &RPCSmartRouterServer{
+		listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"},
+		chainState:     cs,
+	}
+	require.Equal(t, int64(0), cs.GetLatestBlockAllowStale(), "fresh tip starts at 0")
 
 	// The cache-served shape: a reply carrying a (historical) block, but NOT attributed to any
-	// dispatched endpoint (targetEndpoint == nil, as a cache hit is). Even a tip-eligible method
-	// name cannot move the tip without an endpoint to harvest from.
+	// dispatched endpoint (targetEndpoint == nil, as a cache hit is). harvestAndUpdateTipFromRelay
+	// returns early on a nil endpoint, so the tip must not move.
 	cacheReply := &pairingtypes.RelayReply{LatestBlock: 17_460_400}
 	rpcss.harvestAndUpdateTipFromRelay(nil, cm, cacheReply, 1, "")
 
-	require.Equal(t, uint64(0), rpcss.latestBlockHeight.Load(),
-		"Finding 1: a cache-served reply (no attributed endpoint) must not move the bootstrap atomic")
+	require.Equal(t, int64(0), cs.GetLatestBlockAllowStale(),
+		"Finding 1: a cache-served reply (no attributed endpoint) must not move the tip")
 }
 
-// TestHarvest_BootstrapAtomicGatedOnChainStateVerdict locks the chain-level gate on the
-// router-wide bootstrap atomic: a relay-harvested tip that ChainState REJECTS as an anti-lie
-// outlier must not ratchet latestBlockHeight (monotonic-max, no downward correction), even
-// though it passes its own per-endpoint store guard. Without the gate, one lying-high harvest
-// poisons getLatestBlockBestEffort → archive routing for the life of the process whenever
-// ChainState is TTL-stale.
-func TestHarvest_BootstrapAtomicGatedOnChainStateVerdict(t *testing.T) {
+// TestHarvest_ArchiveRoutingTipGuardedByChainState locks the T3 property: archive routing's
+// last-known tip (getLatestBlockAllowStale → ChainState.GetLatestBlockAllowStale) follows only blocks the
+// CHAIN-level anti-lie guard accepted. A relay-harvested tip that ChainState REJECTS as an outlier
+// must NOT move it, even though it passes the per-endpoint store guard. This is what the retired
+// bootstrap atomic's chain-accepted gate used to protect — now it falls out of reading the guarded
+// self-healing tip directly.
+func TestHarvest_ArchiveRoutingTipGuardedByChainState(t *testing.T) {
 	if !rand.Initialized() {
 		rand.InitRandomSeed()
 	}
@@ -361,28 +392,28 @@ func TestHarvest_BootstrapAtomicGatedOnChainStateVerdict(t *testing.T) {
 	// GET_BLOCKNUM (eth_blockNumber): the tip-eligible method whose result IS the node's tip.
 	cm := &mockChainMessage{api: &spectypes.Api{Name: "eth_blockNumber"}, requestedBlock: spectypes.LATEST_BLOCK}
 
-	// An honest tip-eligible harvest ratchets the atomic (ChainState accepts it).
+	// An honest tip-eligible harvest moves the tip (ChainState accepts it).
 	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1000}, gen, "provider1")
-	require.Equal(t, uint64(1000), rpcss.latestBlockHeight.Load(), "an accepted harvest seeds the bootstrap atomic")
+	require.Equal(t, uint64(1000), rpcss.getLatestBlockAllowStale(), "an accepted harvest moves the last-known tip")
 
-	// A plausible advance ratchets the atomic (ChainState accepts; the store accepts a higher
-	// block). Ordered BEFORE the lie so the block-monotonic store does not retain a higher value
-	// that would reject it — see the T4 note below.
+	// A plausible advance moves the tip (ChainState accepts; the store accepts a higher block).
+	// Ordered BEFORE the lie so the block-monotonic store does not retain a higher value that would
+	// reject it — see the T4 note below.
 	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1050}, gen, "provider1")
-	require.Equal(t, uint64(1050), rpcss.latestBlockHeight.Load(), "a plausible advance ratchets the atomic")
+	require.Equal(t, uint64(1050), rpcss.getLatestBlockAllowStale(), "a plausible advance moves the last-known tip")
 
 	// A lying-high harvest passes the per-endpoint store guard (higher block, no anti-lie at that
-	// layer) but ChainState rejects it (fresh-tip anti-lie guard) → the atomic must NOT ratchet.
+	// layer) but ChainState rejects it (fresh-tip anti-lie guard) → the archive-routing tip must NOT move.
 	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1_000_000}, gen, "provider1")
-	require.Equal(t, uint64(1050), rpcss.latestBlockHeight.Load(),
-		"a harvest ChainState rejects as an outlier must not ratchet the monotonic atomic")
+	require.Equal(t, uint64(1050), rpcss.getLatestBlockAllowStale(),
+		"a harvest ChainState rejects as an outlier must not move the last-known tip archive routing serves")
 
 	// T4 consequence: the block-monotonic store RETAINS the lying-high 1_000_000 until it goes
-	// stale, so a subsequent honest-but-lower harvest is rejected and the harvest bails before the
-	// atomic. This is the conscious trade for fixing F2 — only a liar's own tip is inflated (F19,
-	// accepted); the global tip stays protected by ChainState's guard.
+	// stale, so a subsequent honest-but-lower harvest is rejected and the harvest bails. This is the
+	// conscious trade for fixing F2 — only a liar's own tip is inflated (F19, accepted); the global
+	// tip stays protected by ChainState's guard.
 	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1051}, gen, "provider1")
-	require.Equal(t, uint64(1050), rpcss.latestBlockHeight.Load(),
+	require.Equal(t, uint64(1050), rpcss.getLatestBlockAllowStale(),
 		"a lower harvest is rejected while the higher lie is still fresh")
 }
 

--- a/protocol/rpcsmartrouter/chainstate_glue_test.go
+++ b/protocol/rpcsmartrouter/chainstate_glue_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/chainstate"
 	"github.com/magma-Devs/smart-router/protocol/endpointstate"
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/protocol/metrics"
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
 	spectypes "github.com/magma-Devs/smart-router/types/spec"
 	rand "github.com/magma-Devs/smart-router/utils/rand"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -342,18 +344,55 @@ func TestCacheServedReply_DoesNotMoveTip(t *testing.T) {
 		"Finding 1: a cache-served reply (no attributed endpoint) must not move the tip")
 }
 
-// TestHarvest_ArchiveRoutingTipGuardedByChainState locks the T3 property: archive routing's
-// last-known tip (getLatestBlockAllowStale → ChainState.GetLatestBlockAllowStale) follows only blocks the
-// CHAIN-level anti-lie guard accepted. A relay-harvested tip that ChainState REJECTS as an outlier
-// must NOT move it, even though it passes the per-endpoint store guard. This is what the retired
-// bootstrap atomic's chain-accepted gate used to protect — now it falls out of reading the guarded
-// self-healing tip directly.
+// TestHarvest_ArchiveRoutingTipGuardedByChainState locks the T3 property on BOTH readers that the
+// deleted chain-accepted gate used to protect:
+//
+//   - archive routing's last-known tip (getLatestBlockAllowStale → ChainState.GetLatestBlockAllowStale),
+//     and
+//   - the router-wide latest-block METRIC (smartrouter_latest_block), which after T3 is sourced from
+//     the guarded ChainState tip rather than from the raw harvested block.
+//
+// Both must follow only blocks the CHAIN-level anti-lie guard accepted. A relay-harvested tip that
+// ChainState REJECTS as an outlier must move neither, even though it passes the per-endpoint store
+// guard. Asserting the metric matters because after T3 it is the ONLY consumer of the gated
+// GetLatestBlock() read in harvestAndUpdateTipFromRelay — without this, a regression that reported
+// the raw `tip` would go unnoticed.
 func TestHarvest_ArchiveRoutingTipGuardedByChainState(t *testing.T) {
 	if !rand.Initialized() {
 		rand.InitRandomSeed()
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// Empty options => metrics registered on the default registry, no HTTP server started.
+	mm := metrics.NewSmartRouterMetricsManager(metrics.SmartRouterMetricsManagerOptions{})
+	require.NotNil(t, mm)
+
+	// routerLatestBlock reads the smartrouter_latest_block GAUGE for this chain/interface. Unlike the
+	// counters elsewhere in this package it is Set to an ABSOLUTE value, and these tests run
+	// sequentially (no t.Parallel), so the value read straight after a harvest is the one that
+	// harvest reported — no before/after delta needed.
+	routerLatestBlock := func(t *testing.T) float64 {
+		t.Helper()
+		mfs, err := prometheus.DefaultGatherer.Gather()
+		require.NoError(t, err)
+		for _, mf := range mfs {
+			if mf.GetName() != "smartrouter_latest_block" {
+				continue
+			}
+			for _, m := range mf.GetMetric() {
+				lm := map[string]string{}
+				for _, lp := range m.GetLabel() {
+					lm[lp.GetName()] = lp.GetValue()
+				}
+				if lm["spec"] == "ETH1" && lm["apiInterface"] == "jsonrpc" {
+					return m.GetGauge().GetValue()
+				}
+			}
+		}
+		require.FailNow(t, "smartrouter_latest_block not reported for ETH1/jsonrpc")
+		return 0
+	}
 
 	cs := chainstate.NewWithClock("ETH1", chainstate.Config{
 		BucketWidth:      2,
@@ -380,6 +419,7 @@ func TestHarvest_ArchiveRoutingTipGuardedByChainState(t *testing.T) {
 		chainParser:                 parser,
 		endpointChainTrackerManager: m,
 		chainState:                  cs,
+		smartRouterEndpointMetrics:  mm,
 	}
 
 	url := "http://ep:8545"
@@ -395,18 +435,26 @@ func TestHarvest_ArchiveRoutingTipGuardedByChainState(t *testing.T) {
 	// An honest tip-eligible harvest moves the tip (ChainState accepts it).
 	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1000}, gen, "provider1")
 	require.Equal(t, uint64(1000), rpcss.getLatestBlockAllowStale(), "an accepted harvest moves the last-known tip")
+	require.Equal(t, float64(1000), routerLatestBlock(t), "an accepted harvest reports the router-wide metric")
 
 	// A plausible advance moves the tip (ChainState accepts; the store accepts a higher block).
 	// Ordered BEFORE the lie so the block-monotonic store does not retain a higher value that would
 	// reject it — see the T4 note below.
 	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1050}, gen, "provider1")
 	require.Equal(t, uint64(1050), rpcss.getLatestBlockAllowStale(), "a plausible advance moves the last-known tip")
+	require.Equal(t, float64(1050), routerLatestBlock(t), "a plausible advance is reported to the metric")
 
 	// A lying-high harvest passes the per-endpoint store guard (higher block, no anti-lie at that
 	// layer) but ChainState rejects it (fresh-tip anti-lie guard) → the archive-routing tip must NOT move.
 	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1_000_000}, gen, "provider1")
 	require.Equal(t, uint64(1050), rpcss.getLatestBlockAllowStale(),
 		"a harvest ChainState rejects as an outlier must not move the last-known tip archive routing serves")
+	// The T3 metric contract: harvestAndUpdateTipFromRelay reports the GUARDED tip, not the raw
+	// harvested block. The lie reaches the metric write (the per-endpoint store accepted it, so the
+	// harvest does not bail) and is filtered only by the gated GetLatestBlock read — reporting `tip`
+	// here would publish 1_000_000 router-wide.
+	require.Equal(t, float64(1050), routerLatestBlock(t),
+		"the router-wide metric reports the guarded tip, never a lying-high harvest ChainState rejected")
 
 	// T4 consequence: the block-monotonic store RETAINS the lying-high 1_000_000 until it goes
 	// stale, so a subsequent honest-but-lower harvest is rejected and the harvest bails. This is the
@@ -415,6 +463,8 @@ func TestHarvest_ArchiveRoutingTipGuardedByChainState(t *testing.T) {
 	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1051}, gen, "provider1")
 	require.Equal(t, uint64(1050), rpcss.getLatestBlockAllowStale(),
 		"a lower harvest is rejected while the higher lie is still fresh")
+	require.Equal(t, float64(1050), routerLatestBlock(t),
+		"a store-rejected harvest bails before the metric write, leaving the last reported value")
 }
 
 // TestSiteC_SyncReferenceIsChainTip documents the Topic C T1/D4 contract that REPLACED the

--- a/protocol/rpcsmartrouter/chainstate_glue_test.go
+++ b/protocol/rpcsmartrouter/chainstate_glue_test.go
@@ -304,13 +304,13 @@ func TestSiteB_ObservationFresherThanTrackerAtomic(t *testing.T) {
 		"Finding 6: the gated tracker atomic does not see relay-harvested tips")
 }
 
-// TestCacheServedReply_DoesNotPoisonBootstrapAtomic covers the second half of MAG-2160 Finding 1
-// ("cached historical responses cannot poison fallback"). A cache hit's reply.LatestBlock is the
-// block that was current when the response was CACHED — possibly long-historical. The direct
-// cache→atomic write was DELETED; this guards the regression by asserting that the cache-served
-// result shape (no attributed endpoint — cache hits carry ProviderAddress="" and are not a
-// dispatched endpoint's observation) reaches no remaining tip-writer, so a historical cached block
-// cannot move the bootstrap atomic that getLatestBlock falls back to on cold start.
+// TestCacheServedReply_DoesNotMoveTip covers the second half of MAG-2160 Finding 1 ("cached
+// historical responses cannot poison fallback"). A cache hit's reply.LatestBlock is the block that
+// was current when the response was CACHED — possibly long-historical. The direct cache→tip-state
+// write was DELETED; this guards the regression by asserting that the cache-served result shape (no
+// attributed endpoint — cache hits carry ProviderAddress="" and are not a dispatched endpoint's
+// observation) reaches no remaining tip-writer, so a historical cached block cannot move the
+// ChainState tip that every router-wide reader now depends on.
 //
 // NOTE: the cache-READ branch lives inside sendRelayToEndpoint and needs a connected cache backend
 // + full protocolMessage to drive end-to-end; that behavioral path is not reconstructed here. This

--- a/protocol/rpcsmartrouter/relay_observation_harvest_test.go
+++ b/protocol/rpcsmartrouter/relay_observation_harvest_test.go
@@ -369,7 +369,6 @@ func TestHarvestAndUpdateTipFromRelay_HistoricalDoesNotPoisonTip(t *testing.T) {
 
 	require.Equal(t, int64(0), endpointtip.Default().Block(endpointtip.Key("ETH1", "jsonrpc", url)),
 		"a historical response must NOT move the endpoint tip")
-	require.Equal(t, uint64(0), rpcss.latestBlockHeight.Load(), "a historical response must NOT move the bootstrap atomic")
 	// The store may hold a failed-poll record from the nil-connection background poll; what must
 	// NOT exist is a Relay-sourced write of the historical block.
 	if o, exists := m.GetObservation(url); exists {
@@ -383,7 +382,6 @@ func TestHarvestAndUpdateTipFromRelay_HistoricalDoesNotPoisonTip(t *testing.T) {
 
 	require.Equal(t, int64(20_000_000), endpointtip.Default().Block(endpointtip.Key("ETH1", "jsonrpc", url)),
 		"a tip-eligible response moves the endpoint tip")
-	require.Equal(t, uint64(20_000_000), rpcss.latestBlockHeight.Load(), "a tip-eligible response moves the bootstrap atomic")
 	o, obsExists := m.GetObservation(url)
 	require.True(t, obsExists)
 	require.Equal(t, int64(20_000_000), o.LatestBlock)
@@ -460,11 +458,9 @@ func TestHarvest_GenerationCapturedBeforeDispatch_RejectsAfterReplacement(t *tes
 		require.NotEqual(t, int64(20_000_000), o.LatestBlock,
 			"a relay that captured the OLD generation must be rejected after same-URL replacement")
 	}
-	// The generation gate must also block the downstream ungated tip-state writes: a stale relay
-	// dropped from the store must NOT still bump the router bootstrap atomic (the poisoning the
-	// harvest gate exists to prevent).
-	require.Equal(t, uint64(0), rpcss.latestBlockHeight.Load(),
-		"a stale-generation relay must not move the bootstrap atomic after the store rejects it")
+	// The store rejection above is the gate: recordRelayBlockObservation returns false, so the
+	// harvest bails before the downstream tip-state write (OnTipObservation → SetLatestBlock) ever
+	// runs — a stale-generation relay cannot move the tip.
 
 	// Sanity: harvesting with the live generation (genB) IS accepted — proving the rejection
 	// above was the generation gate, not a broken store.

--- a/protocol/rpcsmartrouter/relay_observation_harvest_test.go
+++ b/protocol/rpcsmartrouter/relay_observation_harvest_test.go
@@ -12,10 +12,12 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/endpointstate"
 	"github.com/magma-Devs/smart-router/protocol/endpointtip"
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/protocol/metrics"
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
 	spectypes "github.com/magma-Devs/smart-router/types/spec"
 	specutils "github.com/magma-Devs/smart-router/utils/keeper"
 	rand "github.com/magma-Devs/smart-router/utils/rand"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -422,14 +424,43 @@ func TestHarvest_GenerationCapturedBeforeDispatch_RejectsAfterReplacement(t *tes
 	t.Cleanup(m.Stop)
 
 	const url = "http://ep:8545"
-	const addr = "lava@provider1"
+	const addr = "lava@harvestGenProvider"
 	ep := &lavasession.Endpoint{NetworkAddress: url, Enabled: true}
+	// Empty options => metrics registered on the default registry, no HTTP server started.
+	mm := metrics.NewSmartRouterMetricsManager(metrics.SmartRouterMetricsManagerOptions{})
+	require.NotNil(t, mm)
 	rpcss := &RPCSmartRouterServer{
 		listenEndpoint:              &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"},
 		endpointChainTrackerManager: m,
+		smartRouterEndpointMetrics:  mm,
 		// Needed so the tip gate admits the eth_blockNumber harvest below; the focus here is the
 		// generation gate, but a nil parser would reject the relay before generation is even checked.
 		chainParser: newRealChainParserForHarvest(t, "ETH1"),
+	}
+
+	// endpointLatestBlock reads the rpc_endpoint_latest_block GAUGE for this endpoint (0 when it has
+	// never been published — `addr` is unique to this test, so no other test's value can appear
+	// here). Gauges are Set to an absolute value and this package's tests run sequentially, so the
+	// value read straight after a harvest is the one that harvest published.
+	endpointLatestBlock := func(t *testing.T) float64 {
+		t.Helper()
+		mfs, gerr := prometheus.DefaultGatherer.Gather()
+		require.NoError(t, gerr)
+		for _, mf := range mfs {
+			if mf.GetName() != "rpc_endpoint_latest_block" {
+				continue
+			}
+			for _, mtr := range mf.GetMetric() {
+				lm := map[string]string{}
+				for _, lp := range mtr.GetLabel() {
+					lm[lp.GetName()] = lp.GetValue()
+				}
+				if lm["spec"] == "ETH1" && lm["apiInterface"] == "jsonrpc" && lm["endpoint_id"] == addr {
+					return mtr.GetGauge().GetValue()
+				}
+			}
+		}
+		return 0
 	}
 
 	// Incarnation A: tracker created, generation captured "before dispatch" of relay A.
@@ -458,9 +489,20 @@ func TestHarvest_GenerationCapturedBeforeDispatch_RejectsAfterReplacement(t *tes
 		require.NotEqual(t, int64(20_000_000), o.LatestBlock,
 			"a relay that captured the OLD generation must be rejected after same-URL replacement")
 	}
-	// The store rejection above is the gate: recordRelayBlockObservation returns false, so the
-	// harvest bails before the downstream tip-state write (OnTipObservation → SetLatestBlock) ever
-	// runs — a stale-generation relay cannot move the tip.
+	// The TIP is not gated by the early return below — OnTipObservation → SetLatestBlock fires from
+	// a defer registered INSIDE RecordRelayObservation (endpointstate/observation.go), so a
+	// stale-generation relay never reaches it: the gate leaves tipBlock at 0 and the hook simply
+	// does not fire. That invariant is owned one layer down by
+	// endpointstate/chainstate_feed_test.go ("a rejected (stale-gen) relay feeds no tip"), which
+	// asserts it directly against a hook sink — re-asserting the tip here would be redundant, and
+	// would silently pass if this test's OnTipObservation wiring were ever dropped.
+	//
+	// What harvestAndUpdateTipFromRelay's early return DOES guard is the metric writes after it.
+	// That is the invariant worth pinning at this seam: hoisting the per-endpoint write above the
+	// gate would publish a stale-generation relay's block as an endpoint's latest, and nothing else
+	// in the suite catches it.
+	require.NotEqual(t, float64(20_000_000), endpointLatestBlock(t),
+		"a stale-generation relay must not publish rpc_endpoint_latest_block")
 
 	// Sanity: harvesting with the live generation (genB) IS accepted — proving the rejection
 	// above was the generation gate, not a broken store.
@@ -469,6 +511,11 @@ func TestHarvest_GenerationCapturedBeforeDispatch_RejectsAfterReplacement(t *tes
 	require.True(t, obsExists)
 	require.Equal(t, int64(20_000_000), o.LatestBlock)
 	require.Equal(t, endpointstate.ObservationSourceRelay, o.Source)
+	// Positive control for the metric assertion above — NOT optional. It proves the metrics manager
+	// is wired and that this harvest path publishes at all, so the earlier NotEqual is a real
+	// rejection rather than a vacuous pass against a metric nothing ever writes.
+	require.Equal(t, float64(20_000_000), endpointLatestBlock(t),
+		"a live-generation harvest DOES publish rpc_endpoint_latest_block")
 }
 
 // ---------------------------------------------------------------------------

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -572,8 +572,9 @@ func preferStructuralFailureReason(result *common.RelayResult, failFastReason st
 // not-applicable) and the case where the latest block is not yet known.
 func (rpcss *RPCSmartRouterServer) crossValidationFinalityLabel(protocolMessage chainlib.ProtocolMessage) string {
 	requestedBlock, _ := protocolMessage.RequestedBlock()
-	// Use the router's chain-tracker/estimator-aware latest block, not just the cached counter, so the
-	// finality label is correct whenever any latest-block source is available.
+	// The GATED tip (fresh ChainState tip, else 0) — deliberately the same read cache finalization
+	// uses, so this label agrees with the finalized/temp cache split rather than describing a
+	// different "latest". A 0 yields the "unknown" label instead of a guess.
 	latestBlock := int64(rpcss.getLatestBlock())
 	_, _, blockDistanceForFinalizedData, _ := rpcss.chainParser.ChainBlockStats()
 	return crossValidationFinality(requestedBlock, latestBlock, int64(blockDistanceForFinalizedData))
@@ -3180,8 +3181,8 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 						}
 						// MAG-2160 Finding 1: a cache hit's reply.LatestBlock is the block that was
 						// current when the response was CACHED — it is not a fresh observation of the
-						// chain head and is not gated on tip-eligibility, so it must NOT feed the
-						// bootstrap atomic (it would freeze a stale value during cold start). Tip state
+						// chain head and is not gated on tip-eligibility, so it must NOT feed tip
+						// state (it would plant a long-historical block as the chain head). Tip state
 						// is advanced only by tip-eligible live relays (harvestAndUpdateTipFromRelay)
 						// and the per-endpoint observation store, never by cache replays.
 						relayProcessor.SetResponse(&relaycore.RelayResponse{

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -68,8 +68,7 @@ type RPCSmartRouterServer struct {
 	chainListener        chainlib.ChainListener
 	relayRetriesManager  *lavaprotocol.RelayRetriesManager
 	initialized          atomic.Bool
-	latestBlockHeight    atomic.Uint64 // MAG-2160: retained only as the cold-start fallback for getLatestBlock (the estimator is retired)
-	enableSelectionStats bool          // feature flag to enable selection stats header
+	enableSelectionStats bool // feature flag to enable selection stats header
 
 	// Per-endpoint ChainTracker manager for continuous block polling
 	endpointChainTrackerManager *endpointstate.EndpointMonitor
@@ -794,14 +793,12 @@ func (rpcss *RPCSmartRouterServer) sendRelayWithRetries(ctx context.Context, ret
 						utils.LogAttr("latestBlock", relayResult.Reply.LatestBlock),
 						utils.LogAttr("endpoint", relayResult.ProviderInfo.ProviderAddress),
 					)
-					// Do NOT ratchet the bootstrap atomic here. This crafted GET_BLOCKNUM relay
-					// already flowed through sendRelayToEndpoint → sendRelayToDirectEndpoints →
-					// harvestAndUpdateTipFromRelay, which updates the atomic ONLY when ChainState
-					// accepts the block (the anti-lie gate). A direct updateLatestBlockHeight here
-					// bypassed that gate, so a lying-high health-relay response ChainState rejected
-					// still permanently ratcheted the monotonic atomic — and getLatestBlockBestEffort
-					// serves that poison to archive routing during any TTL-stale window. The gated
-					// harvest is the single atomic-update path; this call was a redundant bypass.
+					// Do NOT write tip state here. This crafted GET_BLOCKNUM relay already flowed
+					// through sendRelayToEndpoint → sendRelayToDirectEndpoints →
+					// harvestAndUpdateTipFromRelay, which drives ChainState.SetLatestBlock through the
+					// anti-lie guard. A direct tip write here would bypass that guard, letting a
+					// lying-high health-relay response ChainState rejected still move the router-wide
+					// tip. The gated harvest is the single tip-update path.
 					rpcss.relaysMonitor.LogRelay()
 					success = true
 					// If this is the first time we send relays, we want to send all of them, instead of break on first successful relay
@@ -838,72 +835,22 @@ func (rpcss *RPCSmartRouterServer) sendCraftedRelays(retries int, initialRelays 
 	return rpcss.sendRelayWithRetries(ctx, retries, initialRelays, protocolMessage)
 }
 
-func (rpcss *RPCSmartRouterServer) getLatestBlock() uint64 {
-	// Site A (MAG-2160): the router-wide tip (archive routing, finality labels) is the per-chain
-	// ChainState OBSERVED tip — TTL-fresh, monotonic, outlier-guarded — replacing the
-	// global-tracker → estimator → atomic ladder. Cache FINALIZATION reads the SAME tip via
-	// getLatestBlockForCacheFinalization (Topic C T1/D4: one reader), which returns the tip-or-0;
-	// it deliberately does NOT fall back to the bootstrap atomic the way this getter does, because
-	// a monotonic-max value with no downward correction can falsely finalize. See that function's
-	// doc block for the bounded residual the tip (vs the old strict baseline) accepts there.
-	if rpcss.chainState != nil {
-		if block, ok := rpcss.chainState.GetLatestBlock(); ok && block > 0 {
-			return uint64(block)
-		}
-		// ChainState is the authority once it has EVER observed a tip. If it is Initialized but
-		// not fresh, the tip has aged past TTL — we must NOT revive a frozen atomic value
-		// (Finding 1). Report unknown (0); a stale-but-real tip is worse than an honest "unknown",
-		// and the atomic's last write could itself be the stale value we just rejected.
-		if rpcss.chainState.Initialized() {
-			return 0
-		}
-	}
-
-	// Genuine cold-start ONLY (ChainState never initialized): in the bootstrap window before the
-	// first observation, fall back to the monotonic atomic — seeded by the tip-eligible init
-	// relay — so getLatestBlock isn't 0 during startup. Once ChainState initializes, this branch
-	// is never taken again, so a post-TTL gap cannot resurrect a frozen atomic.
-	if latest := rpcss.latestBlockHeight.Load(); latest > 0 {
-		return latest
-	}
-
-	return 0
-}
-
-// getLatestBlockBestEffort returns the strict ChainState tip when fresh, otherwise the
-// last-known monotonic atomic tip (seeded by the init relay + tip-eligible relay harvest).
-// It deliberately diverges from getLatestBlock's strict-0-on-stale contract (see the comment
-// there): archive ROUTING only needs a recent-enough head to decide old-vs-recent, and a
-// slightly-stale head mis-classifies at worst a handful of near-head blocks — whereas the
-// strict 0 forces EVERY concrete-block request to the archive pool (archive_parser_rule.go:33).
-// Cache FINALIZATION must keep the strict consensus source (getLatestBlockForCacheFinalization —
-// a stale or optimistic tip there can falsely finalize), so this accessor is for archive routing
-// only. Returns 0 only at genuine cold-start, preserving the conservative force-archive fallback
-// before any tip has ever been observed.
-func (rpcss *RPCSmartRouterServer) getLatestBlockBestEffort() uint64 {
-	if block := rpcss.getLatestBlock(); block > 0 {
-		return block
-	}
-	return rpcss.latestBlockHeight.Load()
-}
-
-// getLatestBlockForCacheFinalization returns the tip cache finalization measures against: the
-// ChainState tip when fresh, else 0. It must NOT fall back to the bootstrap atomic or any
-// best-effort source (see isFinalizedForCacheWrite's doc block): a too-high value here FALSELY
-// finalizes — it writes still-mutable blocks into the long-TTL finalized store, globally and
-// durably.
+// getLatestBlock is the GATED router-wide tip read: the per-chain ChainState OBSERVED tip when
+// TTL-fresh, else 0 (never a stale value). It is shared by the request seenBlock / cache key,
+// finality labels, AND cache finalization — a stale or too-high value must not reach finalization,
+// which would falsely finalize a still-mutable block into the long-TTL store, globally and durably.
 //
-// Topic C T1/D4: this read the strict-majority CONSENSUS baseline until the single-reader
-// decision. Reading the tip is a deliberate, bounded loosening — Recompute now caps the tip at
-// baseline+OutlierThreshold and pulls it up to the baseline, so the tip can lead consensus by at
-// most the outlier threshold rather than being unbounded. The residual risk is real and worth
-// naming: on a pod that never forms a majority (1-2 endpoints) there is nothing to cap against,
-// so a sub-threshold lie still only heals after TTL, and finalization is measured against a value
-// that can lead the true head. A 0 merely under-finalizes: isFinalizedForCacheWrite
-// then falls back to Reply.LatestBlock, which is self-scoped to the reporting provider, so a
-// no-baseline pod degrades to per-reply finalization (echo-block methods land in the short-TTL
-// temp store) rather than trusting an unvetted global value — the safe direction.
-func (rpcss *RPCSmartRouterServer) getLatestBlockForCacheFinalization() uint64 {
+// It reads the guarded tip, not the strict consensus baseline (Topic C T1/D4): Recompute caps the
+// tip at baseline+OutlierThreshold, a deliberate bounded loosening. The named residual is a 1-2
+// endpoint pod with no majority to cap against, where a sub-threshold lie heals only after TTL. A 0
+// merely UNDER-finalizes — the safe direction: isFinalizedForCacheWrite then falls back to the
+// provider's own Reply.LatestBlock (self-scoped), so a no-tip pod degrades to per-reply finalization
+// rather than trusting an unvetted global value.
+//
+// Archive ROUTING instead uses getLatestBlockAllowStale, which tolerates a slightly-stale tip.
+// Cold-start (ChainState never initialized, or aged past TTL) returns 0 — the retired bootstrap
+// atomic (T3) could never heal; the tip is re-seeded by the next observation.
+func (rpcss *RPCSmartRouterServer) getLatestBlock() uint64 {
 	if rpcss.chainState != nil {
 		if block, ok := rpcss.chainState.GetLatestBlock(); ok && block > 0 {
 			return uint64(block)
@@ -912,24 +859,23 @@ func (rpcss *RPCSmartRouterServer) getLatestBlockForCacheFinalization() uint64 {
 	return 0
 }
 
-func (rpcss *RPCSmartRouterServer) updateLatestBlockHeight(blockHeight uint64, providerAddress string) {
-	for {
-		current := rpcss.latestBlockHeight.Load()
-		if blockHeight <= current {
-			break
-		}
-		if rpcss.latestBlockHeight.CompareAndSwap(current, blockHeight) {
-			// Update router-level latest block metric
-			if rpcss.smartRouterEndpointMetrics != nil {
-				rpcss.smartRouterEndpointMetrics.SetRouterLatestBlock(
-					rpcss.listenEndpoint.ChainID,
-					rpcss.listenEndpoint.ApiInterface,
-					int64(blockHeight),
-				)
-			}
-			break
+// getLatestBlockAllowStale returns the last-known ChainState tip for archive ROUTING — the raw
+// self-healing value (TTL-ignored, via GetLatestBlockAllowStale), 0 only before any tip has ever been
+// observed. It deliberately diverges from getLatestBlock's strict-0-on-stale contract: archive
+// routing only needs a recent-enough head to decide old-vs-recent, and a slightly-stale head
+// mis-classifies at worst a handful of near-head blocks — whereas a strict 0 forces EVERY
+// concrete-block request to the archive pool (archive_parser_rule.go:33). The tip self-heals both
+// directions (SetLatestBlock grows it under the outlier guard and re-adopts a lower block once
+// stale), so a stale value here cannot stay stuck on a lie the way the retired bootstrap atomic
+// could. Cache FINALIZATION must NOT use this — it keeps the gated getLatestBlock (a stale or
+// optimistic-high value there can falsely finalize).
+func (rpcss *RPCSmartRouterServer) getLatestBlockAllowStale() uint64 {
+	if rpcss.chainState != nil {
+		if raw := rpcss.chainState.GetLatestBlockAllowStale(); raw > 0 {
+			return uint64(raw)
 		}
 	}
+	return 0
 }
 
 func (rpcss *RPCSmartRouterServer) SendRelay(
@@ -2510,12 +2456,11 @@ func runProbeCycleCore(
 // getTransactionReceipt, getLogs — all carry a positive Reply.LatestBlock) from a "current-tip
 // observation" (eth_blockNumber / eth_getBlockByNumber("latest") / Solana result.context.slot).
 // ONLY the latter may move tip state: the per-endpoint observation store, the endpoint's
-// reactive LatestBlock (read by consistency pre-validation), the bootstrap atomic (latestBlockHeight,
-// the cold-start fallback for getLatestBlock), and the latest-block metric. A historical response
-// updates NONE of these, so it can no longer poison
-// the endpoint tip. The bootstrap atomic is additionally gated on the CHAIN-level ChainState
-// verdict (see the inline comment below) — per-endpoint acceptance alone must not ratchet a
-// router-wide monotonic value. "The block this response serviced" (latestServicedBlock) is a separate
+// reactive LatestBlock (read by consistency pre-validation), and the latest-block metric. A
+// historical response updates NONE of these, so it can no longer poison the endpoint tip. The
+// router-wide latest-block metric is sourced from the guarded ChainState tip (see the inline comment
+// below) — per-endpoint acceptance alone must not move a router-wide value. "The block this response
+// serviced" (latestServicedBlock) is a separate
 // concept the caller handles ungated. No-op when targetEndpoint is nil or the response is not
 // tip-eligible. harvestGen is the generation captured before dispatch (finding 5).
 func (rpcss *RPCSmartRouterServer) harvestAndUpdateTipFromRelay(
@@ -2541,26 +2486,22 @@ func (rpcss *RPCSmartRouterServer) harvestAndUpdateTipFromRelay(
 	if !rpcss.recordRelayBlockObservation(targetEndpoint, harvestGen, tip) {
 		return
 	}
-	// The router-wide bootstrap atomic is monotonic-max with NO downward correction, so it may
-	// only follow blocks the CHAIN-level anti-lie guard accepted — the per-endpoint store's
-	// block-monotonic acceptance above is the wrong scope: that guard has no anti-lie check, so a
-	// lying-high endpoint clears its own per-endpoint guard trivially (any higher block wins).
-	// By the time recordRelayBlockObservation returns, the monitor's
-	// OnTipObservation hook has already driven ChainState.SetLatestBlock with this very block
-	// (synchronously, after obsMu release — see RecordRelayObservation's deferred callback), so
-	// the ChainState tip reflects the verdict: an accepted block reads back as tip >= block, a
-	// rejected outlier reads back lower (or stale). Without this gate, one bogus high harvest
-	// (e.g. a lying Solana context slot) permanently ratchets the atomic, and whenever ChainState
-	// is TTL-stale, getLatestBlockBestEffort serves the lie to archive routing for the life of
-	// the process. The per-endpoint metric below deliberately stays gated on the store only: it
-	// reports THIS endpoint's own view, so the per-endpoint guard is the right scope for it.
-	chainAccepted := true
-	if rpcss.chainState != nil {
-		accepted, ok := rpcss.chainState.GetLatestBlock()
-		chainAccepted = ok && tip <= accepted
-	}
-	if chainAccepted {
-		rpcss.updateLatestBlockHeight(uint64(tip), endpointAddress)
+	// Router-wide latest-block metric, sourced from the guarded tip (the bootstrap atomic is retired,
+	// T3). By the time recordRelayBlockObservation returns, the monitor's OnTipObservation hook has
+	// driven ChainState.SetLatestBlock with this block (synchronously, after obsMu release — see
+	// RecordRelayObservation's deferred callback), so the tip already reflects the verdict: an accepted
+	// block reads back as tip >= block, a rejected outlier reads back lower (or stale). Reporting the
+	// guarded tip (not the raw harvested `tip`) keeps a lying-high endpoint out of the router-wide
+	// metric, the scope the old chain-accepted gate protected. The per-endpoint metric below stays
+	// gated on the store only: it reports THIS endpoint's own view.
+	if rpcss.chainState != nil && rpcss.smartRouterEndpointMetrics != nil {
+		if accepted, ok := rpcss.chainState.GetLatestBlock(); ok {
+			rpcss.smartRouterEndpointMetrics.SetRouterLatestBlock(
+				rpcss.listenEndpoint.ChainID,
+				rpcss.listenEndpoint.ApiInterface,
+				accepted,
+			)
+		}
 	}
 	if rpcss.smartRouterEndpointMetrics != nil {
 		// endpointAddress is the provider name (session map key), so resolveProviderName
@@ -2775,19 +2716,21 @@ func (rpcss *RPCSmartRouterServer) initializeChainTrackers(ctx context.Context) 
 // cache-write goes to the long-TTL finalized store or the short-TTL temp
 // store. Reply.LatestBlock is unreliable for methods that echo the requested
 // block (eth_getBlockByNumber returns result.number = requested), so the
-// router's tracked tip (surfaced via getLatestBlockForCacheFinalization())
-// wins when it is higher.
+// router's tracked tip (surfaced via the GATED getLatestBlock()) wins when it is
+// higher.
 //
-// IMPORTANT — finalization MUST be passed getLatestBlockForCacheFinalization(),
-// never getLatestBlockBestEffort() the way archive routing (#1) does. A higher
+// IMPORTANT — finalization MUST be passed the GATED getLatestBlock() (fresh tip or
+// 0), never getLatestBlockAllowStale() the way archive routing (#1) does. A higher
 // "latest" here FALSELY finalizes (writes a not-yet-final block to the long-TTL
 // store, globally and durably — far worse than replyLatestBlock, which is
 // self-scoped to one provider's reply), so the source must never be a value with
-// no downward correction. The bootstrap atomic is monotonic-max and disqualified
-// for exactly that reason.
+// no downward correction. getLatestBlockAllowStale serves a slightly-stale tip and
+// is disqualified for exactly that reason; the gated getLatestBlock returns 0 when
+// stale (the retired bootstrap atomic never healed — the original reason it too was
+// disqualified).
 //
-// Topic C T1/D4: getLatestBlockForCacheFinalization returned the strict-majority
-// CONSENSUS baseline (or 0) until the single-reader decision; it now returns the
+// Topic C T1/D4: getLatestBlock (the gated read) returned the strict-majority
+// CONSENSUS baseline (or 0) for finalization until the single-reader decision; it now returns the
 // TIP. The tip DOES have a downward path — Recompute snaps it to the baseline
 // when it leads by more than OutlierThreshold, and TTL expiry allows downward
 // re-adoption — but it is a looser bound than the baseline was:
@@ -2932,7 +2875,9 @@ func (rpcss *RPCSmartRouterServer) tryCacheWrite(
 	// reads result.number), so the naive check never marks any historical
 	// block finalized and every entry takes the ~625 ms non-finalized TTL.
 	latestBlock := relayResult.Reply.LatestBlock
-	finalized := isFinalizedForCacheWrite(requestedBlock, latestBlock, int64(rpcss.getLatestBlockForCacheFinalization()), int64(blockDistanceForFinalizedData))
+	// Finalization uses the GATED getLatestBlock (fresh tip or 0), never getLatestBlockAllowStale:
+	// a stale or too-high head here would falsely finalize a mutable block into the long-TTL store.
+	finalized := isFinalizedForCacheWrite(requestedBlock, latestBlock, int64(rpcss.getLatestBlock()), int64(blockDistanceForFinalizedData))
 
 	// Convert LATEST_BLOCK to actual block number for cache key
 	// This must match the logic in cache lookup (sendRelayToEndpoint) to ensure cache hits
@@ -3652,15 +3597,15 @@ func (rpcss *RPCSmartRouterServer) getExtensionsFromDirectiveHeaders(directiveHe
 		utils.LavaFormatTrace("[Archive Debug] Processed extensions", utils.LogAttr("extensions", extensions))
 		if len(extensions) == 1 && extensions[0] == "none" {
 			// none eliminates existing extensions
-			return extensionslib.ExtensionInfo{LatestBlock: rpcss.getLatestBlockBestEffort(), ExtensionOverride: []string{}}
+			return extensionslib.ExtensionInfo{LatestBlock: rpcss.getLatestBlockAllowStale(), ExtensionOverride: []string{}}
 		} else if len(extensions) > 0 {
 			// All extensions from headers use AdditionalExtensions (consistent behavior)
 			utils.LavaFormatTrace("[Archive Debug] Using AdditionalExtensions for all header extensions", utils.LogAttr("extensions", extensions))
-			return extensionslib.ExtensionInfo{LatestBlock: rpcss.getLatestBlockBestEffort(), AdditionalExtensions: extensions}
+			return extensionslib.ExtensionInfo{LatestBlock: rpcss.getLatestBlockAllowStale(), AdditionalExtensions: extensions}
 		}
 	}
 	utils.LavaFormatTrace("[Archive Debug] No extension override header found")
-	return extensionslib.ExtensionInfo{LatestBlock: rpcss.getLatestBlockBestEffort()}
+	return extensionslib.ExtensionInfo{LatestBlock: rpcss.getLatestBlockAllowStale()}
 }
 
 func (rpcss *RPCSmartRouterServer) HandleDirectiveHeadersForMessage(chainMessage chainlib.ChainMessage, directiveHeaders map[string]string) {

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2481,8 +2481,8 @@ func (rpcss *RPCSmartRouterServer) harvestAndUpdateTipFromRelay(
 	// recordRelayBlockObservation funnels through the gated RecordRelayObservation into the
 	// single-source-of-truth endpointtip store. The previous unconditional second write to
 	// targetEndpoint.LatestBlock is gone — it bypassed the generation/monotonic gate and was
-	// the source of tip divergence. The remaining tip-state writes below (router bootstrap
-	// atomic, per-endpoint metric) are gated on acceptance so a stale relay the store drops
+	// the source of tip divergence. The remaining tip-state writes below (the router-wide and
+	// per-endpoint latest-block metrics) are gated on acceptance so a stale relay the store drops
 	// (replaced/removed tracker, or older-than-stored observation) cannot still poison them.
 	if !rpcss.recordRelayBlockObservation(targetEndpoint, harvestGen, tip) {
 		return

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -550,12 +550,14 @@ func TestAppendHeadersToRelayResult_MismatchMetric(t *testing.T) {
 	require.NoError(t, err)
 
 	newServer := func() *RPCSmartRouterServer {
+		cs := chainstate.New("ETH1", chainstate.DefaultConfig(12*time.Second))
+		cs.SetLatestBlock(1_000_000) // so finality resolves (not "unknown")
 		s := &RPCSmartRouterServer{
 			smartRouterEndpointMetrics: mm,
 			listenEndpoint:             &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"},
 			chainParser:                chainParser,
+			chainState:                 cs,
 		}
-		s.latestBlockHeight.Store(1_000_000) // so finality resolves (not "unknown")
 		return s
 	}
 
@@ -665,12 +667,14 @@ func TestWatchCrossValidationStragglers_LauncherGlue(t *testing.T) {
 	}
 	require.NoError(t, err)
 
+	cs := chainstate.New("ETH1", chainstate.DefaultConfig(12*time.Second))
+	cs.SetLatestBlock(1_000_000) // so finality resolves (not "unknown")
 	srv := &RPCSmartRouterServer{
 		smartRouterEndpointMetrics: mm,
 		listenEndpoint:             &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"},
 		chainParser:                chainParser,
+		chainState:                 cs,
 	}
-	srv.latestBlockHeight.Store(1_000_000) // so finality resolves (not "unknown")
 
 	counterFor := func(t *testing.T, name, method, labelName, labelValue string) float64 {
 		t.Helper()
@@ -3323,8 +3327,7 @@ func TestSendRelayToDirectEndpoints_CrossValidationGuardReleasesAllSessions(t *t
 // test_phase2_5_caching.py::test_cache_survives_router_pod_restart.
 //
 // The fix consults the router's tracked chain tip (the per-chain ChainState
-// consensus tip, with the bootstrap atomic latestBlockHeight as cold-start
-// fallback, surfaced via rpcss.getLatestBlock()) and prefers it when it is
+// consensus tip, surfaced via rpcss.getLatestBlock()) and prefers it when it is
 // ahead of the reply's per-response value.
 func TestIsFinalizedForCacheWrite(t *testing.T) {
 	tests := []struct {

--- a/protocol/rpcsmartrouter/shared_state_tip_adopt_test.go
+++ b/protocol/rpcsmartrouter/shared_state_tip_adopt_test.go
@@ -76,6 +76,43 @@ func TestAdoptSharedStateTip(t *testing.T) {
 		}
 		require.NotPanics(t, func() { rpcss.adoptSharedStateTip(ctx, 5000, 1) })
 	})
+
+	// The one case where a peer value is NOT snapped down: a COLD (uninitialized) ChainState has no
+	// reference, so SetLatestBlock's anti-lie guard cannot fire on the first observation and the peer
+	// tip is accepted RAW — the same cold-start hole as a local first-observation lie (F1/F11),
+	// reachable via a peer. Documented here as a bounded residual: it self-heals within one TTL.
+	t.Run("cold-start adopt is accepted raw, then self-heals within one TTL", func(t *testing.T) {
+		// A cold ChainState with a fixed base clock (warped via SetDebugClockOffset for the TTL step).
+		clock := func() time.Time { return time.Unix(1700000000, 0) }
+		cs := chainstate.NewWithClock("ETH1", chainstate.Config{
+			BucketWidth:      2,
+			OutlierThreshold: 100,
+			StalenessWindow:  10 * time.Second,
+			TTL:              10 * time.Second,
+		}, clock)
+		rpcss := &RPCSmartRouterServer{
+			listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"},
+			chainState:     cs,
+			sharedState:    true,
+		}
+
+		// localSeenBlock is 0 on a cold pod, so the not-ahead guard passes; with no reference yet,
+		// the lie is accepted raw.
+		rpcss.adoptSharedStateTip(ctx, liarClaim, 0)
+		got, ok := cs.GetLatestBlock()
+		require.True(t, ok)
+		require.Equal(t, liarClaim, got,
+			"cold-start adopt has no reference to reject against — accepted raw (documented residual)")
+
+		// Bounded: once the poisoned tip goes TTL-stale, the next honest local observation re-adopts
+		// it downward. No manual reset — the lie lives ~one TTL, not the process lifetime.
+		cs.SetDebugClockOffset(11 * time.Second) // past TTL (10s)
+		cs.SetLatestBlock(honestBlock)
+		got, ok = cs.GetLatestBlock()
+		require.True(t, ok)
+		require.Equal(t, honestBlock, got,
+			"the cold-start adopt lie self-heals within one TTL — bounded, not permanent")
+	})
 }
 
 // TestAdoptSharedStateTip_StaleTipTakesLowerPeerValue pins why the adopt log reports

--- a/protocol/rpcsmartrouter/shared_state_tip_adopt_test.go
+++ b/protocol/rpcsmartrouter/shared_state_tip_adopt_test.go
@@ -82,8 +82,11 @@ func TestAdoptSharedStateTip(t *testing.T) {
 	// tip is accepted RAW — the same cold-start hole as a local first-observation lie (F1/F11),
 	// reachable via a peer. Documented here as a bounded residual: it self-heals within one TTL.
 	t.Run("cold-start adopt is accepted raw, then self-heals within one TTL", func(t *testing.T) {
-		// A cold ChainState with a fixed base clock (warped via SetDebugClockOffset for the TTL step).
-		clock := func() time.Time { return time.Unix(1700000000, 0) }
+		// A cold ChainState with a mutable base clock we advance for the TTL step. (Real time is
+		// advanced rather than warped via SetDebugClockOffset: under the MAG-2307 clock model a warp
+		// ages only READS, while writes stamp real time, so a post-warp write would read stale.)
+		now := time.Unix(1700000000, 0)
+		clock := func() time.Time { return now }
 		cs := chainstate.NewWithClock("ETH1", chainstate.Config{
 			BucketWidth:      2,
 			OutlierThreshold: 100,
@@ -106,7 +109,7 @@ func TestAdoptSharedStateTip(t *testing.T) {
 
 		// Bounded: once the poisoned tip goes TTL-stale, the next honest local observation re-adopts
 		// it downward. No manual reset — the lie lives ~one TTL, not the process lifetime.
-		cs.SetDebugClockOffset(11 * time.Second) // past TTL (10s)
+		now = now.Add(11 * time.Second) // real time advances past TTL (10s)
 		cs.SetLatestBlock(honestBlock)
 		got, ok = cs.GetLatestBlock()
 		require.True(t, ok)


### PR DESCRIPTION
## What

Retires the `latestBlockHeight` **bootstrap atomic** — the one tip source that never healed — and points readers at the self-healing `ChainState` tip. Also folds in two cleanups the deletion enables. Stacked on #228.

### The problem
The atomic was monotonic-max with **no downward correction**, so a cold-start or stale lie could stick for the life of the process (F1, F11). Everything else in Topic C got anti-lie guards that heal within seconds; this was the last never-healing store.

### Changes
- **Delete** the atomic, `updateLatestBlockHeight`, and the chain-accepted harvest gate. The router-wide latest-block metric is now sourced from the guarded tip.
- **Add `ChainState.GetLatestBlockAllowStale()`** — the raw, TTL-ignored tip for lenient readers. **Archive routing** (`getLatestBlockAllowStale`) reads it instead of the atomic. The tip self-heals both ways (grows under the outlier guard; re-adopts a lower block once stale), so it can't stay stuck on a lie.
- **Cold-start** is covered by the tip: it's seeded by the first tip-eligible observation (`OnTipObservation → SetLatestBlock`), which ran *before* the atomic ever did — so the atomic covered no window the tip doesn't.
- **Consolidate `getLatestBlockForCacheFinalization` into `getLatestBlock`**: once the atomic was gone the two were byte-identical (both "gated: fresh tip or 0"). Finalization calls `getLatestBlock` directly, with the "must be the gated read" safety note at the call site.
- **Rename** `getLatestBlockBestEffort → getLatestBlockAllowStale` (and the primitive to match) so the name says what you get: the tip, stale allowed.

### Safety
- **Cache finalization is behavior-unchanged** — it keeps the **gated** read (fresh tip or 0). An allow-stale value there could falsely finalize a mutable block into the long-TTL store (durable, global). This is the deliberate carve-out.
- **Archive routing** accepts the residual: a prolonged all-endpoints-silent outage can freeze the tip slightly low → at worst a retryable under-archive, self-healing the instant any endpoint reports. Non-corrupting. (`UpgradeToArchiveIfNeeded` adds the archive extension on retry #1, so an under-archived request that node-errors on a pruning node escalates — the cost is a wasted round-trip, not a wrong answer.)

### ⚠️ Metric semantics change — `smartrouter_latest_block`

Deleting the atomic changes this gauge in ways worth flagging to whoever owns the dashboards. **Nothing here is a bug; it is the self-heal becoming visible.**

- **It is no longer monotonic.** It now follows the guarded tip, which can go **down** — a stale tip re-adopting a lower block, or `Recompute` snapping an over-band tip to the baseline. The old CAS ratchet made it monotonic-max for the process lifetime, so it could only ever climb. **Any panel or alert built on `rate()` / `increase()` over this gauge, or on "latest block never goes backwards", changes behavior.** A decrease is now expected and means the anti-lie guard corrected a bad tip.
- **Its source is the guarded tip, not the raw harvested block.** A lying-high endpoint that ChainState rejects no longer reaches the metric. This is exactly what the deleted chain-accepted gate protected; it now falls out of reading `GetLatestBlock()` directly, and is pinned by a test (below).
- **It is written on every accepted tip-eligible harvest**, not only when the value advances. This sits on the same per-relay path as the existing per-endpoint `rpc_endpoint_latest_block` write, so it is ~2× on an already-per-relay cost rather than a new class of cost.
- **A TTL-stale tip leaves it untouched** — the gauge holds its last reported value rather than dropping to 0, so "no fresh tip" reads as a flat line, not a cliff.

### Getter set is now minimal
`ChainState`: `GetLatestBlock` (fresh), `GetLatestBlockWithTime` (fresh + age), `GetLatestBlockAllowStale` (raw). Router: `getLatestBlock` (gated), `getLatestBlockAllowStale` (stale-tolerant). The finalization duplicate is gone.

## Tests
- Rewrote the atomic tests to assert the **tip / archive-routing reader**: a lying-high harvest stays guarded by ChainState, and the archive tip **heals DOWN** where the atomic stayed stuck.
- `TestHarvest_ArchiveRoutingTipGuardedByChainState` also pins the **metric** contract: after T3 the gated `GetLatestBlock()` read in `harvestAndUpdateTipFromRelay` has exactly one consumer (`smartrouter_latest_block`), and nothing asserted it — the deleted `latestBlockHeight.Load()` used to cover that incidentally. It now asserts the gauge follows honest advances, holds the guarded `1050` when ChainState rejects a lying-high `1_000_000`, and is untouched when the harvest bails at the store gate. Verified to fail (actual `1e+06`) when the source is reverted to the raw `tip`.
- Two server tests now wire a **seeded chainState** instead of the atomic.
- New `TestGetLatestBlockAllowStale` (chainstate) + `TestGetLatestBlockAllowStale_ServesStaleAndHeals` (router).

`go build ./...` + `go vet` clean; full `chainstate`, `endpointstate` and `rpcsmartrouter` suites pass (`chainstate` also under `-race`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
