### PR TITLE
fix(relaycore): drop the finality distance from EndpointLagThreshold

### DIFF
--- a/protocol/relaycore/consistency_config.go
+++ b/protocol/relaycore/consistency_config.go
@@ -50,29 +50,30 @@ func DefaultConsistencyValidationConfig() *ConsistencyValidationConfig {
 //
 // Parameters:
 //   - blockLagForQosSync: The block lag threshold used for QoS sync calculations
-//   - blockDistanceToFinalization: The number of blocks until finalization
 //   - averageBlockTime: The average time between blocks for this chain
 //   - blockGapFactor: polling-relief multiplier on blockLagForQosSync (0 = default 2)
 //
 // Derivation logic:
-//   - EndpointLagThreshold: max(blockLagForQosSync*blockGapFactor, blockDistanceToFinalization), minimum 10
+//   - EndpointLagThreshold: max(blockLagForQosSync*blockGapFactor, 10)
 //   - MaxWaitTime: averageBlockTime * 2 - wait up to 2 average block times
+//
+// EndpointLagThreshold bounds how stale an endpoint may be before we stop routing to it, so it
+// derives from blockLagForQosSync alone: this gate only ever sees LATEST_BLOCK requests, since
+// ShouldSkipConsistencyValidation skips concrete blocks and the finalized/safe/earliest/pending
+// tags. A chain's finality distance bounds something else — when data stops changing — and belongs
+// to cache-write finalization. Raise allowed_block_lag_for_qos_sync, or set
+// --consistency-block-gap-factor, when a chain needs more tolerance.
 func NewConsistencyValidationConfig(
 	blockLagForQosSync int64,
-	blockDistanceToFinalization uint32,
 	averageBlockTime time.Duration,
 	blockGapFactor int64,
 ) *ConsistencyValidationConfig {
-	// Calculate endpoint lag threshold: use the larger of double QoS sync lag
-	// or the finalization distance, to ensure endpoints can serve finalized blocks.
+	// Calculate endpoint lag threshold from the QoS sync lag.
 	gapFactor := int64(2)
 	if blockGapFactor != 0 {
 		gapFactor = blockGapFactor
 	}
 	endpointLagThreshold := blockLagForQosSync * gapFactor
-	if finalizationThreshold := int64(blockDistanceToFinalization); finalizationThreshold > endpointLagThreshold {
-		endpointLagThreshold = finalizationThreshold
-	}
 	// Apply a minimum of 10 blocks
 	if endpointLagThreshold < 10 {
 		endpointLagThreshold = 10
@@ -98,7 +99,7 @@ func NewConsistencyValidationConfig(
 		utils.LogAttr("endpointLagThreshold", config.EndpointLagThreshold),
 		utils.LogAttr("maxWaitTime", config.MaxWaitTime),
 		utils.LogAttr("blockLagForQosSync", blockLagForQosSync),
-		utils.LogAttr("blockDistanceToFinalization", blockDistanceToFinalization),
+		utils.LogAttr("blockGapFactor", gapFactor),
 		utils.LogAttr("averageBlockTime", averageBlockTime),
 	)
 

--- a/protocol/relaycore/consistency_validation_test.go
+++ b/protocol/relaycore/consistency_validation_test.go
@@ -232,55 +232,53 @@ func TestConsistencyValidationConfig_Creation(t *testing.T) {
 		require.Equal(t, 500*time.Millisecond, config.MaxWaitTime)
 	})
 
-	t.Run("config from chain spec - typical EVM", func(t *testing.T) {
-		// Typical EVM: blockLagForQosSync=3, finalization=64, avgBlockTime=12s
-		config := NewConsistencyValidationConfig(3, 64, 12*time.Second, 0)
+	t.Run("config from chain spec - typical EVM, floor dominates", func(t *testing.T) {
+		// Typical EVM: blockLagForQosSync=3, avgBlockTime=12s
+		config := NewConsistencyValidationConfig(3, 12*time.Second, 0)
 		require.NotNil(t, config)
-		// EndpointLagThreshold = max(3*2=6, 64) = 64, but min 10, so 64
-		require.Equal(t, int64(64), config.EndpointLagThreshold)
+		// EndpointLagThreshold = max(3*2=6, 10) = 10 (minimum)
+		require.Equal(t, int64(10), config.EndpointLagThreshold)
 		// MaxWaitTime = min(12s*2=24s, 5s cap) = 5s
 		require.Equal(t, 5*time.Second, config.MaxWaitTime)
 	})
 
-	t.Run("config from chain spec - fast chain", func(t *testing.T) {
-		// Fast chain: blockLagForQosSync=10, finalization=32, avgBlockTime=2s
-		config := NewConsistencyValidationConfig(10, 32, 2*time.Second, 0)
+	t.Run("config from chain spec - fast chain, QoS lag dominates", func(t *testing.T) {
+		// Fast chain: blockLagForQosSync=10, avgBlockTime=2s
+		config := NewConsistencyValidationConfig(10, 2*time.Second, 0)
 		require.NotNil(t, config)
-		// EndpointLagThreshold = max(10*2=20, 32) = 32
-		require.Equal(t, int64(32), config.EndpointLagThreshold)
+		// EndpointLagThreshold = max(10*2=20, 10) = 20
+		require.Equal(t, int64(20), config.EndpointLagThreshold)
 		// MaxWaitTime = 2s*2 = 4s
 		require.Equal(t, 4*time.Second, config.MaxWaitTime)
 	})
 
 	t.Run("config from chain spec - slow chain", func(t *testing.T) {
-		// Slow chain: blockLagForQosSync=1, finalization=6, avgBlockTime=60s
-		config := NewConsistencyValidationConfig(1, 6, 60*time.Second, 0)
+		// Slow chain: blockLagForQosSync=1, avgBlockTime=60s
+		config := NewConsistencyValidationConfig(1, 60*time.Second, 0)
 		require.NotNil(t, config)
-		// EndpointLagThreshold = max(1*2=2, 6) = 10 (minimum)
+		// EndpointLagThreshold = max(1*2=2, 10) = 10 (minimum)
 		require.Equal(t, int64(10), config.EndpointLagThreshold)
 		// MaxWaitTime = min(60s*2=120s, 5s cap) = 5s
 		require.Equal(t, 5*time.Second, config.MaxWaitTime)
 	})
 
 	t.Run("config from chain spec - very fast block time", func(t *testing.T) {
-		// Very fast: blockLagForQosSync=20, finalization=100, avgBlockTime=100ms
-		config := NewConsistencyValidationConfig(20, 100, 100*time.Millisecond, 0)
+		// Very fast: blockLagForQosSync=20, avgBlockTime=100ms
+		config := NewConsistencyValidationConfig(20, 100*time.Millisecond, 0)
 		require.NotNil(t, config)
-		// EndpointLagThreshold = max(20*2=40, 100) = 100
-		require.Equal(t, int64(100), config.EndpointLagThreshold)
+		// EndpointLagThreshold = max(20*2=40, 10) = 40
+		require.Equal(t, int64(40), config.EndpointLagThreshold)
 		// MaxWaitTime = max(100ms*2=200ms, 500ms floor) = 500ms
 		require.Equal(t, 500*time.Millisecond, config.MaxWaitTime)
 	})
 
-	t.Run("block-gap-factor widens the threshold when QoS-lag dominates (polling-relief)", func(t *testing.T) {
-		// Solana-like: blockLagForQosSync=25 with a small finalization distance, so the
-		// QoS-lag term dominates the max() and the factor actually moves the threshold.
-		// (On finalization-dominated chains like EVM the factor is inert until it exceeds
-		// the finalization distance.)
-		require.Equal(t, int64(50), NewConsistencyValidationConfig(25, 5, 400*time.Millisecond, 0).EndpointLagThreshold)  // 0 -> default x2
-		require.Equal(t, int64(50), NewConsistencyValidationConfig(25, 5, 400*time.Millisecond, 2).EndpointLagThreshold)  // explicit 2 == default
-		require.Equal(t, int64(100), NewConsistencyValidationConfig(25, 5, 400*time.Millisecond, 4).EndpointLagThreshold) // x4
-		require.Equal(t, int64(200), NewConsistencyValidationConfig(25, 5, 400*time.Millisecond, 8).EndpointLagThreshold) // x8
+	t.Run("block-gap-factor scales the threshold (polling-relief)", func(t *testing.T) {
+		// Solana-like: blockLagForQosSync=25, so the derived term clears the 10 floor and the
+		// factor actually moves the threshold.
+		require.Equal(t, int64(50), NewConsistencyValidationConfig(25, 400*time.Millisecond, 0).EndpointLagThreshold)  // 0 -> default x2
+		require.Equal(t, int64(50), NewConsistencyValidationConfig(25, 400*time.Millisecond, 2).EndpointLagThreshold)  // explicit 2 == default
+		require.Equal(t, int64(100), NewConsistencyValidationConfig(25, 400*time.Millisecond, 4).EndpointLagThreshold) // x4
+		require.Equal(t, int64(200), NewConsistencyValidationConfig(25, 400*time.Millisecond, 8).EndpointLagThreshold) // x8
 	})
 }
 

--- a/protocol/rpcsmartrouter/probe_loop_test.go
+++ b/protocol/rpcsmartrouter/probe_loop_test.go
@@ -19,8 +19,8 @@ func TestProbeVerdictConfigFor_SourcesLagToleranceFromConsistency(t *testing.T) 
 	const blockTime = time.Second
 
 	t.Run("per-chain threshold overrides the default", func(t *testing.T) {
-		// A wide finalization distance derives EndpointLagThreshold well above 10.
-		cc := relaycore.NewConsistencyValidationConfig(5 /*blockLagForQosSync*/, 64 /*finalization*/, blockTime, 0)
+		// A large QoS-sync lag derives EndpointLagThreshold well above 10.
+		cc := relaycore.NewConsistencyValidationConfig(32 /*blockLagForQosSync*/, blockTime, 0)
 		require.Greater(t, cc.EndpointLagThreshold, int64(10), "precondition: derived threshold exceeds the default")
 
 		cfg := probeVerdictConfigFor(blockTime, cc)

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -158,11 +158,11 @@ func (rpcss *RPCSmartRouterServer) ServeRPCRequests(
 			utils.LogAttr("groupAssignments", groupAssignments))
 	}
 
-	// Initialize consistency validation config from chain spec values
-	blockLagForQosSync, averageBlockTime, blockDistanceForFinalizedData, _ := chainParser.ChainBlockStats()
+	// Initialize consistency validation config from chain spec values. The finalization distance
+	// bounds cache-write finalization, not endpoint staleness — see NewConsistencyValidationConfig.
+	blockLagForQosSync, averageBlockTime, _, _ := chainParser.ChainBlockStats()
 	rpcss.consistencyConfig = relaycore.NewConsistencyValidationConfig(
 		blockLagForQosSync,
-		blockDistanceForFinalizedData,
 		averageBlockTime,
 		relaycore.ConsistencyBlockGapFactorOverride, // polling-relief: 0 = default x2
 	)
@@ -2323,8 +2323,8 @@ func (s *probeLoopStats) snapshot() probeLoopSnapshot {
 //
 // The "keeping up" tolerance is sourced from the SAME per-chain threshold consistency pre-validation
 // uses (relaycore.EndpointLagThreshold), not the probing package's compile-time default of 10. On a
-// chain whose derived threshold exceeds 10 (large blockLagForQosSync, wide finalization distance, or
-// an operator's --consistency-block-gap-factor override) the relay path would otherwise serve an
+// chain whose derived threshold exceeds 10 (large blockLagForQosSync, or an operator's
+// --consistency-block-gap-factor override) the relay path would otherwise serve an
 // endpoint lagging 11..threshold blocks while every probe cycle marked it unhealthy — decaying its
 // QoS and, worse, blocking the F1 re-enable (RecoveryEvidence.PollHealthy requires keepingUp under
 // the same tolerance), so a disabled endpoint within the accepted lag could never recover until the


### PR DESCRIPTION
# Description

`EndpointLagThreshold` was derived as:

```
max(allowed_block_lag_for_qos_sync × gapFactor, block_distance_for_finalized_data, 10)
```

That last term means raising a chain's **finality distance** silently loosens the **endpoint-staleness gate** — two unrelated things. This PR removes it.

## Why the finality term can't do its stated job

The comment justified it as *"to ensure endpoints can serve finalized blocks"*. That cannot hold here:

- The gate it feeds (`ValidateEndpointCapability`, via `rpcsmartrouter_server.go:1924`) runs **only for `LATEST_BLOCK`**. `ShouldSkipConsistencyValidation` skips every concrete block number and the `finalized` / `safe` / `earliest` / `pending` tags — so the finalized-data requests it claimed to protect never reach it.
- For the one case that *does* reach it ("give me the head"), a deeper finality distance argued for tolerating a **staler** head. That's backwards: a chain with deep reorgs is not a chain where a lagging endpoint is more acceptable.

The two values answer unrelated questions — *how deep before the chain stops rewriting a block* vs *how out of date an endpoint may be before we stop routing to it* — and the spec already carries `allowed_block_lag_for_qos_sync` (plus `--consistency-block-gap-factor`) for the latter.

The coupling is inherited verbatim from `lavanet/lava` (`protocol/relaycore/consistency_config.go`), where it made sense alongside provider-side data reliability and finalization proofs. This fork has neither — nothing reads `blocks_in_finalization_proof` at all.

## Blast radius

`block_distance_for_finalized_data` is bound at exactly four non-test sites. This PR touches one:

| Site | Consumer | Changed? |
|---|---|---|
| `rpcsmartrouter_server.go:162` | consistency gate → probe verdicts | **yes** |
| `rpcsmartrouter_server.go:578` | cross-validation finality metric label | no |
| `rpcsmartrouter_server.go:3028` | cache write finalized/temp split | no |
| `chain_fetcher.go:625` | inert — all 5 production `NewChainFetcher` call sites pass `Cache: nil`, and `populateCache` is gated on `cache.CacheActive()` | no |

`EndpointLagThreshold` is the only path from the finality distance into consistency validation and the probe loop: `ValidateEndpointCapability`'s other inputs come from the endpointtip store and `chainstate` (`DefaultConfig` derives everything from block time), and `probeVerdictConfigFor` only copies `LagToleranceBlocks`. `Spec.GetBlockDistanceForFinalizedData()` has zero callers.

## No behaviour change today

Computed `max(2×lag, bdffd, 10)` vs `max(2×lag, 10)` across all 24 specs in `specs/` — **identical for every one**. The `2×lag` term or the 10 floor already dominated everywhere, including `ETH1` (bdffd=8, but 2×2=4 → floor 10 wins) and `BTC` (bdffd=6 → floor 10 wins).

It only takes effect if a chain later raises `block_distance_for_finalized_data` past that point — which is exactly the case this decouples. Context: [lavanet/lava#2316](https://github.com/lavanet/lava/pull/2316) proposes raising it on DOGE (1→40), BCH (1→15), LTC (1→13), TRX (4→20) et al. for cache-immutability reasons. Without this change, importing those values would also quadruple DOGE's tolerated endpoint lag (10→40 blocks, ~15 min → ~60 min) and double TRX's — an unrelated, unrequested loosening. With it, that spec change moves the gate by zero.

## Note on the signature

`blockDistanceToFinalization` is **removed from the parameter list** rather than left unused, so the coupling can't be reintroduced by accident and the signature honestly reflects the derivation. This is a small API break for callers (one production call site, two test files, all updated here). Say the word if you'd rather keep the parameter for signature parity with upstream.

## Tests

- `consistency_validation_test.go` — the three cases that asserted `max(…, finalization)` (expecting 64 / 32 / 100) now assert the QoS-lag derivation, and are re-labelled to say which term binds (floor vs QoS lag). The `block-gap-factor` case keeps its values; only its now-stale comment about the finalization term changed.
- `probe_loop_test.go` — this test used `finalization=64` purely as a *lever* to push the threshold above 10 so it could assert the probe sources its tolerance from the per-chain threshold. Lever switched to `blockLagForQosSync=32`; the assertion is unchanged.

`go build ./...`, `go vet`, and `go test ./protocol/... ./types/... ./utils/...` all pass. `gofumpt` reports nothing on the touched files.

---

## Author Checklist

* [x] read the contribution guide
* [x] included the correct type prefix in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change — internal Go signature only, no client/API surface; flagged under "Note on the signature" above
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests
* [x] updated the relevant documentation or specification, including comments for documenting Go code
* [ ] confirmed all CI checks have passed — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)