### PR TITLE
feat(chaintracker): head-only mode for chains with no block-by-number (MAG-2218)

### DIFF
--- a/protocol/chaintracker/chain_tracker.go
+++ b/protocol/chaintracker/chain_tracker.go
@@ -485,8 +485,10 @@ func (cs *ChainTracker) fetchAllPreviousBlocksIfNecessary(ctx context.Context) (
 		} else if prevLatest > newLatestBlock && cs.consistencyCallback != nil {
 			cs.consistencyCallback(prevLatest, newLatestBlock)
 		} else if newLatestBlock == prevLatest {
-			// Same head as last cycle. Mirrors the hashed path's no-new-block branch, which is
-			// what feeds the not-updated/emergency detection.
+			// Same head as last cycle — feed the not-updated/emergency detection. The hashed
+			// path reaches this via `else if cs.oldBlockCallback != nil`; the guard is redundant
+			// because notUpdated() returns early on a nil callback, so call it unconditionally
+			// rather than duplicate the check.
 			cs.notUpdated()
 		}
 		return false, nil

--- a/protocol/chaintracker/chain_tracker.go
+++ b/protocol/chaintracker/chain_tracker.go
@@ -143,6 +143,9 @@ type ChainTracker struct {
 	relayTipFresh           func(now time.Time) bool
 	maxRelaySkipsBeforePoll int
 	relaySkipsSinceRealPoll int
+	// headOnly (MAG-2218) drops every block-hash fetch: no fork detection, no block queue.
+	// The head still advances from FetchLatestBlockNum. See ChainTrackerConfig.HeadOnlyTracking.
+	headOnly bool
 
 	// allows us to mock the chain fetcher for different use cases for example: Solana needs slot to block number
 	iChainFetcherWrapper IChainFetcherWrapper
@@ -172,6 +175,13 @@ func (cs *ChainTracker) GetLatestBlockData(fromBlock, toBlock, specificBlock int
 	defer cs.blockQueueMu.RUnlock()
 
 	latestBlock = cs.GetAtomicLatestBlockNum()
+	// Head-only (MAG-2218): an empty queue is the steady state here, not a fault. Answer with
+	// the head and no hashes, the way DummyChainTracker does, rather than returning an error
+	// and logging at ERROR on every call. Chains in this mode must run with data reliability
+	// and finalization proofs off, since neither can be satisfied without hashes.
+	if cs.headOnly {
+		return latestBlock, []*BlockStore{}, cs.latestChangeTime, nil
+	}
 	if len(cs.blocksQueue) == 0 {
 		return latestBlock, nil, time.Time{}, utils.LavaFormatError("ChainTracker GetLatestBlockData had no blocks", nil, utils.Attribute{Key: "latestBlock", Value: latestBlock})
 	}
@@ -244,6 +254,17 @@ func (cs *ChainTracker) GetServerBlockMemory() uint64 {
 
 func (cs *ChainTracker) setLatestBlockNum(value int64) {
 	atomic.StoreInt64(&cs.latestBlockNum, value)
+}
+
+// advanceHeadOnly publishes a new head in head-only mode (MAG-2218). It is the second and
+// only other writer of latestBlockNum: replaceBlocksQueue is the hashed path, and it holds
+// blockQueueMu while it swaps the queue and stores the head together. Head-only keeps no
+// queue, but it takes the same lock so a concurrent ResetLatestBlock or getLatestBlockUnsafe
+// cannot observe the head moving out from under it.
+func (cs *ChainTracker) advanceHeadOnly(latestBlock int64) {
+	cs.blockQueueMu.Lock()
+	defer cs.blockQueueMu.Unlock()
+	cs.setLatestBlockNum(latestBlock)
 }
 
 // ResetLatestBlock zeroes the cached latest block under blockQueueMu. After
@@ -447,6 +468,30 @@ func (cs *ChainTracker) fetchAllPreviousBlocksIfNecessary(ctx context.Context) (
 		}
 		return false, err
 	}
+	// Head-only (MAG-2218): the head is all we can learn from this chain, and we already have
+	// it. Everything below needs block hashes — forkChanged fetches one every tick even when the
+	// block is unchanged, and fetchAllPreviousBlocks fetches blocksToSave of them — so on a chain
+	// with no GET_BLOCK_BY_NUM mapping the rest of this cycle can only fail. Publish the head and
+	// return cleanly, which also keeps fetchFails at 0 so the poll cadence does not back off.
+	if cs.headOnly {
+		prevLatest := cs.GetAtomicLatestBlockNum()
+		if newLatestBlock > prevLatest {
+			cs.advanceHeadOnly(newLatestBlock)
+			if cs.newLatestCallback != nil {
+				// No hash to report: head-only keeps no block queue.
+				cs.newLatestCallback(prevLatest, newLatestBlock, "")
+			}
+			cs.setLatestChangeTime(time.Now())
+		} else if prevLatest > newLatestBlock && cs.consistencyCallback != nil {
+			cs.consistencyCallback(prevLatest, newLatestBlock)
+		} else if newLatestBlock == prevLatest {
+			// Same head as last cycle. Mirrors the hashed path's no-new-block branch, which is
+			// what feeds the not-updated/emergency detection.
+			cs.notUpdated()
+		}
+		return false, nil
+	}
+
 	gotNewBlock := cs.gotNewBlock(ctx, newLatestBlock)
 	forked, err := cs.forkChanged(ctx, newLatestBlock)
 	if err != nil {
@@ -704,6 +749,16 @@ func (cs *ChainTracker) fetchInitDataWithRetry(ctx context.Context) (err error) 
 		}
 		return utils.LavaFormatError("critical -- failed fetching data from the node, chain tracker creation error", err, utils.Attribute{Key: "endpoint", Value: cs.endpoint})
 	}
+	// Head-only (MAG-2218): there is no hash to seed a block queue with, and retrying
+	// fetchAllPreviousBlocks would exhaust its attempts and return the "chain tracker creation
+	// error" below — which start() propagates, leaving startTrackerWithRetry looping forever on a
+	// chain that is in fact healthy. Publish the head we just fetched and finish init.
+	if cs.headOnly {
+		cs.advanceHeadOnly(newLatestBlock)
+		cs.setLatestChangeTime(time.Now())
+		return nil
+	}
+
 	for idx := 0; idx < initRetriesCount; idx++ {
 		_, err = cs.fetchAllPreviousBlocks(ctx, newLatestBlock)
 		if err == nil {
@@ -829,6 +884,7 @@ func newCustomChainTracker(chainFetcher ChainFetcher, config ChainTrackerConfig)
 		pollingTimeMultiplier:   time.Duration(pollingTime),
 		averageBlockTime:        config.AverageBlockTime,
 		flatPollInterval:        config.FlatPollInterval,
+		headOnly:                config.HeadOnlyTracking,
 		relayTipFresh:           config.RelayTipFresh,
 		maxRelaySkipsBeforePoll: maxRelaySkips,
 		endpoint:                endpoint,

--- a/protocol/chaintracker/config.go
+++ b/protocol/chaintracker/config.go
@@ -22,6 +22,27 @@ type ChainTrackerConfig struct {
 	ChainId                  string
 	ParseDirectiveEnabled    bool
 
+	// HeadOnlyTracking selects head-only mode (MAG-2218): track the chain head, keep no block
+	// hashes, do no fork detection. Set it for a spec that defines GET_BLOCKNUM but has no viable
+	// GET_BLOCK_BY_NUM mapping — Canton is the case that forced it, because its Ledger API reads
+	// are party-scoped and not addressable by block number, so a generic "get block N" cannot
+	// exist and every hash fetch returns PERMISSION_DENIED.
+	//
+	// Without it such a chain still "works", by accident and badly: start() fails on the hash
+	// step, startTrackerWithRetry retries forever (a warning per cycle, the endpoint parked in
+	// EndpointChainTrackerRetryingStart), and the only reason a tip reaches ChainState at all is
+	// that each retry's FetchLatestBlockNum fires its poll observation on the way past — at the
+	// start-retry backoff, capped at 30s, rather than the intended poll cadence.
+	//
+	// This is NOT ParseDirectiveEnabled=false: that yields a DummyChainTracker, which has no poll
+	// loop at all (StartAndServe returns nil, CurrentPollInterval 0) and reports the MaxInt64
+	// sentinel, so it never calls FetchLatestBlockNum and the tip feed dies with it. That mode is
+	// for chains with no block concept whatsoever; this one is for "has a head, has no hashes".
+	//
+	// GetLatestBlockData returns an empty hash slice in this mode, so data reliability and
+	// finalization proofs must be off for the chain.
+	HeadOnlyTracking bool
+
 	// FlatPollInterval, when > 0, switches this tracker to a FIXED flat cadence
 	// (MAG-2159 / Topic B): the dedicated poll runs at exactly this interval, slowed only
 	// by failure backoff. The adaptive /4, /2, /16 tiers AND the block-gap recalibration

--- a/protocol/chaintracker/head_only_test.go
+++ b/protocol/chaintracker/head_only_test.go
@@ -1,0 +1,162 @@
+package chaintracker_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	chaintracker "github.com/magma-Devs/smart-router/protocol/chaintracker"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/magma-Devs/smart-router/utils"
+	"github.com/stretchr/testify/require"
+)
+
+// MAG-2218 head-only mode. No shipped spec exercises this path — the audit behind the ticket
+// found all 227 specs declare GET_BLOCK_BY_NUM alongside GET_BLOCKNUM — so the regression
+// suite covers none of it and these tests are the only cover it has.
+
+// headlessFetcher models a Canton-shaped chain: the head reads fine, every attempt to fetch a
+// block by number is refused. Canton returns PERMISSION_DENIED because Ledger API update reads
+// are party-scoped; what matters here is only that the hash fetch always errors.
+type headlessFetcher struct {
+	mu          sync.Mutex
+	latestBlock int64
+	hashCalls   atomic.Int64
+	latestCalls atomic.Int64
+}
+
+func (f *headlessFetcher) FetchEndpoint() lavasession.RPCProviderEndpoint {
+	return lavasession.RPCProviderEndpoint{}
+}
+
+func (f *headlessFetcher) FetchLatestBlockNum(ctx context.Context) (int64, error) {
+	f.latestCalls.Add(1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.latestBlock, nil
+}
+
+func (f *headlessFetcher) FetchBlockHashByNum(ctx context.Context, blockNum int64) (string, error) {
+	f.hashCalls.Add(1)
+	return "", fmt.Errorf("PERMISSION_DENIED: update reads are party-scoped")
+}
+
+func (f *headlessFetcher) FetchChainID(ctx context.Context) (string, string, error) {
+	return "", "", utils.LavaFormatError("FetchChainID not supported", nil)
+}
+
+func (f *headlessFetcher) CustomMessage(ctx context.Context, path string, data []byte, connectionType string, apiName string) ([]byte, error) {
+	return nil, utils.LavaFormatError("not implemented", nil)
+}
+
+func (f *headlessFetcher) advance() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.latestBlock++
+}
+
+func headOnlyConfig(headOnly bool) chaintracker.ChainTrackerConfig {
+	return chaintracker.ChainTrackerConfig{
+		BlocksToSave:          10,
+		AverageBlockTime:      TimeForPollingMock,
+		ServerBlockMemory:     100,
+		ParseDirectiveEnabled: true,
+		HeadOnlyTracking:      headOnly,
+		FlatPollInterval:      TimeForPollingMock,
+	}
+}
+
+// The control: without head-only, this fetcher is exactly the failure MAG-2218 describes.
+// If this ever stops failing, the tests below are no longer proving anything.
+func TestHeadOnly_ControlWithoutModeStartFails(t *testing.T) {
+	fetcher := &headlessFetcher{latestBlock: 100}
+	tracker, err := chaintracker.NewChainTracker(context.Background(), fetcher, headOnlyConfig(false))
+	require.NoError(t, err, "construction only validates config, so it must succeed either way")
+
+	err = tracker.StartAndServe(context.Background())
+	require.Error(t, err, "without head-only, init must fail on the hash fetch — this is what leaves startTrackerWithRetry looping forever")
+}
+
+func TestHeadOnly_StartSucceedsWhenHashFetchAlwaysFails(t *testing.T) {
+	fetcher := &headlessFetcher{latestBlock: 100}
+	tracker, err := chaintracker.NewChainTracker(context.Background(), fetcher, headOnlyConfig(true))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, tracker.StartAndServe(ctx), "head-only must start cleanly so the endpoint never parks in RetryingStart")
+	require.Equal(t, int64(100), tracker.GetAtomicLatestBlockNum(), "the head fetched during init must be published")
+}
+
+func TestHeadOnly_NeverFetchesBlockHashes(t *testing.T) {
+	fetcher := &headlessFetcher{latestBlock: 100}
+	tracker, err := chaintracker.NewChainTracker(context.Background(), fetcher, headOnlyConfig(true))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, tracker.StartAndServe(ctx))
+
+	for i := 0; i < 5; i++ {
+		fetcher.advance()
+		time.Sleep(SleepTime)
+	}
+
+	require.Zero(t, fetcher.hashCalls.Load(), "head-only must never call FetchBlockHashByNum — neither the fork check nor the queue read")
+}
+
+func TestHeadOnly_HeadAdvancesAcrossPolls(t *testing.T) {
+	fetcher := &headlessFetcher{latestBlock: 100}
+	tracker, err := chaintracker.NewChainTracker(context.Background(), fetcher, headOnlyConfig(true))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, tracker.StartAndServe(ctx))
+
+	for i := 0; i < 5; i++ {
+		fetcher.advance()
+	}
+
+	require.Eventually(t, func() bool {
+		return tracker.GetAtomicLatestBlockNum() == 105
+	}, 5*time.Second, TimeForPollingMock, "the tip must keep advancing from the poll loop, not merely be set once at init")
+}
+
+// The poll loop is what feeds ChainState via EndpointPoller's observation defer. If head-only
+// stopped polling — the trap the rejected DummyChainTracker approach fell into — the tip feed
+// would go silent, so assert the loop keeps calling upstream.
+func TestHeadOnly_KeepsPolling(t *testing.T) {
+	fetcher := &headlessFetcher{latestBlock: 100}
+	tracker, err := chaintracker.NewChainTracker(context.Background(), fetcher, headOnlyConfig(true))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, tracker.StartAndServe(ctx))
+
+	after := fetcher.latestCalls.Load()
+	require.Eventually(t, func() bool {
+		return fetcher.latestCalls.Load() > after+2
+	}, 5*time.Second, TimeForPollingMock, "head-only must keep polling FetchLatestBlockNum; that call is what feeds the per-endpoint tip observation")
+}
+
+func TestHeadOnly_GetLatestBlockDataReturnsNoHashes(t *testing.T) {
+	fetcher := &headlessFetcher{latestBlock: 100}
+	tracker, err := chaintracker.NewChainTracker(context.Background(), fetcher, headOnlyConfig(true))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, tracker.StartAndServe(ctx))
+
+	latest, hashes, _, err := tracker.GetLatestBlockData(spectypes.NOT_APPLICABLE, spectypes.NOT_APPLICABLE, spectypes.NOT_APPLICABLE)
+	require.NoError(t, err)
+	require.Equal(t, int64(100), latest)
+	require.Empty(t, hashes, "head-only keeps no block queue, so callers must see an empty hash set — data reliability has to be off for such a chain")
+}

--- a/protocol/endpointstate/endpoint_monitor.go
+++ b/protocol/endpointstate/endpoint_monitor.go
@@ -408,13 +408,19 @@ func (m *EndpointMonitor) headOnlyTracking() bool {
 	if m.chainParser == nil {
 		return false
 	}
-	if _, _, hasLatest := m.chainParser.GetParsingByTag(spectypes.FUNCTION_TAG_GET_BLOCKNUM); !hasLatest {
+	// GetParsingByTag returns (val.Parsing, _, true) straight from the map, so a tag present
+	// with a nil directive yields ok==true and an unusable parsing. Treat that as absent on
+	// both tags — the same `ok && parsing != nil` guard resolveTipApiNames uses. Checking only
+	// ok would let a malformed GET_BLOCK_BY_NUM entry keep a head-only chain in the hash-
+	// fetching path, which is the exact failure this mode exists to avoid.
+	latest, _, hasLatest := m.chainParser.GetParsingByTag(spectypes.FUNCTION_TAG_GET_BLOCKNUM)
+	if !hasLatest || latest == nil {
 		// No way to read the head either — not a head-only chain, just an unusable one.
 		// Leave the existing failure path to report it.
 		return false
 	}
-	_, _, hasByNum := m.chainParser.GetParsingByTag(spectypes.FUNCTION_TAG_GET_BLOCK_BY_NUM)
-	return !hasByNum
+	byNum, _, hasByNum := m.chainParser.GetParsingByTag(spectypes.FUNCTION_TAG_GET_BLOCK_BY_NUM)
+	return !hasByNum || byNum == nil
 }
 
 func (m *EndpointMonitor) trackerStartRetryDelay(attempt int) time.Duration {

--- a/protocol/endpointstate/endpoint_monitor.go
+++ b/protocol/endpointstate/endpoint_monitor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/endpointtip"
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
 	"github.com/magma-Devs/smart-router/utils"
 )
 
@@ -261,6 +262,10 @@ func (m *EndpointMonitor) GetOrCreateTracker(
 		BlocksCheckpointDistance: chaintracker.DefaultBlockCheckpointDistance,
 		ChainId:                  m.chainID,
 		ParseDirectiveEnabled:    true, // Always enabled for direct RPC
+		// MAG-2218: a spec with a head but no usable GET_BLOCK_BY_NUM runs head-only rather
+		// than failing every hash fetch forever. ParseDirectiveEnabled stays true — turning it
+		// off would swap in a DummyChainTracker, which polls nothing at all.
+		HeadOnlyTracking: m.headOnlyTracking(),
 		// MAG-2159 (Topic B): per-endpoint trackers use a FIXED flat cadence — the
 		// dedicated poll runs at exactly avgBlockTime/2 (slowed only by failure backoff),
 		// because relay harvest is the primary block signal and the poll is a sparse
@@ -388,6 +393,28 @@ func (m *EndpointMonitor) startTrackerWithRetry(tracker chaintracker.IChainTrack
 		case <-timer.C:
 		}
 	}
+}
+
+// headOnlyTracking reports whether this chain can be tracked by head alone: it exposes a
+// current block/offset (GET_BLOCKNUM) but has no usable "fetch block N" (GET_BLOCK_BY_NUM).
+// Canton is the case that forced this (MAG-2218) — its Ledger API reads are party-scoped and
+// not addressable by block number, so a generic per-block fetch cannot be expressed.
+//
+// Deliberately keyed on the directives the spec actually declares rather than on a chain
+// allowlist, and it mirrors the graceful degradation resolveTipApiNames already does for the
+// same tag. A chain declaring both tags is unaffected — as of MAG-2218 every shipped spec
+// declares both, so this returns false for all of them.
+func (m *EndpointMonitor) headOnlyTracking() bool {
+	if m.chainParser == nil {
+		return false
+	}
+	if _, _, hasLatest := m.chainParser.GetParsingByTag(spectypes.FUNCTION_TAG_GET_BLOCKNUM); !hasLatest {
+		// No way to read the head either — not a head-only chain, just an unusable one.
+		// Leave the existing failure path to report it.
+		return false
+	}
+	_, _, hasByNum := m.chainParser.GetParsingByTag(spectypes.FUNCTION_TAG_GET_BLOCK_BY_NUM)
+	return !hasByNum
 }
 
 func (m *EndpointMonitor) trackerStartRetryDelay(attempt int) time.Duration {

--- a/protocol/endpointstate/head_only_selector_test.go
+++ b/protocol/endpointstate/head_only_selector_test.go
@@ -1,0 +1,85 @@
+package endpointstate
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/magma-Devs/smart-router/protocol/chainlib"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// headOnlyTracking is the production selector for MAG-2218's head-only mode: the tracker
+// tests set the config flag directly, so without this the mode could be entirely dead in
+// production and every one of them would still pass.
+func TestHeadOnlyTracking_Selector(t *testing.T) {
+	directive := &spectypes.ParseDirective{}
+
+	for _, tc := range []struct {
+		name string
+		// nil means the tag is absent (ok=false); otherwise the directive returned with ok=true.
+		latest *spectypes.ParseDirective
+		byNum  *spectypes.ParseDirective
+		// present marks a tag returned with ok=true, which lets us cover ok=true + nil parsing.
+		latestPresent bool
+		byNumPresent  bool
+		want          bool
+	}{
+		{
+			name:          "both tags present: normal chain, hashed tracking",
+			latest:        directive,
+			byNum:         directive,
+			latestPresent: true, byNumPresent: true,
+			want: false,
+		},
+		{
+			name:          "head only, no block-by-number: the Canton shape",
+			latest:        directive,
+			latestPresent: true,
+			want:          true,
+		},
+		{
+			name: "neither tag: not head-only, just untrackable",
+			want: false,
+		},
+		{
+			name:         "no head but has block-by-number: not head-only",
+			byNum:        directive,
+			byNumPresent: true,
+			want:         false,
+		},
+		{
+			// GetParsingByTag returns the map value straight through, so a tag registered with a
+			// nil directive yields ok=true and an unusable parsing. Checking ok alone would keep
+			// this chain in the hash-fetching path — the failure head-only exists to avoid.
+			name:          "block-by-number present but nil: treated as absent",
+			latest:        directive,
+			latestPresent: true, byNumPresent: true, byNum: nil,
+			want: true,
+		},
+		{
+			name:          "head present but nil: not head-only",
+			latestPresent: true, latest: nil,
+			want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			parser := chainlib.NewMockChainParser(ctrl)
+			parser.EXPECT().GetParsingByTag(spectypes.FUNCTION_TAG_GET_BLOCKNUM).
+				Return(tc.latest, nil, tc.latestPresent).AnyTimes()
+			parser.EXPECT().GetParsingByTag(spectypes.FUNCTION_TAG_GET_BLOCK_BY_NUM).
+				Return(tc.byNum, nil, tc.byNumPresent).AnyTimes()
+
+			m := &EndpointMonitor{chainParser: parser}
+			require.Equal(t, tc.want, m.headOnlyTracking())
+		})
+	}
+}
+
+func TestHeadOnlyTracking_NilParserIsSafe(t *testing.T) {
+	m := &EndpointMonitor{}
+	require.False(t, m.headOnlyTracking(), "a nil parser must not panic or enable head-only")
+}


### PR DESCRIPTION
## Problem

A spec can define `GET_BLOCKNUM` without any viable `GET_BLOCK_BY_NUM`. Canton is the case that forced this: its Ledger API update reads are party-scoped and not addressable by block number, so a generic "get block N" cannot be expressed and every hash fetch returns `PERMISSION_DENIED` even with a valid token.

Such a chain is not rejected today — it fails in a way that **looks like it works**:

- `start()` fails on the hash step, so `startTrackerWithRetry` retries forever: a warning every cycle, endpoint parked in `EndpointChainTrackerRetryingStart`
- the only reason a tip reaches ChainState at all is that each retry's `FetchLatestBlockNum` fires its poll observation on the way past
- so the tip refreshes at the start-retry backoff, capped at **30s**, instead of the intended `avgBlockTime/2`

Accidental, and invisible unless you read the logs.

## Approach

Head-only mode keeps the poll loop and drops only the hash work: no fork check, no block queue, head advanced straight from `FetchLatestBlockNum`.

**Deliberately not done by flipping `ParseDirectiveEnabled` to false**, which looks like the one-line version of this. That yields a `DummyChainTracker`, which has no poll loop at all (`StartAndServe` returns nil, `CurrentPollInterval` 0) and reports the MaxInt64 sentinel — it would never call `FetchLatestBlockNum`, so the tip feed would die with it. That mode is for chains with no block concept whatsoever; this one is for "has a head, has no hashes". `TestHeadOnly_KeepsPolling` pins the difference.

Selection is keyed on the directives a spec actually declares, not a chain allowlist, mirroring the graceful degradation `resolveTipApiNames` already does for the same tag.

## Two things found while building it

**`GetLatestBlockData` treated an empty queue as an error** and logged at ERROR on every call. In head-only that queue is empty by construction, so it now answers with the head and no hashes, matching what `DummyChainTracker` already returns. The interface method has no production caller in this fork today.

**The selector had a nil-directive hole.** `GetParsingByTag` returns the map value straight through, so a tag registered with a nil directive yields `existed == true` with an unusable parsing — a spec with a malformed `GET_BLOCK_BY_NUM` would have stayed in the hash-fetching path, exactly the failure this mode exists to avoid. Now guarded with `ok && parsing != nil`.

## Blast radius

An audit over **all 227 specs** found every one declares both tags, so no existing chain changes behaviour — and equally, nothing in the regression suite exercises this path. Hence the dedicated tests, including a control asserting the same fetcher still fails *without* the mode, so the cover cannot quietly stop proving anything.

Per-interface behaviour is automatic: `NewChainParser(rpcEndpoint.ApiInterface)` gives one parser per chain and interface, and `NewEndpointMonitor` is constructed inside `ServeRPCRequests` per listen endpoint — so a chain's REST and gRPC legs decide independently.

Chains in this mode must run with data reliability and finalization proofs off, since neither is satisfiable without hashes.

## Testing

`go test ./protocol/chaintracker/... ./protocol/endpointstate/... ./protocol/rpcsmartrouter/... ./protocol/chainlib/...` — all pass. Head-only tests also pass under `-race`.

⚠️ **Pre-existing, not from this PR:** `TestChainTrackerCallbacks` and `TestChainTrackerFetchSpreadAcrossPollingTime` fail under `-race` due to races in the existing `MockChainFetcher`. Verified by running `-race` on unmodified `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)