### PR TITLE
fix(metrics): mirror the guarded tip into smartrouter_latest_block on every poll observation

### DIFF
--- a/protocol/rpcsmartrouter/chainstate_glue_test.go
+++ b/protocol/rpcsmartrouter/chainstate_glue_test.go
@@ -368,31 +368,7 @@ func TestHarvest_ArchiveRoutingTipGuardedByChainState(t *testing.T) {
 	mm := metrics.NewSmartRouterMetricsManager(metrics.SmartRouterMetricsManagerOptions{})
 	require.NotNil(t, mm)
 
-	// routerLatestBlock reads the smartrouter_latest_block GAUGE for this chain/interface. Unlike the
-	// counters elsewhere in this package it is Set to an ABSOLUTE value, and these tests run
-	// sequentially (no t.Parallel), so the value read straight after a harvest is the one that
-	// harvest reported — no before/after delta needed.
-	routerLatestBlock := func(t *testing.T) float64 {
-		t.Helper()
-		mfs, err := prometheus.DefaultGatherer.Gather()
-		require.NoError(t, err)
-		for _, mf := range mfs {
-			if mf.GetName() != "smartrouter_latest_block" {
-				continue
-			}
-			for _, m := range mf.GetMetric() {
-				lm := map[string]string{}
-				for _, lp := range m.GetLabel() {
-					lm[lp.GetName()] = lp.GetValue()
-				}
-				if lm["spec"] == "ETH1" && lm["apiInterface"] == "jsonrpc" {
-					return m.GetGauge().GetValue()
-				}
-			}
-		}
-		require.FailNow(t, "smartrouter_latest_block not reported for ETH1/jsonrpc")
-		return 0
-	}
+	routerLatestBlock := readRouterLatestBlockGauge
 
 	cs := chainstate.NewWithClock("ETH1", chainstate.Config{
 		BucketWidth:      2,
@@ -654,4 +630,81 @@ func TestSiteC_InClusterEndpointChargedNoSyncGap(t *testing.T) {
 	// the clamp would silently disable lag detection instead of merely tolerating the cluster.
 	require.Equal(t, width+1, syncGapAgainstReference(tip, mode-1, width),
 		"just past BucketWidth the endpoint is charged its real distance")
+}
+
+// readRouterLatestBlockGauge reads the smartrouter_latest_block GAUGE for ETH1/jsonrpc off the
+// default registry. Unlike the counters elsewhere in this package it is Set to an ABSOLUTE value,
+// and these tests run sequentially (no t.Parallel), so the value read straight after a write is
+// the one that write reported — no before/after delta needed. Shared by the relay-harvest test
+// (TestHarvest_ArchiveRoutingTipGuardedByChainState) and the poll-path test below (MAG-2629).
+func readRouterLatestBlockGauge(t *testing.T) float64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != "smartrouter_latest_block" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			lm := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				lm[lp.GetName()] = lp.GetValue()
+			}
+			if lm["spec"] == "ETH1" && lm["apiInterface"] == "jsonrpc" {
+				return m.GetGauge().GetValue()
+			}
+		}
+	}
+	require.FailNow(t, "smartrouter_latest_block not reported for ETH1/jsonrpc")
+	return 0
+}
+
+// MAG-2629 regression pin: the router-wide latest-block gauge must advance under POLL-ONLY
+// traffic. Before the fix, SetRouterLatestBlock had exactly one call site — the relay-harvest
+// path — so on a router serving no relays the gauge froze at the last relay's value while the
+// poll-fed ChainState tip (and the per-endpoint gauges next to it) kept advancing: dashboards
+// read "falling behind head" on an idle pod, indistinguishable from a genuinely stuck tip.
+//
+// onTipObservation is the EndpointMonitor's OnTipObservation hook — the exact function every
+// accepted poll observation drives in production — called here directly so the test needs no
+// tracker, upstream, or relay machinery: the point is that THIS path alone must keep the gauge
+// live. Verified to fail against the pre-fix wiring (hook = bare SetLatestBlock closure).
+func TestOnTipObservation_GaugeAdvancesUnderPollOnlyTraffic(t *testing.T) {
+	// Empty options => metrics registered on the default registry, no HTTP server started.
+	mm := metrics.NewSmartRouterMetricsManager(metrics.SmartRouterMetricsManagerOptions{})
+	require.NotNil(t, mm)
+
+	// Real clock + DefaultConfig, exactly as ServeRPCRequests wires it (TTL = 10×13s = 130s),
+	// so the fresh-path assertions run under production freshness semantics.
+	cs := chainstate.New("ETH1", chainstate.DefaultConfig(13*time.Second))
+
+	rpcss := &RPCSmartRouterServer{
+		chainState:                 cs,
+		smartRouterEndpointMetrics: mm,
+		listenEndpoint:             &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"},
+	}
+
+	// Two consecutive poll observations — no relay anywhere in this test — must move the gauge.
+	rpcss.onTipObservation(25_638_537)
+	require.Equal(t, float64(25_638_537), readRouterLatestBlockGauge(t),
+		"first poll observation must seed the gauge — pre-fix, only a relay could")
+	rpcss.onTipObservation(25_638_545)
+	require.Equal(t, float64(25_638_545), readRouterLatestBlockGauge(t),
+		"the gauge must track the tip under poll-only traffic — the frozen-gauge case from MAG-2629")
+
+	// Only-when-fresh semantics, shared with the relay-path write: warp the ChainState clock past
+	// TTL (stamps stay on the real clock, evaluation is warped — the same mechanism harness
+	// scenario 4 pins), so the gated GetLatestBlock reports stale. A poll observation arriving in
+	// that state must leave the gauge UNTOUCHED: a stale tip must not advance it, and zeroing it
+	// would turn routine TTL expiry into a false "chain reset" on the graph.
+	cs.SetDebugClockOffset(200 * time.Second)
+	rpcss.onTipObservation(25_638_600)
+	require.Equal(t, float64(25_638_545), readRouterLatestBlockGauge(t),
+		"a stale gated read must leave the gauge at its last fresh value")
+	cs.SetDebugClockOffset(0)
+
+	// Nil-guards: fixtures build servers without metrics or ChainState wired — the hook fires
+	// from tracker callbacks and must never panic on such a server.
+	(&RPCSmartRouterServer{}).onTipObservation(1)
+	(&RPCSmartRouterServer{chainState: cs}).onTipObservation(1)
 }

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -217,10 +217,9 @@ func (rpcss *RPCSmartRouterServer) ServeRPCRequests(
 		ApiInterface:     listenEndpoint.ApiInterface,
 		AverageBlockTime: effectiveBlockTime,
 		BlocksToSave:     endpointstate.DefaultBlocksToSave,
-		// Feed every positive poll/relay block into the per-chain tip (cheap monotonic write).
-		OnTipObservation: func(block int64) {
-			rpcss.chainState.SetLatestBlock(block)
-		},
+		// Feed every positive poll/relay block into the per-chain tip (cheap monotonic write)
+		// and mirror the resulting guarded tip into the router-wide latest-block gauge (MAG-2629).
+		OnTipObservation: rpcss.onTipObservation,
 		OnNewBlock: func(endpointURL string, fromBlock, toBlock int64) {
 			utils.LavaFormatTrace("endpoint ChainTracker detected new block",
 				utils.LogAttr("endpoint", endpointURL),
@@ -2451,6 +2450,43 @@ func runProbeCycleCore(
 	return scored, reEnabled, syncOmitted
 }
 
+// onTipObservation is the EndpointMonitor's OnTipObservation hook: it feeds every positive
+// poll/relay block into the per-chain ChainState tip, then mirrors the resulting GUARDED tip into
+// the router-wide smartrouter_latest_block gauge.
+//
+// MAG-2629 — the gauge mirror lives HERE, on the hook that advances the tip, because the gauge
+// used to be written only in the relay-harvest path (harvestAndUpdateTipFromRelay below). The tip
+// itself has two feeders — polls and relay harvest — so on a router serving no relay traffic the
+// gauge froze at the last relay's value while polls kept the real tip fresh: dashboards read
+// "falling behind head" on an idle pod, indistinguishable from a genuinely stuck tip, and
+// contradicting the poll-fed rpc_endpoint_latest_block right next to it. Writing it where the tip
+// changes makes the metric a faithful mirror under poll-only traffic; the harvest-path write
+// remains (redundant, not wrong) as the relay-side immediacy guarantee.
+//
+// Only-when-fresh semantics, same as the harvest-path write: the gated GetLatestBlock returns
+// ok=false when the tip is stale, and the gauge is then left alone — a stale tip must not advance
+// it, and zeroing it would turn routine TTL expiry into a false "chain reset" on the graph. The
+// gauge always carries the guarded tip, never the raw observed block, so a lying-high endpoint
+// cannot inflate it through this path either.
+//
+// Nil-guards cover test fixtures that construct the server without metrics or ChainState wired.
+func (rpcss *RPCSmartRouterServer) onTipObservation(block int64) {
+	if rpcss.chainState == nil {
+		return
+	}
+	rpcss.chainState.SetLatestBlock(block)
+	if rpcss.smartRouterEndpointMetrics == nil || rpcss.listenEndpoint == nil {
+		return
+	}
+	if accepted, ok := rpcss.chainState.GetLatestBlock(); ok {
+		rpcss.smartRouterEndpointMetrics.SetRouterLatestBlock(
+			rpcss.listenEndpoint.ChainID,
+			rpcss.listenEndpoint.ApiInterface,
+			accepted,
+		)
+	}
+}
+
 // harvestAndUpdateTipFromRelay applies a served relay's block to TIP state — but only when the
 // response is tip-eligible (MAG-2159 finding 4). tipBlockFromRelay distinguishes a "block
 // associated with a response" (historical: eth_getBlockByNumber(N), getBlockByHash,
@@ -2495,6 +2531,11 @@ func (rpcss *RPCSmartRouterServer) harvestAndUpdateTipFromRelay(
 	// guarded tip (not the raw harvested `tip`) keeps a lying-high endpoint out of the router-wide
 	// metric, the scope the old chain-accepted gate protected. The per-endpoint metric below stays
 	// gated on the store only: it reports THIS endpoint's own view.
+	//
+	// Since MAG-2629 this is no longer the gauge's only writer: onTipObservation (the hook above)
+	// refreshes it on every accepted poll observation too, so the gauge no longer freezes on a
+	// router serving no relay traffic. This write is now redundant on the relay path (the hook has
+	// already fired by this point) and is kept as the explicit relay-side guarantee.
 	if rpcss.chainState != nil && rpcss.smartRouterEndpointMetrics != nil {
 		if accepted, ok := rpcss.chainState.GetLatestBlock(); ok {
 			rpcss.smartRouterEndpointMetrics.SetRouterLatestBlock(


### PR DESCRIPTION
Fixes [MAG-2629](https://magmadevs.atlassian.net/browse/MAG-2629).

## Bug

`smartrouter_latest_block` was written **only in the relay-harvest path** (`SetRouterLatestBlock` had exactly one call site), while the ChainState tip it reports has **two feeders** — polls and relay harvest. On a router serving no relay traffic the gauge froze at the last relay's value as polls kept the real tip fresh:

- dashboards read "falling behind head" on an idle pod, indistinguishable from a genuinely stuck tip
- it contradicted the poll-fed `rpc_endpoint_latest_block` beside it ("polls fine, consensus broken" — the wrong conclusion)
- on a poll-only router the gauge was never exported at all — *no data*, quieter than a flat line

Archaeology: T3 rewired the gauge to the guarded tip in the relay path; Topic C later added the poll feeder to ChainState, and no matching metric write came with it.

## Fix

The `OnTipObservation` closure becomes a named method, `onTipObservation`: it feeds `ChainState.SetLatestBlock` exactly as before, then mirrors the **gated** `GetLatestBlock()` into the gauge.

- **Only-when-fresh** — a stale gated read leaves the gauge at its last fresh value (zeroing would turn routine TTL expiry into a false "chain reset" on the graph)
- **Guarded, never raw** — a lying-high endpoint cannot inflate the gauge through the poll path either
- The harvest-path write stays: redundant now (the hook fires first on relays too), kept as the explicit relay-side guarantee, comment updated accordingly

## Verification

**Regression pin** — `TestOnTipObservation_GaugeAdvancesUnderPollOnlyTraffic` drives the hook with poll-only traffic: gauge must seed, advance, and hold under a warped-stale read. Verified to **fail against the pre-fix wiring** with `smartrouter_latest_block not reported` — which *is* the bug. The gauge-reading helper is lifted to file scope, shared with the existing harvest-path test.

**Live, real Ethereum mainnet** (PublicNode + Tenderly, zero relays sent after boot):

| | 65 s pre-fix (yesterday, merged main) | 40 s post-fix (temp router, this branch) |
|---|---|---|
| gauge movement | **+0** (frozen 8 behind head) | **+3, 1 block behind the live head** |
| per-endpoint views | +6, tracking head | tracking head |

**Suites** — `rpcsmartrouter`, `metrics`, `provideroptimizer` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MAG-2629]: https://magmadevs.atlassian.net/browse/MAG-2629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ