### PR TITLE
fix(rpcsmartrouter): keep ChainTrackers reconciled; don't demote on one bad cycle

### DIFF
--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -482,6 +482,13 @@ type EndpointWithDirectConnection struct {
 // tracker until a relay happened to hit them (rare, because backups are fallback-only),
 // which meant dedicated-URL backups like base.lava.build had no block data on the dashboard.
 // Returns empty slice if no direct RPC endpoints are configured.
+//
+// NOT a silent filter on reachability (MAG-2622 chased this as a suspect and it was not the
+// cause): IsDirectRPC() IS len(DirectConnections) > 0, and an endpoint only ever reaches the
+// pairing with a connection attached — convertProvidersToSessions drops a URL whose
+// NewDirectRPCConnection failed, and drops the whole provider when every URL failed. So the
+// set returned here is "every configured direct-RPC endpoint currently paired", reachable or
+// not; a DOWN endpoint is present and must be given a tracker (see initializeChainTrackers).
 func (csm *ConsumerSessionManager) GetAllDirectRPCEndpoints() []*EndpointWithDirectConnection {
 	csm.lock.RLock()
 	defer csm.lock.RUnlock()
@@ -491,6 +498,9 @@ func (csm *ConsumerSessionManager) GetAllDirectRPCEndpoints() []*EndpointWithDir
 	collect := func(providers map[string]*ConsumerSessionsWithProvider) {
 		for providerAddr, cswp := range providers {
 			for _, endpoint := range cswp.Endpoints {
+				// The length check is redundant today (IsDirectRPC IS len(DirectConnections) > 0)
+				// but it is what makes the [0] index below safe, so it stays: a future change to
+				// IsDirectRPC must not silently turn this into a panic.
 				if endpoint.IsDirectRPC() && len(endpoint.DirectConnections) > 0 {
 					results = append(results, &EndpointWithDirectConnection{
 						Endpoint:         endpoint,

--- a/protocol/rpcsmartrouter/chaintracker_reconcile_test.go
+++ b/protocol/rpcsmartrouter/chaintracker_reconcile_test.go
@@ -1,0 +1,207 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/endpointstate"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
+	"github.com/magma-Devs/smart-router/utils/rand"
+	"github.com/stretchr/testify/require"
+)
+
+// reconcileFixture is the minimum wiring reconcileChainTrackers touches: a real EndpointMonitor
+// (real ChainParser, so a tracker's background poll goroutine does not panic on a nil parser) and a
+// real ConsumerSessionManager whose pairing the test drives directly.
+type reconcileFixture struct {
+	server  *RPCSmartRouterServer
+	monitor *endpointstate.EndpointMonitor
+	csm     *lavasession.ConsumerSessionManager
+	epoch   uint64
+}
+
+func newReconcileFixture(t *testing.T, ctx context.Context) *reconcileFixture {
+	t.Helper()
+	if !rand.Initialized() {
+		rand.InitRandomSeed()
+	}
+
+	const chainID, apiInterface = "ETH1", "jsonrpc"
+	monitor := endpointstate.NewEndpointMonitor(ctx, endpointstate.EndpointChainTrackerConfig{
+		ChainParser:  newRealChainParserForHarvest(t, chainID),
+		ChainID:      chainID,
+		ApiInterface: apiInterface,
+		// Long block time on purpose: the endpoints below are unreachable, so every tracker's
+		// start retry backs off on this value. Keeping it long keeps the test quiet; nothing
+		// here asserts on poll results, only on tracker REGISTRATION.
+		AverageBlockTime: 30 * time.Second,
+		BlocksToSave:     1,
+	})
+	t.Cleanup(monitor.Stop)
+
+	rpcEndpoint := &lavasession.RPCEndpoint{
+		NetworkAddress: "127.0.0.1:0", ChainID: chainID, ApiInterface: apiInterface, HealthCheckPath: "/",
+	}
+	csm := lavasession.NewConsumerSessionManager(
+		rpcEndpoint,
+		provideroptimizer.NewProviderOptimizer(provideroptimizer.StrategyBalanced, time.Second, uint(1), nil, chainID),
+		nil, "lava@test", lavasession.NewActiveSubscriptionProvidersStorage(),
+	)
+
+	return &reconcileFixture{
+		server: &RPCSmartRouterServer{
+			endpointChainTrackerManager: monitor,
+			sessionManager:              csm,
+			listenEndpoint:              rpcEndpoint,
+		},
+		monitor: monitor,
+		csm:     csm,
+		epoch:   1,
+	}
+}
+
+// admit replaces the live pairing with sessions for exactly these URLs, mirroring what the
+// post-startup admission paths do (retryFailedStaticProviders / applyReverification promote /
+// rebuildPairingFromConfig all rebuild sessions with FRESH DirectRPCConnections).
+//
+// The URLs point at a closed port: NewDirectRPCConnection for HTTP builds a client without
+// dialing, so this reproduces the case that matters — an endpoint that is fully PAIRED and
+// carries a usable connection object while the upstream itself is unreachable.
+func (f *reconcileFixture) admit(t *testing.T, ctx context.Context, urls ...string) {
+	t.Helper()
+	pairing := make(map[uint64]*lavasession.ConsumerSessionsWithProvider, len(urls))
+	for i, url := range urls {
+		conn, err := lavasession.NewDirectRPCConnection(ctx, common.NodeUrl{Url: url}, 5, "jsonrpc")
+		require.NoError(t, err)
+		pairing[uint64(i)] = lavasession.NewConsumerSessionWithProvider(
+			fmt.Sprintf("provider-%d", i),
+			[]*lavasession.Endpoint{{
+				NetworkAddress:    url,
+				Enabled:           true,
+				DirectConnections: []lavasession.DirectRPCConnection{conn},
+			}},
+			999999, f.epoch, int64(1),
+		)
+	}
+	require.NoError(t, f.csm.UpdateAllProviders(f.epoch, pairing, nil))
+}
+
+func (f *reconcileFixture) hasTracker(url string) bool {
+	_, ok := f.monitor.GetTracker(url)
+	return ok
+}
+
+// MAG-2622 — the regression pin, at the level the bug lived: initializeChainTrackers as a whole.
+//
+// An endpoint that is unreachable when the router boots fails startup verification and is held out
+// of the pairing, so the startup pass legitimately does not see it (which is why the boot log read
+// "failed=0 success=1" rather than "failed=2" — skipped, not failed). It is admitted later, with a
+// fresh DirectRPCConnection, by retryFailedStaticProviders / the epoch re-verify. Before the fix
+// nothing registered a tracker at that point and the endpoint never polled for the lifetime of the
+// process — PollIntervalMs=0 with ConsecutivePollFailures=0.
+//
+// Against the pre-fix one-shot initializeChainTrackers this test hangs at the Eventually and fails:
+// there was no second pass to make.
+func TestInitializeChainTrackers_RegistersEndpointAdmittedAfterStartup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	restore := chainTrackerReconcileInterval
+	chainTrackerReconcileInterval = 50 * time.Millisecond
+	t.Cleanup(func() { chainTrackerReconcileInterval = restore })
+
+	f := newReconcileFixture(t, ctx)
+
+	const bootURL = "http://127.0.0.1:1/boot"        // reachable at boot → verified → paired
+	const lateURL = "http://127.0.0.1:1/late"        // down at boot → held out of the pairing
+	const laterURL = "http://127.0.0.1:1/even-later" // second recovery, a later tick
+
+	f.admit(t, ctx, bootURL)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f.server.initializeChainTrackers(ctx)
+	}()
+
+	require.Eventually(t, func() bool { return f.hasTracker(bootURL) }, 5*time.Second, 20*time.Millisecond,
+		"the startup pass must register the endpoint that was paired at boot")
+
+	// The recovery: the previously-down upstream passes re-verification and is admitted.
+	f.admit(t, ctx, bootURL, lateURL)
+	require.Eventually(t, func() bool { return f.hasTracker(lateURL) }, 5*time.Second, 20*time.Millisecond,
+		"an endpoint admitted AFTER startup must be given a ChainTracker by the reconcile loop")
+
+	// Convergence is continuous, not a single second chance.
+	f.admit(t, ctx, bootURL, lateURL, laterURL)
+	require.Eventually(t, func() bool { return f.hasTracker(laterURL) }, 5*time.Second, 20*time.Millisecond,
+		"the reconcile loop must keep converging on every tick, not just once after startup")
+
+	// Registration does not depend on reachability — all three URLs point at a closed port. That is
+	// the fix's core assumption: GetOrCreateTracker does no network I/O, and the poll-failure
+	// backoff (proven healthy for endpoints that go down AFTER their tracker exists) takes it from
+	// here.
+	require.True(t, f.hasTracker(bootURL) && f.hasTracker(lateURL) && f.hasTracker(laterURL))
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("initializeChainTrackers must return when its context is cancelled")
+	}
+}
+
+// The reconcile pass is idempotent and reports honest counts: a second pass over an unchanged
+// pairing creates nothing and attributes every endpoint to alreadyPresent. This is what makes the
+// loop cheap enough to run on a short interval, and it is also what the "success" figure in the
+// startup log now means (created + alreadyPresent, not "attempted").
+func TestReconcileChainTrackers_IdempotentAndCounts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	f := newReconcileFixture(t, ctx)
+	urls := []string{"http://127.0.0.1:1/a", "http://127.0.0.1:1/b", "http://127.0.0.1:1/c"}
+	f.admit(t, ctx, urls...)
+
+	created, present, failed := f.server.reconcileChainTrackers(ctx, true)
+	require.Equal(t, 3, created)
+	require.Equal(t, 0, present)
+	require.Equal(t, 0, failed)
+
+	created, present, failed = f.server.reconcileChainTrackers(ctx, false)
+	require.Equal(t, 0, created, "a steady-state pass must not recreate anything")
+	require.Equal(t, 3, present)
+	require.Equal(t, 0, failed)
+
+	// A tracker removed out from under us (the epoch cleanup's brief-unhealthy window, MAG-2445)
+	// is restored by the next pass rather than waiting for /debug/reset-chaintracker-rows.
+	f.monitor.RemoveTracker(urls[1])
+	created, present, failed = f.server.reconcileChainTrackers(ctx, false)
+	require.Equal(t, 1, created, "a tracker removed after registration must be re-registered")
+	require.Equal(t, 2, present)
+	require.Equal(t, 0, failed)
+	require.True(t, f.hasTracker(urls[1]))
+}
+
+// An empty pairing is a no-op, not a panic — the state a router sits in when every configured
+// upstream failed boot verification, which is exactly the scenario this loop exists to recover from.
+func TestReconcileChainTrackers_EmptyPairingIsNoOp(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	f := newReconcileFixture(t, ctx)
+
+	created, present, failed := f.server.reconcileChainTrackers(ctx, true)
+	require.Zero(t, created)
+	require.Zero(t, present)
+	require.Zero(t, failed)
+
+	// ...and it starts working the moment the first upstream is admitted.
+	f.admit(t, ctx, "http://127.0.0.1:1/first")
+	created, _, _ = f.server.reconcileChainTrackers(ctx, false)
+	require.Equal(t, 1, created)
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -522,7 +522,22 @@ func resetAllProbeBackoff(deps debugMuxDeps) int {
 // reregisterChainTrackerRows re-registers every currently-configured direct-RPC endpoint that lost
 // its ChainTracker row — the recovery tool for MAG-2445, where the epoch cleanup (cleanupStaleTrackers)
 // can delete the row of a provider that was only briefly unhealthy, after which no reset recreates it
-// and the provider returns only on a later ~15-minute rebuild. The source is the config/pairing set
+// and the provider returns only on a later ~15-minute rebuild.
+//
+// Since MAG-2622 the server's own reconcile loop (initializeChainTrackers) re-registers a missing
+// row within chainTrackerReconcileInterval from this SAME source, so this handler is no longer the
+// only way back — its remaining value is being on-demand and auditable: an operator gets the row
+// back immediately (e.g. right after /debug/reset-pairing re-admits a demoted provider) instead of
+// waiting out a tick, and the action is explicit in the support record.
+//
+// Neither path shortens MAG-2445's EXCLUSION window, because both read the LIVE PAIRING: there the
+// epoch re-verify demotes the endpoint OUT of the pairing (applyReverification sees a 503) before
+// cleanupStaleTrackers drops its row, so until a later epoch promotes it back it is absent from
+// GetAllDirectRPCEndpoints entirely. Shortening that means keeping the endpoint paired, not
+// re-registering its tracker. What both paths DO fix is what happens after the promote: the row
+// comes back instead of waiting on a relay to trigger lazy creation.
+//
+// The source is the config/pairing set
 // (GetAllDirectRPCEndpoints, the same source initializeChainTrackers uses at startup), NOT the live
 // health-filtered set cleanupStaleTrackers deletes from — so a temporarily-disabled provider is
 // restored while a genuinely config-removed one is correctly left out. GetOrCreateTracker is

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2643,10 +2643,61 @@ func (rpcss *RPCSmartRouterServer) ensureEndpointChainTracker(
 	}
 }
 
-// initializeChainTrackers creates ChainTrackers for all direct RPC endpoints on startup.
-// This runs in the background and ensures fresh block data is available from the start,
-// avoiding issues where endpoints have stale or no block data for consistency validation.
-// If initialization fails for an endpoint, lazy initialization (ensureEndpointChainTracker) serves as fallback.
+// chainTrackerReconcileInterval is how often initializeChainTrackers re-walks the live pairing
+// looking for direct-RPC endpoints that have no ChainTracker. It is deliberately short relative to
+// the paths that ADMIT an endpoint after startup (retryFailedStaticProviders' 3m ticker, the ~15m
+// epoch re-verify), because it is the only thing standing between a late-admitted endpoint and
+// permanent silence — a reconcile pass is a map lookup per endpoint when nothing is missing, so the
+// cost of running it often is nil. Package-level var, not a const, so tests can shorten it.
+var chainTrackerReconcileInterval = 15 * time.Second
+
+// initializeChainTrackers keeps a ChainTracker registered for every direct-RPC endpoint in the live
+// pairing, for the lifetime of the server. It runs one pass ~100ms after startup and then reconciles
+// on chainTrackerReconcileInterval.
+//
+// MAG-2622 — why this is a LOOP and not the one-shot it used to be. Endpoints enter the pairing at
+// three points AFTER this function's first pass, and none of them registered a tracker:
+//
+//	retryFailedStaticProviders   an upstream that failed boot verification recovers (3m ticker)
+//	applyReverification promote  a demoted provider passes re-verification (epoch tick)
+//	rebuildPairingFromConfig     /debug/reset-pairing re-admits cold
+//
+// All three build fresh DirectRPCConnections, so the endpoint is fully usable and shows up in
+// GetAllDirectRPCEndpoints — it just had no poll loop, forever. Its signature is PollIntervalMs=0
+// with ConsecutivePollFailures=0: not polling, and not even failing. The docstring used to name
+// ensureEndpointChainTracker as the fallback, but that only fires when a relay is ROUTED to the
+// endpoint, and an endpoint with no observations does not score well enough to attract one — a
+// chicken-and-egg that never resolves.
+//
+// The damage is not the missing telemetry. Below chainstate's min-2 rule no consensus baseline can
+// form, which switches OFF the consensus-anchored anti-lie guard in SetLatestBlock and Recompute's
+// snap-down correction, so a cold-start lie becomes permanent and effectively all traffic routes to
+// the one endpoint that does have data. On a 3-endpoint pod with 2 upstreams down at boot, that is
+// the whole pod.
+//
+// Registering for a DOWN endpoint is safe and is the point: GetOrCreateTracker does no network I/O
+// (it registers the row and its observation generation under the manager lock, then starts the poll
+// via `go startTrackerWithRetry`), and the poll-failure backoff already handles unreachability
+// correctly — an endpoint that goes down AFTER its tracker exists backs off and recovers cleanly.
+// This loop simply guarantees the tracker exists so that machinery can apply.
+//
+// Relationship to MAG-2445 (a brief outage across an epoch boundary costing ~15 minutes) — this
+// closes HALF of it, and it matters which half. That bug runs: epoch re-verify sees a 503 and
+// DEMOTES the endpoint out of the pairing (applyReverification) → cleanupStaleTrackers drops its
+// row → the endpoint heals → a later epoch's re-verify PROMOTES it back into the pairing.
+//
+//	exclusion (demote → promote, up to one epoch)   NOT fixed here, and must not be: this loop
+//	                                                reconciles against the LIVE PAIRING, so a
+//	                                                demoted endpoint is correctly invisible to it.
+//	                                                Polling an upstream the re-verifier deliberately
+//	                                                dropped would be wrong. Fix belongs in the demote
+//	                                                decision (spec_reverifier.go), not here.
+//	recovery (promote → polling again)              FIXED here. Nothing on the promote path called
+//	                                                GetOrCreateTracker, so a re-promoted endpoint sat
+//	                                                paired with no poll loop until a relay happened to
+//	                                                land on it via ensureEndpointChainTracker —
+//	                                                non-deterministic and possibly indefinite. It is
+//	                                                now deterministic, within one reconcile tick.
 func (rpcss *RPCSmartRouterServer) initializeChainTrackers(ctx context.Context) {
 	// Small delay to let startup complete and connections stabilize
 	select {
@@ -2659,29 +2710,78 @@ func (rpcss *RPCSmartRouterServer) initializeChainTrackers(ctx context.Context) 
 		return
 	}
 
-	endpoints := rpcss.sessionManager.GetAllDirectRPCEndpoints()
-	if len(endpoints) == 0 {
-		utils.LavaFormatDebug("no direct RPC endpoints to initialize ChainTrackers")
-		return
+	rpcss.reconcileChainTrackers(ctx, true)
+
+	ticker := time.NewTicker(chainTrackerReconcileInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			rpcss.reconcileChainTrackers(ctx, false)
+		}
+	}
+}
+
+// reconcileChainTrackers registers a ChainTracker for every direct-RPC endpoint in the live pairing
+// that does not already have one. Idempotent and cheap when nothing is missing (one RLock'd map
+// lookup per endpoint, no network I/O). Returns the counts so tests can assert on them directly.
+//
+// firstPass controls only logging volume: the startup pass keeps the original
+// "initializing…"/"…complete" Info pair operators grep for, while later passes stay silent unless
+// they actually create something — a creation after startup is a real signal (that endpoint was
+// unobserved until now) and is logged as a warning naming the endpoints, so the condition MAG-2622
+// describes can never again pass silently.
+func (rpcss *RPCSmartRouterServer) reconcileChainTrackers(ctx context.Context, firstPass bool) (created, alreadyPresent, failed int) {
+	if rpcss.endpointChainTrackerManager == nil || rpcss.sessionManager == nil {
+		return 0, 0, 0
 	}
 
-	utils.LavaFormatInfo("initializing ChainTrackers for direct RPC endpoints",
-		utils.LogAttr("count", len(endpoints)),
-		utils.LogAttr("chainID", rpcss.listenEndpoint.ChainID),
-	)
+	chainID := ""
+	if rpcss.listenEndpoint != nil {
+		chainID = rpcss.listenEndpoint.ChainID
+	}
 
-	successCount := 0
-	failCount := 0
+	endpoints := rpcss.sessionManager.GetAllDirectRPCEndpoints()
+	if len(endpoints) == 0 {
+		if firstPass {
+			utils.LavaFormatDebug("no direct RPC endpoints to initialize ChainTrackers")
+		}
+		return 0, 0, 0
+	}
 
-	// Initialize ChainTrackers with staggered delays to avoid thundering herd
-	for i, ep := range endpoints {
+	// Partition first so the 50ms stagger below paces only endpoints that need a NEW tracker.
+	// Staggering the steady-state (all-present) case would make every reconcile pass sleep
+	// 50ms × len(endpoints) for nothing.
+	missing := make([]*lavasession.EndpointWithDirectConnection, 0, len(endpoints))
+	for _, ep := range endpoints {
+		if ep == nil || ep.Endpoint == nil {
+			continue
+		}
+		if _, exists := rpcss.endpointChainTrackerManager.GetTracker(ep.Endpoint.NetworkAddress); exists {
+			alreadyPresent++
+			continue
+		}
+		missing = append(missing, ep)
+	}
+
+	if firstPass {
+		utils.LavaFormatInfo("initializing ChainTrackers for direct RPC endpoints",
+			utils.LogAttr("count", len(endpoints)),
+			utils.LogAttr("chainID", chainID),
+		)
+	}
+
+	createdURLs := make([]string, 0, len(missing))
+	for i, ep := range missing {
 		select {
 		case <-ctx.Done():
 			utils.LavaFormatDebug("ChainTracker initialization cancelled",
 				utils.LogAttr("completed", i),
-				utils.LogAttr("total", len(endpoints)),
+				utils.LogAttr("total", len(missing)),
 			)
-			return
+			return created, alreadyPresent, failed
 		default:
 		}
 
@@ -2689,7 +2789,7 @@ func (rpcss *RPCSmartRouterServer) initializeChainTrackers(ctx context.Context) 
 		if i > 0 {
 			select {
 			case <-ctx.Done():
-				return
+				return created, alreadyPresent, failed
 			case <-time.After(50 * time.Millisecond):
 			}
 		}
@@ -2700,17 +2800,33 @@ func (rpcss *RPCSmartRouterServer) initializeChainTrackers(ctx context.Context) 
 				utils.LogAttr("endpoint", ep.Endpoint.NetworkAddress),
 				utils.LogAttr("provider", ep.ProviderAddress),
 			)
-			failCount++
-		} else {
-			successCount++
+			failed++
+			continue
 		}
+		created++
+		createdURLs = append(createdURLs, ep.Endpoint.NetworkAddress)
 	}
 
-	utils.LavaFormatInfo("ChainTracker initialization complete",
-		utils.LogAttr("success", successCount),
-		utils.LogAttr("failed", failCount),
-		utils.LogAttr("chainID", rpcss.listenEndpoint.ChainID),
-	)
+	switch {
+	case firstPass:
+		utils.LavaFormatInfo("ChainTracker initialization complete",
+			utils.LogAttr("success", created+alreadyPresent),
+			utils.LogAttr("failed", failed),
+			utils.LogAttr("chainID", chainID),
+		)
+	case created > 0 || failed > 0:
+		// Reaching here means an endpoint was in the pairing with no poll loop until this tick.
+		// Warn rather than Info: it is either a post-startup admission (expected, but the operator
+		// should know that endpoint contributed nothing before now) or a tracker that went missing.
+		utils.LavaFormatWarning("ChainTracker reconcile: registered endpoints that had no tracker", nil,
+			utils.LogAttr("created", created),
+			utils.LogAttr("failed", failed),
+			utils.LogAttr("endpoints", createdURLs),
+			utils.LogAttr("chainID", chainID),
+		)
+	}
+
+	return created, alreadyPresent, failed
 }
 
 // isFinalizedForCacheWrite picks the chain tip used to decide whether a

--- a/protocol/rpcsmartrouter/rpcsmartrouter_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_test.go
@@ -947,6 +947,7 @@ func fakeConvertSessions(epoch uint64) func([]*lavasession.RPCStaticProviderEndp
 // covers the post-condition that lives only in updateEpoch (assignment of the
 // applyReverification result back into the router's map at rpcsmartrouter.go:1771).
 func TestUpdateEpoch_ReverifyDemotesFailingStatic(t *testing.T) {
+	withImmediateDemote(t)
 	rig := newReverifyTestRig(t, "LAVA_REVERIFY_DEMOTE", "127.0.0.1:3340")
 	rpsr, chainKey := rig.rpsr, rig.chainKey
 
@@ -1027,6 +1028,7 @@ func TestUpdateEpoch_ReverifyPromotesRecoveredStatic(t *testing.T) {
 // promoted. Asserts on the resulting map composition by name — the survivor set
 // after one full orchestration cycle.
 func TestUpdateEpoch_ReverifyMixedDemoteAndPromote(t *testing.T) {
+	withImmediateDemote(t)
 	rig := newReverifyTestRig(t, "LAVA_REVERIFY_MIXED", "127.0.0.1:3342")
 	rpsr, chainKey := rig.rpsr, rig.chainKey
 
@@ -1075,6 +1077,7 @@ func TestUpdateEpoch_ReverifyMixedDemoteAndPromote(t *testing.T) {
 // "has backups" to consumers iterating the outer map, so the delete branch is
 // load-bearing.
 func TestUpdateEpoch_ReverifyEmptyBackupTierDeletes(t *testing.T) {
+	withImmediateDemote(t)
 	rig := newReverifyTestRig(t, "LAVA_REVERIFY_BACKUP_DELETE", "127.0.0.1:3343")
 	rpsr, chainKey := rig.rpsr, rig.chainKey
 
@@ -1105,6 +1108,7 @@ func TestUpdateEpoch_ReverifyEmptyBackupTierDeletes(t *testing.T) {
 // "backup tier produces a non-empty result post-reverify" case touches — the
 // empty-result delete path is covered separately above.
 func TestUpdateEpoch_ReverifyBackupPartialDemote(t *testing.T) {
+	withImmediateDemote(t)
 	rig := newReverifyTestRig(t, "LAVA_REVERIFY_BACKUP_PARTIAL", "127.0.0.1:3344")
 	rpsr, chainKey := rig.rpsr, rig.chainKey
 
@@ -1204,6 +1208,7 @@ func TestUpdateEpoch_ReverifyPromotesRecoveredBackup(t *testing.T) {
 // outcome between epochs without rebuilding inputs (mirrors the real flow:
 // the same chainReverifyInputs is used across every epoch tick).
 func TestUpdateEpoch_ReverifyCrossEpochDemoteThenPromote(t *testing.T) {
+	withImmediateDemote(t)
 	rig := newReverifyTestRig(t, "LAVA_REVERIFY_CROSS_EPOCH", "127.0.0.1:3346")
 	rpsr, chainKey := rig.rpsr, rig.chainKey
 	sm := rpsr.sessionManagers[chainKey]

--- a/protocol/rpcsmartrouter/spec_reverifier.go
+++ b/protocol/rpcsmartrouter/spec_reverifier.go
@@ -21,6 +21,26 @@ var SpecReVerifyConcurrency = 5
 // implementation detail rarely useful to operators. Exported for tests.
 var SpecReVerifyAttemptTimeout = 30 * time.Second
 
+// reverifyDemoteThreshold is how many CONSECUTIVE re-verify cycles a currently-active provider
+// must fail before it is demoted out of the pairing (MAG-2445). 1 restores the old
+// demote-on-first-failure behaviour.
+//
+// Validate is not a single probe — it already retries 3x per verification (chain_fetcher.go,
+// "we give several chances for starting up"). But those retries run back-to-back with NO delay,
+// so the entire budget is spent inside ~1s. Against an outage measured in seconds or minutes
+// they all fail identically, which is why a 40-second blip that happened to overlap an epoch
+// tick demoted the provider outright and cost it a full epoch (~15m) out of the pairing. Those
+// retries were written for a COLD path (a node still booting); applyReverification reuses
+// Validate on a HOT path where the failure mode is a transient outage, and there the only useful
+// hysteresis is across time.
+//
+// This adds the missing temporal hysteresis, matching how endpoint health already works
+// (MaxConsecutiveConnectionAttempts to disable, consecutiveHealthyProbes to re-enable): a blip
+// must persist across two epoch boundaries to demote. Keeping a genuinely dead provider paired
+// for one extra epoch is cheap — the endpoint-health path disables it within seconds and QoS
+// stops routing to it, so demotion is a coarse cleanup, not the liveness mechanism.
+var reverifyDemoteThreshold = 2
+
 // reverifyTier discriminates which configured list applyReverification operates
 // on. A typed enum prevents the silent miss-routing a stringly-typed tier could
 // cause if a caller ever typoed "back-up" or "primary".
@@ -54,14 +74,26 @@ type chainReverifyInputs struct {
 	// to validateProvider (real network probe). Tests inject a fake to exercise
 	// updateEpoch's orchestration without standing up upstreams.
 	validateFn func(context.Context, *lavasession.RPCStaticProviderEndpoint) error
+	// demoteFailStreak counts CONSECUTIVE failed re-verify cycles per active provider, keyed
+	// "<tier>|<name>" so a name configured in both tiers cannot share a counter. It is the only
+	// state that survives between epoch ticks, and it exists so a transient outage overlapping
+	// one tick cannot demote (MAG-2445 — see reverifyDemoteThreshold). Cleared on success, on
+	// demotion, and whenever the provider is not currently active, so a re-promoted provider
+	// always starts with a full grace budget.
+	//
+	// Guarded by RPCSmartRouter.mu: applyReverification is called only from updateEpoch, which
+	// holds that lock across both tier calls. Lazily allocated so test fixtures that build
+	// chainReverifyInputs by hand need not.
+	demoteFailStreak map[string]int
 }
 
 // applyReverification revalidates configured providers for one tier and
 // reconciles the result against the freshly-built active map. It does two
 // things, in order:
 //
-//   - Demote: drop entries from `fresh` whose provider failed validation
-//     (these were active last cycle but are no longer healthy). The demoted
+//   - Demote: drop entries from `fresh` whose provider has now failed validation on
+//     reverifyDemoteThreshold CONSECUTIVE cycles (a provider failing for the first time is kept,
+//     so a transient outage overlapping one epoch tick costs nothing — MAG-2445). The demoted
 //     sessions are returned so the caller can close their DirectRPCConnections
 //     after UpdateAllProviders has swung over to the new map — closing inline
 //     would race in-flight relays still holding a pointer to the prior map.
@@ -77,7 +109,10 @@ type chainReverifyInputs struct {
 // Validations run in parallel, capped by SpecReVerifyConcurrency, so a worst-
 // case cycle is bounded by ⌈N/conc⌉ × SpecReVerifyAttemptTimeout instead of
 // N × timeout. Pure with respect to RPCSmartRouter state — no field mutation,
-// no UpdateAllProviders, no tracker reconcile; updateEpoch owns those.
+// no UpdateAllProviders, no tracker reconcile; updateEpoch owns those. The ONE
+// exception is inputs.demoteFailStreak, the cross-cycle failure counter this
+// function both reads and advances; it is guarded by RPCSmartRouter.mu, which
+// updateEpoch holds across both tier calls.
 //
 // Configured lists are pre-filtered by chain+ApiInterface at startup (see
 // relevantStaticProviderList in rpcsmartrouter.go), so no further filter is
@@ -129,10 +164,15 @@ func applyReverification(
 	activeNames := byName(fresh)
 	healthyNames := make(map[string]struct{}, len(configured))
 	var toAdmit []*lavasession.RPCStaticProviderEndpoint
+	if inputs.demoteFailStreak == nil {
+		inputs.demoteFailStreak = make(map[string]int)
+	}
 	for i, p := range configured {
 		err := results[i]
 		_, wasActive := activeNames[p.Name]
+		streakKey := tier.String() + "|" + p.Name
 		if err == nil {
+			delete(inputs.demoteFailStreak, streakKey)
 			healthyNames[p.Name] = struct{}{}
 			if !wasActive {
 				toAdmit = append(toAdmit, p)
@@ -143,18 +183,38 @@ func applyReverification(
 			}
 			continue
 		}
-		if wasActive {
-			utils.LavaFormatWarning("re-verify: demoting active "+tier.String(), err,
-				utils.LogAttr("chain", inputs.rpcEndpoint.ChainID),
-				utils.LogAttr("provider", p.Name),
-			)
-		} else {
+		if !wasActive {
+			// Already out of the pairing — nothing to demote, and the streak governs only the
+			// demote decision, so keep it clear (a later promote then gets a full grace budget).
+			delete(inputs.demoteFailStreak, streakKey)
 			utils.LavaFormatDebug("re-verify: failed-init "+tier.String()+" still failing",
 				utils.LogAttr("chain", inputs.rpcEndpoint.ChainID),
 				utils.LogAttr("provider", p.Name),
 				utils.LogAttr("err", err.Error()),
 			)
+			continue
 		}
+
+		// Active and failing: demote only once the failure has persisted across
+		// reverifyDemoteThreshold consecutive cycles (MAG-2445).
+		inputs.demoteFailStreak[streakKey]++
+		streak := inputs.demoteFailStreak[streakKey]
+		if streak < reverifyDemoteThreshold {
+			healthyNames[p.Name] = struct{}{} // grace: stays paired this cycle
+			utils.LavaFormatWarning("re-verify: active "+tier.String()+" failed but kept — under demote threshold", err,
+				utils.LogAttr("chain", inputs.rpcEndpoint.ChainID),
+				utils.LogAttr("provider", p.Name),
+				utils.LogAttr("consecutiveFailures", streak),
+				utils.LogAttr("demoteAfter", reverifyDemoteThreshold),
+			)
+			continue
+		}
+		delete(inputs.demoteFailStreak, streakKey)
+		utils.LavaFormatWarning("re-verify: demoting active "+tier.String(), err,
+			utils.LogAttr("chain", inputs.rpcEndpoint.ChainID),
+			utils.LogAttr("provider", p.Name),
+			utils.LogAttr("consecutiveFailures", streak),
+		)
 	}
 
 	// Demote: drop fresh entries whose provider is unhealthy. Keep their

--- a/protocol/rpcsmartrouter/spec_reverifier_test.go
+++ b/protocol/rpcsmartrouter/spec_reverifier_test.go
@@ -39,7 +39,23 @@ func collectNames(m map[uint64]*lavasession.ConsumerSessionsWithProvider) map[st
 	return out
 }
 
+// withImmediateDemote pins reverifyDemoteThreshold to 1 (demote on the first failed cycle) for
+// the duration of a test, restoring the production value on cleanup.
+//
+// The demote-orchestration tests predate the MAG-2445 hysteresis and are about what the
+// reconciliation DOES with a demote — which map it lands in, whether updateEpoch stores it,
+// whether the session manager sees it — not about how many failed cycles earn one. Driving two
+// cycles in each of them would add noise unrelated to their subject. The threshold itself is
+// pinned by TestApplyReverification_DemoteHysteresis.
+func withImmediateDemote(t *testing.T) {
+	t.Helper()
+	restore := reverifyDemoteThreshold
+	reverifyDemoteThreshold = 1
+	t.Cleanup(func() { reverifyDemoteThreshold = restore })
+}
+
 func TestApplyReverification(t *testing.T) {
+	withImmediateDemote(t)
 	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "rest"}
 
 	tests := []struct {
@@ -258,4 +274,110 @@ func TestValidateProvider_SmokeWiring(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("validateProvider hung past its timeout argument — wiring regression")
 	}
+}
+
+// TestApplyReverification_DemoteHysteresis is the MAG-2445 pin: an active provider that fails a
+// single re-verify cycle keeps its place in the pairing, and only a failure that PERSISTS across
+// reverifyDemoteThreshold consecutive cycles demotes it.
+//
+// The bug this closes: epochs are wall-clock derived (floor((now-2024-01-01)/15m) in
+// common.EpochTimer), so boundaries land on :00/:15/:30/:45 regardless of process uptime. A blip
+// of a few tens of seconds that happened to overlap one tick demoted the provider outright, which
+// cost it a full epoch out of the pairing — and, before MAG-2622, its ChainTracker never came
+// back after the eventual promote either. Validate's own 3x retry does not help: those attempts
+// run back-to-back with no delay, so all three land inside the same outage.
+func TestApplyReverification_DemoteHysteresis(t *testing.T) {
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "rest"}
+	configured := []*lavasession.RPCStaticProviderEndpoint{makeProvider("A"), makeProvider("B")}
+
+	// One inputs value reused across cycles — demoteFailStreak living there is exactly what
+	// carries the failure count from one epoch tick to the next.
+	failing := map[string]bool{}
+	inputs := &chainReverifyInputs{
+		rpcEndpoint:                rpc,
+		convertProvidersToSessions: fakeConvert,
+		configuredStatic:           configured,
+		validateFn: func(_ context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
+			if failing[p.Name] {
+				return errors.New("mock outage")
+			}
+			return nil
+		},
+	}
+
+	// cycle runs one epoch tick over a pairing containing exactly `present`, and reports which
+	// providers survived and which were demoted.
+	cycle := func(epoch uint64, present ...string) (survived map[string]struct{}, demoted []string) {
+		fresh := map[uint64]*lavasession.ConsumerSessionsWithProvider{}
+		for i, n := range present {
+			fresh[uint64(i)] = makeSession(n)
+		}
+		got, demotedSessions := applyReverification(context.Background(), inputs, fresh, reverifyTierStatic, epoch)
+		for _, s := range demotedSessions {
+			demoted = append(demoted, s.PublicLavaAddress)
+		}
+		return collectNames(got), demoted
+	}
+
+	require.Equal(t, 2, reverifyDemoteThreshold, "this test is written against the production threshold")
+
+	// Cycle 1 — B goes down mid-epoch. It must be KEPT: this is the blip.
+	failing["B"] = true
+	survived, demoted := cycle(1, "A", "B")
+	require.Contains(t, survived, "B", "a provider failing its FIRST re-verify cycle must stay paired (MAG-2445)")
+	require.Empty(t, demoted, "no demotion on the first failed cycle")
+
+	// Cycle 2 — still down. The failure has now persisted across two boundaries, so it goes.
+	survived, demoted = cycle(2, "A", "B")
+	require.NotContains(t, survived, "B", "a failure persisting across the threshold must demote")
+	require.Equal(t, []string{"B"}, demoted, "the demoted session must be surfaced for connection teardown")
+	require.Contains(t, survived, "A", "the healthy provider is untouched throughout")
+
+	// A recovered blip must not accumulate toward a later, unrelated one. B is re-promoted on
+	// recovery, then fails once more — that single failure starts a FRESH grace budget rather
+	// than tipping it straight back out.
+	delete(failing, "B")
+	survived, _ = cycle(3, "A")
+	require.Contains(t, survived, "B", "recovered provider is promoted back")
+
+	failing["B"] = true
+	survived, demoted = cycle(4, "A", "B")
+	require.Contains(t, survived, "B",
+		"the streak must reset on success — a later isolated failure gets the full grace budget, not a carried-over count")
+	require.Empty(t, demoted)
+}
+
+// A success between two failures resets the counter, so an endpoint that flaps every other cycle
+// is never demoted by accumulation. Separated from the walk above because it pins the reset rule
+// specifically: without the delete-on-success the two failures would sum to the threshold.
+func TestApplyReverification_SuccessResetsDemoteStreak(t *testing.T) {
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "rest"}
+	configured := []*lavasession.RPCStaticProviderEndpoint{makeProvider("A")}
+
+	var fail bool
+	inputs := &chainReverifyInputs{
+		rpcEndpoint:                rpc,
+		convertProvidersToSessions: fakeConvert,
+		configuredStatic:           configured,
+		validateFn: func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+			if fail {
+				return errors.New("mock outage")
+			}
+			return nil
+		},
+	}
+
+	run := func(epoch uint64) map[string]struct{} {
+		fresh := map[uint64]*lavasession.ConsumerSessionsWithProvider{0: makeSession("A")}
+		got, _ := applyReverification(context.Background(), inputs, fresh, reverifyTierStatic, epoch)
+		return collectNames(got)
+	}
+
+	fail = true
+	require.Contains(t, run(1), "A", "first failure is grace")
+	fail = false
+	require.Contains(t, run(2), "A", "recovered")
+	fail = true
+	require.Contains(t, run(3), "A",
+		"the intervening success must have cleared the streak — otherwise this second failure demotes")
 }

--- a/scripts/pre_setups/test_chaintracker_chainstate_sim.sh
+++ b/scripts/pre_setups/test_chaintracker_chainstate_sim.sh
@@ -134,7 +134,35 @@ relay()     { curl -s --max-time 8 -X POST "http://127.0.0.1:$LISTEN_PORT" -H 'C
 # sim_calls : total upstream calls the eth-sim pool has served (probe-silence proof).
 sim_calls() { curl -s "http://$SIM_CONTROL/stats" | jq '[.providers | to_entries[] | select(.key|startswith("eth-sim:")) | .value.total_calls] | add // 0'; }
 
-stop_router() { pkill -f "$BIN" 2>/dev/null; sleep 2; }
+# stop_router : kill every smartrouter built into this repo's debugging/testbin.
+#
+# Matches on the "debugging/testbin/smartrouter" SUFFIX, not on "$BIN" (the absolute path):
+# pkill -f matches the literal command line, so a router someone launched by RELATIVE path
+# ("./debugging/testbin/smartrouter ...") survives an absolute-path pattern and keeps running
+# alongside the harness's own. Two routers polling the same simulator pool DOUBLE the upstream
+# call volume, which fails scenario 3 (probe silence) with a number that looks like a probe-loop
+# regression, and lets later scenarios read a router that never cold-started. The suffix pattern
+# catches both spellings; the post-check below catches anything else still holding our ports.
+stop_router() {
+	pkill -f "debugging/testbin/smartrouter" 2>/dev/null
+	sleep 2
+	local stray
+	stray=$(pgrep -f "debugging/testbin/smartrouter" | tr '\n' ' ')
+	if [ -n "${stray// /}" ]; then
+		echo "  ⚠️  stray smartrouter still running after stop (pids: $stray) — killing hard"
+		pkill -9 -f "debugging/testbin/smartrouter" 2>/dev/null
+		sleep 1
+	fi
+	# Belt and braces: whatever still holds the debug port would make the next router's
+	# readiness probe answer from the WRONG process, silently invalidating every assertion.
+	local holder
+	holder=$(lsof -ti:"$DEBUG_PORT" 2>/dev/null | tr '\n' ' ')
+	if [ -n "${holder// /}" ]; then
+		echo "  ⚠️  port $DEBUG_PORT still held by pid(s) $holder — killing so assertions read OUR router"
+		kill -9 $holder 2>/dev/null
+		sleep 1
+	fi
+}
 
 # start_router [log-suffix] : boot the router and block until it answers.
 # A restart is the ONLY way to get a genuine cold start: the endpointtip store is

--- a/scripts/pre_setups/test_chaintracker_chainstate_sim.sh
+++ b/scripts/pre_setups/test_chaintracker_chainstate_sim.sh
@@ -1,0 +1,525 @@
+#!/bin/bash
+# =============================================================================
+# ChainTracker / ChainState live-scenario harness — smart-router driven against
+# the provider_simulator (a fault-injectable mock backend).
+#
+# WHAT THIS COVERS
+# The Topic C tip stack: the self-healing per-chain ChainState tip (T3, PR #233),
+# the block-monotonic per-endpoint endpointtip store (T4), and the shared-state
+# chain-level tip (T10, PR #228). Unit tests pin each layer in isolation; this
+# harness exercises how they COMPOSE — which is where the real latencies and
+# failure modes live. Two examples the unit suites structurally cannot show:
+#
+#   * A chain-wide downward move is gated TWICE — first by the per-endpoint store's
+#     staleness backstop, only then by ChainState's own TTL. The end-to-end heal
+#     time (~130 s on ETH1) is a property of the pair, not of either layer.
+#   * A pod can silently degrade below the min-2 consensus rule, which switches the
+#     consensus-anchored anti-lie guard off entirely. No single-layer test sees it.
+#
+# WHY THE SIMULATOR AND NOT REAL NODES
+# Every scenario needs an endpoint to LIE about its block height, or to lag by an
+# exact number of blocks, on demand. Real upstreams cannot be asked to do that. The
+# simulator gives both primitives per-provider:
+#     lie high :  {"providers":{"eth-sim:3":{"responses":{"eth_blockNumber":{"result":"0x..."}}}}}
+#     lag      :  {"providers":{"eth-sim:3":{"blocks_behind":N}}}
+#
+# DERIVED CONSTANTS (ETH1, average_block_time = 13000 ms)
+# Nothing here is a flat constant — every threshold is derived from block time, so
+# the numbers below are ETH1-specific and change per chain:
+#     TTL / staleness window = max(10 x 13 s, 2 s)          = 130 s
+#     outlier threshold      = clamp(1200 s / 13 s, 32, 512) = 92 blocks
+#     poll cadence           = 13 s / 2                      = 6.5 s
+#     consensus bucket width = 5 blocks   (compile-time, widened 2->5 in a61aa6e)
+#     probe loop cadence     = 5 s
+#
+# RUNTIME
+#   --fast   skips the two scenarios that must wait real time (~3 min saved).
+#   Full run is ~10-11 min. The two long poles are the 130 s staleness window in
+#   scenario 5 and scenario 6's cold-start recovery, which must outwait the 3 min
+#   retryFailedStaticProviders ticker before the restored endpoints rejoin the pairing.
+#   NOTE: /debug/chain-state-time-warp CANNOT accelerate that window — the
+#   endpointtip store measures staleness as a delta between OBSERVATION STAMPS,
+#   not against a clock, so the warp never reaches it. Use a fast chain (Solana,
+#   400 ms -> ~4 s window) if you need that scenario to be quick.
+#
+# KNOWN-ISSUE CHECKS
+# Scenario 7 asserts CURRENT (incorrect) behaviour and is tallied as KNOWN, not FAIL,
+# so this script stays green in CI. When it flips to "FIXED", the underlying bug has
+# been fixed and the check should be promoted to a hard assert.
+# Scenario 6 was one of these (MAG-2622) and has been promoted: it is now a hard assert.
+# =============================================================================
+set -uo pipefail
+__dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "$__dir"/../useful_commands.sh
+
+PROJECT_ROOT=$(cd "${__dir}/../.." && pwd)
+# debugging/ is gitignored — every artifact this script produces stays there.
+WORK_DIR="$PROJECT_ROOT/debugging"
+LOGS_DIR="$WORK_DIR/logs"
+mkdir -p "$LOGS_DIR"
+
+LOG_FILE="$LOGS_DIR/CHAINSTATE_ROUTER.log"
+SIM_LOG="$LOGS_DIR/CHAINSTATE_SIM.log"
+CONFIG_FILE="$WORK_DIR/chainstate_sim.yml"
+# The router resolves its config argument against a fixed set of search roots
+# (repo root, repo/config, ~/.lava), so an absolute path outside those roots is
+# reported as "not found". Pass it repo-relative and run with cwd = repo root.
+CONFIG_REL="debugging/chainstate_sim.yml"
+# Built into the working tree rather than installed to GOPATH/bin: the harness must
+# test THIS checkout, not whatever binary happens to be on PATH, and it must not
+# clobber the developer's installed smartrouter.
+BIN="$WORK_DIR/testbin/smartrouter"
+
+SIM_DIR="${SIM_DIR:-$(cd "$PROJECT_ROOT/.." && pwd)/provider_simulator}"
+SIM_CONTROL="127.0.0.1:19000"
+# ETH JSON-RPC primary pool (constants.ETH_PRIMARY_PORTS). Provider keys are
+# "pool:pid" — the bare-pid form is rejected by current simulator builds.
+SIM_1=18545; SIM_2=18546; SIM_3=18547
+P1="eth-sim:1"; P2="eth-sim:2"; P3="eth-sim:3"
+
+# Router ports (distinct from UC-1/UC-2/UC-4 so this can run alongside them).
+LISTEN_PORT=3395
+METRICS_PORT=7799
+DEBUG_PORT=9999
+
+# ETH1-derived constants asserted below (see header).
+TTL_SECONDS=130
+OUTLIER_THRESHOLD=92
+POLL_MS=6500
+SIM_HEAD=20000000
+
+FAST=0
+[[ "${1:-}" == "--fast" ]] && FAST=1
+
+PASS=0; FAIL=0; KNOWN=0
+pass()  { echo "  ✅ PASS:  $1"; PASS=$((PASS + 1)); }
+fail()  { echo "  ❌ FAIL:  $1"; FAIL=$((FAIL + 1)); }
+known() { echo "  ⚠️  KNOWN: $1"; KNOWN=$((KNOWN + 1)); }
+fixed() { echo "  🎉 FIXED: $1"; PASS=$((PASS + 1)); }
+
+for tool in jq python3 curl; do
+	command_exists "$tool" || { echo "✗ ERROR: '$tool' is required."; exit 1; }
+done
+SIM_PY="$(command -v python3.12 || command -v python3)"
+
+# -----------------------------------------------------------------------------
+# Simulator + router control helpers
+# -----------------------------------------------------------------------------
+sim_up()    { curl -s --max-time 2 "http://$SIM_CONTROL/health" >/dev/null 2>&1; }
+sim_reset() { curl -s -X POST "http://$SIM_CONTROL/reset/all" >/dev/null 2>&1; }
+sim_post()  { curl -s -X POST "http://$SIM_CONTROL/scenario" -H 'Content-Type: application/json' -d "$1" >/dev/null; }
+
+# lie_high <provider-key> <decimal-block> : pin that provider's eth_blockNumber.
+lie_high()  { sim_post "{\"providers\":{\"$1\":{\"responses\":{\"eth_blockNumber\":{\"result\":\"$(printf '0x%x' "$2")\"}}}}}"; }
+# lag <provider-key> <blocks> : that provider reports head-N.
+lag()       { sim_post "{\"providers\":{\"$1\":{\"blocks_behind\":$2}}}"; }
+set_mode()  { sim_post "{\"providers\":{\"$1\":{\"mode\":\"$2\"}}}"; }
+
+# cs <field> : one field of the (single-chain) /debug/chain-state row.
+cs() { curl -s "http://127.0.0.1:$DEBUG_PORT/debug/chain-state" | jq -r ".[0].$1"; }
+# ep <port> <field> : one field of the /debug/endpoint-state row for that URL.
+ep() { curl -s "http://127.0.0.1:$DEBUG_PORT/debug/endpoint-state" \
+	| jq -r --arg u "http://127.0.0.1:$1" '.[] | select(.NetworkAddress==$u) | .'"$2"; }
+# metric <full-metric-name> : the scalar value, or "" when absent.
+metric() { curl -s "http://127.0.0.1:$METRICS_PORT/metrics" | grep "^$1{" | awk '{print $NF}' | head -n1; }
+# metric_int <full-metric-name> : same, normalised out of Prometheus 2e+07 notation.
+metric_int() { local v; v=$(metric "$1"); [ -z "$v" ] && { echo ""; return; }; python3 -c "print(int(float('$v')))"; }
+
+warp()      { curl -s -X POST "http://127.0.0.1:$DEBUG_PORT/debug/chain-state-time-warp" \
+	-H 'Content-Type: application/json' -d "{\"offset_seconds\":$1}" >/dev/null; }
+reset_all() { curl -s -X POST "http://127.0.0.1:$DEBUG_PORT/debug/reset-all" >/dev/null; }
+relay()     { curl -s --max-time 8 -X POST "http://127.0.0.1:$LISTEN_PORT" -H 'Content-Type: application/json' \
+	-d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'; }
+
+# sim_calls : total upstream calls the eth-sim pool has served (probe-silence proof).
+sim_calls() { curl -s "http://$SIM_CONTROL/stats" | jq '[.providers | to_entries[] | select(.key|startswith("eth-sim:")) | .value.total_calls] | add // 0'; }
+
+stop_router() { pkill -f "$BIN" 2>/dev/null; sleep 2; }
+
+# start_router [log-suffix] : boot the router and block until it answers.
+# A restart is the ONLY way to get a genuine cold start: the endpointtip store is
+# process-global and /debug/reset-all does not clear it (see scenario 7).
+start_router() {
+	local suffix="${1:-}"
+	[ -n "$suffix" ] && mv "$LOG_FILE" "$LOGS_DIR/CHAINSTATE_ROUTER_$suffix.log" 2>/dev/null
+	( cd "$PROJECT_ROOT" && nohup "$BIN" "$CONFIG_REL" \
+		--log-level debug \
+		--use-static-spec "$PROJECT_ROOT/specs/ethereum.json" \
+		--metrics-listen-address ":$METRICS_PORT" \
+		--debug-address ":$DEBUG_PORT" \
+		--skip-websocket-verification \
+		--min-relay-timeout 5s > "$LOG_FILE" 2>&1 & )
+	for _ in $(seq 1 40); do
+		curl -s --max-time 2 -o /dev/null "http://127.0.0.1:$DEBUG_PORT/debug/chain-state" 2>/dev/null && return 0
+		sleep 1
+	done
+	echo "✗ ERROR: router did not become ready. See $LOG_FILE"; tail -n 25 "$LOG_FILE" | sed 's/^/    /'; exit 1
+}
+
+# await_baseline <timeout-s> : block until a consensus baseline exists.
+await_baseline() {
+	for _ in $(seq 1 "$1"); do [ "$(cs HasBaseline)" = "true" ] && return 0; sleep 1; done
+	return 1
+}
+# await_tip <block> <timeout-s> : block until the observed tip equals <block>.
+await_tip() {
+	for _ in $(seq 1 "$2"); do [ "$(cs ObservedTip)" = "$1" ] && return 0; sleep 1; done
+	return 1
+}
+
+# await_epoch_runway <seconds> : block until the next epoch boundary is at least
+# <seconds> away.
+#
+# Epoch numbers are WALL-CLOCK derived, not uptime derived — common/EpochTimer computes
+# floor((now - 2024-01-01T00:00:00Z) / 15m), and that reference instant is an exact
+# multiple of 900s, so boundaries land on :00/:15/:30/:45 no matter when the router
+# started. Any scenario that deliberately holds an endpoint DOWN across a boundary gets
+# an unrelated epoch re-verify: applyReverification sees the 503, DEMOTES the provider
+# out of the pairing, and cleanupStaleTrackers drops its ChainTracker. The endpoint then
+# vanishes from /debug/endpoint-state entirely (that handler iterates the live pairing),
+# so ep() returns "" and any numeric comparison on it dies with
+# "integer expression expected" — a confusing way to learn the run simply started at an
+# awkward minute. Demotion is correct behaviour; it just isn't what those scenarios are
+# measuring, so they wait it out instead.
+await_epoch_runway() {
+	local need="$1" left
+	left=$(( 900 - ($(date +%s) % 900) ))
+	if [ "$left" -lt "$need" ]; then
+		echo "      epoch boundary in ${left}s but this scenario needs ${need}s of runway — waiting it out..."
+		sleep $(( left + 3 ))
+	fi
+}
+
+echo "==================================================================="
+echo "ChainTracker / ChainState live scenarios — provider_simulator"
+echo "==================================================================="
+echo "  chain ETH1 (average_block_time 13000ms) -> TTL ${TTL_SECONDS}s | outlier ${OUTLIER_THRESHOLD} blocks | poll ${POLL_MS}ms"
+[ "$FAST" -eq 1 ] && echo "  --fast: skipping the two real-time-bound scenarios (5, 8)"
+echo ""
+
+# -----------------------------------------------------------------------------
+# Setup
+# -----------------------------------------------------------------------------
+echo "[Setup] building smartrouter from the working tree -> $BIN"
+mkdir -p "$WORK_DIR/testbin"
+( cd "$PROJECT_ROOT" && go build -o "$BIN" ./cmd/smartrouter ) || { echo "✗ ERROR: build failed"; exit 1; }
+
+if sim_up; then
+	echo "[Setup] provider_simulator already running on $SIM_CONTROL (reusing it)"
+else
+	echo "[Setup] starting provider_simulator from $SIM_DIR"
+	[ -f "$SIM_DIR/run.py" ] || { echo "✗ ERROR: $SIM_DIR/run.py not found. Set SIM_DIR=... to the checkout."; exit 1; }
+	( cd "$SIM_DIR" && nohup "$SIM_PY" -u run.py > "$SIM_LOG" 2>&1 & )
+	for _ in $(seq 1 30); do sim_up && break; sleep 1; done
+	sim_up || { echo "✗ ERROR: simulator did not start. See $SIM_LOG"; exit 1; }
+fi
+sim_reset
+echo "✓ simulator ready (eth-sim pool on $SIM_1/$SIM_2/$SIM_3, head $SIM_HEAD)"
+
+cat > "$CONFIG_FILE" <<EOF
+# Smart Router — ChainTracker/ChainState scenario config.
+# Generated by scripts/pre_setups/test_chaintracker_chainstate_sim.sh (do not hand-edit).
+#
+# THREE endpoints is deliberate and load-bearing: chainstate's consensus needs a
+# strict majority with a minimum of 2 agreeing URLs, so 3 is the smallest pool that
+# can outvote a single liar. Drop to 2 and no baseline can ever form, which switches
+# the consensus-anchored anti-lie guard off — the condition scenario 6 exploits.
+endpoints:
+  - network-address: "0.0.0.0:$LISTEN_PORT"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+
+direct-rpc:
+$(for i in 1 2 3; do
+	port=$(eval echo \$SIM_$i)
+	cat <<PROVIDER
+  - name: "sim-$i"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "http://127.0.0.1:$port"
+        timeout: 10s
+        skip-verifications: [chain-id, pruning, tx-indexing]
+PROVIDER
+done)
+EOF
+echo "✓ config written ($CONFIG_FILE)"
+
+stop_router
+echo "[Setup] starting router"
+start_router
+echo "✓ router ready (listener :$LISTEN_PORT, metrics :$METRICS_PORT, debug :$DEBUG_PORT)"
+
+# =============================================================================
+# 1 — Baseline: consensus forms, and every derived constant is what we think
+# =============================================================================
+echo ""
+echo "[1] BASELINE — 3 agreeing endpoints form a strict-majority consensus"
+await_baseline 60 || true
+tip=$(cs ObservedTip); base=$(cs ConsensusBaseline); poll=$(ep $SIM_1 PollIntervalMs)
+echo "      tip=$tip baseline=$base hasBaseline=$(cs HasBaseline) pollMs=$poll"
+[ "$tip" = "$SIM_HEAD" ] && pass "observed tip is the simulator head ($SIM_HEAD)" \
+	|| fail "observed tip $tip != $SIM_HEAD"
+[ "$(cs HasBaseline)" = "true" ] && pass "consensus baseline formed (min-2 + >50% satisfied)" \
+	|| fail "no consensus baseline formed from 3 agreeing endpoints"
+# Pins the derived cadence: a regression in the block-time derivation shows up here
+# before it shows up as a subtle freshness bug.
+[ "$poll" = "$POLL_MS" ] && pass "poll cadence is average_block_time/2 (${POLL_MS}ms)" \
+	|| fail "poll cadence $poll != $POLL_MS"
+
+# =============================================================================
+# 2 — The T3 headline: a lying-high endpoint cannot move the router-wide tip
+# =============================================================================
+echo ""
+echo "[2] ANTI-LIE GUARD — one endpoint claims head+1,000,000 (>> outlier threshold $OUTLIER_THRESHOLD)"
+LIE=$((SIM_HEAD + 1000000))
+lie_high "$P3" "$LIE"
+sleep 22
+tip=$(cs ObservedTip); base=$(cs ConsensusBaseline)
+router_metric=$(metric_int smartrouter_latest_block)
+ep3_metric=$(curl -s "http://127.0.0.1:$METRICS_PORT/metrics" | grep '^rpc_endpoint_latest_block' | grep 'sim-3' | awk '{print $NF}' | head -n1)
+ep3_metric=$(python3 -c "print(int(float('${ep3_metric:-0}')))")
+echo "      tip=$tip baseline=$base | smartrouter_latest_block=$router_metric | rpc_endpoint_latest_block{sim-3}=$ep3_metric"
+[ "$tip" = "$SIM_HEAD" ] && pass "chain tip rejected the lie (still $SIM_HEAD)" \
+	|| fail "chain tip moved to $tip — the outlier guard did not hold"
+[ "$base" = "$SIM_HEAD" ] && pass "consensus baseline unmoved — the outlier did not define it" \
+	|| fail "baseline moved to $base"
+# The scope split T3 designed: the router-wide gauge follows the GUARDED tip, while
+# the per-endpoint gauge honestly reports that endpoint's own (lying) view.
+[ "$router_metric" = "$SIM_HEAD" ] && pass "smartrouter_latest_block follows the GUARDED tip, not the raw harvest" \
+	|| fail "smartrouter_latest_block=$router_metric leaked the unguarded value"
+[ "$ep3_metric" = "$LIE" ] && pass "rpc_endpoint_latest_block{sim-3} reports the endpoint's OWN view ($LIE)" \
+	|| fail "per-endpoint metric $ep3_metric did not record sim-3's own value"
+sim_reset
+
+# =============================================================================
+# 3 — The prober is a read-only decision plane: zero upstream calls
+# =============================================================================
+echo ""
+echo "[3] PROBE SILENCE — the probe loop (5s) must make NO upstream calls"
+sleep 8
+before=$(sim_calls); sleep 26; after=$(sim_calls); delta=$((after - before))
+# A poll CYCLE is two calls (eth_blockNumber + eth_getBlockByNumber), so 26s at a
+# 6.5s cadence across 3 endpoints is ~24. If the prober also hit the wire we would
+# see roughly a further 5s-cadence worth (~15 more) on top.
+echo "      upstream calls over 26s across 3 endpoints: $delta (poll-only ~24, poll+probe ~39)"
+if [ "$delta" -le 30 ]; then
+	pass "call volume matches the poll cadence alone — probe loop is in-memory only"
+else
+	fail "call volume $delta is consistent with the probe loop hitting the wire"
+fi
+# Stronger than counting: prove every call lands on a poll boundary as a method PAIR.
+pattern=$(curl -s "http://$SIM_CONTROL/history" | python3 -c "
+import sys,json,collections
+h=[e for e in json.load(sys.stdin)['history'] if e['pool']=='eth-sim'][-30:]
+print(','.join(sorted(collections.Counter(e['method'] for e in h))))")
+[ "$pattern" = "eth_blockNumber,eth_getBlockByNumber" ] \
+	&& pass "only poll methods on the wire ($pattern) — no probe-originated traffic" \
+	|| fail "unexpected methods on the wire: $pattern"
+
+# =============================================================================
+# 4 — TTL freshness gate, driven by the ChainState-only debug warp
+# =============================================================================
+echo ""
+echo "[4] TTL GATE — warp +$((TTL_SECONDS + 70))s must make the gated getters report not-found"
+raw_before=$(cs ObservedTip)
+warp $((TTL_SECONDS + 70))
+tf=$(cs TipFresh); bf=$(cs BaselineFresh); raw_after=$(cs ObservedTip)
+echo "      TipFresh=$tf BaselineFresh=$bf | raw ObservedTip preserved: $raw_before -> $raw_after"
+[ "$tf" = "false" ] && [ "$bf" = "false" ] && pass "TipFresh and BaselineFresh both false past TTL" \
+	|| fail "expected both false past TTL; got TipFresh=$tf BaselineFresh=$bf"
+# The raw value must survive: a stale tip reports (0,false) to GATED readers, but
+# GetLatestBlockAllowStale (archive routing) still needs the last-known head.
+[ "$raw_after" = "$raw_before" ] && pass "raw tip preserved under warp (allow-stale readers keep a head)" \
+	|| fail "raw tip changed under warp: $raw_before -> $raw_after"
+warp 0
+sleep 1
+# Clearing the warp must restore freshness IMMEDIATELY. If stored timestamps had been
+# written against the warped clock they would now be future-dated and read as
+# artificially fresh or stale — this is the MAG-2307 "store real / compare warped" fix.
+[ "$(cs TipFresh)" = "true" ] && pass "freshness restored on warp reset — no future-dated timestamps stored" \
+	|| fail "tip still stale after warp reset — a warped timestamp was persisted"
+
+# =============================================================================
+# 5 — The T3 headline the retired bootstrap atomic could never do: heal DOWN
+# =============================================================================
+if [ "$FAST" -eq 1 ]; then
+	echo ""; echo "[5] DOWNWARD HEAL — skipped (--fast)"
+else
+	echo ""
+	echo "[5] DOWNWARD HEAL — all endpoints drop 200 blocks; tip must follow DOWN"
+	echo "    Gated twice: the per-endpoint store rejects a lower block until its own"
+	echo "    stamp goes stale (${TTL_SECONDS}s), and only then can ChainState re-adopt."
+	DROPPED=$((SIM_HEAD - 200))
+	lag "$P1" 200; lag "$P2" 200; lag "$P3" 200
+	echo "      endpoints now report $DROPPED; waiting out the ${TTL_SECONDS}s staleness window..."
+	if await_tip "$DROPPED" 200; then
+		pass "tip healed DOWN to $DROPPED (the retired bootstrap atomic could not)"
+	else
+		fail "tip did not heal down within 200s (currently $(cs ObservedTip))"
+	fi
+	sim_reset
+	# Let the endpoints climb back before the cold-start scenarios.
+	await_tip "$SIM_HEAD" 200 >/dev/null 2>&1 || true
+fi
+
+# =============================================================================
+# 6 — MAG-2622 regression: an endpoint down at boot must still end up polling
+# =============================================================================
+# Was a KNOWN check; promoted to a hard assert when MAG-2622 was fixed
+# (initializeChainTrackers became a reconcile LOOP instead of a one-shot startup pass).
+#
+# Recovery here is two BOUNDED stages, and the wait below has to cover both:
+#   1. re-admission to the pairing  — retryFailedStaticProviders, a 3m ticker. An
+#      endpoint down at boot fails startup verification and is held out of the pairing
+#      entirely, which is why the boot log reads "failed=0 success=1": skipped, not failed.
+#   2. tracker registration         — the reconcile loop, chainTrackerReconcileInterval (15s).
+# Stage 2 was the unbounded one: before the fix the endpoint was re-admitted, looked
+# healthy in ValidAddresses, and still never polled for the life of the process.
+COLD_RECOVERY_TIMEOUT=260 # 3m re-admission + 15s reconcile + margin
+echo ""
+echo "[6] MAG-2622 — an endpoint DOWN at boot must acquire a ChainTracker once it returns"
+echo "    Take 2 of 3 endpoints down, cold-start the router, then restore them."
+echo "    Required: they start polling, a baseline forms, and the poisoned tip is corrected."
+set_mode "$P1" down; set_mode "$P2" down
+COLD_LIE=$((SIM_HEAD + 5000000))
+lie_high "$P3" "$COLD_LIE"
+stop_router
+start_router "run_coldstart"
+sleep 25
+cold_tip=$(cs ObservedTip)
+echo "      after cold start with only the liar reachable: tip=$cold_tip hasBaseline=$(cs HasBaseline)"
+# The cold-start hole itself is DOCUMENTED and accepted (SetLatestBlock cannot guard
+# the very first observation — no reference exists). It is only a problem when the
+# self-heal never arrives, which is what the rest of this scenario now asserts.
+[ "$cold_tip" = "$COLD_LIE" ] && pass "cold-start lie accepted, as SetLatestBlock documents (no reference yet)" \
+	|| echo "      (cold-start lie not reproduced this run — tip=$cold_tip; timing-dependent)"
+
+set_mode "$P1" success; set_mode "$P2" success
+echo "      restored sim-1/sim-2; waiting up to ${COLD_RECOVERY_TIMEOUT}s for re-admission + tracker reconcile..."
+recovered=0
+for i in $(seq 1 "$COLD_RECOVERY_TIMEOUT"); do
+	p1_poll=$(ep $SIM_1 PollIntervalMs)
+	[ -n "$p1_poll" ] && [ "$p1_poll" != "0" ] && [ "$(ep $SIM_1 LatestBlock)" != "0" ] && { recovered=$i; break; }
+	sleep 1
+done
+p1_poll=$(ep $SIM_1 PollIntervalMs); p1_block=$(ep $SIM_1 LatestBlock)
+echo "      sim-1: PollIntervalMs=$p1_poll LatestBlock=$p1_block | hasBaseline=$(cs HasBaseline) tip=$(cs ObservedTip)"
+if [ "$recovered" -gt 0 ]; then
+	pass "sim-1 acquired a tracker after boot and polls at ${p1_poll}ms holding block $p1_block (t+${recovered}s)"
+	# With 2 of 3 honest endpoints polling again the min-2 rule is satisfied, so the
+	# consensus-anchored guard comes back on and Recompute can snap the poisoned tip down.
+	await_baseline 60 && pass "baseline re-formed — the consensus anti-lie guard is back on" \
+		|| fail "sim-1 polls but no baseline formed within 60s"
+else
+	fail "sim-1 never started polling (PollIntervalMs=$p1_poll) despite being reachable again — MAG-2622 regression"
+	echo "         -> a nominal 3-endpoint pod is really a 1-endpoint pod: no baseline can form,"
+	echo "            the anti-lie guard is OFF, and the cold-start lie is permanent."
+	echo "            Check PollIntervalMs in /debug/endpoint-state before trusting HasBaseline."
+fi
+
+# =============================================================================
+# 7 — KNOWN ISSUE: /debug/reset-all does not clear the endpointtip store
+# =============================================================================
+echo ""
+echo "[7] KNOWN ISSUE — /debug/reset-all clears ChainState but not the endpointtip store"
+echo "    Endpoints are held DOWN so they CANNOT re-report; anything that comes back"
+echo "    after the reset must have come from data that survived it."
+sim_reset
+stop_router; start_router "run_resetall"
+await_baseline 60 || true
+pre_tip=$(cs ObservedTip)
+set_mode "$P1" down; set_mode "$P2" down; set_mode "$P3" down
+sleep 3
+reset_all
+echo "      immediately after reset-all: tip=$(cs ObservedTip) initialized=$(cs Initialized)"
+sleep 20
+post_tip=$(cs ObservedTip); post_base=$(cs ConsensusBaseline)
+echo "      t+20s (all endpoints still DOWN): tip=$post_tip baseline=$post_base"
+if [ "$post_base" = "$pre_tip" ] && [ "$pre_tip" != "0" ]; then
+	known "baseline re-formed at the pre-reset block $pre_tip from surviving endpointtip data"
+	echo "         -> reset-all reports 'cleared:[...,chain-state,...]' but the per-endpoint"
+	echo "            tips that FEED it survive for up to ${TTL_SECONDS}s. Use a process restart"
+	echo "            for a genuine cold start, not reset-all."
+else
+	fixed "reset-all now clears the endpointtip store too (baseline stayed cleared)"
+fi
+sim_reset
+
+# =============================================================================
+# 8 — Contrast: an endpoint down AFTER startup recovers correctly
+# =============================================================================
+if [ "$FAST" -eq 1 ]; then
+	echo ""; echo "[8] BACKOFF RECOVERY — skipped (--fast)"
+else
+	echo ""
+	echo "[8] BACKOFF RECOVERY — the contrast that isolates scenario 6's trigger"
+	echo "    Same endpoint, same outage, but the tracker already EXISTS. Must recover."
+	stop_router; start_router "run_backoff"
+	await_baseline 60 || true
+	# This scenario needs sim-2 to stay PAIRED for its whole outage — the point is that an
+	# EXISTING tracker backs off and recovers, which cannot be observed once the endpoint has
+	# left the pairing (no /debug/endpoint-state row at all).
+	#
+	# Belt and braces since the MAG-2445 fix: demotion now needs the failure to persist across
+	# reverifyDemoteThreshold=2 consecutive epoch ticks, and this window (~130s) cannot span two
+	# boundaries 900s apart — so one boundary mid-outage is now survivable. The guard stays
+	# because it costs nothing and keeps the scenario honest if that threshold is ever tuned
+	# back to 1.
+	await_epoch_runway 150
+	set_mode "$P2" down
+	sleep 40
+	down_poll=$(ep $SIM_2 PollIntervalMs); down_fails=$(ep $SIM_2 ConsecutivePollFailures)
+	echo "      during outage: PollIntervalMs=$down_poll (backed off from $POLL_MS) fails=$down_fails"
+	if [ -z "$down_poll" ]; then
+		fail "sim-2 left the pairing during the outage (no endpoint-state row) — expected it to stay paired and back off"
+	elif [ "$down_poll" -gt "$POLL_MS" ]; then
+		pass "poll interval backed off exponentially during the outage"
+	else
+		fail "expected backoff above ${POLL_MS}ms; got $down_poll"
+	fi
+	set_mode "$P2" success
+	echo "      restored; waiting for the poll cadence to return (BACKOFF_MAX_TIME is 1m)..."
+	recovered=0
+	for _ in $(seq 1 90); do
+		[ "$(ep $SIM_2 PollIntervalMs)" = "$POLL_MS" ] && [ "$(ep $SIM_2 LatestBlock)" != "0" ] && { recovered=1; break; }
+		sleep 1
+	done
+	if [ "$recovered" -eq 1 ]; then
+		pass "an endpoint down AFTER startup fully recovers — isolates 'down at init' as the trigger"
+	else
+		fail "endpoint did not recover: PollIntervalMs=$(ep $SIM_2 PollIntervalMs) block=$(ep $SIM_2 LatestBlock)"
+	fi
+fi
+
+# -----------------------------------------------------------------------------
+# Leave the environment healthy and RUNNING for manual poking (repo convention).
+# -----------------------------------------------------------------------------
+sim_reset
+stop_router; start_router "run_final"
+await_baseline 60 >/dev/null 2>&1 || true
+
+echo ""
+echo "==================================================================="
+echo "Result: $PASS passed, $FAIL failed, $KNOWN known-issue"
+echo "==================================================================="
+echo "  Router:    http://127.0.0.1:$LISTEN_PORT   metrics :$METRICS_PORT   debug :$DEBUG_PORT"
+echo "  Simulator: control $SIM_CONTROL, eth-sim on $SIM_1/$SIM_2/$SIM_3"
+echo "  Config:    $CONFIG_FILE"
+echo "  Logs:      $LOG_FILE  (per-scenario restarts saved as *_run*.log)"
+echo ""
+echo "🔬 Poke it by hand:"
+echo "  curl -s http://127.0.0.1:$DEBUG_PORT/debug/chain-state    | jq"
+echo "  curl -s http://127.0.0.1:$DEBUG_PORT/debug/endpoint-state | jq"
+echo "  curl -s http://127.0.0.1:$METRICS_PORT/metrics | grep -E 'latest_block'"
+echo "  # make sim-3 lie:"
+echo "  curl -s -X POST http://$SIM_CONTROL/scenario -H 'Content-Type: application/json' \\"
+echo "    -d '{\"providers\":{\"$P3\":{\"responses\":{\"eth_blockNumber\":{\"result\":\"0x2000000\"}}}}}'"
+echo "  curl -s -X POST http://$SIM_CONTROL/reset/all"
+echo ""
+echo "🟢 Router and simulator LEFT RUNNING."
+echo "✋ Stop when done:  pkill -f '$BIN' ; pkill -f 'run.py'"
+echo "==================================================================="
+
+# Known issues are reported, not failed — this stays green until a real regression.
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
Fixes [MAG-2622](https://magmadevs.atlassian.net/browse/MAG-2622) and [MAG-2445](https://magmadevs.atlassian.net/browse/MAG-2445).

The two turned out to be interlocked: **MAG-2445's recovery half was broken by MAG-2622.** A provider demoted by a blip got its pairing row back on the next epoch, but no poll loop — so the "recovers in minutes" the ticket describes was really "the row returns; polling does not."

---

## MAG-2622 — an endpoint unreachable at boot never gets a ChainTracker

`initializeChainTrackers` ran **once**, ~100 ms after startup. Endpoints enter the pairing at three points after that pass, and none registered a tracker:

| path | trigger |
|---|---|
| `retryFailedStaticProviders` | an upstream that failed boot verification recovers (3 m ticker) |
| `applyReverification` promote | a demoted provider passes re-verification (epoch tick) |
| `rebuildPairingFromConfig` | `/debug/reset-pairing` re-admits cold |

All three build fresh `DirectRPCConnections`, so the endpoint was fully usable and present in `GetAllDirectRPCEndpoints` — it just had no poll loop, for the life of the process. Signature: `PollIntervalMs=0` **and** `ConsecutivePollFailures=0` — not polling, and not even failing. The documented fallback (`ensureEndpointChainTracker`) only fires when a relay is *routed* to the endpoint, and an endpoint with no observations doesn't score well enough to attract one.

The damage isn't the missing telemetry. Below `chainstate`'s min-2 rule no consensus baseline can form, which switches **off** the anti-lie guard in `SetLatestBlock` and `Recompute`'s snap-down correction — a cold-start lie becomes permanent and effectively all traffic routes to the one endpoint that has data. On a 3-endpoint pod with 2 upstreams down at boot, that is the whole pod.

**Fix:** `initializeChainTrackers` becomes a reconcile loop — one startup pass, then every `chainTrackerReconcileInterval` (15 s). `reconcileChainTrackers` partitions present/missing first, so a steady-state pass is one `RLock`'d map lookup per endpoint and skips the 50 ms stagger entirely.

Registering for a **down** endpoint is the point, not a hazard: `GetOrCreateTracker` does no network I/O, and the poll-failure backoff already recovers correctly once a tracker exists (harness scenario [8] proves this). The bug was never that backoff was broken — it was that backoff had nothing to attach to.

A creation after startup now logs a warning naming the endpoints, so the silent case can't recur.

## MAG-2445 — one bad re-verify cycle demotes a provider for a full epoch

Epochs are **wall-clock derived** — `floor((now − 2024-01-01)/15m)` in `common.EpochTimer` — so boundaries land on :00/:15/:30/:45 regardless of process uptime. A router up 19 seconds can hit one, and a 40-second blip that overlaps it demoted the provider outright.

`Validate` does already retry 3× (`chain_fetcher.go`, *"we give several chances for starting up"*), but **back-to-back with no delay** — the whole budget is spent inside ~1 s, so all three attempts land in the same outage. Those retries were written for a *cold* path (a node still booting); `applyReverification` reuses `Validate` on a *hot* path where the failure mode is a transient outage, and there the only useful hysteresis is across time.

**Fix:** demote only after `reverifyDemoteThreshold = 2` **consecutive** failed cycles, matching the temporal hysteresis endpoint health already has (`MaxConsecutiveConnectionAttempts` to disable, `consecutiveHealthyProbes` to re-enable). The streak lives on `chainReverifyInputs.demoteFailStreak`, guarded by `RPCSmartRouter.mu` (held by `updateEpoch` across both tier calls), and resets on success so unrelated flaps can't accumulate into a demotion.

Safe because **demotion is not the liveness mechanism**: a dead upstream is disabled by endpoint health within seconds and QoS stops routing to it. Demotion is the coarse cleanup layered on top, so keeping a dead provider paired one extra epoch is cheap.

---

## Verification

Live against `provider_simulator` — harness **18 passed, 0 failed, 1 known-issue** (the remaining KNOWN is scenario [7], an unrelated `endpointtip`/`reset-all` bug).

MAG-2622, cold start with 2 of 3 endpoints down:
```
16:25:54 INF ChainTracker initialization complete   failed=0 success=1
16:28:54 INF [+] static provider recovered and passed verification  provider=sim-1
16:28:54 INF [+] static provider recovered and passed verification  provider=sim-2
16:28:54 WRN ChainTracker reconcile: registered endpoints that had no tracker
             created=2 endpoints=http://127.0.0.1:18546,http://127.0.0.1:18545
```

MAG-2445, run with `--epoch-duration 40s` so both boundaries fit in two minutes:
```
17:02:01 WRN re-verify: active static failed but kept — under demote threshold
             consecutiveFailures=1 demoteAfter=2 provider=sim-2
         DBG UpdateAllProviders epoch=2029503 pairingListLen=3    <- survived boundary 1
17:02:40 WRN re-verify: demoting active static  consecutiveFailures=2 provider=sim-2
         DBG UpdateAllProviders epoch=2029504 pairingListLen=2    <- demoted at boundary 2
```

Unit tests: the three new pins (`TestInitializeChainTrackers_RegistersEndpointAdmittedAfterStartup`, `TestApplyReverification_DemoteHysteresis`, `TestApplyReverification_SuccessResetsDemoteStreak`) were each verified to **fail against pre-fix code** on the intended assertion, not merely to pass now.

`rpcsmartrouter`, `lavasession`, `endpointstate`, `chainstate`, `endpointtip` all green.

## Notes for review

- **Six existing tests** asserted demote-on-first-failure. Rather than complicate each with a second cycle, they call `withImmediateDemote(t)`, which pins the threshold to 1 and restores it — they're about what `updateEpoch` *does* with a demote, not how one is earned.
- **`GetAllDirectRPCEndpoints` is documented as NOT a reachability filter.** `IsDirectRPC()` *is* `len(DirectConnections) > 0`, so the second clause is redundant; it's kept purely to guard the `[0]` index, and now says so. This was the suspect MAG-2622 originally chased, and it was innocent.
- **Harness scenario [6]** promoted from KNOWN to a hard assert; **scenario [8]** gains an epoch-boundary runway guard so it can't silently measure a demotion instead of a backoff recovery.
- `chainTrackerReconcileInterval` and `reverifyDemoteThreshold` are package vars rather than consts so tests can adjust them; neither is flag-bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MAG-2622]: https://magmadevs.atlassian.net/browse/MAG-2622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAG-2445]: https://magmadevs.atlassian.net/browse/MAG-2445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ