### PR TITLE
fix(grpc): forward auth-headers on gRPC dials (MAG-2218)

### DIFF
--- a/protocol/chainlib/chainproxy/connector.go
+++ b/protocol/chainlib/chainproxy/connector.go
@@ -186,6 +186,10 @@ func NewGRPCConnector(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) 
 		nodeUrl:     nodeUrl,
 	}
 
+	// MAG-2218: warn once per connector, not per dial. createConnection may still upgrade an
+	// unconfigured endpoint to TLS on retry, so this reflects the configured intent.
+	nodeUrl.TokenOverInsecureWarning(nodeUrl.AuthConfig.GetUseTls() || strings.HasPrefix(nodeUrl.Url, "grpcs://"))
+
 	rpcClient, err := connector.createConnection(ctx, nodeUrl, connector.numberOfFreeClients())
 	if err != nil {
 		return nil, utils.LavaFormatError("grpc failed to create the first connection", err, utils.Attribute{Key: "address", Value: nodeUrl.UrlStr()})
@@ -193,6 +197,20 @@ func NewGRPCConnector(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) 
 	connector.addClient(rpcClient)
 	go addClientsAsynchronouslyGrpc(ctx, connector, nConns-1, nodeUrl)
 	return connector, nil
+}
+
+// grpcDialOptions assembles the options shared by every dial this connector makes: the
+// transport credentials the caller decided on, the receive-size cap, and (MAG-2218) the
+// endpoint's configured auth-headers. All three dial sites in this file go through it, so
+// the auth attachment cannot be present on one path and missing on another — which is the
+// class of bug MAG-2218 was.
+func (connector *GRPCConnector) grpcDialOptions(transport grpc.DialOption) []grpc.DialOption {
+	opts := []grpc.DialOption{
+		grpc.WithBlock(),
+		transport,
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxCallRecvMsgSize)),
+	}
+	return append(opts, connector.nodeUrl.GrpcAuthDialOptions()...)
 }
 
 func getTlsConf(nodeUrl common.NodeUrl) *tls.Config {
@@ -254,7 +272,7 @@ func (connector *GRPCConnector) increaseNumberOfClients(ctx context.Context, num
 	var err error
 	for connectionAttempt := 0; connectionAttempt < MaximumNumberOfParallelConnectionsAttempts; connectionAttempt++ {
 		nctx, cancel := connector.nodeUrl.LowerContextTimeoutWithDuration(ctx, common.AverageWorldLatency*2)
-		grpcClient, err = grpc.DialContext(nctx, connector.nodeUrl.Url, grpc.WithBlock(), connector.getTransportCredentials(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxCallRecvMsgSize)))
+		grpcClient, err = grpc.DialContext(nctx, connector.nodeUrl.Url, connector.grpcDialOptions(connector.getTransportCredentials())...)
 		if err != nil {
 			utils.LavaFormatDebug("increaseNumberOfClients, Could not connect to the node, retrying", []utils.Attribute{{Key: "err", Value: err.Error()}, {Key: "Number Of Attempts", Value: connectionAttempt}, {Key: "nodeUrl", Value: connector.nodeUrl.UrlStr()}}...)
 			cancel()
@@ -434,7 +452,7 @@ func (connector *GRPCConnector) createConnection(ctx context.Context, nodeUrl co
 			return nil, ctx.Err()
 		}
 		nctx, cancel := connector.nodeUrl.LowerContextTimeoutWithDuration(ctx, common.AverageWorldLatency*2)
-		rpcClient, err = grpc.DialContext(nctx, addr, grpc.WithBlock(), connector.getTransportCredentials(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxCallRecvMsgSize)))
+		rpcClient, err = grpc.DialContext(nctx, addr, connector.grpcDialOptions(connector.getTransportCredentials())...)
 		cancel()
 		if err == nil {
 			return rpcClient, nil
@@ -448,7 +466,7 @@ func (connector *GRPCConnector) createConnection(ctx context.Context, nodeUrl co
 			}
 			nctx, cancel := connector.nodeUrl.LowerContextTimeoutWithDuration(ctx, common.AverageWorldLatency*2)
 			var errNew error
-			rpcClient, errNew = grpc.DialContext(nctx, addr, grpc.WithBlock(), grpc.WithTransportCredentials(credentialsToConnect), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxCallRecvMsgSize)))
+			rpcClient, errNew = grpc.DialContext(nctx, addr, connector.grpcDialOptions(grpc.WithTransportCredentials(credentialsToConnect))...)
 			cancel()
 			if errNew == nil {
 				// this means our endpoint is TLS, and we support upgrading even if the config didn't explicitly say it

--- a/protocol/chainlib/chainproxy/grpc_auth_connector_test.go
+++ b/protocol/chainlib/chainproxy/grpc_auth_connector_test.go
@@ -1,0 +1,180 @@
+package chainproxy
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/jhump/protoreflect/grpcreflect"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/reflection"
+)
+
+// MAG-2218 regression cover. The defect was that auth-headers reached every transport
+// except gRPC, so an authenticated upstream rejected both relays and the boot-time spec
+// verification. These tests assert the credential actually lands on the wire — a
+// dial-option count alone would not have caught the original bug.
+
+type mdRecorder struct {
+	mu     sync.Mutex
+	unary  []metadata.MD
+	stream []metadata.MD
+}
+
+func (r *mdRecorder) recordUnary(md metadata.MD) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.unary = append(r.unary, md)
+}
+
+func (r *mdRecorder) recordStream(md metadata.MD) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stream = append(r.stream, md)
+}
+
+func (r *mdRecorder) snapshot() (unary, stream []metadata.MD) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]metadata.MD(nil), r.unary...), append([]metadata.MD(nil), r.stream...)
+}
+
+// startRecordingGRPCServer starts a plaintext gRPC server that records the metadata of
+// every call. Plaintext is deliberate: it is the case grpc-go refuses if the credentials
+// declare RequireTransportSecurity, so it is the case worth regression-testing.
+func startRecordingGRPCServer(t *testing.T) (addr string, rec *mdRecorder) {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	rec = &mdRecorder{}
+	srv := grpc.NewServer(
+		grpc.UnaryInterceptor(func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+			md, _ := metadata.FromIncomingContext(ctx)
+			rec.recordUnary(md)
+			return handler(ctx, req)
+		}),
+		grpc.StreamInterceptor(func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+			md, _ := metadata.FromIncomingContext(ss.Context())
+			rec.recordStream(md)
+			return handler(srv, ss)
+		}),
+	)
+	healthpb.RegisterHealthServer(srv, health.NewServer())
+	reflection.Register(srv) // exercises the descriptor path the router uses for gRPC
+	go srv.Serve(lis)
+	t.Cleanup(func() {
+		srv.Stop()
+		lis.Close()
+	})
+	return lis.Addr().String(), rec
+}
+
+func firstValue(mds []metadata.MD, key string) string {
+	for _, md := range mds {
+		if vals := md.Get(key); len(vals) > 0 {
+			return vals[0]
+		}
+	}
+	return ""
+}
+
+func TestGRPCConnector_SendsAuthHeadersOnUnaryCall(t *testing.T) {
+	addr, rec := startRecordingGRPCServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	connector, err := NewGRPCConnector(ctx, 1, common.NodeUrl{
+		Url:        addr,
+		AuthConfig: common.AuthConfig{AuthHeaders: map[string]string{"Authorization": "Bearer unit-test-token"}},
+	})
+	if err != nil {
+		t.Fatalf("NewGRPCConnector: %v", err)
+	}
+	defer connector.Close()
+
+	conn, err := connector.GetRpc(ctx, true)
+	if err != nil {
+		t.Fatalf("GetRpc: %v", err)
+	}
+	defer connector.ReturnRpc(conn)
+
+	if _, err := healthpb.NewHealthClient(conn).Check(ctx, &healthpb.HealthCheckRequest{}); err != nil {
+		t.Fatalf("health check: %v", err)
+	}
+
+	unary, _ := rec.snapshot()
+	if got := firstValue(unary, "authorization"); got != "Bearer unit-test-token" {
+		t.Fatalf("auth header did not reach the upstream on a unary call, got %q", got)
+	}
+}
+
+// Boot-time spec verification resolves gRPC method descriptors through server reflection.
+// If the credential rode only on unary calls, verification would still fail against an
+// upstream that authenticates reflection — so cover it separately.
+func TestGRPCConnector_SendsAuthHeadersOnReflection(t *testing.T) {
+	addr, rec := startRecordingGRPCServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	connector, err := NewGRPCConnector(ctx, 1, common.NodeUrl{
+		Url:        addr,
+		AuthConfig: common.AuthConfig{AuthHeaders: map[string]string{"Authorization": "Bearer reflect-token"}},
+	})
+	if err != nil {
+		t.Fatalf("NewGRPCConnector: %v", err)
+	}
+	defer connector.Close()
+
+	conn, err := connector.GetRpc(ctx, true)
+	if err != nil {
+		t.Fatalf("GetRpc: %v", err)
+	}
+	defer connector.ReturnRpc(conn)
+
+	if _, err := grpcreflect.NewClientAuto(ctx, conn).ListServices(); err != nil {
+		t.Fatalf("reflection ListServices: %v", err)
+	}
+
+	_, stream := rec.snapshot()
+	if got := firstValue(stream, "authorization"); got != "Bearer reflect-token" {
+		t.Fatalf("auth header did not reach the upstream on the reflection stream, got %q", got)
+	}
+}
+
+func TestGRPCConnector_NoAuthHeadersSendsNone(t *testing.T) {
+	addr, rec := startRecordingGRPCServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	connector, err := NewGRPCConnector(ctx, 1, common.NodeUrl{Url: addr})
+	if err != nil {
+		t.Fatalf("NewGRPCConnector: %v", err)
+	}
+	defer connector.Close()
+
+	conn, err := connector.GetRpc(ctx, true)
+	if err != nil {
+		t.Fatalf("GetRpc: %v", err)
+	}
+	defer connector.ReturnRpc(conn)
+
+	if _, err := healthpb.NewHealthClient(conn).Check(ctx, &healthpb.HealthCheckRequest{}); err != nil {
+		t.Fatalf("health check: %v", err)
+	}
+
+	unary, _ := rec.snapshot()
+	if got := firstValue(unary, "authorization"); got != "" {
+		t.Fatalf("expected no authorization metadata when none is configured, got %q", got)
+	}
+}

--- a/protocol/common/grpc_auth.go
+++ b/protocol/common/grpc_auth.go
@@ -1,0 +1,116 @@
+package common
+
+import (
+	"context"
+	"strings"
+
+	"github.com/magma-Devs/smart-router/utils"
+	"google.golang.org/grpc"
+)
+
+// MAG-2218: auth-headers were honoured by every transport EXCEPT gRPC — HTTP sets them
+// in DoHTTPRequest, WebSocket in ensureClient, REST/TendermintRPC on the outgoing request,
+// and the JSON-RPC connector via rpcClient.SetHeader. gRPC read them nowhere, so an
+// authenticated upstream (Canton's Ledger API being the case that surfaced it) answered
+// Unauthenticated for every call, including the boot-time spec verification.
+//
+// The fix attaches them at DIAL time rather than at each call site: both gRPC stacks
+// (the chainlib GrpcChainProxy used by boot verification, and the lavasession
+// GRPCDirectRPCConnection used by relays and per-endpoint polls) construct their
+// connections through chainproxy.GRPCConnector, and the subscription manager's pool is
+// the only other dialler. Attaching there covers unary calls, server reflection and
+// streams at once, so the paths cannot drift apart later.
+
+// grpcAuthCredentials attaches statically-configured auth headers to every outgoing gRPC
+// call. It implements google.golang.org/grpc/credentials.PerRPCCredentials.
+type grpcAuthCredentials struct {
+	headers map[string]string
+}
+
+// GetRequestMetadata returns the configured headers for every call. The context and the
+// call URI are ignored — these headers are static per endpoint, not per request.
+func (c grpcAuthCredentials) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	return c.headers, nil
+}
+
+// RequireTransportSecurity reports false so the credentials can be used on plaintext
+// (grpc://) upstreams. Returning true would make grpc-go refuse the dial outright
+// whenever the transport is insecure.NewCredentials(), which is exactly the local-node
+// and private-network case operators run against. See TokenOverInsecureWarning for the
+// operator-facing warning that accompanies this choice.
+func (c grpcAuthCredentials) RequireTransportSecurity() bool { return false }
+
+// isLegalGrpcHeaderName reports whether name is usable as a gRPC metadata key.
+// grpc-go lowercases keys on the way out, so the check runs against the lowered form.
+// An illegal name is rejected by the HTTP/2 transport at call time rather than at config
+// parse, which surfaces as an opaque per-relay failure — so it is screened here instead.
+func isLegalGrpcHeaderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	// "-bin" keys carry binary metadata and require base64-encoded values; auth headers
+	// configured as YAML strings are not that, so reject rather than corrupt them.
+	if strings.HasSuffix(name, "-bin") {
+		return false
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+		case r == '-', r == '_', r == '.':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// GrpcAuthDialOptions returns the dial options that attach this endpoint's configured
+// auth-headers to every outgoing gRPC call. It returns nil when no auth headers are
+// configured, so callers can append unconditionally.
+//
+// Header names are lowercased (grpc-go does this anyway) and screened; illegal names are
+// dropped with an error rather than being allowed to fail opaquely at call time.
+func (url *NodeUrl) GrpcAuthDialOptions() []grpc.DialOption {
+	if url == nil {
+		return nil
+	}
+	configured := url.GetAuthHeaders()
+	if len(configured) == 0 {
+		return nil
+	}
+
+	headers := make(map[string]string, len(configured))
+	for name, value := range configured {
+		lowered := strings.ToLower(name)
+		if !isLegalGrpcHeaderName(lowered) {
+			utils.LavaFormatError("dropping illegal gRPC auth-header name", nil,
+				utils.LogAttr("header", name),
+				utils.LogAttr("url", url.UrlStr()),
+				utils.LogAttr("hint", "gRPC metadata keys allow a-z, 0-9, '-', '_', '.' and must not end in -bin"),
+			)
+			continue
+		}
+		headers[lowered] = value
+	}
+	if len(headers) == 0 {
+		return nil
+	}
+
+	return []grpc.DialOption{grpc.WithPerRPCCredentials(grpcAuthCredentials{headers: headers})}
+}
+
+// TokenOverInsecureWarning emits a one-line warning when auth headers are configured for
+// an endpoint whose transport is not secured. The credentials deliberately permit this
+// (see RequireTransportSecurity), matching how the HTTP and WebSocket paths already send
+// auth headers over plaintext http:// — but a bearer token on the wire in the clear is
+// worth telling the operator about. Callers pass the transport decision they actually
+// made, since the scheme alone does not determine it.
+func (url *NodeUrl) TokenOverInsecureWarning(transportIsSecure bool) {
+	if url == nil || transportIsSecure || len(url.GetAuthHeaders()) == 0 {
+		return
+	}
+	utils.LavaFormatWarning("sending gRPC auth headers over an insecure (plaintext) connection", nil,
+		utils.LogAttr("url", url.UrlStr()),
+		utils.LogAttr("hint", "use grpcs:// or auth-config.use-tls to protect the credential in transit"),
+	)
+}

--- a/protocol/common/grpc_auth_test.go
+++ b/protocol/common/grpc_auth_test.go
@@ -1,0 +1,103 @@
+package common
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGrpcAuthDialOptions_NoHeadersReturnsNil(t *testing.T) {
+	url := &NodeUrl{Url: "grpc://127.0.0.1:9090"}
+	if opts := url.GrpcAuthDialOptions(); opts != nil {
+		t.Fatalf("expected nil dial options when no auth-headers are configured, got %d", len(opts))
+	}
+}
+
+func TestGrpcAuthDialOptions_NilReceiverIsSafe(t *testing.T) {
+	var url *NodeUrl
+	if opts := url.GrpcAuthDialOptions(); opts != nil {
+		t.Fatal("expected nil dial options for a nil NodeUrl")
+	}
+}
+
+func TestGrpcAuthDialOptions_AttachesWhenConfigured(t *testing.T) {
+	url := &NodeUrl{
+		Url:        "grpc://127.0.0.1:9090",
+		AuthConfig: AuthConfig{AuthHeaders: map[string]string{"Authorization": "Bearer tok"}},
+	}
+	opts := url.GrpcAuthDialOptions()
+	if len(opts) != 1 {
+		t.Fatalf("expected exactly one dial option, got %d", len(opts))
+	}
+}
+
+// The credential payload is what actually reaches the wire, so assert on it directly
+// rather than only on the dial-option count.
+func TestGrpcAuthCredentials_LowercasesNames(t *testing.T) {
+	creds := grpcAuthCredentials{headers: map[string]string{}}
+	url := &NodeUrl{
+		AuthConfig: AuthConfig{AuthHeaders: map[string]string{
+			"Authorization": "Bearer tok",
+			"X-API-Key":     "abc123",
+		}},
+	}
+	// Rebuild through the same screening path the dial option uses.
+	for name, value := range url.GetAuthHeaders() {
+		lowered := toLowerForTest(name)
+		if isLegalGrpcHeaderName(lowered) {
+			creds.headers[lowered] = value
+		}
+	}
+
+	md, err := creds.GetRequestMetadata(context.Background())
+	if err != nil {
+		t.Fatalf("GetRequestMetadata: %v", err)
+	}
+	if md["authorization"] != "Bearer tok" {
+		t.Errorf("authorization not lowercased/preserved: %#v", md)
+	}
+	if md["x-api-key"] != "abc123" {
+		t.Errorf("x-api-key not lowercased/preserved: %#v", md)
+	}
+}
+
+func TestGrpcAuthCredentials_DoesNotRequireTransportSecurity(t *testing.T) {
+	// Returning true here would make grpc-go refuse every plaintext dial, which is the
+	// local-node and private-network case operators actually run.
+	if (grpcAuthCredentials{}).RequireTransportSecurity() {
+		t.Fatal("RequireTransportSecurity must be false so insecure dials are permitted")
+	}
+}
+
+func TestIsLegalGrpcHeaderName(t *testing.T) {
+	legal := []string{"authorization", "x-api-key", "x_api_key", "a.b.c", "k3y"}
+	for _, name := range legal {
+		if !isLegalGrpcHeaderName(name) {
+			t.Errorf("expected %q to be legal", name)
+		}
+	}
+	illegal := []string{"", "Authorization", "x api key", "x:key", "hdr-bin", "héader"}
+	for _, name := range illegal {
+		if isLegalGrpcHeaderName(name) {
+			t.Errorf("expected %q to be illegal", name)
+		}
+	}
+}
+
+func TestGrpcAuthDialOptions_DropsIllegalNamesEntirely(t *testing.T) {
+	url := &NodeUrl{
+		AuthConfig: AuthConfig{AuthHeaders: map[string]string{"bad header": "v"}},
+	}
+	if opts := url.GrpcAuthDialOptions(); opts != nil {
+		t.Fatal("expected nil dial options when every configured header name is illegal")
+	}
+}
+
+func toLowerForTest(s string) string {
+	out := []rune(s)
+	for i, r := range out {
+		if r >= 'A' && r <= 'Z' {
+			out[i] = r + ('a' - 'A')
+		}
+	}
+	return string(out)
+}

--- a/protocol/rpcsmartrouter/upstream_grpc_pool.go
+++ b/protocol/rpcsmartrouter/upstream_grpc_pool.go
@@ -87,7 +87,8 @@ func (c *UpstreamGRPCStreamConnection) connect(ctx context.Context, timeout time
 	var dialOpts []grpc.DialOption
 	scheme := strings.ToLower(parsedURL.Scheme)
 
-	if scheme == "grpcs" || c.nodeUrl.AuthConfig.UseTLS {
+	transportIsSecure := scheme == "grpcs" || c.nodeUrl.AuthConfig.UseTLS
+	if transportIsSecure {
 		// Use TLS
 		tlsConfig := &tls.Config{}
 		if c.nodeUrl.AuthConfig.AllowInsecure {
@@ -106,6 +107,12 @@ func (c *UpstreamGRPCStreamConnection) connect(ctx context.Context, timeout time
 	dialOpts = append(dialOpts,
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(512*1024*1024)),
 	)
+
+	// MAG-2218: attach the endpoint's configured auth-headers. This pool backs
+	// GetReflectionConnection (live, via RPCSmartRouterServer.GetGRPCReflectionConnection)
+	// and the subscription manager's upstream streams, neither of which sent credentials.
+	c.nodeUrl.TokenOverInsecureWarning(transportIsSecure)
+	dialOpts = append(dialOpts, c.nodeUrl.GrpcAuthDialOptions()...)
 
 	// grpc.NewClient is lazy — it does not establish a connection here.
 	// We force a state transition under the configured timeout so the


### PR DESCRIPTION
## Problem

`auth-headers` were honoured by every transport **except gRPC**:

| transport | where it applies them |
|---|---|
| HTTP | `direct_rpc_connection.go:319`, `:416` |
| WebSocket | `direct_rpc_connection.go:532`, `upstream_ws_pool.go:57` |
| REST | `rest.go:508` |
| TendermintRPC | `tendermintRPC.go:721` |
| JSON-RPC connector | `connector.go:95-100` |
| **gRPC** | **nowhere** |

So an authenticated gRPC upstream answered `Unauthenticated` for every call — including the boot-time spec verification, which is why the provider failed to *verify* rather than merely failing relays. Surfaced by Canton (MAG-2218), but it affects any authenticated gRPC upstream.

## Approach

Attach at **dial time** rather than per call site. Both gRPC stacks construct their connections through `chainproxy.GRPCConnector` — the chainlib `GrpcChainProxy` used by boot verification, and the lavasession `GRPCDirectRPCConnection` used by relays and per-endpoint polls — so one `PerRPCCredentials` on the connector's dial options covers unary calls, server reflection and streams at once.

`connectorNodeUrl` is already a value copy of `g.nodeUrl`, so `AuthConfig` was inside the connector all along — unused, not unplumbed.

Two notes on scope, both differing from the ticket's description:

- The ticket lists **three** paths to fix. The third (streaming) is dead code — `createUpstreamStream` is only reachable from `StartSubscription`, which has zero callers (see MAG-2643). It gets the credential here but stays untestable end to end.
- The connector itself had **three dial sites** (`:257`, `:437`, `:451`), not one. They now share `grpcDialOptions`, so the attachment cannot be present on one path and missing on another — the class of bug this was.

A `SendRequest`-only patch would not have fixed verification, since that path goes through `GrpcChainProxy`.

## Design decisions

**`RequireTransportSecurity()` reports false.** Returning true makes grpc-go refuse every plaintext dial, which is the local-node and private-network case operators actually run, and it matches HTTP/WS which already send auth headers over plaintext `http://`. A warning is logged once per connector when credentials are configured on an unsecured transport.

**Header names are lowercased and screened at dial time.** An HTTP/2-illegal name would otherwise be rejected by the transport at call time and surface as an opaque per-relay failure rather than a config error.

## Testing

`go test ./protocol/common/... ./protocol/chainlib/... ./protocol/lavasession/... ./protocol/rpcsmartrouter/...` — all pass.

New tests assert the credential actually reaches the wire, against a plaintext server, on **both** a unary call and the reflection stream. A dial-option count alone would not have caught the original defect.

## Not covered

Validation against a real authenticated upstream (step 1.7 of the MAG-2218 plan) — needs a live CNQS node and token, so this is unit-tested but **not** verified end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)