### PR TITLE
fix(endpointstate): send REST POST block polls to the method path (MAG-2597)

### DIFF
--- a/protocol/endpointstate/endpoint_poller.go
+++ b/protocol/endpointstate/endpoint_poller.go
@@ -365,6 +365,7 @@ func (ecf *EndpointPoller) ObserveLatestBlockPoll(block int64, transportLatency 
 
 // sendRawRequest sends a raw request to the endpoint and returns the response.
 // For REST/GET requests, requestData is a URL path that must be appended to the base URL.
+// For REST/POST requests, requestData is the JSON body and apiName is the URL path.
 // For JSON-RPC/POST requests, requestData is the JSON body.
 func (ecf *EndpointPoller) sendRawRequest(ctx context.Context, requestData []byte, connectionType string, apiName string) ([]byte, error) {
 	if ecf.directConnection == nil {
@@ -374,31 +375,16 @@ func (ecf *EndpointPoller) sendRawRequest(ctx context.Context, requestData []byt
 	// REST GET: requestData is a URL path (e.g. "/cosmos/base/tendermint/v1beta1/blocks/latest")
 	// Must be appended to the base URL and sent as an HTTP GET.
 	if connectionType == "GET" {
-		httpDoer, ok := ecf.directConnection.(lavasession.HTTPDirectRPCDoer)
-		if !ok {
-			return nil, fmt.Errorf("connection does not support HTTP requests for endpoint %s", ecf.endpointURL)
-		}
+		return ecf.doRESTRequest(ctx, "GET", string(requestData), nil)
+	}
 
-		fullURL, err := common.JoinURLPath(ecf.directConnection.GetURL(), string(requestData))
-		if err != nil {
-			return nil, fmt.Errorf("failed to build REST URL: %w", err)
-		}
-
-		resp, err := httpDoer.DoHTTPRequest(ctx, lavasession.HTTPRequestParams{
-			Method: "GET",
-			URL:    fullURL,
-		})
-		if err != nil {
-			return nil, err
-		}
-		if resp.StatusCode >= 400 {
-			return nil, &lavasession.HTTPStatusError{
-				StatusCode: resp.StatusCode,
-				Status:     fmt.Sprintf("%d", resp.StatusCode),
-				Body:       resp.Body,
-			}
-		}
-		return resp.Body, nil
+	// REST with a non-GET method (Tron's rest collection is POST-typed): the method lives
+	// in the URL path, not the body. Unlike JSON-RPC — where every call targets the base
+	// URL and the method is named in the body — a REST POST must be sent to its own path,
+	// so append apiName the way the GET branch appends the template. Without this the poll
+	// lands on the bare base URL and the upstream answers 405 (MAG-2597).
+	if ecf.apiInterface == spectypes.APIInterfaceRest {
+		return ecf.doRESTRequest(ctx, connectionType, apiName, requestData)
 	}
 
 	// JSON-RPC / Tendermint RPC / gRPC / POST: send requestData as the body.
@@ -416,6 +402,43 @@ func (ecf *EndpointPoller) sendRawRequest(ctx context.Context, requestData []byt
 		return nil, err
 	}
 	return response.Data, nil
+}
+
+// doRESTRequest sends one REST call to path (appended to the endpoint's base URL) and
+// returns the response body. body is nil for GET. A >=400 status is returned as an
+// HTTPStatusError so callers can distinguish an upstream rejection from a transport error.
+func (ecf *EndpointPoller) doRESTRequest(ctx context.Context, method, path string, body []byte) ([]byte, error) {
+	httpDoer, ok := ecf.directConnection.(lavasession.HTTPDirectRPCDoer)
+	if !ok {
+		return nil, fmt.Errorf("connection does not support HTTP requests for endpoint %s", ecf.endpointURL)
+	}
+
+	fullURL, err := common.JoinURLPath(ecf.directConnection.GetURL(), path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build REST URL: %w", err)
+	}
+
+	params := lavasession.HTTPRequestParams{
+		Method: method,
+		URL:    fullURL,
+		Body:   body,
+	}
+	if body != nil {
+		params.ContentType = "application/json"
+	}
+
+	resp, err := httpDoer.DoHTTPRequest(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return nil, &lavasession.HTTPStatusError{
+			StatusCode: resp.StatusCode,
+			Status:     fmt.Sprintf("%d", resp.StatusCode),
+			Body:       resp.Body,
+		}
+	}
+	return resp.Body, nil
 }
 
 // chainFetcherMetadata returns metadata for constructing chain messages.

--- a/protocol/endpointstate/endpoint_poller.go
+++ b/protocol/endpointstate/endpoint_poller.go
@@ -337,12 +337,17 @@ func (ecf *EndpointPoller) FetchEndpoint() lavasession.RPCProviderEndpoint {
 // endpoint ChainTracker on Solana, which in turn starves every per-endpoint
 // metric that depends on OnNewBlock (latest_block, fetch_latest_success, …).
 //
-// The `path` argument is accepted for interface compatibility with
-// chainlib.ChainFetcher.CustomMessage but is not needed here: POST callers
-// (like SVMChainTracker) pass the body in `data` with `path=""`, and GET
-// callers already encode the URL suffix in `data` per sendRawRequest's REST
-// convention (see connectionType == "GET" branch below).
+// `path` is meaningful on exactly one route: REST non-GET, the only route that puts a
+// caller-chosen path in the URL (see sendRawRequest). There an explicit path wins over
+// apiName, so a caller that supplies one is not silently redirected to the method name.
+// Every other route ignores it, deliberately: jsonrpc and tendermintrpc target the base
+// URL, gRPC carries apiName as a method header (a path must not hijack it), and REST GET
+// already encodes the URL suffix in `data`. SVM callers — the only callers today — pass
+// path="" and take the apiName fallback.
 func (ecf *EndpointPoller) CustomMessage(ctx context.Context, path string, data []byte, connectionType string, apiName string) ([]byte, error) {
+	if path != "" && connectionType != "GET" && ecf.apiInterface == spectypes.APIInterfaceRest {
+		apiName = path
+	}
 	return ecf.sendRawRequest(ctx, data, connectionType, apiName)
 }
 

--- a/protocol/endpointstate/endpoint_poller_test.go
+++ b/protocol/endpointstate/endpoint_poller_test.go
@@ -2,8 +2,11 @@ package endpointstate
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"testing"
 
+	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
 	spectypes "github.com/magma-Devs/smart-router/types/spec"
 	"github.com/stretchr/testify/require"
@@ -127,4 +130,247 @@ func TestEndpointPoller_CustomMessage_PropagatesMissingConnection(t *testing.T) 
 
 	_, err := fetcher.CustomMessage(context.Background(), "", []byte(`{}`), "POST", "getLatestBlockhash")
 	require.Error(t, err, "CustomMessage must fail when there is no direct connection")
+}
+
+// recordingConnection captures exactly what the poller handed the transport, so a test can
+// assert WHICH url, method and body a given (apiInterface, connectionType) pair targets. It
+// implements both DirectRPCConnection (the jsonrpc / tendermintrpc / gRPC route) and
+// HTTPDirectRPCDoer (the REST route), so one mock can show that REST leaves through
+// DoHTTPRequest carrying a path while jsonrpc stays on SendRequest against the base URL.
+type recordingConnection struct {
+	url        string
+	statusCode int    // status returned by DoHTTPRequest; 0 means 200
+	respBody   []byte // body returned by both routes
+
+	httpCalls []lavasession.HTTPRequestParams
+	sendCalls []recordedSend
+}
+
+type recordedSend struct {
+	data    []byte
+	headers map[string]string
+}
+
+func (m *recordingConnection) SendRequest(ctx context.Context, data []byte, headers map[string]string) (*lavasession.DirectRPCResponse, error) {
+	m.sendCalls = append(m.sendCalls, recordedSend{data: data, headers: headers})
+	return &lavasession.DirectRPCResponse{Data: m.respBody, StatusCode: http.StatusOK}, nil
+}
+
+func (m *recordingConnection) DoHTTPRequest(ctx context.Context, params lavasession.HTTPRequestParams) (*lavasession.HTTPDirectRPCResponse, error) {
+	m.httpCalls = append(m.httpCalls, params)
+	status := m.statusCode
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &lavasession.HTTPDirectRPCResponse{StatusCode: status, Body: m.respBody}, nil
+}
+
+func (m *recordingConnection) GetProtocol() lavasession.DirectRPCProtocol {
+	return lavasession.DirectRPCProtocolHTTP
+}
+func (m *recordingConnection) Close() error                { return nil }
+func (m *recordingConnection) GetURL() string              { return m.url }
+func (m *recordingConnection) GetNodeUrl() *common.NodeUrl { return nil }
+
+// TestEndpointPoller_SendRawRequestRouting pins WHERE each (apiInterface, connectionType)
+// pair sends its poll — the one decision in this file that has now been wrong twice.
+//
+// REST POST used to hand the body to SendRequest, which POSTs to the bare base URL: Tron
+// answered 405 on every poll until endpoint availability hit zero and the interface stopped
+// serving ("No pairings available", MAG-2597). Because the fix keys on apiInterface rather
+// than on connectionType, the rows that matter most here are the NEGATIVE ones — jsonrpc,
+// tendermintrpc and gRPC all reach that branch with connectionType POST and must keep
+// targeting the base URL, gRPC with its method in a header. A REST fix that silently
+// redirected every jsonrpc chain would be a far worse bug than the one it fixed, and only a
+// test can hold that line in CI (the live probe that found the bug cannot).
+func TestEndpointPoller_SendRawRequestRouting(t *testing.T) {
+	const baseURL = "https://node.example.com/gateway/KEY"
+
+	for _, tc := range []struct {
+		name            string
+		apiInterface    string
+		connectionType  string
+		requestData     string
+		apiName         string
+		wantURL         string // non-empty: expect the REST route, targeting this full URL
+		wantMethod      string
+		wantBody        string
+		wantContentType string
+		wantGrpcHeader  string // non-empty: expect this x-grpc-method on the SendRequest route
+	}{
+		{
+			name:           "rest GET appends the template to the base URL and sends no body",
+			apiInterface:   spectypes.APIInterfaceRest,
+			connectionType: "GET",
+			requestData:    "/cosmos/base/tendermint/v1beta1/blocks/latest",
+			apiName:        "/cosmos/base/tendermint/v1beta1/blocks/latest",
+			wantURL:        baseURL + "/cosmos/base/tendermint/v1beta1/blocks/latest",
+			wantMethod:     "GET",
+		},
+		{
+			name:            "rest POST appends apiName to the base URL and sends the template as the body",
+			apiInterface:    spectypes.APIInterfaceRest,
+			connectionType:  "POST",
+			requestData:     `{"detail":false}`,
+			apiName:         "/wallet/getnowblock",
+			wantURL:         baseURL + "/wallet/getnowblock",
+			wantMethod:      "POST",
+			wantBody:        `{"detail":false}`,
+			wantContentType: "application/json",
+		},
+		{
+			name:           "jsonrpc POST keeps the base URL and names the method in the body",
+			apiInterface:   spectypes.APIInterfaceJsonRPC,
+			connectionType: "POST",
+			requestData:    `{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}`,
+			apiName:        "eth_blockNumber",
+			wantBody:       `{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}`,
+		},
+		{
+			name:           "tendermintrpc POST keeps the base URL",
+			apiInterface:   spectypes.APIInterfaceTendermintRPC,
+			connectionType: "POST",
+			requestData:    `{"jsonrpc":"2.0","id":1,"method":"status","params":[]}`,
+			apiName:        "status",
+			wantBody:       `{"jsonrpc":"2.0","id":1,"method":"status","params":[]}`,
+		},
+		{
+			name:           "grpc POST keeps the base URL and carries the method in a header",
+			apiInterface:   spectypes.APIInterfaceGrpc,
+			connectionType: "POST",
+			requestData:    "{}",
+			apiName:        "cosmos.base.tendermint.v1beta1.Service/GetLatestBlock",
+			wantBody:       "{}",
+			wantGrpcHeader: "cosmos.base.tendermint.v1beta1.Service/GetLatestBlock",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := &recordingConnection{url: baseURL, respBody: []byte(`{"ok":true}`)}
+			poller := NewEndpointPoller(
+				&lavasession.Endpoint{NetworkAddress: baseURL, Enabled: true},
+				conn,
+				nil, // chainParser unused: sendRawRequest does no parsing
+				"TRX",
+				tc.apiInterface,
+			)
+
+			got, err := poller.sendRawRequest(context.Background(), []byte(tc.requestData), tc.connectionType, tc.apiName)
+			require.NoError(t, err)
+			require.Equal(t, `{"ok":true}`, string(got), "the upstream body must be returned verbatim")
+
+			if tc.wantURL != "" {
+				require.Empty(t, conn.sendCalls, "REST must not fall through to the base-URL SendRequest route")
+				require.Len(t, conn.httpCalls, 1)
+				call := conn.httpCalls[0]
+				require.Equal(t, tc.wantURL, call.URL, "REST polls the method path, not the host root (MAG-2597)")
+				require.Equal(t, tc.wantMethod, call.Method)
+				require.Equal(t, tc.wantBody, string(call.Body))
+				require.Equal(t, tc.wantContentType, call.ContentType)
+				return
+			}
+
+			require.Empty(t, conn.httpCalls, "only REST may be rewritten onto a path — this interface must keep the base URL")
+			require.Len(t, conn.sendCalls, 1)
+			call := conn.sendCalls[0]
+			require.Equal(t, tc.wantBody, string(call.data))
+			require.Equal(t, "application/json", call.headers["Content-Type"])
+			require.Equal(t, tc.wantGrpcHeader, call.headers[lavasession.GRPCMethodHeader],
+				"gRPC dials the method from this header; every other interface must leave it unset")
+		})
+	}
+}
+
+// TestEndpointPoller_CustomMessage_PathArgument pins the contract of CustomMessage's `path`
+// argument. It used to be ignored outright, which was harmless only because REST non-GET had
+// no path of its own — every request went to the base URL. Now that REST non-GET routes on a
+// path, ignoring it would silently send a caller that passed "/wallet/getnowblock" to the
+// method name instead. The gRPC row is the other half of the contract: there apiName is the
+// dialed method, so a path must never displace it.
+func TestEndpointPoller_CustomMessage_PathArgument(t *testing.T) {
+	const baseURL = "https://node.example.com/gateway/KEY"
+
+	for _, tc := range []struct {
+		name           string
+		apiInterface   string
+		path           string
+		apiName        string
+		wantURL        string // non-empty: expect the REST route with this URL
+		wantGrpcHeader string
+	}{
+		{
+			name:         "rest POST prefers an explicit path over apiName",
+			apiInterface: spectypes.APIInterfaceRest,
+			path:         "/wallet/getnowblock",
+			apiName:      "getnowblock",
+			wantURL:      baseURL + "/wallet/getnowblock",
+		},
+		{
+			name:         "rest POST falls back to apiName when no path is given",
+			apiInterface: spectypes.APIInterfaceRest,
+			path:         "",
+			apiName:      "/wallet/getnowblock",
+			wantURL:      baseURL + "/wallet/getnowblock",
+		},
+		{
+			name:           "grpc POST ignores path so it cannot displace the method header",
+			apiInterface:   spectypes.APIInterfaceGrpc,
+			path:           "/some/http/path",
+			apiName:        "cosmos.base.tendermint.v1beta1.Service/GetLatestBlock",
+			wantGrpcHeader: "cosmos.base.tendermint.v1beta1.Service/GetLatestBlock",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := &recordingConnection{url: baseURL, respBody: []byte(`{"ok":true}`)}
+			poller := NewEndpointPoller(
+				&lavasession.Endpoint{NetworkAddress: baseURL, Enabled: true},
+				conn,
+				nil,
+				"TRX",
+				tc.apiInterface,
+			)
+
+			_, err := poller.CustomMessage(context.Background(), tc.path, []byte(`{}`), "POST", tc.apiName)
+			require.NoError(t, err)
+
+			if tc.wantURL != "" {
+				require.Len(t, conn.httpCalls, 1)
+				require.Equal(t, tc.wantURL, conn.httpCalls[0].URL)
+				return
+			}
+
+			require.Empty(t, conn.httpCalls)
+			require.Len(t, conn.sendCalls, 1)
+			require.Equal(t, tc.wantGrpcHeader, conn.sendCalls[0].headers[lavasession.GRPCMethodHeader])
+		})
+	}
+}
+
+// TestEndpointPoller_RESTRejectionSurfacesHTTPStatus pins the failure shape of the bug this
+// change fixes: an upstream rejection on the REST route must come back as a typed
+// *HTTPStatusError carrying the code, because that is what the relay path reads to classify
+// the error (rpcsmartrouter_server.go reads StatusCode off this type). A bare error would
+// classify a 405 as an unknown transport failure.
+func TestEndpointPoller_RESTRejectionSurfacesHTTPStatus(t *testing.T) {
+	const baseURL = "https://api.trongrid.io"
+
+	conn := &recordingConnection{
+		url:        baseURL,
+		statusCode: http.StatusMethodNotAllowed,
+		respBody:   []byte("405 Not Allowed"),
+	}
+	poller := NewEndpointPoller(
+		&lavasession.Endpoint{NetworkAddress: baseURL, Enabled: true},
+		conn,
+		nil,
+		"TRX",
+		spectypes.APIInterfaceRest,
+	)
+
+	_, err := poller.sendRawRequest(context.Background(), []byte(`{}`), "POST", "/wallet/getnowblock")
+	require.Error(t, err)
+
+	var statusErr *lavasession.HTTPStatusError
+	require.True(t, errors.As(err, &statusErr), "REST rejections must stay typed for error classification")
+	require.Equal(t, http.StatusMethodNotAllowed, statusErr.StatusCode)
+	require.Equal(t, "405 Not Allowed", string(statusErr.Body), "the upstream body must survive for diagnostics")
 }


### PR DESCRIPTION
# Description

Closes: [MAG-2597](https://magmadevs.atlassian.net/browse/MAG-2597)

`EndpointPoller.sendRawRequest` handled REST `GET` and REST `POST` asymmetrically. The GET branch joins the request data onto the base URL as a path; the POST branch handed the body to `directConnection.SendRequest`, which POSTs to `nodeUrl.Url` — the **bare base URL**. `parsing.ApiName` was passed into the function but used only as a gRPC header, never for HTTP.

Any spec whose `GET_BLOCKNUM` directive lives in a `rest` collection with `"type": "POST"` therefore polled the host root. Tron answers that with **405 on every poll**, which drives endpoint availability to zero until the router stops serving the interface entirely (`"No pairings available."`).

**Most critical file to review:** `protocol/endpointstate/endpoint_poller.go`.

### Why this went unnoticed

The relay path was never affected — `chainlib/rest.go:50-53` sets `urlPath = craftData.Path` for POST — so relays worked while block-polling failed. In the probe that surfaced this, 92/100 REST POST methods passed while the chain tracker was failing 100%. `smartrouter health` is built on `ChainFetcher`, which uses the correct path, so the diagnostic tool could not reproduce it either.

### The fix

REST non-GET now goes through the same path-joining helper as REST GET (`doRESTRequest`), which also removes the duplicated httpDoer cast / `JoinURLPath` / status-check block.

Gated on **`apiInterface == rest`**, not on `connectionType == POST` — jsonrpc, tendermintrpc and gRPC all reach that branch with POST and must keep targeting the base URL. A rest fix that silently redirected every jsonrpc chain would be a far worse bug than the one being fixed, so the jsonrpc path is verified live below, not just reasoned about.

## Testing

Three router runs, same config, **one variable each**, against TRX mainnet + TRXT Shasta + TRXN Nile. `TRXN` was grafted in from [lava-specs#96](https://github.com/Magma-Devs/lava-specs/pull/96) so the `TRX → TRXT → TRXN` inheritance chain is genuinely exercised.

| Run | Binary | `tron.json` | TRX | TRXT | TRXN | Chain-tracker hash reads |
|---|---|---|---|---|---|---|
| A | `main` | `main` (path in body slot) | 20× 405 | 20× 405 | 20× 405 | 0 |
| B | `main` | spec fix ([lava-specs#101](https://github.com/Magma-Devs/lava-specs/pull/101)) | 20× 405 | 20× 405 | 20× 405 | 0 |
| C | **this PR** | spec fix | ✅ | ✅ | ✅ | 51 |

Run B matters: the companion spec fix **alone** leaves failure counts byte-identical to the baseline. This change is what restores rest polling.

Run C, per chain, with real hashes off the chain tracker:

```
TRX  (mainnet)   latestBlock=84829439
TRXT (Shasta)    latestBlock=66980760   hash=0000000003fe0b9845e86c62c6558189466c2a7bee
TRXN (Nile)      latestBlock=69550153   hash=00000000042540494f6038570c4cadd7ddd1ae43c5
```

End-to-end relays through the router (`POST /wallet/getnowblock` per listener) vs. the same call direct to upstream:

| Chain | via router | direct upstream |
|---|---|---|
| TRX | 84830254 | 84830255 |
| TRXT | 66981568 | 66981569 |
| TRXN | 69550966 | 69550968 |

**jsonrpc no-regression** (this binary, TRX jsonrpc): `smartrouter_latest_block{apiInterface="jsonrpc",spec="TRX"}` = 84830298, `eth_blockNumber` through the router returned `0x50e686d` = 84830317, 0 poll failures.

`go build ./...` clean; `protocol/endpointstate` and `protocol/lavasession` tests pass.

## Notes for reviewers

- **Unit tests.** This is covered end-to-end above but has no new unit test. `sendRawRequest` is a method on `EndpointPoller` and needs a `directConnection` to exercise; the existing `direct_rpc_connection_test.go` covers `SendRequest`/`DoHTTPRequest` at the transport layer but nothing asserts *which* URL the poller targets per interface. A table test over (apiInterface, connectionType) → expected URL would lock in the jsonrpc-vs-rest split — happy to add it here if preferred over a follow-up.
- **Separate observation, not addressed here.** In run C the rest chain tracker was demonstrably working (51 hash reads, relays returning correct heights) yet **no `smartrouter_latest_block` series appeared for any rest spec**, while the jsonrpc run emits one. The gauge looks like it is not wired on the rest path. Not a regression from this change; worth its own ticket.
- **Environmental.** TronGrid's free tier throttles at `allowed_rps(3)`; back-to-back runs produce 429 cascades that can fail boot verification. Runs above were spaced ~2 min apart, and the remaining 429s are on the verification-relay path, never on the `GET_BLOCKNUM` poll, so they don't contaminate the 405 counts.

---

## Author Checklist

I have...

* [x] read the contribution guide
* [x] included the correct type prefix in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change — n/a, no API or client breaking change
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification — MAG-2597, and the companion spec fix lava-specs#101
* [x] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration tests — **not done**: verified end-to-end against three live chains instead; see the first reviewer note
* [x] updated the relevant documentation or specification — the doc comment on `sendRawRequest` now states the REST POST contract, and `doRESTRequest` is documented
* [ ] confirmed all CI checks have passed — pending on this PR


[MAG-2597]: https://magmadevs.atlassian.net/browse/MAG-2597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ