### PR TITLE
fix(stack): land T4 (#226) and T10 (#228) on main after out-of-order stack merges

### DIFF
--- a/ecosystem/cache/handlers.go
+++ b/ecosystem/cache/handlers.go
@@ -320,13 +320,13 @@ func (s *RelayerCacheServer) performInt64WriteWithValidationAndRetry(
 	}
 }
 
-func (s *RelayerCacheServer) setSeenBlockOnSharedStateMode(chainId, sharedStateId string, seenBlock int64) {
+func (s *RelayerCacheServer) setSeenBlockOnSharedStateMode(chainId, sharedStateId string, seenBlock int64, ttl time.Duration) {
 	if sharedStateId == "" {
 		return
 	}
 	key := latestBlockKey(chainId, sharedStateId)
 	set := func() {
-		s.CacheServer.finalizedCache.SetWithTTL(key, seenBlock, 0, s.CacheServer.ExpirationFinalized)
+		s.CacheServer.finalizedCache.SetWithTTL(key, seenBlock, 0, ttl)
 	}
 	get := func() int64 {
 		return s.getSeenBlockForSharedStateMode(chainId, sharedStateId)
@@ -375,7 +375,7 @@ func (s *RelayerCacheServer) SetRelay(ctx context.Context, relayCacheSet *relayt
 		cache.SetWithTTL(string(cacheKey), cacheValue, cacheValue.Cost(), s.getExpirationForChain(time.Duration(relayCacheSet.AverageBlockTime), relayCacheSet.BlockHash))
 	}
 
-	s.setSeenBlockOnSharedStateMode(relayCacheSet.ChainId, relayCacheSet.SharedStateId, latestKnownBlock)
+	s.setSeenBlockOnSharedStateMode(relayCacheSet.ChainId, relayCacheSet.SharedStateId, latestKnownBlock, s.CacheServer.SharedStateTipExpiration(time.Duration(relayCacheSet.AverageBlockTime)))
 	s.setLatestBlock(latestBlockKey(relayCacheSet.ChainId, ""), latestKnownBlock)
 	s.setBlocksHashesToHeights(relayCacheSet.ChainId, relayCacheSet.BlocksHashesToHeights)
 	return &emptypb.Empty{}, nil

--- a/ecosystem/cache/server.go
+++ b/ecosystem/cache/server.go
@@ -32,6 +32,12 @@ const (
 	ExpirationNodeErrorsOnFinalizedFlagName      = "expiration-finalized-node-errors"
 	FlagCacheSizeName                            = "max-items"
 	DefaultExpirationForNonFinalized             = 500 * time.Millisecond
+	// SharedStateTipBlockMultiplier bounds how long a pod's published chain tip lives in the
+	// shared cache: SharedStateTipBlockMultiplier * averageBlockTime. It mirrors the smart
+	// router's own tip-staleness horizon (chainstate.StalenessWindow) so a dead pod's tip
+	// evaporates on roughly the same timescale the router considers a tip stale, rather than
+	// lingering for the full finalized (~1h) TTL.
+	SharedStateTipBlockMultiplier                = 10
 	DefaultExpirationTimeFinalizedMultiplier     = 1.0
 	DefaultExpirationTimeNonFinalizedMultiplier  = 1.0
 	DefaultExpirationBlocksHashesToHeights       = 48 * time.Hour
@@ -201,6 +207,15 @@ func (cs *CacheServer) Serve(ctx context.Context, listenAddr string) {
 func (cs *CacheServer) ExpirationForChain(averageBlockTimeForChain time.Duration) time.Duration {
 	eighthBlock := averageBlockTimeForChain / 8
 	return lavaslices.Max([]time.Duration{eighthBlock, cs.ExpirationNonFinalized})
+}
+
+// SharedStateTipExpiration returns the TTL for a pod's published chain tip in shared-state
+// mode: SharedStateTipBlockMultiplier * averageBlockTime, floored at ExpirationNonFinalized so
+// a chain whose spec omits the average block time still gets a sane, non-zero TTL (a zero TTL
+// would never expire).
+func (cs *CacheServer) SharedStateTipExpiration(averageBlockTimeForChain time.Duration) time.Duration {
+	ttl := averageBlockTimeForChain * SharedStateTipBlockMultiplier
+	return lavaslices.Max([]time.Duration{ttl, cs.ExpirationNonFinalized})
 }
 
 func (cs *CacheServer) GetTotalCacheSize() int64 {

--- a/ecosystem/cache/server.go
+++ b/ecosystem/cache/server.go
@@ -37,14 +37,25 @@ const (
 	// router's own tip-staleness horizon (chainstate.StalenessWindow) so a dead pod's tip
 	// evaporates on roughly the same timescale the router considers a tip stale, rather than
 	// lingering for the full finalized (~1h) TTL.
-	SharedStateTipBlockMultiplier                = 10
-	DefaultExpirationTimeFinalizedMultiplier     = 1.0
-	DefaultExpirationTimeNonFinalizedMultiplier  = 1.0
-	DefaultExpirationBlocksHashesToHeights       = 48 * time.Hour
-	DefaultExpirationTimeFinalized               = time.Hour
-	DefaultExpirationNodeErrors                  = 250 * time.Millisecond
-	CacheNumCounters                             = 100000000 // expect 10M items
-	unixPrefix                                   = "unix:"
+	SharedStateTipBlockMultiplier = 10
+	// MinSharedStateTipExpiration is the absolute floor for that TTL, mirroring the router-side
+	// floor (chainstate.minStalenessWindow) rather than importing it — ecosystem/cache is a
+	// standalone binary and must not depend on protocol/. It is a hard-coded constant, NOT an
+	// operator-tunable duration, because it underwrites two guarantees the tunables cannot:
+	//   - non-zero: ristretto treats a zero TTL as "never expires", so a dead pod's tip would
+	//     linger forever. ExpirationNonFinalized alone cannot prevent this — it is
+	//     flag * multiplier, both operator-settable, and either being 0 makes it 0.
+	//   - long enough to be useful: a chain tip must outlive the gap between requests. At the
+	//     500ms ExpirationNonFinalized default a tip published for a spec with no
+	//     average_block_time would evaporate between relays, silently disabling shared state.
+	MinSharedStateTipExpiration                 = 2 * time.Second
+	DefaultExpirationTimeFinalizedMultiplier    = 1.0
+	DefaultExpirationTimeNonFinalizedMultiplier = 1.0
+	DefaultExpirationBlocksHashesToHeights      = 48 * time.Hour
+	DefaultExpirationTimeFinalized              = time.Hour
+	DefaultExpirationNodeErrors                 = 250 * time.Millisecond
+	CacheNumCounters                            = 100000000 // expect 10M items
+	unixPrefix                                  = "unix:"
 )
 
 type CacheServer struct {
@@ -210,12 +221,18 @@ func (cs *CacheServer) ExpirationForChain(averageBlockTimeForChain time.Duration
 }
 
 // SharedStateTipExpiration returns the TTL for a pod's published chain tip in shared-state
-// mode: SharedStateTipBlockMultiplier * averageBlockTime, floored at ExpirationNonFinalized so
-// a chain whose spec omits the average block time still gets a sane, non-zero TTL (a zero TTL
-// would never expire).
+// mode: SharedStateTipBlockMultiplier * averageBlockTime, floored at ExpirationNonFinalized and
+// then at the hard MinSharedStateTipExpiration.
+//
+// The second floor is the load-bearing one. ExpirationNonFinalized is derived from two operator
+// flags (duration * multiplier), so it is neither guaranteed non-zero — a zero TTL means "never
+// expires" in ristretto, so a dead pod's tip would linger forever — nor guaranteed long enough:
+// at its 500ms default a tip for a spec that omits average_block_time (0 * multiplier = 0) would
+// evaporate between relays and silently disable shared state. MinSharedStateTipExpiration is a
+// constant precisely so no flag combination can defeat either guarantee.
 func (cs *CacheServer) SharedStateTipExpiration(averageBlockTimeForChain time.Duration) time.Duration {
 	ttl := averageBlockTimeForChain * SharedStateTipBlockMultiplier
-	return lavaslices.Max([]time.Duration{ttl, cs.ExpirationNonFinalized})
+	return lavaslices.Max([]time.Duration{ttl, cs.ExpirationNonFinalized, MinSharedStateTipExpiration})
 }
 
 func (cs *CacheServer) GetTotalCacheSize() int64 {

--- a/ecosystem/cache/shared_state_tip_test.go
+++ b/ecosystem/cache/shared_state_tip_test.go
@@ -1,0 +1,58 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSharedStateTipExpiration locks the shared-state tip TTL contract (T10): a pod's published
+// tip lives for SharedStateTipBlockMultiplier * averageBlockTime, floored at ExpirationNonFinalized
+// so a chain with an unknown block time still gets a sane, non-zero TTL instead of never expiring.
+func TestSharedStateTipExpiration(t *testing.T) {
+	cs := &CacheServer{ExpirationNonFinalized: 500 * time.Millisecond}
+
+	// Normal chain: 12s block → 120s TTL (well above the floor, far below the ~1h finalized TTL).
+	require.Equal(t, 120*time.Second, cs.SharedStateTipExpiration(12*time.Second))
+
+	// Fast chain: 400ms block → 4s (still above the floor).
+	require.Equal(t, 4*time.Second, cs.SharedStateTipExpiration(400*time.Millisecond))
+
+	// Unknown block time (spec omits average_block_time): 0*10 = 0 → floored so it is not eternal.
+	require.Equal(t, cs.ExpirationNonFinalized, cs.SharedStateTipExpiration(0))
+}
+
+// TestSharedStateTip_RoundTripAndKeyIsolation is the T10 fix: a tip written under one shared-state
+// id is readable only under the SAME id. The historical bug was that the write used a chain-level
+// id and the read used a per-user id, so the read never resolved the write. This test proves the
+// round-trip works when the ids match and misses when they do not, and that writes are max-merged.
+func TestSharedStateTip_RoundTripAndKeyIsolation(t *testing.T) {
+	cs := &CacheServer{
+		finalizedCache:         newRistrettoForTest(t),
+		ExpirationNonFinalized: 500 * time.Millisecond,
+	}
+	srv := &RelayerCacheServer{CacheServer: cs}
+
+	const chainID = "ETH1"
+	const writeID = "ETH1jsonrpc" // == listenEndpoint.Key(): the chain-level id both sides now use
+
+	srv.setSeenBlockOnSharedStateMode(chainID, writeID, 1000, time.Minute)
+	cs.finalizedCache.Wait()
+
+	// Aligned id → round-trips.
+	require.Equal(t, int64(1000), srv.getSeenBlockForSharedStateMode(chainID, writeID))
+
+	// Mismatched (old per-user) id → miss, returns 0. This is the pre-T10 breakage, now asserted
+	// to stay dead only for a genuinely different id.
+	require.Equal(t, int64(0), srv.getSeenBlockForSharedStateMode(chainID, "mydapp__1.2.3.4"))
+
+	// Max-merge: a lower write is ignored, a higher write wins.
+	srv.setSeenBlockOnSharedStateMode(chainID, writeID, 900, time.Minute)
+	cs.finalizedCache.Wait()
+	require.Equal(t, int64(1000), srv.getSeenBlockForSharedStateMode(chainID, writeID), "lower write must not lower the shared tip")
+
+	srv.setSeenBlockOnSharedStateMode(chainID, writeID, 1100, time.Minute)
+	cs.finalizedCache.Wait()
+	require.Equal(t, int64(1100), srv.getSeenBlockForSharedStateMode(chainID, writeID), "higher write must advance the shared tip")
+}

--- a/ecosystem/cache/shared_state_tip_test.go
+++ b/ecosystem/cache/shared_state_tip_test.go
@@ -9,7 +9,8 @@ import (
 
 // TestSharedStateTipExpiration locks the shared-state tip TTL contract (T10): a pod's published
 // tip lives for SharedStateTipBlockMultiplier * averageBlockTime, floored at ExpirationNonFinalized
-// so a chain with an unknown block time still gets a sane, non-zero TTL instead of never expiring.
+// and then at the hard MinSharedStateTipExpiration, so a chain with an unknown block time still
+// gets a usable, non-zero TTL instead of never expiring.
 func TestSharedStateTipExpiration(t *testing.T) {
 	cs := &CacheServer{ExpirationNonFinalized: 500 * time.Millisecond}
 
@@ -19,8 +20,27 @@ func TestSharedStateTipExpiration(t *testing.T) {
 	// Fast chain: 400ms block → 4s (still above the floor).
 	require.Equal(t, 4*time.Second, cs.SharedStateTipExpiration(400*time.Millisecond))
 
-	// Unknown block time (spec omits average_block_time): 0*10 = 0 → floored so it is not eternal.
-	require.Equal(t, cs.ExpirationNonFinalized, cs.SharedStateTipExpiration(0))
+	// Unknown block time (spec omits average_block_time): 0*10 = 0. The 500ms
+	// ExpirationNonFinalized would be non-zero but far too short for a chain tip — it would
+	// evaporate between relays — so the hard floor takes over.
+	require.Equal(t, MinSharedStateTipExpiration, cs.SharedStateTipExpiration(0))
+}
+
+// TestSharedStateTipExpiration_FloorSurvivesZeroedFlags is the guarantee ExpirationNonFinalized
+// cannot make on its own: it is flag * multiplier, both operator-settable, so either being 0
+// zeroes it. A zero TTL means "never expires" in ristretto, which would strand a dead pod's tip
+// in the shared cache forever — the exact failure the floor exists to prevent.
+func TestSharedStateTipExpiration_FloorSurvivesZeroedFlags(t *testing.T) {
+	cs := &CacheServer{ExpirationNonFinalized: 0}
+
+	require.Equal(t, MinSharedStateTipExpiration, cs.SharedStateTipExpiration(0),
+		"a zeroed non-finalized expiration must not produce an eternal tip")
+	require.Equal(t, MinSharedStateTipExpiration, cs.SharedStateTipExpiration(100*time.Millisecond),
+		"a sub-floor derived TTL is lifted to the floor, not left at 1s")
+	require.Positive(t, cs.SharedStateTipExpiration(0), "the TTL is never zero")
+
+	// A real block time still dominates both floors.
+	require.Equal(t, 120*time.Second, cs.SharedStateTipExpiration(12*time.Second))
 }
 
 // TestSharedStateTip_RoundTripAndKeyIsolation is the T10 fix: a tip written under one shared-state

--- a/protocol/chainstate/chain_state.go
+++ b/protocol/chainstate/chain_state.go
@@ -122,12 +122,22 @@ func outlierThresholdForBlockTime(averageBlockTime time.Duration) int64 {
 	return blocks
 }
 
+// StalenessWindow is the ONE derivation of the "fresh/alive horizon" from a chain's average
+// block time: max(DefaultStalenessMultiplier × avgBlockTime, minStalenessWindow). It is the
+// single source of truth for the concept — the consensus window / tip TTL (DefaultConfig), the
+// probe's liveness horizon, and the per-endpoint tip's staleness backstop (endpointtip, fed via
+// the monitor) all read it, so tuning DefaultStalenessMultiplier moves every one in lockstep. A
+// non-positive block time falls back to the floor.
+func StalenessWindow(averageBlockTime time.Duration) time.Duration {
+	return max(time.Duration(DefaultStalenessMultiplier)*averageBlockTime, minStalenessWindow)
+}
+
 // DefaultConfig derives the freshness/consensus window AND the outlier threshold from a chain's
-// average block time (D6): StalenessWindow = TTL = max(DefaultStalenessMultiplier × avgBlockTime,
-// floor); OutlierThreshold = clamp(OutlierTimeBudget / avgBlockTime, floor, ceiling). BucketWidth
-// stays a block-count constant (clustering tolerance is intrinsically in blocks, not time).
+// average block time (D6): StalenessWindow = TTL = StalenessWindow(avgBlockTime); OutlierThreshold
+// = clamp(OutlierTimeBudget / avgBlockTime, floor, ceiling). BucketWidth stays a block-count
+// constant (clustering tolerance is intrinsically in blocks, not time).
 func DefaultConfig(averageBlockTime time.Duration) Config {
-	window := max(time.Duration(DefaultStalenessMultiplier)*averageBlockTime, minStalenessWindow)
+	window := StalenessWindow(averageBlockTime)
 	return Config{
 		BucketWidth:      DefaultBucketWidth,
 		OutlierThreshold: outlierThresholdForBlockTime(averageBlockTime),

--- a/protocol/chainstate/chain_state.go
+++ b/protocol/chainstate/chain_state.go
@@ -122,12 +122,14 @@ func outlierThresholdForBlockTime(averageBlockTime time.Duration) int64 {
 	return blocks
 }
 
-// StalenessWindow is the ONE derivation of the "fresh/alive horizon" from a chain's average
-// block time: max(DefaultStalenessMultiplier × avgBlockTime, minStalenessWindow). It is the
-// single source of truth for the concept — the consensus window / tip TTL (DefaultConfig), the
-// probe's liveness horizon, and the per-endpoint tip's staleness backstop (endpointtip, fed via
-// the monitor) all read it, so tuning DefaultStalenessMultiplier moves every one in lockstep. A
-// non-positive block time falls back to the floor.
+// StalenessWindow derives the "fresh/alive horizon" from a chain's average block time:
+// max(DefaultStalenessMultiplier × avgBlockTime, minStalenessWindow). The consensus window / tip
+// TTL (DefaultConfig) and the per-endpoint tip's staleness backstop (endpointtip, fed via the
+// monitor) both call it, so they move in lockstep. The shared knob across the codebase is the
+// MULTIPLIER, not this function: the probe's liveness horizon (probing.DefaultVerdictConfig)
+// re-derives with DefaultStalenessMultiplier but a deliberately different floor (minProbeStaleness),
+// so it tracks the multiplier without reading this function. A non-positive block time falls back
+// to the floor.
 func StalenessWindow(averageBlockTime time.Duration) time.Duration {
 	return max(time.Duration(DefaultStalenessMultiplier)*averageBlockTime, minStalenessWindow)
 }

--- a/protocol/chainstate/chain_state.go
+++ b/protocol/chainstate/chain_state.go
@@ -122,14 +122,13 @@ func outlierThresholdForBlockTime(averageBlockTime time.Duration) int64 {
 	return blocks
 }
 
-// StalenessWindow derives the "fresh/alive horizon" from a chain's average block time:
-// max(DefaultStalenessMultiplier × avgBlockTime, minStalenessWindow). The consensus window / tip
-// TTL (DefaultConfig) and the per-endpoint tip's staleness backstop (endpointtip, fed via the
-// monitor) both call it, so they move in lockstep. The shared knob across the codebase is the
-// MULTIPLIER, not this function: the probe's liveness horizon (probing.DefaultVerdictConfig)
-// re-derives with DefaultStalenessMultiplier but a deliberately different floor (minProbeStaleness),
-// so it tracks the multiplier without reading this function. A non-positive block time falls back
-// to the floor.
+// StalenessWindow is the ONE derivation of the "fresh/alive horizon" from a chain's average block
+// time: max(DefaultStalenessMultiplier × avgBlockTime, minStalenessWindow). Every consumer of the
+// concept reads it — the consensus window / tip TTL (DefaultConfig) and the per-endpoint tip's
+// staleness backstop (endpointtip, fed via the monitor) use it directly, and the probe's liveness
+// horizon (probing.DefaultVerdictConfig) composes it with its own wider floor (max(StalenessWindow,
+// minProbeStaleness)) — so tuning the derivation here moves all of them in lockstep. A non-positive
+// block time falls back to the floor.
 func StalenessWindow(averageBlockTime time.Duration) time.Duration {
 	return max(time.Duration(DefaultStalenessMultiplier)*averageBlockTime, minStalenessWindow)
 }

--- a/protocol/endpointstate/endpoint_monitor.go
+++ b/protocol/endpointstate/endpoint_monitor.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/magma-Devs/smart-router/protocol/chainlib"
+	"github.com/magma-Devs/smart-router/protocol/chainstate"
 	"github.com/magma-Devs/smart-router/protocol/chaintracker"
 	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/endpointtip"
@@ -87,9 +88,13 @@ type EndpointMonitor struct {
 
 	// Chain-specific timing
 	averageBlockTime time.Duration
-	blocksToSave     uint64
-	retryMinDelay    time.Duration
-	retryMaxDelay    time.Duration
+	// tipStaleAfter is the per-endpoint tip staleness horizon (T4/C-D): the shared
+	// chainstate.StalenessWindow, derived once and passed to every endpointtip.Store.Set to
+	// gate downward (reorg) moves.
+	tipStaleAfter time.Duration
+	blocksToSave  uint64
+	retryMinDelay time.Duration
+	retryMaxDelay time.Duration
 
 	// relayGateFreshness is the maximum age of a relay-harvested tip that still suppresses
 	// a dedicated poll (MAG-2159 Topic B / Pass 2 — the "gate freshness threshold"). A
@@ -176,6 +181,7 @@ func NewEndpointMonitor(ctx context.Context, config EndpointChainTrackerConfig) 
 		chainID:           config.ChainID,
 		apiInterface:      config.ApiInterface,
 		averageBlockTime:  avgBlockTime,
+		tipStaleAfter:     chainstate.StalenessWindow(avgBlockTime),
 		blocksToSave:      blocksToSave,
 		retryMinDelay:     defaultTrackerStartRetryMin,
 		retryMaxDelay:     defaultTrackerStartRetryMax,

--- a/protocol/endpointstate/endpoint_monitor.go
+++ b/protocol/endpointstate/endpoint_monitor.go
@@ -501,7 +501,7 @@ func (m *EndpointMonitor) GetLatestBlockData(endpointURL string) (latestBlock in
 // against exactly the value the reset asked to discard, defeating ResetLatestBlock's
 // "consistency sees <= 0 and skips" contract until the next poll happens to overwrite it.
 // We Remove the store entry (not Set 0): the store ignores non-positive writes and its
-// time-monotonic guard cannot represent "cleared", so removal is the only way to zero it.
+// block-monotonic guard cannot represent "cleared", so removal is the only way to zero it.
 // endpointtip's lock is a leaf that never calls back into the monitor, so taking it under
 // m.mu (read) introduces no lock-order inversion — same idiom as RemoveTracker/Stop.
 func (m *EndpointMonitor) ResetAllLatestBlocks() int {

--- a/protocol/endpointstate/endpoint_monitor_lifecycle_test.go
+++ b/protocol/endpointstate/endpoint_monitor_lifecycle_test.go
@@ -211,7 +211,7 @@ func TestEndpointMonitor_ResetAllLatestBlocks_ClearsEndpointTipStore(t *testing.
 	// Seed a stale tip in the shared store, as a prior poll/relay observation would have.
 	require.True(t, endpointtip.Default().Set(key, endpointtip.Tip{
 		Block: 1000, ObservedAt: time.Now(), Source: endpointtip.SourcePoll,
-	}))
+	}, 0))
 	require.Equal(t, int64(1000), endpointtip.Default().Block(key),
 		"precondition: the store holds the pre-reset block")
 

--- a/protocol/endpointstate/observation.go
+++ b/protocol/endpointstate/observation.go
@@ -117,16 +117,15 @@ func (m *EndpointMonitor) recordPollObservation(endpointURL string, gen uint64, 
 		o.LastPollError = ""
 		o.ConsecutivePollFailures = 0
 		// The block triple lives in the single-source-of-truth endpointtip store, not on
-		// this record. Set applies the same time-monotonic guard the record used to (a
-		// poll older than the stored observation is dropped wholesale) and reports whether
-		// it advanced the tip — only then do we feed the per-chain consensus tip. Called
-		// under obsMu: lock order is obsMu → store lock everywhere (the store has no
-		// callbacks, so this cannot deadlock).
+		// this record. Set applies the block-monotonic guard (T4) and reports whether it
+		// advanced the tip — only then do we feed the per-chain consensus tip. Called under
+		// obsMu: lock order is obsMu → store lock everywhere (the store has no callbacks, so
+		// this cannot deadlock).
 		if endpointtip.Default().Set(m.tipKey(endpointURL), endpointtip.Tip{
 			Block:      block,
 			ObservedAt: at,
 			Source:     endpointtip.SourcePoll,
-		}) {
+		}, m.tipStaleAfter) {
 			tipBlock = block // feed the per-chain tip after unlock
 		}
 	} else {
@@ -196,13 +195,13 @@ func (m *EndpointMonitor) RecordRelayObservation(endpointURL string, gen uint64,
 		m.observations[endpointURL] = EndpointObservation{}
 	}
 
-	// Set applies the time-monotonic guard (a relay older than the stored observation is
-	// dropped) and reports whether it advanced the tip. Lock order obsMu → store lock.
+	// Set applies the block-monotonic guard (T4) and reports whether it advanced the tip.
+	// Lock order obsMu → store lock.
 	if endpointtip.Default().Set(m.tipKey(endpointURL), endpointtip.Tip{
 		Block:      block,
 		ObservedAt: at,
 		Source:     endpointtip.SourceRelay,
-	}) {
+	}, m.tipStaleAfter) {
 		tipBlock = block // feed the per-chain tip after unlock
 		return true
 	}

--- a/protocol/endpointstate/observation.go
+++ b/protocol/endpointstate/observation.go
@@ -32,9 +32,11 @@ const (
 //   - The block triple (LatestBlock / ObservedAt / Source) is the single-source-of-truth
 //     tip owned by the endpointtip store, NOT stored on this record. GetObservation and
 //     SnapshotObservations populate the triple from that store at read time, so callers
-//     see a consistent value while the tip lives in exactly one place. ObservedAt is
-//     monotonic — a later write never moves it backward, and a stale observation (older
-//     than the current ObservedAt) is ignored — enforced in endpointtip.Store.Set.
+//     see a consistent value while the tip lives in exactly one place. ObservedAt only
+//     advances (a write never carries it backward), but the store's guard is
+//     block-monotonic (T4), not time-monotonic: a higher-or-equal block always applies,
+//     while a lower block is dropped as a late straggler while the stored tip is fresh and
+//     accepted only once it goes stale (a real reorg down) — enforced in endpointtip.Store.Set.
 //   - The poll-health fields (LastPollAttempt, LastSuccessfulPoll, LastPollLatency,
 //     LastPollError, ConsecutivePollFailures) are written *only* by the poll path and
 //     are the only fields physically stored in the monitor's observation map.
@@ -43,7 +45,7 @@ const (
 type EndpointObservation struct {
 	// Block observation (delegated to the endpointtip store; filled on read, never stored here):
 	LatestBlock int64             // most recent observed block for this endpoint
-	ObservedAt  time.Time         // wall-clock of the observation that set LatestBlock (monotonic)
+	ObservedAt  time.Time         // freshness stamp of the latest block observation; only advances
 	Source      ObservationSource // origin of the latest block observation
 
 	// Poll-health fields (written only by the poll path):
@@ -142,7 +144,9 @@ func (m *EndpointMonitor) recordPollObservation(endpointURL string, gen uint64, 
 
 // RecordRelayObservation records a block harvested from a served relay response. It
 // updates only the block triple (Source = Relay) — never the poll-health fields — and
-// honors the monotonic ObservedAt guard.
+// goes through the store's block-monotonic guard (T4): the harvested block is kept only
+// when it is higher than or equal to the stored tip; a lower one is treated as a late
+// straggler and dropped until the stored tip goes stale.
 //
 // gen is the observation generation the caller captured for this endpoint (see
 // ObservationGeneration / GetOrCreateTracker). Like recordPollObservation, the write is

--- a/protocol/endpointtip/store.go
+++ b/protocol/endpointtip/store.go
@@ -1,23 +1,15 @@
 // Package endpointtip holds the single, process-wide source of truth for the
 // per-endpoint observed block tip.
 //
-// Why a standalone leaf package: the tip is written by the high layer
-// (endpointstate's poll + relay-harvest observers) but also read by the low layer
-// (lavasession's per-endpoint QoS sync-block). endpointstate already imports
-// lavasession, so lavasession cannot import endpointstate to reach the observation
-// store — that would be an import cycle. A leaf package that imports only the
-// standard library can be imported by BOTH layers, so they share ONE store instead
-// of each keeping its own copy (the divergence that this package exists to remove).
+// It is a standard-library-only leaf so both the high layer (endpointstate's poll +
+// relay observers, which write it) and the low layer (lavasession's QoS sync-block,
+// which reads it) can import it without a cycle — sharing ONE store rather than each
+// keeping a divergent copy. It stores the whole {Block, ObservedAt, Source} triple so
+// the guard and the relay-freshness gate see a consistent value.
 //
-// The store holds the whole atomic tip triple {Block, ObservedAt, Source} — never a
-// bare block — because the monotonic guard needs Block and ObservedAt together and
-// the relay-freshness gate reads Source. Splitting the triple across two stores would
-// reintroduce exactly the divergence this consolidation removes.
-//
-// Generation gating (rejecting writes from a removed/replaced tracker) is NOT done
-// here: this leaf cannot know about tracker lifecycles. Callers in endpointstate
-// gate on generation FIRST and only then call Set, which applies the time-monotonic
-// guard.
+// Generation gating (rejecting writes from a removed tracker) is done by the
+// endpointstate callers before Set; this leaf only applies the block-monotonic guard
+// with a staleness backstop (T4/C-D — see Set).
 package endpointtip
 
 import (
@@ -54,9 +46,13 @@ func (s Source) String() string {
 // either advances all three or none.
 type Tip struct {
 	Block      int64     // most recent observed block (always > 0 once set)
-	ObservedAt time.Time // wall-clock of the observation that set Block (monotonic)
+	ObservedAt time.Time // wall-clock of the observation that set Block (freshness stamp)
 	Source     Source    // origin of this observation
 }
+
+// The staleness horizon is NOT defined here — this leaf is pure mechanism. The caller
+// (endpointstate's monitor) derives it from chainstate.StalenessWindow, the one source of
+// truth for the fresh/alive horizon, and passes it to Set as staleAfter.
 
 // Store is the per-endpoint tip store, keyed by the composite Key. It is safe for
 // concurrent use. The exported instance type (rather than only package globals) lets
@@ -78,27 +74,37 @@ func Key(chainID, apiInterface, url string) string {
 	return chainID + "|" + apiInterface + "|" + url
 }
 
-// Set applies a tip observation under the time-monotonic guard: a write whose
-// ObservedAt predates the stored ObservedAt is dropped wholesale so no field
-// regresses. Equal timestamps apply (last-writer-wins, the documented deterministic
-// tie-break, matching the prior observation-record semantics). A non-positive block is
-// ignored. Returns true iff the write was applied (the caller uses this to decide
-// whether to feed the per-chain consensus tip).
+// Set applies a tip observation, block-monotonic with a staleness backstop (T4/C-D):
+// higher wins, equal refreshes the stamp, lower is rejected while fresh (a late
+// straggler must not regress the tip — F2) and accepted once stale (a real reorg down).
 //
-// The guard is time-monotonic, NOT block-monotonic — it relocates the exact semantics
-// the observation record used before consolidation; it is deliberately not "improved"
-// to max-block.
-func (s *Store) Set(key string, t Tip) bool {
+// Staleness is the gap between the stored and incoming observation stamps (> staleAfter),
+// not wall-clock — deterministic, no clock. A rejected write must not refresh the stamp,
+// else a repeated straggler keeps the tip forever fresh. staleAfter<=0 is up-only.
+// Returns true iff the stored tip now reflects this block (gates the consensus feed).
+func (s *Store) Set(key string, t Tip, staleAfter time.Duration) bool {
 	if t.Block <= 0 {
 		return false
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if cur, ok := s.tips[key]; ok && t.ObservedAt.Before(cur.ObservedAt) {
-		return false
+	cur, ok := s.tips[key]
+	switch {
+	case !ok || t.Block > cur.Block:
+		s.tips[key] = t
+		return true
+	case t.Block == cur.Block:
+		if t.ObservedAt.After(cur.ObservedAt) {
+			s.tips[key] = t // advance the freshness stamp, never backwards
+		}
+		return true
+	default: // lower block
+		if staleAfter > 0 && t.ObservedAt.Sub(cur.ObservedAt) > staleAfter {
+			s.tips[key] = t // stored tip went stale → accept the reorg
+			return true
+		}
+		return false // still fresh → reject the straggler (F2)
 	}
-	s.tips[key] = t
-	return true
 }
 
 // Get returns the stored tip and whether one exists. The returned Tip is a value copy,

--- a/protocol/endpointtip/store.go
+++ b/protocol/endpointtip/store.go
@@ -42,8 +42,19 @@ func (s Source) String() string {
 	}
 }
 
-// Tip is the atomic per-endpoint tip triple. The three fields move together — a write
-// either advances all three or none.
+// Tip is the atomic per-endpoint tip triple: a write either takes all three fields or none,
+// so no reader ever sees a Block from one observation beside a Source from another.
+//
+// ONE deliberate exception, in Set's higher-block branch: an accepted higher block keeps its own
+// Block and Source but may retain the STORED ObservedAt, because the freshness stamp must only
+// ever advance (see Set). The stored triple is then a hybrid — the incoming observation's block
+// and source, stamped with the later of the two observation times. Both stamps are genuine
+// observations of this endpoint, so the stamp still means "when we last saw this endpoint's
+// tip", which is what every reader wants it for; the one reader that also keys off Source
+// (freshRelayTip, the poll-suppression gate) can therefore see a relay tip stamped slightly
+// later than the relay actually arrived. The over-suppression is bounded by the gap between the
+// caller's time.Now() and this write — lock acquisition, i.e. sub-millisecond — so it is
+// accepted rather than paid for with a second stamp field.
 type Tip struct {
 	Block      int64     // most recent observed block (always > 0 once set)
 	ObservedAt time.Time // wall-clock of the observation that set Block (freshness stamp)
@@ -95,7 +106,9 @@ func (s *Store) Set(key string, t Tip, staleAfter time.Duration) bool {
 	switch {
 	case !ok || t.Block > cur.Block:
 		if ok && cur.ObservedAt.After(t.ObservedAt) {
-			t.ObservedAt = cur.ObservedAt // freshness stamp only advances, never regresses
+			// Freshness stamp only advances, never regresses — this is the one place the triple
+			// is stored as a hybrid (incoming Block+Source, stored ObservedAt); see Tip's doc.
+			t.ObservedAt = cur.ObservedAt
 		}
 		s.tips[key] = t
 		return true

--- a/protocol/endpointtip/store.go
+++ b/protocol/endpointtip/store.go
@@ -80,8 +80,11 @@ func Key(chainID, apiInterface, url string) string {
 //
 // Staleness is the gap between the stored and incoming observation stamps (> staleAfter),
 // not wall-clock — deterministic, no clock. A rejected write must not refresh the stamp,
-// else a repeated straggler keeps the tip forever fresh. staleAfter<=0 is up-only.
-// Returns true iff the stored tip now reflects this block (gates the consensus feed).
+// else a repeated straggler keeps the tip forever fresh. The freshness stamp only ever
+// advances (an accepted write never carries it backwards, even when the block jumps up on
+// an earlier-stamped cross-source observation), so the staleness gap can't be widened by a
+// stamp regression. staleAfter<=0 is up-only. Returns true iff the stored tip now reflects
+// this block (gates the consensus feed).
 func (s *Store) Set(key string, t Tip, staleAfter time.Duration) bool {
 	if t.Block <= 0 {
 		return false
@@ -91,6 +94,9 @@ func (s *Store) Set(key string, t Tip, staleAfter time.Duration) bool {
 	cur, ok := s.tips[key]
 	switch {
 	case !ok || t.Block > cur.Block:
+		if ok && cur.ObservedAt.After(t.ObservedAt) {
+			t.ObservedAt = cur.ObservedAt // freshness stamp only advances, never regresses
+		}
 		s.tips[key] = t
 		return true
 	case t.Block == cur.Block:

--- a/protocol/endpointtip/store_test.go
+++ b/protocol/endpointtip/store_test.go
@@ -7,41 +7,104 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestStore_Set_TimeMonotonicGuard pins the relocated guard: a write older than the
-// stored observation is dropped wholesale (no field regresses), a newer write applies,
-// and an equal timestamp applies (last-writer-wins). This is the exact semantics the
-// observation record enforced before consolidation — it must not become block-monotonic.
-func TestStore_Set_TimeMonotonicGuard(t *testing.T) {
+// TestStore_Set_BlockMonotonic pins the T4/C-D rule: the tip orders by BLOCK, not by
+// arrival time. A higher block always wins; an equal block refreshes freshness; a
+// newer-but-LOWER straggler is rejected while the stored tip is fresh (the F2 bug). This
+// is the inverse of the old time-monotonic guard.
+func TestStore_Set_BlockMonotonic(t *testing.T) {
 	s := NewStore()
 	k := Key("ETH1", "jsonrpc", "https://a.example:443")
 	base := time.Unix(1_000, 0)
+	const ttl = 100 * time.Second
 
-	require.True(t, s.Set(k, Tip{Block: 100, ObservedAt: base, Source: SourcePoll}))
+	// First observation stores.
+	require.True(t, s.Set(k, Tip{Block: 100, ObservedAt: base, Source: SourcePoll}, ttl))
 	require.Equal(t, int64(100), s.Block(k))
 
-	// Older observation is dropped wholesale, even though its block is higher.
-	require.False(t, s.Set(k, Tip{Block: 999, ObservedAt: base.Add(-time.Second), Source: SourceRelay}))
+	// Higher block wins — even carrying an EARLIER arrival stamp (block, not time, is the
+	// comparator now; the inverse of the old guard).
+	require.True(t, s.Set(k, Tip{Block: 200, ObservedAt: base.Add(-time.Second), Source: SourceRelay}, ttl))
+	require.Equal(t, int64(200), s.Block(k))
+
+	// The F2 straggler: a LOWER block observed only slightly later is rejected (< ttl since
+	// the stored tip's observation, so the stored tip is still fresh).
+	require.False(t, s.Set(k, Tip{Block: 198, ObservedAt: base.Add(2 * time.Second), Source: SourceRelay}, ttl))
 	got, ok := s.Get(k)
 	require.True(t, ok)
-	require.Equal(t, int64(100), got.Block, "stale write must not move the block")
-	require.Equal(t, SourcePoll, got.Source, "stale write must not move the source")
-
-	// Newer observation applies even with a LOWER block (guard is time-, not block-monotonic).
-	require.True(t, s.Set(k, Tip{Block: 50, ObservedAt: base.Add(time.Second), Source: SourceRelay}))
-	require.Equal(t, int64(50), s.Block(k))
-
-	// Equal timestamp applies (last-writer-wins).
-	require.True(t, s.Set(k, Tip{Block: 77, ObservedAt: base.Add(time.Second), Source: SourcePoll}))
-	require.Equal(t, int64(77), s.Block(k))
+	require.Equal(t, int64(200), got.Block, "a newer-but-lower straggler must not regress the tip")
+	require.Equal(t, SourceRelay, got.Source, "rejected write must not move the source")
+	require.Equal(t, base.Add(-time.Second), got.ObservedAt, "rejected write must not refresh the stamp")
 }
 
-// TestStore_Set_RejectsNonPositive guards that a zero/negative block is never stored,
-// matching the upstream "block <= 0" rejection in the observation writers.
+// TestStore_Set_EqualBlockRefreshesFreshness pins that an equal block re-proves liveness:
+// it advances the freshness stamp (so a healthy endpoint sitting at a stable head keeps
+// re-confirming and never goes stale) without moving the block, and never regresses it.
+func TestStore_Set_EqualBlockRefreshesFreshness(t *testing.T) {
+	s := NewStore()
+	k := Key("ETH1", "jsonrpc", "u")
+	base := time.Unix(1_000, 0)
+	const ttl = 10 * time.Second
+
+	require.True(t, s.Set(k, Tip{Block: 100, ObservedAt: base, Source: SourcePoll}, ttl))
+
+	// Re-report the SAME block 9s later: the stamp advances to base+9s.
+	require.True(t, s.Set(k, Tip{Block: 100, ObservedAt: base.Add(9 * time.Second), Source: SourcePoll}, ttl))
+	got, _ := s.Get(k)
+	require.Equal(t, base.Add(9*time.Second), got.ObservedAt, "equal-block confirmation advances the stamp")
+
+	// A lower block observed 8s after the REFRESH (base+17s) is only 8s < ttl past the
+	// refreshed stamp → still fresh → rejected. Without the refresh it would be 17s > ttl.
+	require.False(t, s.Set(k, Tip{Block: 99, ObservedAt: base.Add(17 * time.Second), Source: SourcePoll}, ttl))
+	require.Equal(t, int64(100), s.Block(k), "the equal-block refresh kept the tip fresh")
+
+	// A delayed equal block must NOT drag the stamp backward.
+	require.True(t, s.Set(k, Tip{Block: 100, ObservedAt: base, Source: SourceRelay}, ttl))
+	got, _ = s.Get(k)
+	require.Equal(t, base.Add(9*time.Second), got.ObservedAt, "stamp only advances, never regresses")
+}
+
+// TestStore_Set_StaleBackstopAcceptsReorg is the reorg half of C-D: while the stored tip
+// is fresh a lower block is rejected; once no higher block has re-confirmed it for longer
+// than the horizon, the same lower block is accepted (the endpoint genuinely fell back).
+// No fork signal is involved — the observation-time gap is the sole downward mechanism
+// (D-FORK resolved). Staleness is measured in observation time, so this is deterministic.
+func TestStore_Set_StaleBackstopAcceptsReorg(t *testing.T) {
+	s := NewStore()
+	k := Key("ETH1", "jsonrpc", "u")
+	base := time.Unix(1_000, 0)
+	const ttl = 100 * time.Second
+
+	require.True(t, s.Set(k, Tip{Block: 1001, ObservedAt: base, Source: SourcePoll}, ttl))
+
+	// Reorg to 1000 observed 30s later → within the horizon → rejected (stale-high, bounded).
+	require.False(t, s.Set(k, Tip{Block: 1000, ObservedAt: base.Add(30 * time.Second), Source: SourcePoll}, ttl))
+	require.Equal(t, int64(1001), s.Block(k))
+
+	// The endpoint keeps reporting 1000; 101s after the (never-refreshed) stored stamp the
+	// gap exceeds the horizon → accept the downward move. Self-heals to the true head.
+	require.True(t, s.Set(k, Tip{Block: 1000, ObservedAt: base.Add(101 * time.Second), Source: SourcePoll}, ttl))
+	require.Equal(t, int64(1000), s.Block(k), "stale stored tip → accept the endpoint's true head")
+}
+
+// TestStore_Set_ZeroStaleAfterDisablesDownward: staleAfter<=0 is pure up-only (never
+// accepts a lower block). Used by never-stale test seeds, which Remove-then-Set anyway.
+func TestStore_Set_ZeroStaleAfterDisablesDownward(t *testing.T) {
+	s := NewStore()
+	k := Key("ETH1", "jsonrpc", "u")
+	base := time.Unix(1_000, 0)
+
+	require.True(t, s.Set(k, Tip{Block: 100, ObservedAt: base, Source: SourcePoll}, 0))
+	// Even a far-later lower block is rejected when staleness is disabled.
+	require.False(t, s.Set(k, Tip{Block: 50, ObservedAt: base.Add(time.Hour), Source: SourcePoll}, 0))
+	require.Equal(t, int64(100), s.Block(k))
+}
+
+// TestStore_Set_RejectsNonPositive guards that a zero/negative block is never stored.
 func TestStore_Set_RejectsNonPositive(t *testing.T) {
 	s := NewStore()
 	k := Key("ETH1", "jsonrpc", "u")
-	require.False(t, s.Set(k, Tip{Block: 0, ObservedAt: time.Unix(1, 0)}))
-	require.False(t, s.Set(k, Tip{Block: -5, ObservedAt: time.Unix(1, 0)}))
+	require.False(t, s.Set(k, Tip{Block: 0, ObservedAt: time.Unix(1, 0)}, time.Minute))
+	require.False(t, s.Set(k, Tip{Block: -5, ObservedAt: time.Unix(1, 0)}, time.Minute))
 	require.Equal(t, int64(0), s.Block(k))
 	_, ok := s.Get(k)
 	require.False(t, ok)
@@ -57,8 +120,8 @@ func TestStore_Key_NoCrossChainCollision(t *testing.T) {
 	require.NotEqual(t, kEth, kLava)
 
 	now := time.Unix(2_000, 0)
-	s.Set(kEth, Tip{Block: 111, ObservedAt: now, Source: SourcePoll})
-	s.Set(kLava, Tip{Block: 222, ObservedAt: now, Source: SourcePoll})
+	s.Set(kEth, Tip{Block: 111, ObservedAt: now, Source: SourcePoll}, time.Minute)
+	s.Set(kLava, Tip{Block: 222, ObservedAt: now, Source: SourcePoll}, time.Minute)
 	require.Equal(t, int64(111), s.Block(kEth))
 	require.Equal(t, int64(222), s.Block(kLava))
 }
@@ -68,7 +131,7 @@ func TestStore_Key_NoCrossChainCollision(t *testing.T) {
 func TestStore_RemoveAndReset(t *testing.T) {
 	s := NewStore()
 	k := Key("ETH1", "jsonrpc", "u")
-	s.Set(k, Tip{Block: 5, ObservedAt: time.Unix(1, 0), Source: SourcePoll})
+	s.Set(k, Tip{Block: 5, ObservedAt: time.Unix(1, 0), Source: SourcePoll}, time.Minute)
 	require.Equal(t, int64(5), s.Block(k))
 
 	s.Remove(k)
@@ -76,7 +139,7 @@ func TestStore_RemoveAndReset(t *testing.T) {
 	require.False(t, ok)
 	require.Equal(t, int64(0), s.Block(k))
 
-	s.Set(k, Tip{Block: 9, ObservedAt: time.Unix(2, 0), Source: SourcePoll})
+	s.Set(k, Tip{Block: 9, ObservedAt: time.Unix(2, 0), Source: SourcePoll}, time.Minute)
 	s.Reset()
 	require.Equal(t, int64(0), s.Block(k), "Reset clears the whole store")
 }

--- a/protocol/endpointtip/store_test.go
+++ b/protocol/endpointtip/store_test.go
@@ -22,9 +22,12 @@ func TestStore_Set_BlockMonotonic(t *testing.T) {
 	require.Equal(t, int64(100), s.Block(k))
 
 	// Higher block wins — even carrying an EARLIER arrival stamp (block, not time, is the
-	// comparator now; the inverse of the old guard).
+	// comparator now; the inverse of the old guard). The freshness stamp is anchored forward,
+	// though: it stays at the stored (later) base, never regressing to the earlier one.
 	require.True(t, s.Set(k, Tip{Block: 200, ObservedAt: base.Add(-time.Second), Source: SourceRelay}, ttl))
 	require.Equal(t, int64(200), s.Block(k))
+	gotHigh, _ := s.Get(k)
+	require.Equal(t, base, gotHigh.ObservedAt, "higher block accepts but the stamp only advances")
 
 	// The F2 straggler: a LOWER block observed only slightly later is rejected (< ttl since
 	// the stored tip's observation, so the stored tip is still fresh).
@@ -33,7 +36,7 @@ func TestStore_Set_BlockMonotonic(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, int64(200), got.Block, "a newer-but-lower straggler must not regress the tip")
 	require.Equal(t, SourceRelay, got.Source, "rejected write must not move the source")
-	require.Equal(t, base.Add(-time.Second), got.ObservedAt, "rejected write must not refresh the stamp")
+	require.Equal(t, base, got.ObservedAt, "rejected write must not refresh the stamp")
 }
 
 // TestStore_Set_EqualBlockRefreshesFreshness pins that an equal block re-proves liveness:
@@ -61,6 +64,35 @@ func TestStore_Set_EqualBlockRefreshesFreshness(t *testing.T) {
 	require.True(t, s.Set(k, Tip{Block: 100, ObservedAt: base, Source: SourceRelay}, ttl))
 	got, _ = s.Get(k)
 	require.Equal(t, base.Add(9*time.Second), got.ObservedAt, "stamp only advances, never regresses")
+}
+
+// TestStore_Set_HigherBlockDoesNotRegressStamp pins that the higher-block branch anchors the
+// freshness stamp forward too: a higher block carrying an EARLIER observation stamp (reachable
+// cross-source — a relay skips the poll's arrival gate) is accepted for its block but keeps the
+// stored (later) stamp, so the staleness gap can't be widened by a stamp regression. Without the
+// anchor, a subsequent lower straggler would cross the horizon sooner than intended and wrongly
+// regress the tip (a residual F2).
+func TestStore_Set_HigherBlockDoesNotRegressStamp(t *testing.T) {
+	s := NewStore()
+	k := Key("ETH1", "jsonrpc", "u")
+	base := time.Unix(1_000, 0)
+	const ttl = 100 * time.Second
+
+	// Stored: block 200 observed at base+50s (e.g. a fresh poll).
+	require.True(t, s.Set(k, Tip{Block: 200, ObservedAt: base.Add(50 * time.Second), Source: SourcePoll}, ttl))
+
+	// A higher block 201 arrives carrying an EARLIER stamp (base+0s). Block wins, but the stamp
+	// must stay at the later base+50s.
+	require.True(t, s.Set(k, Tip{Block: 201, ObservedAt: base, Source: SourceRelay}, ttl))
+	got, _ := s.Get(k)
+	require.Equal(t, int64(201), got.Block, "higher block wins")
+	require.Equal(t, base.Add(50*time.Second), got.ObservedAt, "stamp must not regress below the stored one")
+	require.Equal(t, SourceRelay, got.Source, "the accepted higher block carries its own source")
+
+	// A lower block 200 observed at base+120s is 70s past the anchored stamp (< ttl) → still fresh
+	// → rejected. Had the stamp regressed to base+0s, this would be 120s > ttl and wrongly accepted.
+	require.False(t, s.Set(k, Tip{Block: 200, ObservedAt: base.Add(120 * time.Second), Source: SourcePoll}, ttl))
+	require.Equal(t, int64(201), s.Block(k), "anchored stamp keeps the tip fresh; straggler rejected")
 }
 
 // TestStore_Set_StaleBackstopAcceptsReorg is the reorg half of C-D: while the stored tip

--- a/protocol/probing/verdict.go
+++ b/protocol/probing/verdict.go
@@ -39,14 +39,16 @@ type VerdictConfig struct {
 }
 
 // DefaultVerdictConfig derives the verdict thresholds from a chain's average block time. The
-// per-endpoint "alive" horizon (StalenessWindow) shares ONE multiplier with the chainstate
-// consensus window — chainstate.DefaultStalenessMultiplier — so the liveness horizon and the
-// consensus freshness window never silently diverge when that horizon is tuned. Only the floor
-// differs (minProbeStaleness here vs chainstate.minStalenessWindow), since a per-endpoint probe
-// tolerates a slightly wider floor than the per-chain consensus.
+// per-endpoint "alive" horizon is chainstate.StalenessWindow raised to this package's own floor:
+// StalenessWindow already applies the shared DefaultStalenessMultiplier (so the liveness horizon
+// and the consensus freshness window never silently diverge when that derivation is tuned), and
+// the outer max lifts it to minProbeStaleness, a slightly wider floor than the per-chain consensus
+// (chainstate.minStalenessWindow) because a per-endpoint probe must not flip to "dead" on one slow
+// poll. Since minProbeStaleness > chainstate.minStalenessWindow the result is identical to deriving
+// the multiplier term inline; calling StalenessWindow just keeps the derivation in one place.
 func DefaultVerdictConfig(averageBlockTime time.Duration) VerdictConfig {
 	return VerdictConfig{
-		StalenessWindow:    max(time.Duration(chainstate.DefaultStalenessMultiplier)*averageBlockTime, minProbeStaleness),
+		StalenessWindow:    max(chainstate.StalenessWindow(averageBlockTime), minProbeStaleness),
 		LagToleranceBlocks: DefaultLagToleranceBlocks,
 		ReEnableHysteresis: DefaultProbeReEnableHysteresis,
 	}

--- a/protocol/rpcsmartrouter/chainstate_glue_test.go
+++ b/protocol/rpcsmartrouter/chainstate_glue_test.go
@@ -365,15 +365,25 @@ func TestHarvest_BootstrapAtomicGatedOnChainStateVerdict(t *testing.T) {
 	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1000}, gen, "provider1")
 	require.Equal(t, uint64(1000), rpcss.latestBlockHeight.Load(), "an accepted harvest seeds the bootstrap atomic")
 
-	// A lying-high harvest passes the per-endpoint store guard (higher + newer) but ChainState
-	// rejects it (fresh-tip anti-lie guard) → the atomic must NOT ratchet.
+	// A plausible advance ratchets the atomic (ChainState accepts; the store accepts a higher
+	// block). Ordered BEFORE the lie so the block-monotonic store does not retain a higher value
+	// that would reject it — see the T4 note below.
+	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1050}, gen, "provider1")
+	require.Equal(t, uint64(1050), rpcss.latestBlockHeight.Load(), "a plausible advance ratchets the atomic")
+
+	// A lying-high harvest passes the per-endpoint store guard (higher block, no anti-lie at that
+	// layer) but ChainState rejects it (fresh-tip anti-lie guard) → the atomic must NOT ratchet.
 	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1_000_000}, gen, "provider1")
-	require.Equal(t, uint64(1000), rpcss.latestBlockHeight.Load(),
+	require.Equal(t, uint64(1050), rpcss.latestBlockHeight.Load(),
 		"a harvest ChainState rejects as an outlier must not ratchet the monotonic atomic")
 
-	// A plausible advance flows normally again.
-	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1050}, gen, "provider1")
-	require.Equal(t, uint64(1050), rpcss.latestBlockHeight.Load(), "a plausible advance still ratchets the atomic")
+	// T4 consequence: the block-monotonic store RETAINS the lying-high 1_000_000 until it goes
+	// stale, so a subsequent honest-but-lower harvest is rejected and the harvest bails before the
+	// atomic. This is the conscious trade for fixing F2 — only a liar's own tip is inflated (F19,
+	// accepted); the global tip stays protected by ChainState's guard.
+	rpcss.harvestAndUpdateTipFromRelay(ep, cm, &pairingtypes.RelayReply{LatestBlock: 1051}, gen, "provider1")
+	require.Equal(t, uint64(1050), rpcss.latestBlockHeight.Load(),
+		"a lower harvest is rejected while the higher lie is still fresh")
 }
 
 // TestSiteC_SyncReferenceIsChainTip documents the Topic C T1/D4 contract that REPLACED the

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2132,11 +2132,13 @@ func (rpcss *RPCSmartRouterServer) recordRelayBlockObservation(endpoint *lavases
 // (the documented single source of truth) and falling back to the poll-tracker atomic only when
 // the store has no positive value (MAG-2160 Finding 6 + follow-up review).
 //
-// The store is fed by BOTH the poll observer AND relay harvest under a TIME-monotonic guard, so it
-// always reflects the newest observation — including a newer LOWER block after a reorg/rollback or
-// a stale-tip self-heal. The poll atomic, by contrast, advances only on a real poll that saw a new
-// block (replaceBlocksQueue runs only when gotNewBlock || forked) and never regresses on a plain
-// rollback, so it can sit STALE-HIGH while the store already holds the correct lower tip. Taking
+// The store is fed by BOTH the poll observer AND relay harvest under the T4 block-monotonic guard,
+// so it DOES eventually correct downward after a reorg/rollback — but not immediately: a newer
+// LOWER block is held off while the stored higher tip is still fresh and adopted once that tip goes
+// stale, so the downward correction lags by up to the staleness window. The poll atomic, by
+// contrast, advances only on a real poll that saw a new block (replaceBlocksQueue runs only when
+// gotNewBlock || forked) and never regresses on a plain rollback at all, so it can sit STALE-HIGH
+// indefinitely while the store already holds — or is about to adopt — the correct lower tip. Taking
 // max() (the earlier implementation) would then pick the stale atomic and make consistency
 // pre-validation believe a rolled-back endpoint is still caught up. Preferring the store fixes both
 // that reorg case AND the original traffic-gate-frozen case (there the store is the fresher/higher
@@ -2810,20 +2812,25 @@ func isFinalizedForCacheWrite(requestedBlock, replyLatestBlock, trackedLatestBlo
 // adoptSharedStateTip feeds a peer pod's chain tip — read from the shared cache under the
 // chain-level key, so it is the fleet-max of every pod's guarded tip — into this pod's
 // ChainState, but only when it is ahead of our local view. SetLatestBlock applies the same
-// outlier/Recompute guards as a local observation, so a poisoned peer value is snapped down
+// anti-lie guards as a local observation (outlier threshold against the clustered baseline, or
+// against the fresh tip before a baseline exists), so a poisoned peer value is snapped down
 // rather than trusted (T10). No-op when shared state is off or ChainState is not yet wired.
 func (rpcss *RPCSmartRouterServer) adoptSharedStateTip(ctx context.Context, peerTip, localSeenBlock int64) {
 	if !rpcss.sharedState || rpcss.chainState == nil || peerTip <= localSeenBlock {
 		return
 	}
-	// SetLatestBlock re-guards: advanced=false means the anti-lie guard rejected/snapped down the
-	// peer tip (e.g. a lying-high value). Log the outcome so a rejected peer tip is visible rather
-	// than silent — a stream of adopted=false is the signature of a poisoned shared tip.
+	// SetLatestBlock re-guards. Its `advanced` return means "the tip moved UP" — it is false both
+	// when the guard rejected the peer value AND when a stale local tip was re-adopted DOWNWARD to
+	// it, so it cannot on its own distinguish rejection from acceptance. Compare the resulting tip
+	// to the peer value for that: peer_tip_taken is true iff ChainState now holds the peer's block
+	// (accepted upward, already equal, or stale-tip downward self-heal), so peer_tip_taken=false is
+	// the unambiguous signature of a rejected/snapped-down — i.e. poisoned — shared tip.
 	tip, _, advanced := rpcss.chainState.SetLatestBlock(peerTip)
 	utils.LavaFormatDebug("shared-state tip fed to chain state",
 		utils.LogAttr("peer_tip", peerTip),
 		utils.LogAttr("local_seen_block", localSeenBlock),
-		utils.LogAttr("adopted", advanced),
+		utils.LogAttr("peer_tip_taken", tip == peerTip),
+		utils.LogAttr("tip_advanced", advanced),
 		utils.LogAttr("chain_state_tip", tip),
 		utils.LogAttr("GUID", ctx),
 	)

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2541,8 +2541,9 @@ func (rpcss *RPCSmartRouterServer) harvestAndUpdateTipFromRelay(
 	}
 	// The router-wide bootstrap atomic is monotonic-max with NO downward correction, so it may
 	// only follow blocks the CHAIN-level anti-lie guard accepted — the per-endpoint store's
-	// time-monotonic acceptance above is the wrong scope (a lying-high endpoint passes its own
-	// per-endpoint guard). By the time recordRelayBlockObservation returns, the monitor's
+	// block-monotonic acceptance above is the wrong scope: that guard has no anti-lie check, so a
+	// lying-high endpoint clears its own per-endpoint guard trivially (any higher block wins).
+	// By the time recordRelayBlockObservation returns, the monitor's
 	// OnTipObservation hook has already driven ChainState.SetLatestBlock with this very block
 	// (synchronously, after obsMu release — see RecordRelayObservation's deferred callback), so
 	// the ChainState tip reflects the verdict: an accepted block reads back as tip >= block, a

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2807,6 +2807,23 @@ func isFinalizedForCacheWrite(requestedBlock, replyLatestBlock, trackedLatestBlo
 	return spectypes.IsFinalizedBlock(requestedBlock, latest, finalizationDistance)
 }
 
+// adoptSharedStateTip feeds a peer pod's chain tip — read from the shared cache under the
+// chain-level key, so it is the fleet-max of every pod's guarded tip — into this pod's
+// ChainState, but only when it is ahead of our local view. SetLatestBlock applies the same
+// outlier/Recompute guards as a local observation, so a poisoned peer value is snapped down
+// rather than trusted (T10). No-op when shared state is off or ChainState is not yet wired.
+func (rpcss *RPCSmartRouterServer) adoptSharedStateTip(ctx context.Context, peerTip, localSeenBlock int64) {
+	if !rpcss.sharedState || rpcss.chainState == nil || peerTip <= localSeenBlock {
+		return
+	}
+	utils.LavaFormatDebug("shared-state tip is newer, feeding to chain state",
+		utils.LogAttr("peer_tip", peerTip),
+		utils.LogAttr("local_seen_block", localSeenBlock),
+		utils.LogAttr("GUID", ctx),
+	)
+	rpcss.chainState.SetLatestBlock(peerTip)
+}
+
 // tryCacheWrite attempts to write a successful relay response to the cache.
 // It runs in a separate goroutine to avoid blocking the relay response.
 // Cache writes are skipped when:
@@ -3029,10 +3046,10 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 	userData := protocolMessage.GetUserData()
 	var sharedStateId string // defaults to "", if shared state is disabled then no shared state will be used.
 	if rpcss.sharedState {
-		// Per-caller shared-state id. The retired consistency store used to own this key
-		// derivation; it is now a plain function, byte-identical so entries written by an older
-		// build still resolve. Moving shared state to a chain-level key is T10.
-		sharedStateId = relaycore.UserDataKey(userData)
+		// Chain-level shared-state id (T10): matches the write key in tryCacheWrite, so the
+		// value each pod publishes (its guarded chain tip) round-trips. Must equal the write
+		// key or the read never resolves it.
+		sharedStateId = rpcss.listenEndpoint.Key()
 	}
 
 	chainId, apiInterface := rpcss.GetChainIdAndApiInterface()
@@ -3168,31 +3185,10 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 					)
 					reply := cacheReply.GetReply()
 
-					// BEHAVIOR DROPPED (Topic C C-G, consciously accepted): inter-consumer-instance
-					// consistency via the cache server's seen block. This used to raise this
-					// request's SeenBlock (and the per-user consistency cache) to a seen block
-					// reported by ANOTHER router instance, so a user whose requests were balanced
-					// across instances kept a shared read-your-writes floor.
-					//
-					// It is removed rather than repointed because there is nothing to repoint it
-					// to: the tip is per-router-instance, and adopting a cross-instance value here
-					// would reintroduce exactly the vector C-G closes — an ungated block from
-					// outside this instance's anti-lie guards flowing into request resolution and
-					// the cache key.
-					//
-					// Cost: none in practice — this path was already dead. The write and read used
-					// DIFFERENT SharedStateIds (write: listenEndpoint.Key() = chainID+apiInterface,
-					// below in tryCacheWrite; read: relaycore.UserDataKey(userData) =
-					// dappId__consumerIp), and the cache server keys the value as
-					// chainID + "_" + sharedStateId (ecosystem/cache/handlers.go:556). The two keys
-					// can never collide, so getSeenBlockForSharedStateMode missed every time and
-					// returned 0. Both lines date to the initial smart-router commit (22cbf32).
-					//
-					// The PUBLISH side is deliberately left intact (tryCacheWrite still sends
-					// SeenBlock + SharedStateId), and what it now publishes is the guarded tip.
-					// Rebuilding the adopt side properly — chain-level key, value fed through
-					// ChainState.SetLatestBlock so it passes the anti-lie guards — is tracked as
-					// follow-up task T10.
+					// Cross-pod consistency (T10): peer pods publish their guarded chain tip under
+					// the shared chain-level key; the server returns the fleet-max. Adopt it through
+					// the same anti-lie guards as a local observation.
+					rpcss.adoptSharedStateTip(ctx, cacheReply.GetSeenBlock(), localRelayData.SeenBlock)
 
 					// handle cache reply
 					if cacheError == nil && reply != nil {

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2816,12 +2816,17 @@ func (rpcss *RPCSmartRouterServer) adoptSharedStateTip(ctx context.Context, peer
 	if !rpcss.sharedState || rpcss.chainState == nil || peerTip <= localSeenBlock {
 		return
 	}
-	utils.LavaFormatDebug("shared-state tip is newer, feeding to chain state",
+	// SetLatestBlock re-guards: advanced=false means the anti-lie guard rejected/snapped down the
+	// peer tip (e.g. a lying-high value). Log the outcome so a rejected peer tip is visible rather
+	// than silent — a stream of adopted=false is the signature of a poisoned shared tip.
+	tip, _, advanced := rpcss.chainState.SetLatestBlock(peerTip)
+	utils.LavaFormatDebug("shared-state tip fed to chain state",
 		utils.LogAttr("peer_tip", peerTip),
 		utils.LogAttr("local_seen_block", localSeenBlock),
+		utils.LogAttr("adopted", advanced),
+		utils.LogAttr("chain_state_tip", tip),
 		utils.LogAttr("GUID", ctx),
 	)
-	rpcss.chainState.SetLatestBlock(peerTip)
 }
 
 // tryCacheWrite attempts to write a successful relay response to the cache.

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -2643,9 +2643,14 @@ func TestSmartRouterSessionLeakPrevention_SingleProvider(t *testing.T) {
 // chain|apiInterface|url. ObservedAt = time.Now() keeps the time-monotonic guard happy for
 // successive seeds within a test.
 func seedEndpointTip(chainID, apiInterface, url string, block int64) {
+	key := endpointtip.Key(chainID, apiInterface, url)
+	// T4: the store is block-monotonic, so a re-seed to a lower block would be rejected.
+	// Tests want an exact value, so drop any prior entry first (staleAfter=0 = up-only).
+	endpointtip.Default().Remove(key)
 	endpointtip.Default().Set(
-		endpointtip.Key(chainID, apiInterface, url),
+		key,
 		endpointtip.Tip{Block: block, ObservedAt: time.Now(), Source: endpointtip.SourcePoll},
+		0,
 	)
 }
 

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -2640,8 +2640,8 @@ func TestSmartRouterSessionLeakPrevention_SingleProvider(t *testing.T) {
 // seedEndpointTip writes a poll-sourced tip into the shared single-source-of-truth
 // endpointtip store so the consistency/syncGap readers (which now read that store instead
 // of a per-Endpoint atomic) observe the block under test. It keys exactly as production:
-// chain|apiInterface|url. ObservedAt = time.Now() keeps the time-monotonic guard happy for
-// successive seeds within a test.
+// chain|apiInterface|url. The store is block-monotonic (T4), so a re-seed to a lower block
+// would be rejected; the helper drops any prior entry first and seeds up-only (staleAfter=0).
 func seedEndpointTip(chainID, apiInterface, url string, block int64) {
 	key := endpointtip.Key(chainID, apiInterface, url)
 	// T4: the store is block-monotonic, so a re-seed to a lower block would be rejected.

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -2666,11 +2666,13 @@ func seedChainTip(block int64) *chainstate.ChainState {
 
 // TestEndpointTipPreferStore locks the MAG-2160 Finding 6 fix + follow-up review: consistency
 // pre-validation prefers the endpointtip store (the single source of truth) and falls back to the
-// poll-tracker atomic ONLY when the store is empty. The store is fed by both poll and relay under a
-// time-monotonic guard, so it reflects the newest observation — including a newer LOWER block after
-// a reorg. A naive max() would keep a STALE-HIGH atomic winning there, making a rolled-back endpoint
-// look caught up; prefer-store fixes that while still winning the traffic-gate-frozen case (where
-// the store is the fresher/higher value).
+// poll-tracker atomic ONLY when the store is empty. The store is fed by both poll and relay; under
+// the T4 block-monotonic guard it self-heals a reorg DOWN — a newer lower block is held off while
+// the old higher tip is still fresh and adopted once that tip goes stale, so the downward correction
+// is delayed by up to the staleness window, not immediate. Either way the store eventually reflects
+// the true head, while the monotonic-max atomic never corrects downward at all — so a naive max()
+// would keep a STALE-HIGH atomic winning and make a rolled-back endpoint look caught up; prefer-store
+// fixes that while still winning the traffic-gate-frozen case (where the store is the fresher/higher value).
 func TestEndpointTipPreferStore(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/protocol/rpcsmartrouter/shared_state_tip_adopt_test.go
+++ b/protocol/rpcsmartrouter/shared_state_tip_adopt_test.go
@@ -1,0 +1,79 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/chainstate"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/stretchr/testify/require"
+)
+
+// newAdoptTestServer builds an rpcss whose ChainState is seeded to `seed` under a fixed clock, so
+// the tip stays fresh for the whole test (no TTL flakiness). OutlierThreshold is 100.
+func newAdoptTestServer(t *testing.T, sharedState bool, seed int64) *RPCSmartRouterServer {
+	t.Helper()
+	clock := func() time.Time { return time.Unix(1700000000, 0) }
+	cs := chainstate.NewWithClock("ETH1", chainstate.Config{
+		BucketWidth:      2,
+		OutlierThreshold: 100,
+		StalenessWindow:  10 * time.Second,
+		TTL:              10 * time.Second,
+	}, clock)
+	if _, _, ok := cs.SetLatestBlock(seed); !ok {
+		t.Fatalf("seed SetLatestBlock(%d) did not take", seed)
+	}
+	return &RPCSmartRouterServer{
+		listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"},
+		chainState:     cs,
+		sharedState:    sharedState,
+	}
+}
+
+func tip(t *testing.T, rpcss *RPCSmartRouterServer) int64 {
+	t.Helper()
+	block, ok := rpcss.chainState.GetLatestBlock()
+	require.True(t, ok, "tip should be known and fresh")
+	return block
+}
+
+// TestAdoptSharedStateTip covers the T10 adopt glue: a peer pod's fleet-max tip is fed into
+// ChainState only when shared state is on and the peer is ahead, and only through the anti-lie
+// guard — so an over-threshold peer value is snapped down, never trusted raw.
+func TestAdoptSharedStateTip(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("shared state off is a no-op", func(t *testing.T) {
+		rpcss := newAdoptTestServer(t, false, 1000)
+		rpcss.adoptSharedStateTip(ctx, 1005, 1000)
+		require.Equal(t, int64(1000), tip(t, rpcss))
+	})
+
+	t.Run("peer not ahead is a no-op", func(t *testing.T) {
+		rpcss := newAdoptTestServer(t, true, 1000)
+		rpcss.adoptSharedStateTip(ctx, 1000, 1000) // equal
+		rpcss.adoptSharedStateTip(ctx, 999, 1000)  // lower
+		require.Equal(t, int64(1000), tip(t, rpcss))
+	})
+
+	t.Run("peer ahead within threshold is adopted", func(t *testing.T) {
+		rpcss := newAdoptTestServer(t, true, 1000)
+		rpcss.adoptSharedStateTip(ctx, 1050, 1000)
+		require.Equal(t, int64(1050), tip(t, rpcss), "a plausible peer tip advances the local tip")
+	})
+
+	t.Run("over-threshold peer value is snapped down by the guard", func(t *testing.T) {
+		rpcss := newAdoptTestServer(t, true, 1000)
+		rpcss.adoptSharedStateTip(ctx, 1101, 1000) // 1000 + OutlierThreshold(100) + 1
+		require.Equal(t, int64(1000), tip(t, rpcss), "a lying-high peer tip is rejected, not trusted raw")
+	})
+
+	t.Run("nil chain state does not panic", func(t *testing.T) {
+		rpcss := &RPCSmartRouterServer{
+			listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"},
+			sharedState:    true,
+		}
+		require.NotPanics(t, func() { rpcss.adoptSharedStateTip(ctx, 5000, 1) })
+	})
+}

--- a/protocol/rpcsmartrouter/shared_state_tip_adopt_test.go
+++ b/protocol/rpcsmartrouter/shared_state_tip_adopt_test.go
@@ -77,3 +77,46 @@ func TestAdoptSharedStateTip(t *testing.T) {
 		require.NotPanics(t, func() { rpcss.adoptSharedStateTip(ctx, 5000, 1) })
 	})
 }
+
+// TestAdoptSharedStateTip_StaleTipTakesLowerPeerValue pins why the adopt log reports
+// peer_tip_taken (tip == peerTip) and not just SetLatestBlock's `advanced`: advanced means "the
+// tip moved UP", so it is false in TWO opposite situations — the guard rejected the peer value,
+// and a stale local tip was re-adopted DOWNWARD to it. Reading advanced alone would report this
+// adoption as a rejection, the exact conflation the adopt logging exists to avoid.
+//
+// Reachable whenever the local tip has gone stale and localSeenBlock < peerTip < local tip.
+func TestAdoptSharedStateTip_StaleTipTakesLowerPeerValue(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	cs := chainstate.NewWithClock("ETH1", chainstate.Config{
+		BucketWidth:      2,
+		OutlierThreshold: 100,
+		StalenessWindow:  10 * time.Second,
+		TTL:              10 * time.Second,
+	}, func() time.Time { return now })
+	if _, _, ok := cs.SetLatestBlock(2000); !ok {
+		t.Fatal("seed SetLatestBlock(2000) did not take")
+	}
+	rpcss := &RPCSmartRouterServer{
+		listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"},
+		chainState:     cs,
+		sharedState:    true,
+	}
+
+	// While the local tip is fresh, a lower peer tip is refused outright.
+	rpcss.adoptSharedStateTip(context.Background(), 1500, 1000)
+	require.Equal(t, int64(2000), tip(t, rpcss), "a fresh local tip refuses a lower peer value")
+
+	// Let the local tip go stale (no accepted observation within TTL).
+	now = now.Add(30 * time.Second)
+
+	// The same lower peer tip is now re-adopted downward — SetLatestBlock reports advanced=false
+	// here, yet the peer value WAS taken. tip == peerTip is what separates this from a rejection.
+	tipBefore, _, advanced := cs.SetLatestBlock(1500)
+	require.False(t, advanced, "a downward re-adoption is not an advance")
+	require.Equal(t, int64(1500), tipBefore, "...but the stale tip did take the peer value")
+
+	// And through the adopt path itself, for the same reason.
+	now = now.Add(30 * time.Second)
+	rpcss.adoptSharedStateTip(context.Background(), 1400, 1000)
+	require.Equal(t, int64(1400), tip(t, rpcss), "a stale local tip self-heals down to the peer value")
+}


### PR DESCRIPTION
## What

Lands **#226 (T4)** and **#228 (T10)** on `main`, **plus 3 commits addressing this PR's own review**. Both stacked PRs are already approved and marked Merged, but neither reached `main` — this PR carries their combined work the last step.

> **Updated:** this PR originally carried no new code. It now also contains 3 review-fix commits (`ee754cf`, `708b810`, `be4b2fc`) — see [Review fixes](#review-fixes) below. Commits `ac2165c`…`3e626e7` are still exactly as reviewed in #226/#228.

## Why this is needed

The stack was merged **bottom-up without retargeting**, so each merge landed in a branch that had already been copied upward:

| Time | PR | Merged into | Reached main? |
|---|---|---|---|
| 11:14:49 | #225 | `main` | ✅ |
| 11:15:28 | #226 | `unify-seenBlock-chainTip` | ❌ — `unify` had gone to main 39s earlier |
| 11:15:56 | #228 | `t4-block-monotonic-endpoint-tip` | ❌ — `t4` had gone to `unify` 28s earlier |

Each PR still pointed at its original stacked parent rather than `main`, so #226 and #228 merged correctly *into the stack* and never propagated. Ancestry confirms it — no branch is an ancestor of any other:

```
main   in-main      NOT-in-unify  NOT-in-t4
unify  NOT-in-main  in-unify      NOT-in-t4
t4     NOT-in-main  NOT-in-unify  in-t4
```

`t4-block-monotonic-endpoint-tip` already holds **both** T4 and T10 (because #228 merged into it), so a single PR from it closes the gap. #226 and #228 cannot be reused — GitHub will not re-target or re-merge a merged PR.

## Contents — 9 commits

**T4** (from #226, unchanged)
- `ac2165c` refactor(endpointtip): block-monotonic per-endpoint tip with a staleness backstop
- `42be4f8` refactor(endpointtip): anchor freshness stamp forward; fix staleness-window docs
- `8fe9926` docs(endpointtip): correct stale time-monotonic comments to block-monotonic (T4)
- `739a755` refactor(probing): derive liveness horizon via chainstate.StalenessWindow

**T10** (from #228, unchanged)
- `d374308` fix(shared-state): rebuild cross-pod consistency on the guarded chain tip (T10)
- `3e626e7` refactor(shared-state): log adopt outcome so a rejected peer tip is visible

**Review fixes** (new — see below)
- `ee754cf` fix(cache): floor the shared-state tip TTL at a hard minimum
- `708b810` docs(rpcsmartrouter): fix the T4 doc the sweep missed; separate adopt outcomes
- `be4b2fc` docs(endpointtip): document the one write that stores a hybrid tip triple

`14 files changed, 546 insertions(+), 146 deletions(-)`

<a name="review-fixes"></a>
## Review fixes

Three commits addressing findings from the review on this PR. All three concern code inherited from #226/#228 — none was introduced by the re-land. **Only the first changes behavior.**

### `ee754cf` — shared-state tip TTL floor (behavior change)

`SharedStateTipExpiration` floored the tip TTL at `ExpirationNonFinalized`, justified in its docstring as guaranteeing "a sane, non-zero TTL (a zero TTL would never expire)". `ExpirationNonFinalized` cannot underwrite either half:

- **Not guaranteed non-zero.** It is `flag * multiplier` (`server.go:75`) and *both* are operator-settable, so `--expiration-non-finalized=0` makes it `0`. Ristretto reads a zero TTL as *never expires* — a dead pod's tip would be stranded in the shared cache permanently, the exact failure the floor exists to prevent.
- **Not guaranteed useful.** At its 500ms default it is ~3 orders of magnitude short for a chain tip. A spec omitting `average_block_time` yields `0 * 10 = 0`, so the published tip evaporates between relays and shared state silently degrades back to off — the condition T10 exists to fix.

The root cause is borrowing a floor from an unrelated concept: `ExpirationNonFinalized` answers "how long may a cached RPC *response* be reused?" (short on purpose), while this answers "how long is a peer pod's *chain tip* worth knowing?" (should track the staleness horizon).

Adds `MinSharedStateTipExpiration = 2s` as a third, independent `max()` term, mirroring the router-side floor (`chainstate.minStalenessWindow`) without `ecosystem/cache` depending on `protocol/`. Deliberately a constant rather than a flag — a tunable minimum reintroduces the same hole.

**Blast radius is one case: a spec with no `average_block_time`.** Since `abt * 10 >= 2s` for any `abt >= 200ms`, every real chain (ETH 12s, Solana 400ms) is unchanged.

### `708b810` — T4 doc the sweep missed + adopt-outcome logging (no behavior change)

- `endpointTipPreferStore`'s doc still asserted the retired contract: *"fed … under a TIME-monotonic guard, so it always reflects the newest observation — including a newer LOWER block after a reorg/rollback."* Under T4 that second clause is false — a lower block is held off while the stored higher tip is fresh, so the downward correction lags by up to the staleness window. This is the same correction `8fe9926` applied to `TestEndpointTipPreferStore`'s rationale; the test-side twin was fixed while the production doc was not, leaving the only surviving `time-monotonic` reference in the tree.
- `adoptSharedStateTip` logged `adopted=advanced`, but `SetLatestBlock` returns `advanced=false` in **two opposite** situations: the guard rejected the peer value, *and* a stale local tip was re-adopted **downward** to it (`chain_state.go:324-328` sets the tip, then returns false). So the field `3e626e7` added specifically to make a rejected peer tip visible could not distinguish rejection from acceptance. Now logs `peer_tip_taken` (`tip == peerTip`), which maps correctly across all five `SetLatestBlock` outcomes, alongside `tip_advanced` under a name that says what it means. `TestAdoptSharedStateTip_StaleTipTakesLowerPeerValue` pins the distinction against the real `ChainState`.
- The same function's doc credited `SetLatestBlock` with "outlier/**Recompute** guards" — it never calls `Recompute`.

### `be4b2fc` — hybrid tip triple (docs only)

`Tip` is documented as atomic — "a write either advances all three or none" — but `Set`'s higher-block branch keeps the incoming `Block`/`Source` while retaining the **stored** `ObservedAt` (the anchoring from `42be4f8`). The anchoring is correct and unchanged; what was undocumented is the effect on `freshRelayTip`, the one reader keying off `Source` *and* `ObservedAt` together — it can see `Source=Relay` stamped with a poll's timestamp. The window is bounded by lock acquisition (both paths stamp `time.Now()` immediately before the store write), which is why this is a comment rather than a second stamp field.

## Branch note

This PR is opened from `stack-repair-t4-t10`, a clean branch created by rebasing `t4-block-monotonic-endpoint-tip` onto `main`.

A PR directly from `t4-block-monotonic-endpoint-tip` does **not** work (attempted in #234, now closed). Because this repo rebase-merges, `main` holds #225's content under *rewritten* SHAs while `t4` still carries the originals. Their merge-base is therefore `fd7b054` — before #225 landed — so GitHub's three-dot diff pulled in #225's changes too (30 files, +1413/-1067) and the merge reported `CONFLICTING`, with 4 both-changed hunks where #225's original commits collide with the already-applied copies on `main`.

Rebasing drops those three by patch-id, which a merge cannot do:

```
warning: skipped previously applied commit 0978c48
warning: skipped previously applied commit 5f72efd
warning: skipped previously applied commit 9b900ab
Successfully rebased and updated detached HEAD.
```

The result is this branch: merge-base is the current `main` tip, so the three-dot diff equals the true content difference, and it merges cleanly. No shared branch was rewritten; `t4-block-monotonic-endpoint-tip` is untouched.

## Verification

The re-land was audited by tree identity: before the review-fix commits, this branch's tree was **byte-identical** (`13a6d924…`) to `t4-block-monotonic-endpoint-tip`, the branch that held both #226 and #228 — proving nothing was added or dropped by the rebase. The merge-base with `main` is `main`'s own tip, so the three-dot diff equals the true content difference.

With the review fixes applied: `go build ./...` clean, `go vet ./...` clean (module-wide — this matters, since `Store.Set` gained a required parameter and `go build` skips `_test.go`), `gofmt` clean, and `chainstate`, `endpointstate`, `endpointtip`, `probing`, `ecosystem/cache` and the full `rpcsmartrouter` suite all pass.

## After this merges

#233 (T3) is the last of the stack and currently based on `t10-shared-chaintip`. Once this lands it will be rebased onto `main` and retargeted. Dry-run already done: 9 already-applied commits auto-drop (including the two T10 commits #233 carries), 6 T3 commits survive, zero conflicts. Note that dry-run predates the three review-fix commits here, so it is worth re-running against the merged `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
