### PR TITLE
feat(metrics): collapse batch method labels into bounded signatures

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -130,6 +130,49 @@ with read/write.
 | `smartrouter_requests_archive_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Archive requests. |
 | `smartrouter_requests_batch_total` | Counter | `spec`, `apiInterface`, `provider_address`, `method` | Batch requests. |
 
+#### Batch requests and the `method` label
+
+For a batch request there is no single method, so the `method` label carries a
+**batch signature**: the sorted set of distinct sub-methods, prefixed with `batch:`.
+
+```
+[eth_call ×30, eth_getBalance]   →   method="batch:eth_call+eth_getBalance"
+[eth_call ×3]                    →   method="batch:eth_call"
+```
+
+Order and repetition are deliberately dropped. They are what a raw joined label would
+encode, and they make cardinality unbounded — order contributes permutations, repetition
+contributes one series per batch length. The set is the part that identifies the *type*
+of batch, and it is what client code actually determines. The magnitude that repetition
+used to encode moves to `smartrouter_batch_size`.
+
+Because the signature carries the method label on the whole request-breakdown family,
+per-batch-type success rate, latency, and provider breakdown all work:
+
+```promql
+# error rate per batch type
+sum by (method) (rate(smartrouter_requests_failed_total{method=~"batch:.*"}[5m]))
+  / sum by (method) (rate(smartrouter_requests_total{method=~"batch:.*"}[5m]))
+```
+
+Single-method requests are untouched — `method="eth_call"` means exactly what it always
+did, so a `method=~"batch:.*"` / `method!~"batch:.*"` pair cleanly splits batch from
+single traffic.
+
+Two bounds keep the label space finite. A spec may register at most **64** distinct
+signatures, and one signature may name at most **8** distinct methods; anything beyond
+either lands in `method="batch:other"`. Both are declared in
+[`batch_method_label.go`](../protocol/metrics/batch_method_label.go).
+
+| Metric | Type | Labels | Description |
+| --- | --- | --- | --- |
+| `smartrouter_batch_size` | Histogram | `spec`, `apiInterface` | Sub-requests per batch. Single-element batches produce no separator in the api name, so they are indistinguishable from single requests here and are not observed. |
+| `smartrouter_batch_signature_overflow_total` | Counter | `spec`, `reason` | Normalizations that fell into `batch:other`. `reason="cap"`: the spec exhausted its 64-signature budget. `reason="wide"`: one batch spanned more than 8 distinct methods. |
+
+**Alert on the overflow counter.** While it is zero, batch-type breakdowns are complete.
+Once it is non-zero they are lossy — some batch types are being merged into `batch:other`
+— which is a signal to raise the cap, not to distrust the other series.
+
 #### Errors
 
 | Metric | Type | Labels | Description |

--- a/protocol/metrics/batch_method_label.go
+++ b/protocol/metrics/batch_method_label.go
@@ -1,0 +1,193 @@
+package metrics
+
+import (
+	"sort"
+	"strings"
+	"sync"
+)
+
+const (
+	// batchMethodSeparator mirrors chainlib's SEP — the token batch parsing uses to
+	// join every sub-method into one synthetic api name (protocol/chainlib/jsonRPC.go,
+	// protocol/chainlib/tendermintRPC.go). It is redeclared here rather than imported
+	// because chainlib already imports this package; importing back would be a cycle.
+	batchMethodSeparator = "&"
+
+	// BatchMethodPrefix namespaces every collapsed batch label value so dashboards can
+	// separate batch traffic from single-method traffic with a prefix match
+	// (method=~"batch:.*") rather than an allowlist of method names.
+	BatchMethodPrefix = "batch:"
+
+	// BatchMethodOther is the overflow bucket, emitted when a batch's signature is past
+	// the per-spec cap or spans more distinct methods than maxBatchSignatureElements.
+	// It is what makes the `method` label bounded no matter what a client sends.
+	BatchMethodOther = BatchMethodPrefix + "other"
+
+	// batchSignatureElementSeparator joins sub-methods inside a signature. It is
+	// deliberately NOT batchMethodSeparator: that is what keeps normalization
+	// idempotent, since an already-collapsed value then carries no separator.
+	batchSignatureElementSeparator = "+"
+
+	// maxBatchSignaturesPerSpec caps how many distinct signatures one spec may
+	// register. Distinct method SETS are 2^N in theory but a handful in practice —
+	// batch shapes are emitted by customer code, not drawn at random. The cap is the
+	// backstop for when that assumption is wrong, and
+	// smartrouter_batch_signature_overflow_total reports when it binds.
+	maxBatchSignaturesPerSpec = 64
+
+	// maxBatchSignatureElements caps how many distinct methods a single signature may
+	// name, so one pathological batch can't mint a kilobyte-long label value.
+	maxBatchSignatureElements = 8
+)
+
+// Reasons for the smartrouter_batch_signature_overflow_total `reason` label.
+const (
+	batchOverflowReasonCap  = "cap"
+	batchOverflowReasonWide = "wide"
+)
+
+// buildBatchSignature turns a raw joined batch api name into an order-invariant and
+// repetition-invariant signature: the sorted SET of its sub-methods.
+//
+// Dropping order and repetition is the entire point. They are what made the raw name
+// unbounded — order contributes permutations, repetition contributes length variants —
+// while the set is what a client's code actually determines. So
+//
+//	eth_call&eth_call&…&eth_call&eth_getBalance  →  batch:eth_call+eth_getBalance
+//
+// collapses thousands of observed series onto one, and the magnitude that repetition
+// used to (uselessly) encode is recovered from the smartrouter_batch_size histogram.
+//
+// Sub-methods need no allowlist check: chainlib resolves every element against the spec
+// through getSupportedApi and hard-fails the parse before any batch name is built, so a
+// name reaching here only ever contains spec-declared api names, never raw client input.
+//
+// size is the batch's element count including repeats. tooWide reports a batch spanning
+// more than maxBatchSignatureElements distinct methods, for which the caller emits
+// BatchMethodOther instead of an unwieldy label value.
+func buildBatchSignature(apiName string) (signature string, size int, tooWide bool) {
+	parts := strings.Split(apiName, batchMethodSeparator)
+	seen := make(map[string]struct{}, len(parts))
+	distinct := make([]string, 0, len(parts))
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		size++
+		if _, duplicate := seen[part]; duplicate {
+			continue
+		}
+		seen[part] = struct{}{}
+		distinct = append(distinct, part)
+	}
+
+	if len(distinct) == 0 || len(distinct) > maxBatchSignatureElements {
+		return BatchMethodOther, size, true
+	}
+
+	sort.Strings(distinct)
+	return BatchMethodPrefix + strings.Join(distinct, batchSignatureElementSeparator), size, false
+}
+
+// batchSignatureRegistry bounds the set of batch signatures allowed to become label
+// values, tracked per spec so a chatty chain can't consume another chain's budget.
+type batchSignatureRegistry struct {
+	lock     sync.RWMutex
+	admitted map[string]map[string]struct{} // spec -> set of admitted signatures
+}
+
+func newBatchSignatureRegistry() *batchSignatureRegistry {
+	return &batchSignatureRegistry{admitted: make(map[string]map[string]struct{})}
+}
+
+// admit reports whether signature may be used as a label value for spec.
+//
+// Admission is monotone: an admitted signature stays admitted, and a full cap stays
+// full. That is what keeps paired call sites consistent — the in-flight gauge's Add at
+// relay start and Sub at relay end normalize the same api name to the same string, so
+// the gauge cannot leak a stuck non-zero series.
+func (r *batchSignatureRegistry) admit(spec, signature string) bool {
+	if r == nil {
+		return false
+	}
+
+	r.lock.RLock()
+	if signatures, ok := r.admitted[spec]; ok {
+		if _, alreadyAdmitted := signatures[signature]; alreadyAdmitted {
+			r.lock.RUnlock()
+			return true
+		}
+	}
+	r.lock.RUnlock()
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	signatures, ok := r.admitted[spec]
+	if !ok {
+		signatures = make(map[string]struct{}, maxBatchSignaturesPerSpec)
+		r.admitted[spec] = signatures
+	}
+	if _, alreadyAdmitted := signatures[signature]; alreadyAdmitted {
+		return true
+	}
+	if len(signatures) >= maxBatchSignaturesPerSpec {
+		return false
+	}
+	signatures[signature] = struct{}{}
+	return true
+}
+
+// normalizeMethodLabel collapses a raw batch api name into a bounded signature and
+// returns single-method names untouched.
+//
+// It is idempotent, because a collapsed value carries no batchMethodSeparator. That
+// matters: the public recorders delegate to one another (RecordDirectRelayEnd →
+// RecordRelaySuccess → AddEndpointRelayServiced), and each normalizes at its own
+// boundary so that calling any of them directly is still safe.
+func (m *SmartRouterMetricsManager) normalizeMethodLabel(spec, method string) string {
+	if m == nil || !strings.Contains(method, batchMethodSeparator) {
+		return method
+	}
+
+	signature, _, tooWide := buildBatchSignature(method)
+	if tooWide {
+		m.recordBatchSignatureOverflow(spec, batchOverflowReasonWide)
+		return BatchMethodOther
+	}
+	if !m.batchSignatures.admit(spec, signature) {
+		m.recordBatchSignatureOverflow(spec, batchOverflowReasonCap)
+		return BatchMethodOther
+	}
+	return signature
+}
+
+func (m *SmartRouterMetricsManager) recordBatchSignatureOverflow(spec, reason string) {
+	if m == nil || m.batchSignatureOverflow == nil {
+		return
+	}
+	m.batchSignatureOverflow.WithLabelValues(spec, reason).Inc()
+}
+
+// observeBatchSize records how many sub-requests a batch carried — the magnitude that
+// the collapsed `method` label deliberately no longer encodes.
+//
+// This must be called from exactly ONE place (RecordDirectRelayEnd, once per completed
+// relay). The other recorders normalize but must not observe, or a single request would
+// be counted once per recorder it passes through.
+//
+// Single-element batches carry no separator in their api name, so they are
+// indistinguishable from single requests here and are not observed.
+func (m *SmartRouterMetricsManager) observeBatchSize(spec, apiInterface, method string) {
+	if m == nil || m.batchSize == nil || !strings.Contains(method, batchMethodSeparator) {
+		return
+	}
+
+	_, size, _ := buildBatchSignature(method)
+	if size == 0 {
+		return
+	}
+	m.batchSize.WithLabelValues(spec, apiInterface).Observe(float64(size))
+}

--- a/protocol/metrics/batch_method_label_test.go
+++ b/protocol/metrics/batch_method_label_test.go
@@ -1,0 +1,312 @@
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// newSmartRouterForBatchLabelTest extends the request-group test manager with the
+// batch-shape collaborators, so normalization admits real signatures instead of
+// degrading to BatchMethodOther on a nil registry.
+func newSmartRouterForBatchLabelTest() *SmartRouterMetricsManager {
+	m := newSmartRouterForRequestGroupTest()
+	m.batchSize = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{Name: "t_sr_batch_size", Buckets: []float64{2, 5, 10, 50}},
+		[]string{"spec", "apiInterface"},
+	)
+	m.batchSignatureOverflow = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "t_sr_batch_overflow"},
+		[]string{"spec", "reason"},
+	)
+	m.batchSignatures = newBatchSignatureRegistry()
+	return m
+}
+
+// joinedBatchName builds a raw batch api name the way chainlib does.
+func joinedBatchName(methods ...string) string {
+	return strings.Join(methods, batchMethodSeparator)
+}
+
+// repeatMethod returns n copies of method, for building homogeneous batches.
+func repeatMethod(method string, n int) []string {
+	out := make([]string, n)
+	for i := range out {
+		out[i] = method
+	}
+	return out
+}
+
+// histogramTotals sums sample count and sum across every series of a histogram.
+// The batch-size histogram is only labeled (spec, apiInterface) and these tests
+// drive a single pair, so totals are unambiguous.
+func histogramTotals(t *testing.T, h prometheus.Collector) (count uint64, sum float64) {
+	t.Helper()
+	registry := prometheus.NewPedanticRegistry()
+	require.NoError(t, registry.Register(h))
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		for _, metric := range family.GetMetric() {
+			if histogram := metric.GetHistogram(); histogram != nil {
+				count += histogram.GetSampleCount()
+				sum += histogram.GetSampleSum()
+			}
+		}
+	}
+	return count, sum
+}
+
+func TestBuildBatchSignature(t *testing.T) {
+	cases := []struct {
+		name          string
+		apiName       string
+		wantSignature string
+		wantSize      int
+		wantTooWide   bool
+	}{
+		{
+			name:          "homogeneous batch collapses to one method",
+			apiName:       joinedBatchName(repeatMethod("eth_call", 3)...),
+			wantSignature: "batch:eth_call",
+			wantSize:      3,
+		},
+		{
+			// The shape observed in production: a long run of eth_call with a
+			// different tail, which minted its own series per batch length.
+			name:          "mixed batch keeps the distinct set only",
+			apiName:       joinedBatchName(append(repeatMethod("eth_call", 30), "eth_getBalance")...),
+			wantSignature: "batch:eth_call+eth_getBalance",
+			wantSize:      31,
+		},
+		{
+			name:          "signature is order invariant",
+			apiName:       joinedBatchName("eth_getBalance", "eth_call"),
+			wantSignature: "batch:eth_call+eth_getBalance",
+			wantSize:      2,
+		},
+		{
+			name:          "single element carries no separator but still normalizes",
+			apiName:       "eth_call",
+			wantSignature: "batch:eth_call",
+			wantSize:      1,
+		},
+		{
+			name:          "empty segments are skipped and yield the overflow bucket",
+			apiName:       joinedBatchName("", "", ""),
+			wantSignature: BatchMethodOther,
+			wantSize:      0,
+			wantTooWide:   true,
+		},
+		{
+			name: "too many distinct methods falls back to the overflow bucket",
+			apiName: joinedBatchName(
+				"m1", "m2", "m3", "m4", "m5", "m6", "m7", "m8", "m9",
+			),
+			wantSignature: BatchMethodOther,
+			wantSize:      9,
+			wantTooWide:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			signature, size, tooWide := buildBatchSignature(tc.apiName)
+			require.Equal(t, tc.wantSignature, signature)
+			require.Equal(t, tc.wantSize, size)
+			require.Equal(t, tc.wantTooWide, tooWide)
+		})
+	}
+}
+
+// TestNormalizeMethodLabelLeavesSingleMethodsAlone guards the property that makes
+// this change safe to deploy: non-batch traffic keeps its exact method label, so
+// every existing dashboard and alert keyed on method="eth_call" is untouched.
+func TestNormalizeMethodLabelLeavesSingleMethodsAlone(t *testing.T) {
+	m := newSmartRouterForBatchLabelTest()
+	for _, method := range []string{"eth_call", "eth_getBlockByNumber", "debug_traceTransaction", ""} {
+		require.Equal(t, method, m.normalizeMethodLabel("ETH1", method))
+	}
+	require.Equal(t, 0, testutil.CollectAndCount(m.batchSignatureOverflow), "single methods must not report overflow")
+}
+
+func TestNormalizeMethodLabelIsIdempotent(t *testing.T) {
+	m := newSmartRouterForBatchLabelTest()
+	raw := joinedBatchName(append(repeatMethod("eth_call", 4), "eth_getBalance")...)
+
+	once := m.normalizeMethodLabel("ETH1", raw)
+	twice := m.normalizeMethodLabel("ETH1", once)
+
+	require.Equal(t, "batch:eth_call+eth_getBalance", once)
+	require.Equal(t, once, twice, "re-normalizing an already collapsed label must be a no-op")
+}
+
+// TestNormalizeMethodLabelCollapsesPermutations is the regression test for the
+// cardinality blowup: every ordering and length of the same method set must land on
+// a single label value, where the raw joined name produced one series each.
+func TestNormalizeMethodLabelCollapsesPermutations(t *testing.T) {
+	m := newSmartRouterForBatchLabelTest()
+
+	raw := []string{
+		joinedBatchName("eth_call", "eth_getBalance"),
+		joinedBatchName("eth_getBalance", "eth_call"),
+		joinedBatchName("eth_call", "eth_call", "eth_getBalance"),
+		joinedBatchName("eth_getBalance", "eth_call", "eth_call", "eth_call"),
+		joinedBatchName(append(repeatMethod("eth_call", 60), "eth_getBalance")...),
+	}
+
+	collapsed := make(map[string]struct{})
+	for _, apiName := range raw {
+		collapsed[m.normalizeMethodLabel("ETH1", apiName)] = struct{}{}
+	}
+
+	require.Len(t, collapsed, 1, "all permutations of one method set must share a label value")
+	require.Contains(t, collapsed, "batch:eth_call+eth_getBalance")
+}
+
+// TestNormalizeMethodLabelCapsSignaturesPerSpec proves the label space stays bounded
+// even against an adversarial client cycling through method sets, and that hitting
+// the cap is observable rather than silent.
+func TestNormalizeMethodLabelCapsSignaturesPerSpec(t *testing.T) {
+	m := newSmartRouterForBatchLabelTest()
+
+	distinct := make(map[string]struct{})
+	for i := range maxBatchSignaturesPerSpec * 4 {
+		// Each iteration is a genuinely new method set, so admission cannot dedupe it.
+		apiName := joinedBatchName("eth_call", fmt.Sprintf("eth_method_%d", i))
+		distinct[m.normalizeMethodLabel("ETH1", apiName)] = struct{}{}
+	}
+
+	require.LessOrEqual(t, len(distinct), maxBatchSignaturesPerSpec+1,
+		"admitted signatures plus the overflow bucket must not exceed the cap")
+	require.Contains(t, distinct, BatchMethodOther, "past the cap everything must land in the overflow bucket")
+	require.Positive(t,
+		testutil.ToFloat64(m.batchSignatureOverflow.WithLabelValues("ETH1", batchOverflowReasonCap)),
+		"hitting the cap must be reported so a lossy breakdown is detectable")
+}
+
+// TestNormalizeMethodLabelBudgetsPerSpec checks one chatty spec cannot consume
+// another spec's signature budget.
+func TestNormalizeMethodLabelBudgetsPerSpec(t *testing.T) {
+	m := newSmartRouterForBatchLabelTest()
+
+	for i := range maxBatchSignaturesPerSpec * 2 {
+		m.normalizeMethodLabel("ETH1", joinedBatchName("eth_call", fmt.Sprintf("eth_method_%d", i)))
+	}
+
+	// A different spec starts with a full budget despite ETH1 having exhausted its own.
+	require.Equal(t, "batch:eth_call+eth_getBalance",
+		m.normalizeMethodLabel("POLYGON1", joinedBatchName("eth_getBalance", "eth_call")))
+}
+
+// TestNormalizeMethodLabelIsStablePerSignature covers the in-flight gauge pairing
+// hazard: relay start and relay end normalize independently, so an unstable mapping
+// would Add one series and Sub another, leaving a gauge stuck above zero forever.
+func TestNormalizeMethodLabelIsStablePerSignature(t *testing.T) {
+	m := newSmartRouterForBatchLabelTest()
+	raw := joinedBatchName("eth_call", "eth_getBalance")
+
+	first := m.normalizeMethodLabel("ETH1", raw)
+
+	// Exhaust the budget between the two calls — the already-admitted signature must
+	// survive, because admission never evicts.
+	for i := range maxBatchSignaturesPerSpec * 2 {
+		m.normalizeMethodLabel("ETH1", joinedBatchName("eth_call", fmt.Sprintf("eth_method_%d", i)))
+	}
+
+	require.Equal(t, first, m.normalizeMethodLabel("ETH1", raw))
+}
+
+// TestRecordDirectRelayEndCollapsesBatchLabel is the end-to-end assertion: many raw
+// batch names that used to mint a series each now share one, and the batch counter
+// still segments them.
+func TestRecordDirectRelayEndCollapsesBatchLabel(t *testing.T) {
+	m := newSmartRouterForBatchLabelTest()
+
+	for size := 2; size <= 40; size++ {
+		apiName := joinedBatchName(append(repeatMethod("eth_call", size), "eth_getBalance")...)
+		m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", apiName, 10, true, &RelayMetrics{IsBatch: true})
+	}
+
+	require.Equal(t, 1, testutil.CollectAndCount(m.routerRequestsTotal),
+		"39 distinct raw batch names must collapse onto a single series")
+
+	labels := []string{"ETH1", "jsonrpc", "ep1", "batch:eth_call+eth_getBalance"}
+	require.Equal(t, float64(39), testutil.ToFloat64(m.routerRequestsTotal.WithLabelValues(labels...)))
+	require.Equal(t, float64(39), testutil.ToFloat64(m.routerRequestsBatch.WithLabelValues(labels...)))
+	require.Equal(t, float64(0), testutil.ToFloat64(m.routerRequestsRead.WithLabelValues(labels...)),
+		"batch requests must not also count as reads")
+}
+
+// TestRecordDirectRelayEndObservesBatchSizeOnce guards against the double-count trap:
+// RecordDirectRelayEnd fans out to several recorders that each normalize, but only
+// one of them may observe the size histogram.
+func TestRecordDirectRelayEndObservesBatchSizeOnce(t *testing.T) {
+	m := newSmartRouterForBatchLabelTest()
+	apiName := joinedBatchName(repeatMethod("eth_call", 5)...)
+
+	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", apiName, 10, true, &RelayMetrics{IsBatch: true})
+
+	count, sum := histogramTotals(t, m.batchSize)
+	require.Equal(t, uint64(1), count, "one relay must produce exactly one batch-size observation")
+	require.Equal(t, float64(5), sum, "the observed value must be the batch's element count")
+}
+
+// TestRecordDirectRelayEndSkipsBatchSizeForSingleMethods documents the known blind
+// spot: a single-element batch produces an api name with no separator, so it is
+// indistinguishable from a plain single request at the metrics layer.
+func TestRecordDirectRelayEndSkipsBatchSizeForSingleMethods(t *testing.T) {
+	m := newSmartRouterForBatchLabelTest()
+
+	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_call", 10, true, &RelayMetrics{IsBatch: true})
+
+	count, _ := histogramTotals(t, m.batchSize)
+	require.Equal(t, uint64(0), count)
+	require.Equal(t, float64(1), testutil.ToFloat64(
+		m.routerRequestsTotal.WithLabelValues("ETH1", "jsonrpc", "ep1", "eth_call")))
+}
+
+// TestInFlightGaugeReturnsToZeroForBatches pairs a relay start with a relay end using
+// the raw api name, as the router does, and asserts the in-flight gauge settles back
+// at zero rather than leaking a stuck series.
+func TestInFlightGaugeReturnsToZeroForBatches(t *testing.T) {
+	m := newSmartRouterForBatchLabelTest()
+	apiName := joinedBatchName(append(repeatMethod("eth_call", 7), "eth_getLogs")...)
+
+	m.RecordDirectRelayStart("ETH1", "jsonrpc", "ep1", apiName)
+	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", apiName, 10, true, &RelayMetrics{IsBatch: true})
+
+	registry := prometheus.NewPedanticRegistry()
+	require.NoError(t, registry.Register(m.endpointInFlight))
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	for _, family := range families {
+		for _, metric := range family.GetMetric() {
+			require.Equal(t, float64(0), metric.GetGauge().GetValue(),
+				"start and end must normalize to the same series")
+		}
+	}
+}
+
+// TestRecordCacheHitRequestCollapsesBatchLabel covers the cache-hit path, which
+// bypasses RecordDirectRelayEnd entirely.
+func TestRecordCacheHitRequestCollapsesBatchLabel(t *testing.T) {
+	m := newSmartRouterForBatchLabelTest()
+
+	for size := 2; size <= 10; size++ {
+		apiName := joinedBatchName(repeatMethod("eth_call", size)...)
+		m.RecordCacheHitRequest("ETH1", "jsonrpc", apiName, &RelayMetrics{IsBatch: true})
+	}
+
+	require.Equal(t, 1, testutil.CollectAndCount(m.routerRequestsTotal))
+	require.Equal(t, float64(9), testutil.ToFloat64(
+		m.routerRequestsTotal.WithLabelValues("ETH1", "jsonrpc", "Cached", "batch:eth_call")))
+
+	count, _ := histogramTotals(t, m.batchSize)
+	require.Equal(t, uint64(9), count, "cached batch traffic must still land in the size histogram")
+}

--- a/protocol/metrics/smartrouter_metrics_manager.go
+++ b/protocol/metrics/smartrouter_metrics_manager.go
@@ -124,6 +124,14 @@ type SmartRouterMetricsManager struct {
 	routerRequestsArchive    *prometheus.CounterVec
 	routerRequestsBatch      *prometheus.CounterVec
 
+	// Batch-request shape metrics. The `method` label on every family above is collapsed
+	// for batches (see batch_method_label.go) — batchSize carries the element count the
+	// collapse drops, and batchSignatureOverflow reports when the signature cap binds.
+	batchSize              *prometheus.HistogramVec
+	batchSignatureOverflow *prometheus.CounterVec
+	// batchSignatures bounds how many distinct batch signatures may become label values.
+	batchSignatures *batchSignatureRegistry
+
 	// Internal state
 	lock                    sync.RWMutex
 	endpointsHealthChecksOk uint64
@@ -484,6 +492,18 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 		Help: "Total number of batch requests on the smart router.",
 	}, routerRequestLabels)
 
+	batchSize := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "smartrouter_batch_size",
+		Help: "Number of sub-requests per batch request. This carries the magnitude that the collapsed method label intentionally drops. Single-element batches are indistinguishable from single requests at this layer and are not observed.",
+		// Batch sizes are small-and-clustered with a long tail; buckets start at 2
+		// because a 1-element batch never reaches this histogram.
+		Buckets: []float64{2, 3, 5, 10, 25, 50, 100, 250, 500},
+	}, []string{"spec", "apiInterface"})
+	batchSignatureOverflow := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "smartrouter_batch_signature_overflow_total",
+		Help: `Label normalizations that fell into method="batch:other". reason="cap": the spec exhausted its distinct-signature budget. reason="wide": one batch spanned more distinct methods than a signature may name. Non-zero means per-batch-type breakdowns are lossy — raise the cap or accept the aggregation.`,
+	}, []string{"spec", "reason"})
+
 	cacheLabels := []string{"spec", "apiInterface", "method"}
 	cacheRequestsTotalMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "smartrouter_cache_requests_total",
@@ -543,6 +563,8 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	routerRequestsDebugTrace = registerOrReuse(routerRequestsDebugTrace)
 	routerRequestsArchive = registerOrReuse(routerRequestsArchive)
 	routerRequestsBatch = registerOrReuse(routerRequestsBatch)
+	batchSize = registerOrReuse(batchSize)
+	batchSignatureOverflow = registerOrReuse(batchSignatureOverflow)
 	cacheRequestsTotalMetric = registerOrReuse(cacheRequestsTotalMetric)
 	cacheSuccessTotalMetric = registerOrReuse(cacheSuccessTotalMetric)
 	cacheFailedTotalMetric = registerOrReuse(cacheFailedTotalMetric)
@@ -619,6 +641,11 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 		routerRequestsDebugTrace: routerRequestsDebugTrace,
 		routerRequestsArchive:    routerRequestsArchive,
 		routerRequestsBatch:      routerRequestsBatch,
+
+		// Batch shape group
+		batchSize:              batchSize,
+		batchSignatureOverflow: batchSignatureOverflow,
+		batchSignatures:        newBatchSignatureRegistry(),
 
 		// Cache group
 		cacheRequestsTotalMetric: cacheRequestsTotalMetric,
@@ -749,6 +776,7 @@ func (m *SmartRouterMetricsManager) AddEndpointRelayServiced(spec, apiInterface,
 	if m == nil {
 		return
 	}
+	function = m.normalizeMethodLabel(spec, function)
 	labels := map[string]string{"spec": spec, "apiInterface": apiInterface, "endpoint_id": endpointID, "function": function}
 	m.endpointTotalRelaysServiced.WithLabelValues(labels).Inc()
 }
@@ -758,6 +786,7 @@ func (m *SmartRouterMetricsManager) AddEndpointRelayErrored(spec, apiInterface, 
 	if m == nil {
 		return
 	}
+	function = m.normalizeMethodLabel(spec, function)
 	labels := map[string]string{"spec": spec, "apiInterface": apiInterface, "endpoint_id": endpointID, "function": function}
 	m.endpointTotalErrored.WithLabelValues(labels).Inc()
 }
@@ -767,6 +796,7 @@ func (m *SmartRouterMetricsManager) SetEndpointEndToEndLatency(spec, apiInterfac
 	if m == nil {
 		return
 	}
+	function = m.normalizeMethodLabel(spec, function)
 	m.endpointEndToEndLatency.WithLabelValues(spec, apiInterface, endpointID, function).Observe(latencyMs)
 }
 
@@ -775,6 +805,7 @@ func (m *SmartRouterMetricsManager) AddEndpointInFlightRequest(spec, apiInterfac
 	if m == nil {
 		return
 	}
+	function = m.normalizeMethodLabel(spec, function)
 	labels := map[string]string{"spec": spec, "apiInterface": apiInterface, "endpoint_id": endpointID, "function": function}
 	m.endpointInFlight.WithLabelValues(labels).Add(1)
 }
@@ -784,6 +815,7 @@ func (m *SmartRouterMetricsManager) SubEndpointInFlightRequest(spec, apiInterfac
 	if m == nil {
 		return
 	}
+	function = m.normalizeMethodLabel(spec, function)
 	labels := map[string]string{"spec": spec, "apiInterface": apiInterface, "endpoint_id": endpointID, "function": function}
 	m.endpointInFlight.WithLabelValues(labels).Sub(1)
 }
@@ -943,6 +975,7 @@ func (m *SmartRouterMetricsManager) RecordRelaySuccess(spec, apiInterface, endpo
 	if m == nil {
 		return
 	}
+	function = m.normalizeMethodLabel(spec, function)
 	if m.routerTotalRelaysServiced != nil {
 		m.routerTotalRelaysServiced.WithLabelValues(spec, apiInterface, function).Inc()
 	}
@@ -957,6 +990,7 @@ func (m *SmartRouterMetricsManager) RecordRouterEndToEndLatency(spec, apiInterfa
 	if m == nil {
 		return
 	}
+	function = m.normalizeMethodLabel(spec, function)
 	m.routerEndToEndLatency.WithLabelValues(spec, apiInterface, function).Observe(latencyMs)
 }
 
@@ -966,6 +1000,7 @@ func (m *SmartRouterMetricsManager) RecordRelayError(spec, apiInterface, endpoin
 	if m == nil {
 		return
 	}
+	function = m.normalizeMethodLabel(spec, function)
 	if m.routerTotalErrored != nil {
 		m.routerTotalErrored.WithLabelValues(spec, apiInterface, function).Inc()
 	}
@@ -992,6 +1027,12 @@ func (m *SmartRouterMetricsManager) RecordDirectRelayEnd(spec, apiInterface, end
 	if m == nil {
 		return
 	}
+	// Observe the batch's element count BEFORE collapsing the label, and do it only
+	// here: this is the single once-per-completed-relay entry point, so the other
+	// recorders normalize without observing and a batch is counted exactly once.
+	m.observeBatchSize(spec, apiInterface, function)
+	function = m.normalizeMethodLabel(spec, function)
+
 	m.SubEndpointInFlightRequest(spec, apiInterface, endpointID, function)
 
 	if success {
@@ -1034,6 +1075,11 @@ func (m *SmartRouterMetricsManager) RecordCacheHitRequest(spec, apiInterface, fu
 	if m == nil {
 		return
 	}
+	// Cache hits bypass RecordDirectRelayEnd entirely, so this path observes the batch
+	// size itself — otherwise cached batch traffic would be missing from the histogram.
+	m.observeBatchSize(spec, apiInterface, function)
+	function = m.normalizeMethodLabel(spec, function)
+
 	routerLabels := []string{spec, apiInterface, "Cached", function}
 	m.routerRequestsTotal.WithLabelValues(routerLabels...).Inc()
 	m.routerRequestsSuccess.WithLabelValues(routerLabels...).Inc()
@@ -1095,6 +1141,7 @@ func (m *SmartRouterMetricsManager) SetRelayNodeErrorMetric(chainId string, apiI
 	if m == nil {
 		return
 	}
+	method = m.normalizeMethodLabel(chainId, method)
 	m.incidentNodeErrorsTotalMetric.WithLabelValues(chainId, apiInterface, providerAddress, method).Inc()
 }
 
@@ -1102,6 +1149,7 @@ func (m *SmartRouterMetricsManager) RecordCacheResult(chainId, apiInterface, met
 	if m == nil {
 		return
 	}
+	method = m.normalizeMethodLabel(chainId, method)
 	m.cacheRequestsTotalMetric.WithLabelValues(chainId, apiInterface, method).Inc()
 	if hit {
 		m.cacheSuccessTotalMetric.WithLabelValues(chainId, apiInterface, method).Inc()
@@ -1117,6 +1165,7 @@ func (m *SmartRouterMetricsManager) SetProtocolError(chainId string, apiInterfac
 	if m == nil {
 		return
 	}
+	method = m.normalizeMethodLabel(chainId, method)
 	m.incidentProtocolErrorsTotalMetric.WithLabelValues(chainId, apiInterface, providerAddress, method).Inc()
 }
 
@@ -1124,6 +1173,7 @@ func (m *SmartRouterMetricsManager) RecordIncidentRetry(chainId string, apiInter
 	if m == nil {
 		return
 	}
+	method = m.normalizeMethodLabel(chainId, method)
 	m.incidentRetriesTotalMetric.WithLabelValues(chainId, apiInterface, method).Inc()
 	m.incidentRetryAttemptsHistogram.WithLabelValues(chainId, apiInterface, method).Observe(float64(count))
 	if success {
@@ -1137,6 +1187,7 @@ func (m *SmartRouterMetricsManager) RecordIncidentConsistency(chainId string, ap
 	if m == nil {
 		return
 	}
+	method = m.normalizeMethodLabel(chainId, method)
 	m.incidentConsistencyTotalMetric.WithLabelValues(chainId, apiInterface, method).Inc()
 	if success {
 		m.incidentConsistencySuccessMetric.WithLabelValues(chainId, apiInterface, method).Inc()
@@ -1149,6 +1200,7 @@ func (m *SmartRouterMetricsManager) RecordIncidentHedgeResult(chainId string, ap
 	if m == nil {
 		return
 	}
+	method = m.normalizeMethodLabel(chainId, method)
 	m.incidentHedgeTotalMetric.WithLabelValues(chainId, apiInterface, method).Inc()
 	m.incidentHedgeAttemptsHistogram.WithLabelValues(chainId, apiInterface, method).Observe(float64(count))
 	if success {
@@ -1162,6 +1214,7 @@ func (m *SmartRouterMetricsManager) SetCrossValidationMetric(chainId, apiInterfa
 	if m == nil {
 		return
 	}
+	method = m.normalizeMethodLabel(chainId, method)
 	m.crossValidationRequestsTotalMetric.WithLabelValues(chainId, apiInterface, method).Inc()
 	if success {
 		m.crossValidationSuccessTotalMetric.WithLabelValues(chainId, apiInterface, method).Inc()
@@ -1190,6 +1243,7 @@ func (m *SmartRouterMetricsManager) SetCrossValidationMismatchMetric(chainId, ap
 	if group == "" {
 		group = common.DefaultProviderGroup
 	}
+	method = m.normalizeMethodLabel(chainId, method)
 	m.crossValidationMismatchTotalMetric.WithLabelValues(chainId, apiInterface, method, group, finality).Inc()
 }
 
@@ -1203,6 +1257,7 @@ func (m *SmartRouterMetricsManager) SetCrossValidationFailureMetric(chainId, api
 	if m == nil || reason == "" {
 		return
 	}
+	method = m.normalizeMethodLabel(chainId, method)
 	m.crossValidationFailuresTotalMetric.WithLabelValues(chainId, apiInterface, method, reason).Inc()
 }
 


### PR DESCRIPTION
## Summary

`smartrouter_requests_total` on `atlas-prd` is carrying **51,083 series**, nearly all at value `1`. The cause is the `method` label on batch requests:

```
method="eth_call&eth_call&eth_call&…&eth_call&eth_getBalance"
```

A JSON-RPC batch has no single method, so batch parsing synthesizes an api name by joining every sub-method with `&` ([`jsonRPC.go:227`](https://github.com/Magma-Devs/smart-router/blob/main/protocol/chainlib/jsonRPC.go#L227), same in `tendermintRPC.go:233`). That joined string reached the label verbatim, so every distinct batch composition minted its own permanent series. It multiplies across the ~15 metric families that share the label, and the histograms multiply again by bucket count.

The cost isn't only Prometheus memory and slow `topk(… by (method))` queries. **Batched traffic never appeared under its own methods at all** — the `eth_call` volume inside those batches was invisible in every per-method breakdown.

## Approach

The label now carries a **batch signature**: the sorted set of distinct sub-methods, prefixed `batch:`.

```
[eth_call ×30, eth_getBalance]   →   method="batch:eth_call+eth_getBalance"
[eth_call ×3]                    →   method="batch:eth_call"
```

Order and repetition are dropped deliberately — they are exactly what made the raw name unbounded (order contributes permutations, repetition one series per batch length), while the set is what identifies the *type* of batch and is what client code actually determines. The magnitude repetition used to encode moves to a size histogram.

Keeping the signature on the existing label (rather than a separate family) means per-batch-type success rate, latency, and provider breakdown all work:

```promql
sum by (method) (rate(smartrouter_requests_failed_total{method=~"batch:.*"}[5m]))
  / sum by (method) (rate(smartrouter_requests_total{method=~"batch:.*"}[5m]))
```

**Normalization is applied at every recorder boundary**, not just the request-group family — `crossValidationLabels`, `incidentMethodLabels`, `incidentProviderLabels`, and `cacheLabels` all carried the same raw `method`, so leaving them would have left four smaller versions of the same leak.

## New metrics

| Metric | Type | Labels | Description |
| --- | --- | --- | --- |
| `smartrouter_batch_size` | Histogram | `spec`, `apiInterface` | Sub-requests per batch — the magnitude the collapsed label drops. |
| `smartrouter_batch_signature_overflow_total` | Counter | `spec`, `reason` | Normalizations that fell into `batch:other`. `reason="cap"` / `reason="wide"`. |

## Design notes

- **Bounded by construction.** A spec may register at most 64 distinct signatures; one signature may name at most 8 distinct methods. Anything past either lands in `method="batch:other"` and is counted, so a lossy breakdown is detectable rather than silent.
- **Admission never evicts.** This is load-bearing for the in-flight gauge: relay start and relay end normalize independently, so an unstable mapping would `Add` one series and `Sub` another and pin a gauge above zero forever.
- **Idempotent.** A collapsed value carries no separator, so the recorders that delegate to one another (`RecordDirectRelayEnd` → `RecordRelaySuccess` → `AddEndpointRelayServiced`) can each normalize defensively.
- **Batch size is observed once per relay**, only on the two entry points not reached via another recorder (`RecordDirectRelayEnd`, `RecordCacheHitRequest`). Observing anywhere in the fan-out would count one request several times.
- **No allowlist needed on sub-methods.** `getSupportedApi` hard-fails the parse on unknown methods before any batch name is built, so the joined name only ever contains spec-declared api names — never raw client input.

## Behaviour changes

- **Single-method traffic is untouched** — `method="eth_call"` means exactly what it did before, so existing dashboards and alerts keep working. `method=~"batch:.*"` / `method!~"batch:.*"` cleanly splits batch from single traffic.
- Dashboards that grouped batch traffic by the raw joined name will now see `batch:*` values. Nothing was querying those usefully — each series had a count of 1.
- **Known blind spot:** a single-element batch produces an api name with no separator, so it is indistinguishable from a plain single request here. It keeps its real method name and is not observed in the size histogram. Documented, with a test asserting it so it reads as a decision rather than a bug.

## Test plan

- `go test ./protocol/metrics/` — 15 new tests, including the production shape from the screenshot (30 `eth_call` + `eth_getBalance`) and an end-to-end check that **39 distinct raw batch names collapse to 1 series**.
- Coverage: signature invariants (order, repetition, width), idempotency, per-spec cap + budget isolation, stability across cap exhaustion, once-per-relay size observation, in-flight gauge returning to zero, and the cache-hit path.
- `go test ./protocol/metrics/ -race` on the batch + request-group suites: clean.
- `go vet`, `gofmt`, `go build ./...`: clean.
- Pre-existing failures unrelated to this change, verified identical on a clean tree at `main`: `TestHappyFlow` (race) and `TestAnalyzeWebSocketErrorAndWriteMessage` (websocket dial).

## Follow-up

The 64/8 caps are not validated against real traffic — it is not knowable from the metric alone whether those 51k series hide 12 distinct method sets or 4,000. `smartrouter_batch_signature_overflow_total` is what answers that: watch it after deploy and raise the cap if it moves.
