### PR TITLE
feat(optimizer)(MAG-2387): restart availability from a probation baseline on proven recovery [DO NOT MERGE]

### DIFF
--- a/protocol/provideroptimizer/provider_optimizer.go
+++ b/protocol/provideroptimizer/provider_optimizer.go
@@ -122,9 +122,12 @@ type ProviderData struct {
 const providerLockStripes = 256
 
 // providerSyncFloor is one stripe: it serializes the score read-modify-write for every provider
-// hashing to it AND holds the authoritative monotonic SyncBlock floor for those providers.
+// hashing to it, and holds the per-provider state that must NOT live in the async cache — the
+// authoritative monotonic SyncBlock floor, and the sustained-health bookkeeping behind the recovery
+// rebase. Both exist for the same reason: they have to be readable and writable synchronously under
+// the stripe lock, which providersStorage cannot guarantee.
 //
-// Why a floor at all (Finding 5): the three writers (appendRelayData, AppendProbeData, the legacy
+// Why a floor at all: the three writers (appendRelayData, AppendProbeData, the legacy
 // AppendProbeRelayData) each do getProviderData → mutate → providersStorage.Set. ristretto's Set is
 // ASYNC — a subsequent Get can miss a just-written value (the package's own tests sleep to let it
 // settle) — so the cache cannot be the source of truth for "SyncBlock never decreases": a serialized
@@ -133,6 +136,58 @@ const providerLockStripes = 256
 type providerSyncFloor struct {
 	mu    sync.Mutex
 	floor map[string]uint64 // provider → highest SyncBlock ever accepted (lazily created)
+	// probeRecovery tracks each provider's consecutive fully-healthy probe samples and whether the
+	// current recovery episode has already been acted on. Guarded by the same mu as floor: every
+	// writer already holds the stripe lock. Lazily created.
+	probeRecovery map[string]*probeRecoveryState
+}
+
+// probeRecoveryState is one provider's sustained-health bookkeeping.
+type probeRecoveryState struct {
+	streak  uint64 // consecutive fully-healthy probe samples
+	rebased bool   // this recovery episode already triggered a rebase
+}
+
+// recordProbeHealthLocked advances a provider's consecutive fully-healthy probe streak and reports
+// whether it has JUST crossed into proven recovery — true at most once per recovery episode. Caller
+// MUST hold s.mu.
+//
+// "Fully healthy" is strict: AppendProbeData's availability is the FRACTION of the provider's
+// endpoints healthy this cycle, so anything below 1.0 means part of the provider is still down and
+// must not count toward proven recovery. Any imperfect sample resets the streak AND re-arms the
+// episode, which is what makes this safe against a flapping provider: alternating good/bad cycles
+// never reach the bar, and a provider that genuinely dips again can be rebased on its NEXT real
+// recovery.
+//
+// The once-per-episode latch lives HERE, in the stripe, rather than being inferred from the stored
+// availability score — because providersStorage is ristretto and its Set is async, so a caller
+// cannot reliably read back the value it just wrote (the same hazard the SyncBlock floor above
+// exists to solve). Deciding from cache state would make the rebase fire repeatedly under rapid
+// writes.
+func (s *providerSyncFloor) recordProbeHealthLocked(provider string, availability float64, bar uint64) bool {
+	if s.probeRecovery == nil {
+		s.probeRecovery = make(map[string]*probeRecoveryState)
+	}
+	st, ok := s.probeRecovery[provider]
+	if !ok {
+		st = &probeRecoveryState{}
+		s.probeRecovery[provider] = st
+	}
+
+	if availability < 1.0 {
+		st.streak = 0
+		st.rebased = false // re-arm: a later genuine recovery is allowed to rebase again
+		return false
+	}
+	if st.rebased {
+		return false // already acted on for this episode
+	}
+	st.streak++
+	if st.streak < bar {
+		return false
+	}
+	st.rebased = true
+	return true
 }
 
 // applyLocked stamps providerData.SyncBlock to the authoritative monotonic floor — the max of the
@@ -518,6 +573,25 @@ func (po *ProviderOptimizer) AppendProbeData(providerAddress string, availabilit
 	halfTime := po.calculateHalfTime(providerAddress, sampleTime)
 	weight := score.ProbeUpdateWeight
 
+	// Sustained probe health overrules a collapsed availability average. Without this, a provider that
+	// has recovered keeps being scored off the availability=0 samples fed here during its outage:
+	// climbing back over score.MinAcceptableAvailability costs four units of success weight per unit of
+	// accumulated failure weight, so the composite stays pinned at MinSelectionChance for roughly four
+	// times the outage length even though every probe since has been perfect.
+	//
+	// RebaseAvailabilityOnRecovery covers only the endpoint disable→enable transition. A provider whose
+	// endpoints stayed nominally enabled throughout the outage never crosses that edge, so this is the
+	// path that handles the general case.
+	//
+	// The bar is CONSECUTIVE fully-healthy cycles, which is what makes it safe to apply: a flapping
+	// provider resets its streak on every imperfect sample and never qualifies, and a partially
+	// degraded provider reports the FRACTION of its healthy endpoints, so anything short of all of them
+	// fails the strict test. Rebasing BEFORE this cycle's own sample is applied lets that healthy
+	// sample land on top of the probation baseline rather than under it.
+	if stripe.recordProbeHealthLocked(providerAddress, availability, probeRecoveryStreakBar) {
+		po.rebaseAvailabilityLocked(providerAddress, &providerData, sampleTime, "sustained probe health")
+	}
+
 	providerData, updateErr := po.updateDecayingWeightedAverage(providerData, score.AvailabilityScoreType, availability, weight, halfTime, 0, sampleTime)
 	if updateErr != nil {
 		return
@@ -552,6 +626,129 @@ func (po *ProviderOptimizer) AppendProbeData(providerAddress string, availabilit
 		utils.LogAttr("syncBlock", syncBlock),
 		utils.LogAttr("hasSync", hasSync),
 	)
+}
+
+// recoveryProbationDenom is the denominator a recovered provider's availability average is rebased
+// onto: one relay's worth of evidence (score.RelayUpdateWeight), i.e. four probe cycles.
+//
+// It is deliberately SMALL, because an oversized denominator is precisely what the rebase exists to
+// clear — the more accumulated weight an average carries, the less any subsequent sample moves it.
+// Starting small hands control back to the provider's actual post-recovery behaviour within a handful
+// of cycles, and it cuts both ways: a still-broken provider re-collapses on its next bad sample,
+// while a genuinely healthy one climbs past the threshold in about four good ones. Probation, not
+// amnesty.
+//
+// The value is exactly 1.0 rather than some other pair that also divides to the target, because
+// dividing by 1.0 is lossless in IEEE-754: the rebased Resolve() therefore returns EXACTLY
+// score.MinAcceptableAvailability. CalculateScore's dead-provider test is a strict
+// `availability < score.MinAcceptableAvailability`, so a result even one ULP low would re-trigger the
+// starvation collapse and leave the rebase with no observable effect. Changing this constant means
+// re-checking that exactness.
+const recoveryProbationDenom = score.RelayUpdateWeight
+
+// probeRecoveryStreakBar is how many CONSECUTIVE fully-healthy probe cycles count as proven recovery
+// for the availability rebase. It mirrors probing.DefaultProbeReEnableHysteresis (3) — the same bar
+// the prober uses to re-enable a disabled endpoint — deliberately duplicated as a local constant
+// rather than imported, to keep provideroptimizer free of a dependency on the probing package.
+// At the usual ~5s probe cadence this is ~15s of unbroken health before the score is lifted.
+const probeRecoveryStreakBar uint64 = 3
+
+// RebaseAvailabilityOnRecovery restarts a provider's availability average from a probationary
+// baseline once the prober has proven the provider recovered. Callers are the recovery paths:
+// the prober's endpoint re-enable, and the sustained-health check inside AppendProbeData.
+//
+// Why the optimizer needs telling at all: the prober reaches its own recovery verdict from K
+// consecutive healthy polls (Endpoint.RecordProbeVerdict) and returns the provider to routing via
+// ConsumerSessionManager.RestoreRecoveredProvider — but that only clears the SESSION-level block. The
+// stored score is untouched, and it collapsed from the availability=0 samples AppendProbeData fed
+// throughout the outage. Since climbing back over score.MinAcceptableAvailability requires success
+// weight >= (min*denom - num)/(1-min), every unit of failure weight costs four units of success weight
+// to cancel at the current 0.80 minimum. A provider therefore stays at the MinSelectionChance floor
+// for several times the length of its outage — long after the router has otherwise concluded it is
+// healthy. Rebasing closes that gap.
+//
+// The baseline is score.MinAcceptableAvailability exactly, NOT 1.0. A provider with seconds of proven
+// uptime has not earned parity with a peer that never failed, and a perfect score would swing real
+// traffic onto it immediately. Landing exactly AT the minimum clears the dead-provider collapse (the
+// test is a strict `<`) and returns the provider to normal weighted selection in the bottom tier: its
+// availability CONTRIBUTION is still zero, since normalizeAvailability rescales [min, 1.0] onto
+// [0.0, 1.0], but its latency, sync and stake contributions stop being discarded. That recovered
+// composite comes mostly from those three, not from availability.
+//
+// Latency and sync stores are left untouched: an availability outage does not invalidate them, and
+// they carry their own decay.
+//
+// No-op when availability already sits at or above the minimum, so this can never LOWER a score. That
+// also makes it idempotent, which matters because a provider with several endpoints recovering in one
+// probe cycle produces one call per endpoint.
+func (po *ProviderOptimizer) RebaseAvailabilityOnRecovery(providerAddress string) {
+	stripe := po.providerStripe(providerAddress)
+	stripe.mu.Lock()
+	defer stripe.mu.Unlock()
+
+	providerData, found := po.getProviderData(providerAddress)
+	if !found {
+		return // no accumulated history to rebase; the default store is already availability 1.0
+	}
+	// Restore the authoritative monotonic SyncBlock floor before the Set below, exactly as the other
+	// writers in this file do: observed=0 is a pure preserve, so a stale cached read cannot regress a
+	// block already recorded by a concurrent relay or probe.
+	stripe.applyLocked(providerAddress, 0, &providerData)
+
+	if po.rebaseAvailabilityLocked(providerAddress, &providerData, po.now(), "probe re-enable") {
+		po.providersStorage.Set(providerAddress, providerData, 1)
+	}
+}
+
+// rebaseAvailabilityLocked performs the rebase on an ALREADY-READ providerData and reports whether
+// it changed anything. It never takes a lock, so callers that already hold the provider's stripe
+// lock (AppendProbeData) can reuse it without re-entering a non-reentrant mutex. The caller is
+// responsible for persisting providerData afterwards.
+//
+// `at` MUST be the timestamp the caller will use for any sample it applies next, NOT a fresh
+// po.now(). ScoreStore.Update rejects a sample older than the store's own Time with
+// TimeConflictingScoresError; stamping the rebuilt store even microseconds ahead of the caller's
+// already-captured sampleTime makes that rejection fire, and AppendProbeData's error path returns
+// before persisting — silently discarding both the sample and the rebase.
+func (po *ProviderOptimizer) rebaseAvailabilityLocked(providerAddress string, providerData *ProviderData, at time.Time, trigger string) bool {
+	current, err := providerData.Availability.Resolve()
+	if err != nil {
+		utils.LavaFormatWarning("cannot rebase availability on recovery, unresolvable score", err,
+			utils.LogAttr("providerAddress", providerAddress),
+		)
+		return false
+	}
+	if current >= score.MinAcceptableAvailability {
+		return false // already acceptable by the optimizer's own bar — never downgrade
+	}
+
+	// Rebuild the availability store at the probation baseline, carrying the existing config forward so
+	// a tuned weight or half-life is not silently reset to package defaults by the rebase.
+	cfg := providerData.Availability.GetConfig()
+	rebased, err := score.NewCustomScoreStore(
+		score.AvailabilityScoreType,
+		score.MinAcceptableAvailability*recoveryProbationDenom,
+		recoveryProbationDenom,
+		at,
+		score.WithWeight(cfg.Weight),
+		score.WithDecayHalfLife(cfg.HalfLife),
+		score.WithLatencyCuFactor(cfg.LatencyCuFactor),
+	)
+	if err != nil {
+		utils.LavaFormatWarning("cannot rebase availability on recovery, store construction failed", err,
+			utils.LogAttr("providerAddress", providerAddress),
+		)
+		return false
+	}
+	providerData.Availability = rebased
+
+	utils.LavaFormatInfo("optimizer rebased availability after proven recovery",
+		utils.LogAttr("providerAddress", providerAddress),
+		utils.LogAttr("trigger", trigger),
+		utils.LogAttr("availability_before", current),
+		utils.LogAttr("availability_after", score.MinAcceptableAvailability),
+	)
+	return true
 }
 
 // CalculateQoSScoresForMetrics calculates QoS scores for all providers for metrics reporting

--- a/protocol/provideroptimizer/recovery_rebase_test.go
+++ b/protocol/provideroptimizer/recovery_rebase_test.go
@@ -1,0 +1,352 @@
+package provideroptimizer
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/utils/score"
+	"github.com/stretchr/testify/require"
+)
+
+// ristrettoSettle gives the async cache Set time to admit the entry, matching the existing
+// provideroptimizer test convention.
+const ristrettoSettle = 5 * time.Millisecond
+
+// collapseAvailability drives a provider's availability average below the acceptable minimum the
+// same way a real outage does: the prober feeds availability=0 once per cycle at ProbeUpdateWeight.
+// Returns the resolved availability at the end of the outage.
+//
+// The per-sample sleep is load-bearing, not padding. providersStorage.Set is async (ristretto), so a
+// tight loop keeps re-reading the PREVIOUS entry and every write lands on the same stale base — the
+// denominator then stops at one sample's weight (0.25) instead of accumulating across the outage
+// (7.5 over 30 cycles). Accumulated denominator is the quantity these tests are about, and real probe
+// cycles are seconds apart, so accumulation is what the sleep reproduces.
+func collapseAvailability(t *testing.T, po *ProviderOptimizer, addr string, cycles int) float64 {
+	t.Helper()
+	for i := 0; i < cycles; i++ {
+		po.AppendProbeData(addr, 0, 0, false, 0, false, SyncReference{})
+		time.Sleep(time.Millisecond)
+	}
+	time.Sleep(ristrettoSettle)
+	data, found := po.getProviderData(addr)
+	require.True(t, found, "the outage must have recorded provider data")
+	avail, err := data.Availability.Resolve()
+	require.NoError(t, err)
+	require.Less(t, avail, score.MinAcceptableAvailability,
+		"precondition: the outage must have collapsed availability below the acceptable minimum")
+	return avail
+}
+
+// healthyProbeCyclesToClearThreshold counts how many healthy probe cycles the provider needs before
+// its availability climbs back to score.MinAcceptableAvailability — i.e. how long it stays collapsed
+// at the MinSelectionChance starvation floor. Capped so a regression fails fast instead of hanging.
+func healthyProbeCyclesToClearThreshold(t *testing.T, po *ProviderOptimizer, addr string, cap int) int {
+	t.Helper()
+	for n := 1; n <= cap; n++ {
+		po.AppendProbeData(addr, 1.0, 10*time.Millisecond, true, 0, false, SyncReference{})
+		time.Sleep(ristrettoSettle)
+		data, _ := po.getProviderData(addr)
+		if avail, err := data.Availability.Resolve(); err == nil && avail >= score.MinAcceptableAvailability {
+			return n
+		}
+	}
+	return cap + 1 // sentinel: did not clear within the cap
+}
+
+// TestRebaseAvailabilityOnRecovery_LiftsProviderOffTheStarvationFloor is the headline behaviour: after
+// an outage collapses availability, a proven-recovery signal restarts the average at EXACTLY the
+// acceptable minimum — precisely the bound CalculateScore's dead-provider test uses (a strict `<`) —
+// so the provider stops being collapsed to MinSelectionChance.
+func TestRebaseAvailabilityOnRecovery_LiftsProviderOffTheStarvationFloor(t *testing.T) {
+	po := setupProviderOptimizer(1)
+	const addr = "recovered"
+
+	before := collapseAvailability(t, po, addr, 30)
+
+	po.RebaseAvailabilityOnRecovery(addr)
+	time.Sleep(ristrettoSettle)
+
+	data, found := po.getProviderData(addr)
+	require.True(t, found)
+	after, err := data.Availability.Resolve()
+	require.NoError(t, err)
+
+	require.Greater(t, after, before, "the rebase must lift the collapsed availability")
+	// Bit-for-bit exact, not merely close: num/denom with denom==1.0 is lossless in IEEE-754. A result
+	// even one ULP low re-triggers the dead-provider collapse, leaving the rebase with no effect.
+	require.Equal(t, score.MinAcceptableAvailability, after,
+		"the rebase must land exactly on the acceptable minimum")
+	require.False(t, after < score.MinAcceptableAvailability,
+		"the rebased provider must clear CalculateScore's strict availabilityDead bound")
+}
+
+// TestRebaseAvailabilityOnRecovery_RecoveryDoesNotOutlastTheOutage bounds recovery against the outage
+// that caused it. It first derives, from the average the outage actually produced, how many healthy
+// cycles the raw decaying-average arithmetic would demand — success weight >= (min*denom - num)/(1-min),
+// i.e. four units of success per unit of failure at the 0.80 minimum — then asserts the optimizer
+// completes recovery within the sustained-health bar instead. Both halves matter: the first pins WHY
+// the rebase is needed, so this test still fails loudly if the arithmetic is ever changed such that
+// recovery is no longer disproportionate.
+func TestRebaseAvailabilityOnRecovery_RecoveryDoesNotOutlastTheOutage(t *testing.T) {
+	po := setupProviderOptimizer(1)
+	const addr = "recovered"
+	const outageCycles = 30
+
+	collapseAvailability(t, po, addr, outageCycles)
+
+	// What recovery would cost on the raw average alone, from the real accumulated Num/Denom.
+	data, _ := po.getProviderData(addr)
+	num, denom := data.Availability.GetNum(), data.Availability.GetDenom()
+	neededWeight := (score.MinAcceptableAvailability*denom - num) / (1 - score.MinAcceptableAvailability)
+	unrebasedCycles := int(math.Ceil(neededWeight / score.ProbeUpdateWeight))
+	require.Greater(t, unrebasedCycles, 3*outageCycles,
+		"precondition: on the raw average a %d-cycle outage costs %d healthy cycles to undo, which is what makes the rebase necessary",
+		outageCycles, unrebasedCycles)
+
+	// The bound the optimizer must honour: sustained health clears the threshold in a handful of cycles.
+	got := healthyProbeCyclesToClearThreshold(t, po, addr, 50)
+	require.LessOrEqual(t, got, int(probeRecoveryStreakBar)+1,
+		"recovery must complete within the sustained-health bar (+1 for the cycle that observes it), got %d", got)
+}
+
+// TestSustainedProbeHealth_RebasesWithoutAnyEndpointTransition is the reason the rebase cannot hang
+// off the endpoint enable/disable edge alone. A provider whose endpoints stay nominally ENABLED
+// through an outage never crosses that edge — Endpoint.RecordProbeVerdict early-returns for enabled
+// endpoints — yet its score still collapsed, from the very availability=0 samples the prober fed.
+// This is the shape a real outage most commonly takes.
+func TestSustainedProbeHealth_RebasesWithoutAnyEndpointTransition(t *testing.T) {
+	po := setupProviderOptimizer(1)
+	const addr = "no-transition"
+
+	collapseAvailability(t, po, addr, 30)
+
+	// Feed exactly the bar's worth of fully-healthy cycles. No endpoint state is involved at all.
+	for i := uint64(0); i < probeRecoveryStreakBar; i++ {
+		po.AppendProbeData(addr, 1.0, 10*time.Millisecond, true, 0, false, SyncReference{})
+		time.Sleep(ristrettoSettle)
+	}
+
+	data, _ := po.getProviderData(addr)
+	avail, err := data.Availability.Resolve()
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, avail, score.MinAcceptableAvailability,
+		"sustained probe health alone must lift the score, with no endpoint re-enable involved")
+}
+
+// TestSustainedProbeHealth_FlappingProviderNeverQualifies is the central safety property. A provider
+// alternating good/bad cycles must NEVER reach the bar, or it would reset its own accumulated failure
+// history forever and keep drawing traffic it has not earned.
+func TestSustainedProbeHealth_FlappingProviderNeverQualifies(t *testing.T) {
+	po := setupProviderOptimizer(1)
+	const addr = "flapper"
+
+	collapseAvailability(t, po, addr, 30)
+
+	for i := 0; i < 40; i++ {
+		availability := 1.0
+		if i%2 == 1 {
+			availability = 0
+		}
+		po.AppendProbeData(addr, availability, 10*time.Millisecond, true, 0, false, SyncReference{})
+		time.Sleep(time.Millisecond)
+	}
+	time.Sleep(ristrettoSettle)
+
+	data, _ := po.getProviderData(addr)
+	avail, err := data.Availability.Resolve()
+	require.NoError(t, err)
+	require.Less(t, avail, score.MinAcceptableAvailability,
+		"a flapping provider must stay collapsed — an imperfect sample resets the streak")
+}
+
+// TestSustainedProbeHealth_PartialDegradationNeverQualifies — availability is the FRACTION of the
+// provider's endpoints healthy this cycle, so a provider with one endpoint still down feeds < 1.0
+// forever. That is genuine ongoing degradation, not stale outage debt, and must not be rebased.
+func TestSustainedProbeHealth_PartialDegradationNeverQualifies(t *testing.T) {
+	po := setupProviderOptimizer(1)
+	const addr = "half-down"
+
+	collapseAvailability(t, po, addr, 30)
+
+	for i := 0; i < 40; i++ {
+		po.AppendProbeData(addr, 0.5, 10*time.Millisecond, true, 0, false, SyncReference{})
+		time.Sleep(time.Millisecond)
+	}
+	time.Sleep(ristrettoSettle)
+
+	data, _ := po.getProviderData(addr)
+	avail, err := data.Availability.Resolve()
+	require.NoError(t, err)
+	require.Less(t, avail, score.MinAcceptableAvailability,
+		"a partially-degraded provider (fraction < 1.0) must never reach the sustained-health bar")
+}
+
+// TestSustainedProbeHealth_ReArmsAfterAGenuineDip — the once-per-episode latch must not be permanent:
+// a provider that recovers, later genuinely fails again, and then recovers again must be rebased on
+// the second recovery too.
+func TestSustainedProbeHealth_ReArmsAfterAGenuineDip(t *testing.T) {
+	po := setupProviderOptimizer(1)
+	const addr = "second-recovery"
+
+	feedHealthy := func(n int) {
+		for i := 0; i < n; i++ {
+			po.AppendProbeData(addr, 1.0, 10*time.Millisecond, true, 0, false, SyncReference{})
+			time.Sleep(ristrettoSettle)
+		}
+	}
+
+	// First outage and recovery.
+	collapseAvailability(t, po, addr, 30)
+	feedHealthy(int(probeRecoveryStreakBar))
+	data, _ := po.getProviderData(addr)
+	first, err := data.Availability.Resolve()
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, first, score.MinAcceptableAvailability, "precondition: first recovery lifted the score")
+
+	// Second outage, deep enough to collapse again, then a second recovery.
+	collapseAvailability(t, po, addr, 60)
+	feedHealthy(int(probeRecoveryStreakBar))
+
+	data, _ = po.getProviderData(addr)
+	second, err := data.Availability.Resolve()
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, second, score.MinAcceptableAvailability,
+		"a genuine dip must re-arm the latch so the next real recovery is rebased too")
+}
+
+// TestRebaseAvailabilityOnRecovery_NeverLowersAHealthyScore guards the no-downgrade rule. A perfectly
+// healthy provider can reach this path (any endpoint re-enable calls it), and rebasing it to the bare
+// minimum would be a demotion for recovering.
+func TestRebaseAvailabilityOnRecovery_NeverLowersAHealthyScore(t *testing.T) {
+	po := setupProviderOptimizer(1)
+	const addr = "healthy"
+
+	for i := 0; i < 20; i++ {
+		po.AppendProbeData(addr, 1.0, 10*time.Millisecond, true, 0, false, SyncReference{})
+	}
+	time.Sleep(ristrettoSettle)
+	data, _ := po.getProviderData(addr)
+	before, err := data.Availability.Resolve()
+	require.NoError(t, err)
+	require.Greater(t, before, score.MinAcceptableAvailability, "precondition: provider is healthy")
+
+	po.RebaseAvailabilityOnRecovery(addr)
+	time.Sleep(ristrettoSettle)
+
+	data, _ = po.getProviderData(addr)
+	after, err := data.Availability.Resolve()
+	require.NoError(t, err)
+	require.Equal(t, before, after, "a provider already above the minimum must be left untouched")
+}
+
+// TestRebaseAvailabilityOnRecovery_IsIdempotent — one provider with several endpoints recovering in
+// the same probe cycle triggers one call per endpoint. Repeated calls must not compound.
+func TestRebaseAvailabilityOnRecovery_IsIdempotent(t *testing.T) {
+	po := setupProviderOptimizer(1)
+	const addr = "multi-endpoint"
+
+	collapseAvailability(t, po, addr, 30)
+
+	po.RebaseAvailabilityOnRecovery(addr)
+	time.Sleep(ristrettoSettle)
+	data, _ := po.getProviderData(addr)
+	first, err := data.Availability.Resolve()
+	require.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		po.RebaseAvailabilityOnRecovery(addr)
+	}
+	time.Sleep(ristrettoSettle)
+	data, _ = po.getProviderData(addr)
+	repeated, err := data.Availability.Resolve()
+	require.NoError(t, err)
+
+	require.Equal(t, first, repeated, "repeat calls in one cycle must be a no-op, not compounding")
+}
+
+// TestRebaseAvailabilityOnRecovery_StillBrokenProviderReCollapsesFast is the safety half: the rebase
+// is a probation baseline, not an amnesty. Because it deliberately restarts on a SMALL denominator, a
+// provider that is not actually healthy falls straight back to collapsed on its next bad sample.
+func TestRebaseAvailabilityOnRecovery_StillBrokenProviderReCollapsesFast(t *testing.T) {
+	po := setupProviderOptimizer(1)
+	const addr = "still-broken"
+
+	collapseAvailability(t, po, addr, 30)
+	po.RebaseAvailabilityOnRecovery(addr)
+	time.Sleep(ristrettoSettle)
+
+	// One failing probe cycle after the rebase.
+	po.AppendProbeData(addr, 0, 0, false, 0, false, SyncReference{})
+	time.Sleep(ristrettoSettle)
+
+	data, _ := po.getProviderData(addr)
+	avail, err := data.Availability.Resolve()
+	require.NoError(t, err)
+	require.Less(t, avail, score.MinAcceptableAvailability,
+		"a provider that is still failing must collapse again immediately — the rebase is probation, not amnesty")
+}
+
+// TestRebaseAvailabilityOnRecovery_PreservesOtherDimensions — the outage invalidated availability, not
+// the provider's measured latency/sync or its tracked sync block. Rebasing must touch only
+// availability.
+func TestRebaseAvailabilityOnRecovery_PreservesOtherDimensions(t *testing.T) {
+	po := setupProviderOptimizer(1)
+	const addr = "provider1"
+	now := time.Now()
+	ref := freshRef(2000, now.Add(-time.Second))
+
+	// Build real latency/sync history and a tracked sync block, then collapse availability.
+	for i := 0; i < 10; i++ {
+		po.AppendProbeData(addr, 1.0, 25*time.Millisecond, true, 1500, true, ref)
+	}
+	time.Sleep(ristrettoSettle)
+	before, _ := po.getProviderData(addr)
+	latencyBefore := before.Latency.GetNum() / before.Latency.GetDenom()
+	syncBefore := before.Sync.GetNum() / before.Sync.GetDenom()
+	blockBefore := before.SyncBlock
+	require.NotZero(t, blockBefore, "precondition: a sync block was tracked")
+
+	collapseAvailability(t, po, addr, 30)
+	po.RebaseAvailabilityOnRecovery(addr)
+	time.Sleep(ristrettoSettle)
+
+	after, _ := po.getProviderData(addr)
+	require.Equal(t, latencyBefore, after.Latency.GetNum()/after.Latency.GetDenom(),
+		"latency history must survive the rebase")
+	require.Equal(t, syncBefore, after.Sync.GetNum()/after.Sync.GetDenom(),
+		"sync history must survive the rebase")
+	require.Equal(t, blockBefore, after.SyncBlock,
+		"the tracked sync block must survive the rebase (monotonic floor)")
+}
+
+// TestRebaseAvailabilityOnRecovery_PreservesScoreConfig — a tuned weight/half-life must not be
+// silently reset to package defaults by rebuilding the store.
+func TestRebaseAvailabilityOnRecovery_PreservesScoreConfig(t *testing.T) {
+	po := setupProviderOptimizer(1)
+	const addr = "tuned"
+
+	collapseAvailability(t, po, addr, 30)
+	data, _ := po.getProviderData(addr)
+	cfgBefore := data.Availability.GetConfig()
+
+	po.RebaseAvailabilityOnRecovery(addr)
+	time.Sleep(ristrettoSettle)
+
+	data, _ = po.getProviderData(addr)
+	require.Equal(t, cfgBefore, data.Availability.GetConfig(),
+		"the rebase must carry the existing score config forward")
+}
+
+// TestRebaseAvailabilityOnRecovery_UnknownProviderIsNoop — a provider with no accumulated history has
+// nothing to rebase (its default store already resolves to 1.0); the call must not create an entry
+// that would replace that default with the lower probation value.
+func TestRebaseAvailabilityOnRecovery_UnknownProviderIsNoop(t *testing.T) {
+	po := setupProviderOptimizer(1)
+
+	require.NotPanics(t, func() { po.RebaseAvailabilityOnRecovery("never-seen") })
+	time.Sleep(ristrettoSettle)
+
+	_, found := po.getProviderData("never-seen")
+	require.False(t, found, "rebasing an unknown provider must not manufacture a stored entry")
+}

--- a/protocol/rpcsmartrouter/probe_loop_test.go
+++ b/protocol/rpcsmartrouter/probe_loop_test.go
@@ -35,9 +35,11 @@ func TestProbeVerdictConfigFor_SourcesLagToleranceFromConsistency(t *testing.T) 
 }
 
 // recordingAppender captures AppendProbeData calls so tests can assert the one-sample-per-provider
-// rule and the fed values.
+// rule and the fed values, plus RebaseAvailabilityOnRecovery calls so tests can assert the prober
+// reports a proven recovery to the optimizer.
 type recordingAppender struct {
-	calls []probeCall
+	calls   []probeCall
+	rebased []string
 }
 
 type probeCall struct {
@@ -52,6 +54,10 @@ type probeCall struct {
 
 func (r *recordingAppender) AppendProbeData(provider string, availability float64, latency time.Duration, hasLatency bool, syncBlock uint64, hasSync bool, syncRef provideroptimizer.SyncReference) {
 	r.calls = append(r.calls, probeCall{provider, availability, latency, hasLatency, syncBlock, hasSync, syncRef})
+}
+
+func (r *recordingAppender) RebaseAvailabilityOnRecovery(provider string) {
+	r.rebased = append(r.rebased, provider)
 }
 
 func ep(url, provider string, enabled bool) *lavasession.EndpointWithDirectConnection {
@@ -110,6 +116,73 @@ func TestProbeCycle_ReEnablesRecoveredEndpoint(t *testing.T) {
 	cycle(int(probeCfg().ReEnableHysteresis))
 	require.True(t, dc.Endpoint.Enabled, "the probe re-enables a recovered endpoint after K distinct polls")
 	require.Equal(t, []string{"provider1"}, recovered, "recovery restores the provider's routing state (F2)")
+}
+
+// TestProbeCycle_RecoveryRebasesOptimizerAvailability pins the wiring that proving recovery reaches
+// the OPTIMIZER, not only the session manager. Returning a provider to routing while the optimizer
+// still scores it off the availability=0 samples this same loop fed during the outage leaves its
+// composite pinned at MinSelectionChance for several times the outage length. The rebase must fire
+// exactly on the re-enable cycle: not before it, and not again on every healthy cycle after.
+func TestProbeCycle_RecoveryRebasesOptimizerAvailability(t *testing.T) {
+	const url = "http://ep:8545"
+	base := time.Unix(1_700_000_000, 0)
+
+	dc := ep(url, "provider1", false) // starts disabled
+	endpoints := []*lavasession.EndpointWithDirectConnection{dc}
+	appender := &recordingAppender{}
+
+	cycle := func(i int) {
+		pollTime := base.Add(time.Duration(i) * time.Second)
+		now := pollTime.Add(time.Millisecond)
+		getObs := func(string) (endpointstate.EndpointObservation, bool) {
+			return freshObs(1000, now.Add(-time.Second), pollTime, 20*time.Millisecond), true
+		}
+		runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{}, now, probeCfg(), appender, nil)
+	}
+
+	// Before the K-th healthy poll the endpoint has not proven recovery — no rebase may fire, or a
+	// still-broken provider would be handed the probation baseline every single cycle.
+	for i := 1; i < int(probeCfg().ReEnableHysteresis); i++ {
+		cycle(i)
+		require.Empty(t, appender.rebased, "no rebase before recovery is proven (cycle %d)", i)
+	}
+
+	// The re-enable cycle rebases exactly once.
+	cycle(int(probeCfg().ReEnableHysteresis))
+	require.True(t, dc.Endpoint.Enabled, "precondition: the endpoint re-enabled")
+	require.Equal(t, []string{"provider1"}, appender.rebased,
+		"proving recovery must rebase the provider's availability in the optimizer")
+
+	// Steady state afterwards: the endpoint is already enabled, so RecordProbeVerdict no longer
+	// reports a transition and the rebase must not repeat.
+	for i := int(probeCfg().ReEnableHysteresis) + 1; i <= int(probeCfg().ReEnableHysteresis)+3; i++ {
+		cycle(i)
+	}
+	require.Equal(t, []string{"provider1"}, appender.rebased,
+		"the rebase fires on the recovery transition only, not every healthy cycle")
+}
+
+// TestProbeCycle_NoRebaseWithoutRecovery — an endpoint that never proves recovery (failing polls) must
+// never have its optimizer availability rebased, however many cycles run.
+func TestProbeCycle_NoRebaseWithoutRecovery(t *testing.T) {
+	const url = "http://ep:8545"
+	now := time.Unix(1_700_000_000, 0)
+	dc := ep(url, "provider1", false)
+	endpoints := []*lavasession.EndpointWithDirectConnection{dc}
+	appender := &recordingAppender{}
+	getObs := func(string) (endpointstate.EndpointObservation, bool) {
+		return endpointstate.EndpointObservation{
+			LatestBlock:             1000,
+			ObservedAt:              now.Add(-time.Second),
+			LastSuccessfulPoll:      now.Add(-2 * time.Second),
+			ConsecutivePollFailures: 3,
+		}, true
+	}
+	for i := 0; i < 10; i++ {
+		runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{}, now, probeCfg(), appender, nil)
+	}
+	require.False(t, dc.Endpoint.Enabled)
+	require.Empty(t, appender.rebased, "a provider that never recovers must never be rebased")
 }
 
 // TestProbeCycle_FailedPollDoesNotReEnable: a disabled endpoint whose last poll FAILED

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2215,11 +2215,14 @@ func (rpcss *RPCSmartRouterServer) recomputeChainStateConsensus() {
 	rpcss.chainState.Recompute(obs)
 }
 
-// probeQoSAppender is the narrow optimizer capability the prober uses to feed QoS (Topic E's
-// AppendProbeData). The concrete *provideroptimizer.ProviderOptimizer satisfies it; an inline
-// assertion keeps the lavasession optimizer interface unchanged.
+// probeQoSAppender is the narrow optimizer capability the prober needs: feeding per-cycle QoS samples
+// (AppendProbeData) and reporting a proven-recovery verdict so the optimizer can lift a score that
+// collapsed during the outage (RebaseAvailabilityOnRecovery). The concrete
+// *provideroptimizer.ProviderOptimizer satisfies it; an inline assertion keeps the lavasession
+// optimizer interface unchanged.
 type probeQoSAppender interface {
 	AppendProbeData(provider string, availability float64, latency time.Duration, hasLatency bool, syncBlock uint64, hasSync bool, syncRef provideroptimizer.SyncReference)
+	RebaseAvailabilityOnRecovery(provider string)
 }
 
 // Compile-time guard: the concrete optimizer must satisfy probeQoSAppender. Without this, the
@@ -2426,6 +2429,15 @@ func runProbeCycleCore(
 			reEnabled++
 			if onRecover != nil {
 				onRecover(ep.ProviderAddress)
+			}
+			// Returning the provider to routing is only half of "this provider is back": the optimizer
+			// still scores it off the availability=0 samples this same loop fed throughout the outage,
+			// which keeps its composite pinned at MinSelectionChance for several times the outage
+			// length. Tell the optimizer as well. Done BEFORE the AppendProbeData feed below so this
+			// cycle's own healthy sample lands on top of the probation baseline rather than under it,
+			// and idempotent, so several endpoints of one provider recovering together is harmless.
+			if appender != nil {
+				appender.RebaseAvailabilityOnRecovery(ep.ProviderAddress)
 			}
 		}
 		verdictsByProvider[ep.ProviderAddress] = append(verdictsByProvider[ep.ProviderAddress], verdict)


### PR DESCRIPTION
## The problem

A provider that recovered from an outage kept getting ~1% of traffic for minutes afterwards.

Availability is a decaying weighted average kept as `num / denom`. Crossing back over `MinAcceptableAvailability` (0.80) requires success weight `>= (min*denom - num) / (1 - min)` — **four units of success weight per unit of accumulated failure weight**, because `0.8 / (1 - 0.8) = 4`. The one-hour half-life removes under 2% over the few minutes an outage lasts, so nothing fades in time to help.

A three-minute outage (30 probe checks at weight 0.25) therefore needs ~120 healthy checks — about twelve minutes — to climb back over the line. Worse in production, where real relays fail during the outage and each carries **four times** a probe's weight.

Nothing corrected this. The prober reaches its own recovery verdict from K consecutive healthy polls and returns the provider to routing via `RestoreRecoveredProvider` — but that only clears the session-level block. The optimizer was never told, and went on scoring the provider off the `availability=0` samples the prober itself had fed throughout the outage. **The router spent minutes contradicting a verdict it had reached in seconds.**

Note the collapse itself is *intentional* (`weighted_selector.go`, the `availabilityDead` branch): a dead provider must not coast on stale latency/sync numbers. This PR does not change that. It changes how a provider gets back out.

## The change

On proven recovery, the availability average restarts at exactly `MinAcceptableAvailability` over a denominator of one relay's weight:

```
num = 0.8, denom = 1.0   ->   availability = exactly 0.80
```

**Why the minimum and not 1.0.** A provider with seconds of proven uptime hasn't earned parity with a peer that never failed. Landing exactly *at* the minimum clears the dead-provider collapse (the test is a strict `<`) and returns it to normal weighted selection in the **bottom tier**: its availability contribution is still zero, but its latency, sync and stake contributions stop being discarded. Most of the recovered composite comes from those three.

**Why denominator 1.0.** The oversized denominator *is* the pathology — the more accumulated weight an average carries, the less any new sample moves it. Starting small hands control back to current behaviour within a handful of cycles, and it cuts both ways: a still-broken provider re-collapses on its next failing sample. Probation, not amnesty.

It is exactly `1.0` rather than another pair that also divides to 0.8, because dividing by 1.0 is lossless in IEEE-754 — the rebased `Resolve()` returns *bit-for-bit* `MinAcceptableAvailability`. One ULP low and the collapse re-fires and the change has no observable effect. There's a `require.Equal` pinning it.

### Two paths report recovery

| Path | Covers |
|---|---|
| `Endpoint.RecordProbeVerdict` -> `RebaseAvailabilityOnRecovery` | the endpoint disable -> enable transition |
| `AppendProbeData` (sustained health) | the general case, where endpoints stayed nominally enabled and no transition ever occurs |

The second exists because the first turned out **not to fire in the reported scenario**. `RecordProbeVerdict` early-returns for enabled endpoints, and a provider whose endpoints never got disabled never crosses that edge — yet its score still collapsed. That is the shape a real outage most commonly takes, and it's the shape the reproductions take.

The bar in that path is **three consecutive fully-healthy probe cycles**, latched to fire once per recovery episode. Any imperfect sample resets the streak and re-arms the latch. The latch lives in the lock stripe rather than being inferred from the stored score, because `providersStorage` is ristretto and its `Set` is async — a caller can't reliably read back what it just wrote.

## Conformance against the product spec

The spec: *"A provider is confirmed recovered after K consecutive successful health checks at probe cadence. Defaults: K=3, cadence 5s (~15s total). K=3 is a starting assumption, not a measured optimum — it stays a config knob. On confirmation, the failure history stops counting against the availability score. Selection weight then ramps with continued successes and reaches full normal share within ~1 minute. Any failure during the ramp drops the weight immediately and restarts confirmation."*

| # | Requirement | Status | Detail |
|---|---|---|---|
| 1 | K consecutive successful health checks, K=3, ~15s | **Partial** | K=3 and ~15s hold (measured 18.1s on ETH). Two shortfalls — see 1a/1b below. |
| 1a | K stays a **config knob** | ❌ **Gap** | `probeRecoveryStreakBar` is a compile-time `const`. So is the prober's own `DefaultProbeReEnableHysteresis`. Neither has flag plumbing today; changing K means recompiling. |
| 1b | K *health checks* | ❌ **Gap** | The streak counts probe **cycles**, not distinct checks. The prober runs every ~5s but health data refreshes at `averageBlockTime / 2`. On ETH (6.5s) three cycles are three real checks; on BTC (60s poll) three cycles can read the *same* poll. `RecordProbeVerdict` already requires a strictly newer `LastSuccessfulPoll` — this path should adopt the same rule. |
| 2 | Failure history stops counting on confirmation | ✅ **Met** | The rebase discards accumulated `num`/`denom` and restarts at `0.8 / 1.0`. |
| 3 | Weight **ramps**, full share within ~1 min | ❌ **Gap** | It *jumps*. See below — the significant one. |
| 4 | Any failure during the ramp drops weight immediately and restarts confirmation | ✅ **Met** | Confirmation genuinely restarts (streak reset + latch re-arm on any sample < 1.0). A **relay** failure re-collapses the provider for the first ~16 checks (~96s), covering the whole ramp window. A **probe-only** failure stops being decisive after 4 checks (~24s). |
| 5 | Motivation: 2-provider pods keep failover headroom | ✅ **Addressed** | Survivor carries the full load for ~16s instead of 10-40 min. |

### Gap 3 in detail — it jumps rather than ramps

At confirmation the availability ingredient contributes zero, but latency, sync and stake all return at **full value at once**:

| Time from heal | Composite | First-pick share | Fraction of fair share |
|---|---|---|---|
| 0 – 12.6s | 0.01 | 0/40 | 0% |
| **15.8s** (confirmation) | **0.675** | **9/40** | **~68%** |
| 25s | ~0.75 | 13/40 | ~100% |

One probe cycle after confirming it already carries about two-thirds of a fair share, and full share by ~25s. The spec wants it starting low and reaching full at ~60s, precisely because *"a just-recovered provider is the most likely to fail again."*

There is a mild built-in ramp afterwards — composite drifts 0.67 -> ~0.87 over ~72s as raw availability climbs 0.80 -> 0.95 — but it rides on top of a jump that has already delivered most of the traffic.

**This cannot be fixed by rebasing to a lower value.** Anything below 0.80 re-triggers the collapse and pins the provider back at 0.01; the threshold is binary and there is no "slightly alive" value. A true ramp needs a separate probation multiplier on selection weight — roughly `weight = composite * min(1, cyclesSinceConfirmation / rampCycles)` applied at `weighted_selector.go` (`SelectionWeight: compositeScore`), fed from the per-provider state this PR already tracks in the stripe, and reset on any failure. That is a genuine addition touching the selection path, which is why it is **not** in this PR.

## Measurements

Three-provider simulated ETH chain, local k3d, ~3 minute outage.

| | Before outage | During | 90s after healing |
|---|---|---|---|
| **Without this change** | 0.915 | 0.010 | 0.010 — no recovery |
| **With this change** | 0.915 | 0.010 | **0.675, reached at 18.1s** |

First-pick share, sampled 40 requests at a time (fair share ≈ 13/40):

```
 0 – 12.6s    0/40     still collapsed
    15.8s     9/40     rebase fires
    19.0s    11/40     climbing
    25s+     12–14/40  steady at fair share
```

## Observability

The rebase emits one log line per event:

```
optimizer rebased availability after proven recovery
  providerAddress=... trigger="sustained probe health"
  availability_before=0.2504 availability_after=0.8
```

Two things reviewers should know about the metrics:

- **Only `rpc_endpoint_selection_score{score_type="composite"}` shows the recovery** as a step 0.01 -> ~0.67. The `availability` series does **not** move at the rebase: raw 0.80 rescales to exactly 0.0, the same value it already showed. It lifts off zero only once raw availability clears 0.80 under its own steam a few checks later.
- **Neither series is live.** Both are written in `SetProviderSelected`, which runs only on normal unpinned selection. With no traffic the gauges are stale and will not show the jump until the next real request.

There is currently **no metric** for the rebase event, only the log. A counter (`..._rebased_total{provider, trigger}`) would make repeated rebasing — the flapping-provider signature — alertable. Not included here; happy to add.

## Risk / trade-offs

1. **Failure history is erased, not faded.** After a rebase the router cannot tell a 30-second outage from a 30-minute one. That long memory was the defect, so removing it is the point — but long-run availability reputation is gone. Latency and sync history are untouched.
2. **The score is jumpy for ~24s after recovery.** A nearly-empty jar is what makes recovery fast and also what makes it twitchy. A marginal provider can sawtooth between the floor and ~85% with a period around 30s. Truthful, but noisier than the old flat line.
3. **It slightly softens the dead-provider protection.** Stale-but-flattering latency numbers count again after three good checks, until real relays refresh them.
4. **It also fires at startup.** Providers sit around 0.667 during the first cycles after boot and get rebased to 0.80. Probably a small improvement, but the log line appears on every restart.
5. **Partially degraded providers get no help, by design.** "Fully healthy" means availability exactly 1.0, so a provider with some endpoints permanently dead never qualifies.
6. **The streak map has no eviction.** One small struct per provider per stripe. The sibling SyncBlock floor map in the same struct behaves identically, so this follows the existing pattern.

## Testing

- `protocol/provideroptimizer/recovery_rebase_test.go` — new, 12 tests: the lift works; the bit-exact 0.80 guarantee; never lowers a healthy score; idempotent across multi-endpoint recovery; still-broken re-collapses; flapping never qualifies; partial degradation never qualifies; latency/sync/sync-block survive; score config carried forward; unknown provider is a no-op; the latch re-arms after a genuine dip.
- `protocol/rpcsmartrouter/probe_loop_test.go` — 2 tests: the prober reports recovery exactly once on the transition, and never when the provider has not recovered.
- `provideroptimizer`, `rpcsmartrouter`, `lavasession`, `utils/score`, `probing` all pass. `go vet ./...` clean, `gofmt` clean.

**Pre-existing flake, unrelated:** `lavasession/TestEndpointHealthRecovery` fails intermittently under parallel load (`"disabled endpoints should make GetSessions fail"`). Verified against unmodified `origin/main` in a clean worktree — 2 failures in 6 loaded runs there, versus 2 in 6 on this branch, and 0 in 14 when run unloaded on either. Same rate both sides; not caused by this change. Worth its own ticket.

## Follow-ups

In the order I'd suggest:

1. **Gap 1b** — require a strictly newer successful poll per streak increment, matching `RecordProbeVerdict`. Smallest, and a correctness issue on slow chains.
2. **Gap 1a** — make K a flag rather than a const, on both this path and the prober's.
3. **Gap 3** — the probation ramp. Worth deciding first where the ramp should *start*, since that is the risk dial and the spec doesn't pin it.

Relates to MAG-2387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BpPUfXZtNX2Sm9VS35W33
