### PR TITLE
fix(smart-router): gate probe re-enable on replaying the failing relay (MAG-2550)

### DIFF
--- a/protocol/lavasession/common.go
+++ b/protocol/lavasession/common.go
@@ -57,7 +57,16 @@ const (
 	// maxRelayProbePayloadBytes caps the recorded failing-relay request (MAG-2550 recovery evidence).
 	// A read-only JSON-RPC call is normally well under 1KB; anything larger (giant batches, abusive
 	// payloads) is not worth holding per-endpoint for the prober and is simply not recorded.
-	maxRelayProbePayloadBytes                               = 8 * 1024
+	maxRelayProbePayloadBytes = 8 * 1024
+	// maxRelayProbeAttempts bounds how many consecutive replays of ONE recorded failing relay may
+	// conclude non-recovered (still-failing or inconclusive) before the evidence is dropped and the
+	// episode falls back to the poll-only re-enable path with its trial budget. Without this bound,
+	// evidence whose replay can never pass (a request that is simply too expensive for this
+	// endpoint, pruned state, a permanently unclassifiable reply) would hold the endpoint out of
+	// rotation until the epoch reset even though it is healthy for everything else. The trial
+	// budget still caps client exposure after the fallback re-enable, so giving up on the evidence
+	// keeps the anti-flap protection while guaranteeing a bounded escape (MAG-2550 review).
+	maxRelayProbeAttempts                            uint64 = 3
 	TimeoutForEstablishingAConnection                       = 1500 * time.Millisecond // 1.5 seconds
 	MaximumNumberOfFailuresAllowedPerConsumerSession        = 15
 	RelayNumberIncrement                                    = 1

--- a/protocol/lavasession/common.go
+++ b/protocol/lavasession/common.go
@@ -46,7 +46,18 @@ const (
 	// even a perpetually-flapping endpoint is re-probed within a bounded window (~60s at a 5s cadence)
 	// — deliberately far below the ~15-minute epoch re-probe, so the dampening never parks a node that
 	// is genuinely healthy for cheap traffic. A successful relay (Endpoint.ResetHealth) decays it to 0.
-	maxReenableProbeFlaps                            uint64 = 2
+	maxReenableProbeFlaps uint64 = 2
+	// probeReenableTrialBudget is the consecutive-relay-failure budget granted by a PROBE re-enable
+	// (RecordProbeVerdict / ConfirmRelayRecovery), replacing the full MaxConsecutiveConnectionAttempts
+	// reset. A probe-granted re-enable rests on cheap-poll evidence (plus at most ONE replayed relay),
+	// not on real traffic, so a still-broken endpoint must fall back out of rotation after a handful of
+	// real failures — not after burning another 50 client requests (MAG-2550). A successful real relay
+	// (Endpoint.ResetHealth) upgrades the endpoint to the full budget.
+	probeReenableTrialBudget uint64 = 3
+	// maxRelayProbePayloadBytes caps the recorded failing-relay request (MAG-2550 recovery evidence).
+	// A read-only JSON-RPC call is normally well under 1KB; anything larger (giant batches, abusive
+	// payloads) is not worth holding per-endpoint for the prober and is simply not recorded.
+	maxRelayProbePayloadBytes                               = 8 * 1024
 	TimeoutForEstablishingAConnection                       = 1500 * time.Millisecond // 1.5 seconds
 	MaximumNumberOfFailuresAllowedPerConsumerSession        = 15
 	RelayNumberIncrement                                    = 1

--- a/protocol/lavasession/consumer_types.go
+++ b/protocol/lavasession/consumer_types.go
@@ -207,9 +207,19 @@ type Endpoint struct {
 	// successful relay (ResetHealth) decays it back to 0. The cap keeps a flapping endpoint re-probed
 	// within a bounded window rather than parked until the epoch transition.
 	reenableProbeFlaps uint64
-	Addons             map[string]struct{}
-	Extensions         map[string]struct{}
-	mu                 sync.RWMutex // Protects Connections, ConnectionRefusals, Enabled, consecutiveHealthyProbes, disabledAt, lastRecoveryPoll, probeReenabled, reenableProbeFlaps
+	// relayProbeMethod / relayProbePayload capture the most recent health-affecting relay failure
+	// attributable to a READ-ONLY method (recorded by the relay path via RecordFailingRelay just
+	// before MarkUnhealthy — never for writes/subscriptions/hanging APIs, and never for
+	// unsupported-method responses, which don't reach MarkUnhealthy at all). While present on a
+	// DISABLED endpoint they GATE the probe re-enable: poll hysteresis alone is not enough, the
+	// prober must replay this exact request successfully first (MAG-2550 — the poll method and the
+	// failing relay method measure different things, so polls can never prove the relay path
+	// recovered). Cleared on every re-enable so each disable episode records fresh evidence.
+	relayProbeMethod  string
+	relayProbePayload []byte
+	Addons            map[string]struct{}
+	Extensions        map[string]struct{}
+	mu                sync.RWMutex // Protects Connections, ConnectionRefusals, Enabled, consecutiveHealthyProbes, disabledAt, lastRecoveryPoll, probeReenabled, reenableProbeFlaps, relayProbeMethod, relayProbePayload
 
 	// Per-endpoint observed tip lives in the shared endpointtip store (single source of
 	// truth), keyed by chain+apiInterface+NetworkAddress — not on the Endpoint — so the
@@ -240,6 +250,10 @@ type EndpointHealthSnapshot struct {
 	DisabledAt               time.Time
 	ConsecutiveHealthyProbes uint64 // distinct post-disable successful polls counted toward F1 re-enable
 	LastRecoveryPoll         time.Time
+	// RelayProbeMethod is the read-only method recorded as this disable episode's failing relay
+	// (MAG-2550) — the request the prober must replay successfully before re-enabling. Empty when
+	// no method-attributable evidence was recorded (transport-fault episodes, write methods).
+	RelayProbeMethod string
 }
 
 // HealthSnapshot returns the endpoint's enable/recovery state under e.mu. Read-only companion to
@@ -254,6 +268,7 @@ func (e *Endpoint) HealthSnapshot() EndpointHealthSnapshot {
 		DisabledAt:               e.disabledAt,
 		ConsecutiveHealthyProbes: e.consecutiveHealthyProbes,
 		LastRecoveryPoll:         e.lastRecoveryPoll,
+		RelayProbeMethod:         e.relayProbeMethod,
 	}
 }
 
@@ -295,10 +310,53 @@ func (e *Endpoint) clearRecoveryStreakLocked() {
 // streak AND the disable timestamp, so a re-enabled endpoint gets a clean slate and a future
 // disable starts a fresh streak. Every re-enable site funnels through this, making "an Enabled
 // transition resets the recovery fields" a property of the type rather than a block each caller
-// must remember to copy. Caller must hold e.mu.
+// must remember to copy. The recorded failing-relay evidence is cleared here too: it belongs to
+// the disable episode that just ended — if the endpoint is still broken, the trial traffic after
+// re-enable re-records fresh evidence on its way back down. Caller must hold e.mu.
 func (e *Endpoint) clearRecoveryTrackingLocked() {
 	e.clearRecoveryStreakLocked()
 	e.disabledAt = time.Time{}
+	e.relayProbeMethod = ""
+	e.relayProbePayload = nil
+}
+
+// RecordFailingRelay stores one health-affecting relay failure as replayable recovery evidence for
+// this endpoint's next disable episode (MAG-2550). The caller (the relay path, just before
+// MarkUnhealthy) is responsible for eligibility: READ-ONLY methods only — never writes,
+// subscriptions, hanging APIs, or unsupported-method responses — and a self-contained payload
+// (JSON-RPC POST body). Oversized or empty payloads are dropped rather than truncated: a replay of
+// half a request proves nothing. Rolling: the newest eligible failure wins, so the evidence always
+// reflects what was failing when the disable threshold was finally crossed.
+func (e *Endpoint) RecordFailingRelay(method string, payload []byte) {
+	if method == "" || len(payload) == 0 || len(payload) > maxRelayProbePayloadBytes {
+		return
+	}
+	// Copy: the caller's buffer is the live request data owned by the relay path.
+	stored := make([]byte, len(payload))
+	copy(stored, payload)
+	e.mu.Lock()
+	e.relayProbeMethod = method
+	e.relayProbePayload = stored
+	e.mu.Unlock()
+}
+
+// reenableFromProbeLocked applies a PROBE-GRANTED Enabled→true transition. Unlike ResetHealth
+// (real-relay evidence → full clean slate), a probe grant rests on cheap polls plus at most one
+// replayed relay, so the endpoint returns to rotation with only a TRIAL refusal budget
+// (probeReenableTrialBudget consecutive failures re-disable it) instead of a fresh
+// MaxConsecutiveConnectionAttempts — bounding each flap cycle's client exposure (MAG-2550).
+// Caller must hold e.mu and logs the transition itself.
+func (e *Endpoint) reenableFromProbeLocked() {
+	e.Enabled = true
+	e.ConnectionRefusals = 0
+	if MaxConsecutiveConnectionAttempts > probeReenableTrialBudget {
+		e.ConnectionRefusals = MaxConsecutiveConnectionAttempts - probeReenableTrialBudget
+	}
+	// Mark the re-enable as probe-granted: a subsequent disable with this still set is a flap,
+	// a successful relay clears it (ResetHealth). clearRecoveryTrackingLocked deliberately does NOT
+	// touch reenableProbeFlaps — the escalation must persist across re-enables to dampen the flap.
+	e.probeReenabled = true
+	e.clearRecoveryTrackingLocked()
 }
 
 // MarkUnhealthy increments connection refusals and disables endpoint if threshold exceeded.
@@ -405,13 +463,16 @@ func (e *Endpoint) RecordProbeVerdict(recoveryPoll time.Time, recoveryHealthy bo
 		return false
 	}
 
-	e.Enabled = true
-	e.ConnectionRefusals = 0
-	// Mark the re-enable as probe-granted: a subsequent disable with this still set is a flap (above),
-	// a successful relay clears it (ResetHealth). clearRecoveryTrackingLocked deliberately does NOT
-	// touch reenableProbeFlaps — the escalation must persist across re-enables to dampen the flap.
-	e.probeReenabled = true
-	e.clearRecoveryTrackingLocked()
+	// Poll hysteresis satisfied — but if this disable episode recorded a failing READ-ONLY relay,
+	// polls alone are categorically insufficient evidence (the poll method and the failing relay
+	// method measure different things — MAG-2550). Hold the re-enable; the endpoint is now a
+	// replay candidate (PendingRelayProbe) and the prober must confirm with ConfirmRelayRecovery
+	// after successfully replaying the recorded request, or report RelayProbeFailed.
+	if len(e.relayProbePayload) > 0 {
+		return false
+	}
+
+	e.reenableFromProbeLocked()
 	utils.LavaFormatInfo("probe re-enabled recovered endpoint",
 		utils.LogAttr("endpoint", e.NetworkAddress),
 		utils.LogAttr("is_direct_rpc", e.IsDirectRPC()),
@@ -419,6 +480,84 @@ func (e *Endpoint) RecordProbeVerdict(recoveryPoll time.Time, recoveryHealthy bo
 		utils.LogAttr("reenable_probe_flaps", e.reenableProbeFlaps),
 	)
 	return true
+}
+
+// PendingRelayProbe reports whether this endpoint is a REPLAY CANDIDATE: disabled, poll hysteresis
+// satisfied (RecordProbeVerdict is holding the re-enable), and a failing read-only relay recorded
+// for the episode. The prober calls this right after RecordProbeVerdict each cycle; when ok, it
+// replays the returned payload OUTSIDE the endpoint mutex and reports the outcome via
+// ConfirmRelayRecovery / RelayProbeFailed. The candidate state is derived (not a stored flag), so
+// a later failed poll automatically withdraws candidacy until the streak is re-earned.
+// reEnableAfterK must be the same K passed to RecordProbeVerdict; <1 is treated as 1.
+func (e *Endpoint) PendingRelayProbe(reEnableAfterK uint64) (method string, payload []byte, ok bool) {
+	if reEnableAfterK < 1 {
+		reEnableAfterK = 1
+	}
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if e.Enabled || len(e.relayProbePayload) == 0 {
+		return "", nil, false
+	}
+	if e.consecutiveHealthyProbes < reEnableAfterK<<e.reenableProbeFlaps {
+		return "", nil, false
+	}
+	// Copy so the caller can use the payload after the lock is released without racing a
+	// concurrent RecordFailingRelay from an in-flight relay straggler.
+	payload = make([]byte, len(e.relayProbePayload))
+	copy(payload, e.relayProbePayload)
+	return e.relayProbeMethod, payload, true
+}
+
+// ConfirmRelayRecovery is the prober reporting that the recorded failing relay REPLAYED
+// SUCCESSFULLY against this endpoint — the relay-path evidence the poll could never supply
+// (MAG-2550). It completes the two-step re-enable that RecordProbeVerdict held open. Returns true
+// only on the actual Enabled→true transition (false if something else — a straggler relay's
+// ResetHealth, an epoch reset — re-enabled the endpoint meanwhile).
+func (e *Endpoint) ConfirmRelayRecovery() bool {
+	e.mu.Lock()
+	if e.Enabled {
+		e.mu.Unlock()
+		return false
+	}
+	e.reenableFromProbeLocked()
+	addr, isDirect, flaps := e.NetworkAddress, e.IsDirectRPC(), e.reenableProbeFlaps
+	e.mu.Unlock()
+
+	utils.LavaFormatInfo("probe re-enabled recovered endpoint",
+		utils.LogAttr("endpoint", addr),
+		utils.LogAttr("is_direct_rpc", isDirect),
+		utils.LogAttr("relay_probe", "confirmed"),
+		utils.LogAttr("reenable_probe_flaps", flaps),
+	)
+	return true
+}
+
+// RelayProbeFailed is the prober reporting that the recorded failing relay STILL FAILS on replay:
+// the endpoint answers cheap polls but its relay path is demonstrably still broken. The streak
+// resets (the next replay attempt must re-earn the full poll hysteresis — this paces replays, one
+// per earned streak, instead of one per probe cycle) and the flap escalation advances: unlike the
+// legacy escalation, which needed a re-enable→re-disable cycle THROUGH REAL CLIENT TRAFFIC to
+// learn this, the replay proves poll-healthy/relay-broken without exposing a single client request.
+// lastRecoveryPoll is preserved (invalid-evidence convention) so an already-counted poll cannot be
+// re-counted toward the next streak.
+func (e *Endpoint) RelayProbeFailed() {
+	e.mu.Lock()
+	if e.Enabled {
+		e.mu.Unlock()
+		return
+	}
+	e.consecutiveHealthyProbes = 0
+	if e.reenableProbeFlaps < maxReenableProbeFlaps {
+		e.reenableProbeFlaps++
+	}
+	addr, method, flaps := e.NetworkAddress, e.relayProbeMethod, e.reenableProbeFlaps
+	e.mu.Unlock()
+
+	utils.LavaFormatInfo("relay probe still failing, endpoint stays disabled",
+		utils.LogAttr("endpoint", addr),
+		utils.LogAttr("method", method),
+		utils.LogAttr("reenable_probe_flaps", flaps),
+	)
 }
 
 // ResetHealth resets connection refusals and re-enables endpoint.
@@ -435,16 +574,26 @@ func (e *Endpoint) ResetHealth() bool {
 		e.mu.Unlock()
 		return false
 	}
+	wasEnabled := e.Enabled
 	e.ConnectionRefusals = 0
 	e.Enabled = true
 	e.clearRecoveryTrackingLocked()
 	addr, isDirect := e.NetworkAddress, e.IsDirectRPC()
 	e.mu.Unlock()
 
-	utils.LavaFormatInfo("re-enabled healthy endpoint",
-		utils.LogAttr("endpoint", addr),
-		utils.LogAttr("is_direct_rpc", isDirect),
-	)
+	if wasEnabled {
+		// Already enabled with a nonzero refusal count — typically a probe-granted trial budget
+		// (reenableFromProbeLocked) that a real relay just validated. Not a re-enable transition.
+		utils.LavaFormatDebug("relay success validated endpoint, full health restored",
+			utils.LogAttr("endpoint", addr),
+			utils.LogAttr("is_direct_rpc", isDirect),
+		)
+	} else {
+		utils.LavaFormatInfo("re-enabled healthy endpoint",
+			utils.LogAttr("endpoint", addr),
+			utils.LogAttr("is_direct_rpc", isDirect),
+		)
+	}
 	return true
 }
 

--- a/protocol/lavasession/consumer_types.go
+++ b/protocol/lavasession/consumer_types.go
@@ -209,7 +209,7 @@ type Endpoint struct {
 	reenableProbeFlaps uint64
 	// relayProbeMethod / relayProbePayload capture the most recent health-affecting relay failure
 	// attributable to a READ-ONLY method (recorded by the relay path via RecordFailingRelay just
-	// before MarkUnhealthy — never for writes/subscriptions/hanging APIs, and never for
+	// before MarkUnhealthy — never for writes/subscriptions/hanging APIs/batches, and never for
 	// unsupported-method responses, which don't reach MarkUnhealthy at all). While present on a
 	// DISABLED endpoint they GATE the probe re-enable: poll hysteresis alone is not enough, the
 	// prober must replay this exact request successfully first (MAG-2550 — the poll method and the
@@ -217,9 +217,20 @@ type Endpoint struct {
 	// recovered). Cleared on every re-enable so each disable episode records fresh evidence.
 	relayProbeMethod  string
 	relayProbePayload []byte
-	Addons            map[string]struct{}
-	Extensions        map[string]struct{}
-	mu                sync.RWMutex // Protects Connections, ConnectionRefusals, Enabled, consecutiveHealthyProbes, disabledAt, lastRecoveryPoll, probeReenabled, reenableProbeFlaps, relayProbeMethod, relayProbePayload
+	// relayProbeTimeout is the relay path's effective timeout for the recorded request (the spec's
+	// per-API/CU-derived budget it was actually given when it failed). The replay must judge the
+	// request under AT LEAST this budget: a flat probe timeout below the relay path's would fail
+	// every slow-but-recovered heavy method forever (MAG-2550 review).
+	relayProbeTimeout time.Duration
+	// relayProbeAttempts counts consecutive replays of the CURRENT evidence that concluded
+	// non-recovered (still-failing or inconclusive). At maxRelayProbeAttempts the evidence is
+	// dropped (dropRelayProbeEvidenceLocked) so the episode falls back to the poll-only re-enable
+	// path — the bounded escape hatch for evidence whose replay can never pass. Reset when fresh
+	// evidence is recorded.
+	relayProbeAttempts uint64
+	Addons             map[string]struct{}
+	Extensions         map[string]struct{}
+	mu                 sync.RWMutex // Protects Connections, ConnectionRefusals, Enabled, consecutiveHealthyProbes, disabledAt, lastRecoveryPoll, probeReenabled, reenableProbeFlaps, relayProbeMethod, relayProbePayload, relayProbeTimeout, relayProbeAttempts
 
 	// Per-endpoint observed tip lives in the shared endpointtip store (single source of
 	// truth), keyed by chain+apiInterface+NetworkAddress — not on the Endpoint — so the
@@ -252,8 +263,17 @@ type EndpointHealthSnapshot struct {
 	LastRecoveryPoll         time.Time
 	// RelayProbeMethod is the read-only method recorded as this disable episode's failing relay
 	// (MAG-2550) — the request the prober must replay successfully before re-enabling. Empty when
-	// no method-attributable evidence was recorded (transport-fault episodes, write methods).
+	// no replayable evidence was recorded (non-JSON-RPC interfaces, writes, subscriptions, hanging
+	// APIs, batches, oversized payloads) or when the evidence was dropped after
+	// maxRelayProbeAttempts non-recovered replays.
 	RelayProbeMethod string
+	// RelayProbeAttempts is how many consecutive replays of the current evidence concluded
+	// non-recovered; the evidence is dropped at maxRelayProbeAttempts (the poll-only fallback).
+	RelayProbeAttempts uint64
+	// ReenableProbeFlaps is the current flap-escalation level (effective re-enable hysteresis is
+	// reEnableAfterK << ReenableProbeFlaps) — on-call's answer to "why is this endpoint earning
+	// such a long streak".
+	ReenableProbeFlaps uint64
 }
 
 // HealthSnapshot returns the endpoint's enable/recovery state under e.mu. Read-only companion to
@@ -269,6 +289,8 @@ func (e *Endpoint) HealthSnapshot() EndpointHealthSnapshot {
 		ConsecutiveHealthyProbes: e.consecutiveHealthyProbes,
 		LastRecoveryPoll:         e.lastRecoveryPoll,
 		RelayProbeMethod:         e.relayProbeMethod,
+		RelayProbeAttempts:       e.relayProbeAttempts,
+		ReenableProbeFlaps:       e.reenableProbeFlaps,
 	}
 }
 
@@ -316,18 +338,29 @@ func (e *Endpoint) clearRecoveryStreakLocked() {
 func (e *Endpoint) clearRecoveryTrackingLocked() {
 	e.clearRecoveryStreakLocked()
 	e.disabledAt = time.Time{}
+	e.dropRelayProbeEvidenceLocked()
+}
+
+// dropRelayProbeEvidenceLocked forgets the episode's recorded failing relay — on re-enable (the
+// evidence belongs to the episode that just ended) or when maxRelayProbeAttempts consecutive
+// replays failed to prove recovery (the poll-only fallback). Caller must hold e.mu.
+func (e *Endpoint) dropRelayProbeEvidenceLocked() {
 	e.relayProbeMethod = ""
 	e.relayProbePayload = nil
+	e.relayProbeTimeout = 0
+	e.relayProbeAttempts = 0
 }
 
 // RecordFailingRelay stores one health-affecting relay failure as replayable recovery evidence for
 // this endpoint's next disable episode (MAG-2550). The caller (the relay path, just before
 // MarkUnhealthy) is responsible for eligibility: READ-ONLY methods only — never writes,
-// subscriptions, hanging APIs, or unsupported-method responses — and a self-contained payload
-// (JSON-RPC POST body). Oversized or empty payloads are dropped rather than truncated: a replay of
-// half a request proves nothing. Rolling: the newest eligible failure wins, so the evidence always
-// reflects what was failing when the disable threshold was finally crossed.
-func (e *Endpoint) RecordFailingRelay(method string, payload []byte) {
+// subscriptions, hanging APIs, batches, or unsupported-method responses — and a self-contained
+// payload (JSON-RPC POST body). Oversized or empty payloads are dropped rather than truncated: a
+// replay of half a request proves nothing. relayTimeout is the relay path's effective timeout for
+// this request, so the replay judges it under the same budget it failed with. Rolling: the newest
+// eligible failure wins (and restarts the replay-attempt budget), so the evidence always reflects
+// what was failing when the disable threshold was finally crossed.
+func (e *Endpoint) RecordFailingRelay(method string, payload []byte, relayTimeout time.Duration) {
 	if method == "" || len(payload) == 0 || len(payload) > maxRelayProbePayloadBytes {
 		return
 	}
@@ -337,6 +370,8 @@ func (e *Endpoint) RecordFailingRelay(method string, payload []byte) {
 	e.mu.Lock()
 	e.relayProbeMethod = method
 	e.relayProbePayload = stored
+	e.relayProbeTimeout = relayTimeout
+	e.relayProbeAttempts = 0
 	e.mu.Unlock()
 }
 
@@ -489,23 +524,25 @@ func (e *Endpoint) RecordProbeVerdict(recoveryPoll time.Time, recoveryHealthy bo
 // ConfirmRelayRecovery / RelayProbeFailed. The candidate state is derived (not a stored flag), so
 // a later failed poll automatically withdraws candidacy until the streak is re-earned.
 // reEnableAfterK must be the same K passed to RecordProbeVerdict; <1 is treated as 1.
-func (e *Endpoint) PendingRelayProbe(reEnableAfterK uint64) (method string, payload []byte, ok bool) {
+// The returned timeout is the relay path's recorded effective budget for the request (0 when the
+// recording predates the budget — the replayer applies its own floor either way).
+func (e *Endpoint) PendingRelayProbe(reEnableAfterK uint64) (method string, payload []byte, relayTimeout time.Duration, ok bool) {
 	if reEnableAfterK < 1 {
 		reEnableAfterK = 1
 	}
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 	if e.Enabled || len(e.relayProbePayload) == 0 {
-		return "", nil, false
+		return "", nil, 0, false
 	}
 	if e.consecutiveHealthyProbes < reEnableAfterK<<e.reenableProbeFlaps {
-		return "", nil, false
+		return "", nil, 0, false
 	}
 	// Copy so the caller can use the payload after the lock is released without racing a
 	// concurrent RecordFailingRelay from an in-flight relay straggler.
 	payload = make([]byte, len(e.relayProbePayload))
 	copy(payload, e.relayProbePayload)
-	return e.relayProbeMethod, payload, true
+	return e.relayProbeMethod, payload, e.relayProbeTimeout, true
 }
 
 // ConfirmRelayRecovery is the prober reporting that the recorded failing relay REPLAYED
@@ -540,6 +577,12 @@ func (e *Endpoint) ConfirmRelayRecovery() bool {
 // learn this, the replay proves poll-healthy/relay-broken without exposing a single client request.
 // lastRecoveryPoll is preserved (invalid-evidence convention) so an already-counted poll cannot be
 // re-counted toward the next streak.
+//
+// The replay-attempt budget advances too: after maxRelayProbeAttempts consecutive non-recovered
+// replays the evidence is DROPPED and the episode falls back to the poll-only re-enable path — a
+// replay that can never pass (too expensive for this endpoint, pruned state) must not park an
+// otherwise-recovered endpoint until the epoch reset. The trial refusal budget still bounds client
+// exposure after the fallback re-enable.
 func (e *Endpoint) RelayProbeFailed() {
 	e.mu.Lock()
 	if e.Enabled {
@@ -550,14 +593,73 @@ func (e *Endpoint) RelayProbeFailed() {
 	if e.reenableProbeFlaps < maxReenableProbeFlaps {
 		e.reenableProbeFlaps++
 	}
-	addr, method, flaps := e.NetworkAddress, e.relayProbeMethod, e.reenableProbeFlaps
+	evidenceDropped := e.advanceRelayProbeAttemptLocked()
+	addr, method, flaps, attempts := e.NetworkAddress, e.relayProbeMethod, e.reenableProbeFlaps, e.relayProbeAttempts
 	e.mu.Unlock()
 
+	if evidenceDropped {
+		utils.LavaFormatWarning("relay probe evidence dropped after repeated failed replays, falling back to poll-only re-enable", nil,
+			utils.LogAttr("endpoint", addr),
+			utils.LogAttr("max_replay_attempts", maxRelayProbeAttempts),
+			utils.LogAttr("reenable_probe_flaps", flaps),
+		)
+		return
+	}
 	utils.LavaFormatInfo("relay probe still failing, endpoint stays disabled",
 		utils.LogAttr("endpoint", addr),
 		utils.LogAttr("method", method),
+		utils.LogAttr("replay_attempts", attempts),
 		utils.LogAttr("reenable_probe_flaps", flaps),
 	)
+}
+
+// RelayProbeInconclusive is the prober reporting that the replay PROVED NOTHING either way: the
+// recorded failing handler was never exercised (rate-limited), or the reply was unclassifiable (a
+// proxy's HTML error page on 200, an unrecognized 4xx). Unlike RelayProbeFailed it must NOT
+// escalate the flap hysteresis — no relay-path failure was demonstrated — but it also must not
+// confirm recovery. The streak resets so the next replay is paced by a re-earned poll streak
+// rather than fired every probe cycle, and the replay-attempt budget advances so permanently
+// unjudgeable evidence (the gate silently degrading to "never confirm") is dropped after
+// maxRelayProbeAttempts, falling back to the poll-only path instead of parking the endpoint.
+func (e *Endpoint) RelayProbeInconclusive() {
+	e.mu.Lock()
+	if e.Enabled {
+		e.mu.Unlock()
+		return
+	}
+	e.consecutiveHealthyProbes = 0
+	evidenceDropped := e.advanceRelayProbeAttemptLocked()
+	addr, method, attempts := e.NetworkAddress, e.relayProbeMethod, e.relayProbeAttempts
+	e.mu.Unlock()
+
+	if evidenceDropped {
+		utils.LavaFormatWarning("relay probe evidence dropped after repeated inconclusive replays, falling back to poll-only re-enable", nil,
+			utils.LogAttr("endpoint", addr),
+			utils.LogAttr("max_replay_attempts", maxRelayProbeAttempts),
+		)
+		return
+	}
+	utils.LavaFormatInfo("relay probe inconclusive, endpoint stays disabled",
+		utils.LogAttr("endpoint", addr),
+		utils.LogAttr("method", method),
+		utils.LogAttr("replay_attempts", attempts),
+	)
+}
+
+// advanceRelayProbeAttemptLocked consumes one replay attempt of the current evidence and reports
+// whether that exhausted the budget (evidence dropped → poll-only fallback). No-op without
+// evidence: a stale verdict racing an already-dropped or re-recorded episode must not charge the
+// new episode's budget. Caller must hold e.mu.
+func (e *Endpoint) advanceRelayProbeAttemptLocked() (evidenceDropped bool) {
+	if len(e.relayProbePayload) == 0 {
+		return false
+	}
+	e.relayProbeAttempts++
+	if e.relayProbeAttempts < maxRelayProbeAttempts {
+		return false
+	}
+	e.dropRelayProbeEvidenceLocked()
+	return true
 }
 
 // ResetHealth resets connection refusals and re-enables endpoint.

--- a/protocol/lavasession/endpoint_probe_reenable_test.go
+++ b/protocol/lavasession/endpoint_probe_reenable_test.go
@@ -49,7 +49,8 @@ func TestRecordProbeVerdict_ReEnablesAfterKDistinctPostDisablePolls(t *testing.T
 	require.True(t, e.Enabled)
 
 	e.mu.RLock()
-	require.Equal(t, uint64(0), e.ConnectionRefusals, "re-enable resets the relay refusal count")
+	require.Equal(t, uint64(MaxConsecutiveConnectionAttempts-probeReenableTrialBudget), e.ConnectionRefusals,
+		"a probe-granted re-enable carries only a TRIAL refusal budget, not the full threshold (MAG-2550)")
 	require.Equal(t, uint64(0), e.consecutiveHealthyProbes, "the hysteresis streak resets after re-enable")
 	require.True(t, e.disabledAt.IsZero(), "disabledAt cleared on re-enable")
 	e.mu.RUnlock()
@@ -153,10 +154,12 @@ func TestRecordProbeVerdict_NeverTouchesEnabledEndpoint(t *testing.T) {
 	require.False(t, e.Enabled, "the relay path can still disable despite intervening healthy probes")
 }
 
-// TestRecordProbeVerdict_DistinctFromRelayThreshold: the re-enable threshold (K) and the relay
-// disable threshold (50) are independent, so a freshly re-enabled endpoint takes the full relay
-// threshold to disable again (anti-flap).
-func TestRecordProbeVerdict_DistinctFromRelayThreshold(t *testing.T) {
+// TestRecordProbeVerdict_TrialBudgetOnProbeReEnable: a probe-granted re-enable is a TRIAL, not a
+// clean slate (MAG-2550) — the endpoint tolerates probeReenableTrialBudget consecutive relay
+// failures (so it isn't one blip from re-disabling) but falls back out of rotation after that,
+// instead of burning another full MaxConsecutiveConnectionAttempts of real client traffic. A
+// successful real relay (ResetHealth) is what restores the full budget.
+func TestRecordProbeVerdict_TrialBudgetOnProbeReEnable(t *testing.T) {
 	const k = 2
 	require.NotEqual(t, uint64(k), uint64(MaxConsecutiveConnectionAttempts),
 		"re-enable hysteresis and relay disable threshold must differ (anti-flap)")
@@ -166,11 +169,27 @@ func TestRecordProbeVerdict_DistinctFromRelayThreshold(t *testing.T) {
 	require.False(t, healthyPoll(e, probeBase.Add(1*time.Second), k))
 	require.True(t, healthyPoll(e, probeBase.Add(2*time.Second), k), "re-enabled after K distinct healthy polls")
 
-	for i := 0; i < MaxConsecutiveConnectionAttempts-1; i++ {
+	// The trial tolerates budget-1 failures without re-disabling…
+	for i := uint64(0); i < probeReenableTrialBudget-1; i++ {
 		e.markUnhealthyAt(probeBase.Add(3 * time.Second))
 	}
-	require.True(t, e.Enabled, "a re-enabled endpoint isn't one failure from disabling — refusals were reset")
+	require.True(t, e.Enabled, "a re-enabled endpoint isn't one failure from disabling — the trial budget absorbs blips")
+	// …and the budget-th consecutive failure ends the trial.
 	e.markUnhealthyAt(probeBase.Add(3 * time.Second))
+	require.False(t, e.Enabled, "a still-broken endpoint re-disables after the trial budget, not after another full threshold")
+
+	// A successful real relay during a trial restores the FULL consecutive-failure budget. The
+	// failed trial was a probe-grant flap, so the second re-enable needs the escalated k<<1 polls.
+	for i := 0; i < 2*k-1; i++ {
+		require.False(t, healthyPoll(e, probeBase.Add(time.Duration(4+i)*time.Second), k))
+	}
+	require.True(t, healthyPoll(e, probeBase.Add(time.Duration(3+2*k)*time.Second), k))
+	require.True(t, e.ResetHealth(), "a successful relay validates the trial")
+	for i := 0; i < MaxConsecutiveConnectionAttempts-1; i++ {
+		e.markUnhealthyAt(probeBase.Add(6 * time.Second))
+	}
+	require.True(t, e.Enabled, "after relay validation the endpoint has the full failure budget again")
+	e.markUnhealthyAt(probeBase.Add(6 * time.Second))
 	require.False(t, e.Enabled)
 }
 

--- a/protocol/lavasession/endpoint_relay_probe_test.go
+++ b/protocol/lavasession/endpoint_relay_probe_test.go
@@ -16,10 +16,13 @@ import (
 // evidence is the canonical recorded failing request used across these tests.
 var evidencePayload = []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"to":"0x0"},"latest"]}`)
 
+// evidenceTimeout is the relay path's effective budget recorded with the canonical evidence.
+const evidenceTimeout = 15 * time.Second
+
 func recordedDisabledEndpoint(t *testing.T) *Endpoint {
 	t.Helper()
 	e := &Endpoint{NetworkAddress: "http://ep:8545", Enabled: true}
-	e.RecordFailingRelay("eth_call", evidencePayload)
+	e.RecordFailingRelay("eth_call", evidencePayload, evidenceTimeout)
 	disableAt(t, e, probeBase)
 	return e
 }
@@ -40,11 +43,13 @@ func TestRelayProbe_GatesReEnableUntilConfirmed(t *testing.T) {
 		require.False(t, e.Enabled)
 	}
 
-	// The endpoint is a replay candidate carrying the exact recorded request.
-	method, payload, ok := e.PendingRelayProbe(k)
+	// The endpoint is a replay candidate carrying the exact recorded request AND the relay path's
+	// effective timeout for it — the replay must judge under the budget the request failed with.
+	method, payload, relayTimeout, ok := e.PendingRelayProbe(k)
 	require.True(t, ok, "poll hysteresis satisfied + recorded evidence → replay candidate")
 	require.Equal(t, "eth_call", method)
 	require.Equal(t, evidencePayload, payload)
+	require.Equal(t, evidenceTimeout, relayTimeout, "the recorded relay timeout travels with the evidence")
 
 	// A successful replay completes the two-step re-enable.
 	require.True(t, e.ConfirmRelayRecovery())
@@ -58,7 +63,7 @@ func TestRelayProbe_GatesReEnableUntilConfirmed(t *testing.T) {
 
 	// Cleared evidence means the NEXT disable episode (if transport-fault-only) is poll-gated only.
 	disableAt(t, e, probeBase.Add(100*time.Second))
-	_, _, ok = e.PendingRelayProbe(k)
+	_, _, _, ok = e.PendingRelayProbe(k)
 	require.False(t, ok, "no recorded evidence → no replay candidacy")
 }
 
@@ -68,19 +73,19 @@ func TestRelayProbe_NotPendingBeforeHysteresis(t *testing.T) {
 	const k = 3
 	e := recordedDisabledEndpoint(t)
 
-	_, _, ok := e.PendingRelayProbe(k)
+	_, _, _, ok := e.PendingRelayProbe(k)
 	require.False(t, ok, "no candidacy before any healthy poll")
 
 	for i := 1; i < k; i++ {
 		require.False(t, healthyPoll(e, probeBase.Add(time.Duration(i)*time.Second), k))
-		_, _, ok = e.PendingRelayProbe(k)
+		_, _, _, ok = e.PendingRelayProbe(k)
 		require.False(t, ok, "no candidacy before the full poll hysteresis (streak %d < K=%d)", i, k)
 	}
 
 	// An ENABLED endpoint is never a candidate, even with stale evidence fields.
 	enabled := &Endpoint{NetworkAddress: "http://ep:8545", Enabled: true}
-	enabled.RecordFailingRelay("eth_call", evidencePayload)
-	_, _, ok = enabled.PendingRelayProbe(k)
+	enabled.RecordFailingRelay("eth_call", evidencePayload, evidenceTimeout)
+	_, _, _, ok = enabled.PendingRelayProbe(k)
 	require.False(t, ok, "an enabled endpoint is never a replay candidate")
 }
 
@@ -94,12 +99,12 @@ func TestRelayProbe_FailedReplayResetsStreakAndEscalates(t *testing.T) {
 	for i := 1; i <= k; i++ {
 		require.False(t, healthyPoll(e, probeBase.Add(time.Duration(i)*time.Second), k))
 	}
-	_, _, ok := e.PendingRelayProbe(k)
+	_, _, _, ok := e.PendingRelayProbe(k)
 	require.True(t, ok)
 
 	e.RelayProbeFailed()
 	require.False(t, e.Enabled, "a failed replay keeps the endpoint disabled")
-	_, _, ok = e.PendingRelayProbe(k)
+	_, _, _, ok = e.PendingRelayProbe(k)
 	require.False(t, ok, "a failed replay resets the streak — candidacy must be re-earned")
 	e.mu.RLock()
 	require.Equal(t, uint64(1), e.reenableProbeFlaps, "a failed replay escalates the flap counter without client exposure")
@@ -109,14 +114,14 @@ func TestRelayProbe_FailedReplayResetsStreakAndEscalates(t *testing.T) {
 	for i := 1; i <= k; i++ {
 		require.False(t, healthyPoll(e, probeBase.Add(time.Duration(k+i)*time.Second), k))
 	}
-	_, _, ok = e.PendingRelayProbe(k)
+	_, _, _, ok = e.PendingRelayProbe(k)
 	require.False(t, ok, "after a failed replay the next candidacy needs the escalated K<<1 streak")
 
 	// The escalated streak completes → candidate again; this time the replay succeeds.
 	for i := 1; i <= k; i++ {
 		require.False(t, healthyPoll(e, probeBase.Add(time.Duration(2*k+i)*time.Second), k))
 	}
-	_, _, ok = e.PendingRelayProbe(k)
+	_, _, _, ok = e.PendingRelayProbe(k)
 	require.True(t, ok, "the escalated streak re-earns candidacy")
 	require.True(t, e.ConfirmRelayRecovery())
 	require.True(t, e.Enabled)
@@ -131,11 +136,11 @@ func TestRelayProbe_FailedPollWithdrawsCandidacy(t *testing.T) {
 
 	require.False(t, healthyPoll(e, probeBase.Add(1*time.Second), k))
 	require.False(t, healthyPoll(e, probeBase.Add(2*time.Second), k))
-	_, _, ok := e.PendingRelayProbe(k)
+	_, _, _, ok := e.PendingRelayProbe(k)
 	require.True(t, ok)
 
 	require.False(t, e.RecordProbeVerdict(probeBase.Add(3*time.Second), false, k), "a failed poll")
-	_, _, ok = e.PendingRelayProbe(k)
+	_, _, _, ok = e.PendingRelayProbe(k)
 	require.False(t, ok, "a failed poll withdraws replay candidacy")
 }
 
@@ -145,32 +150,33 @@ func TestRelayProbe_FailedPollWithdrawsCandidacy(t *testing.T) {
 func TestRecordFailingRelay_Guards(t *testing.T) {
 	e := &Endpoint{NetworkAddress: "http://ep:8545", Enabled: true}
 
-	e.RecordFailingRelay("", evidencePayload)
+	e.RecordFailingRelay("", evidencePayload, evidenceTimeout)
 	require.Empty(t, e.HealthSnapshot().RelayProbeMethod, "empty method is not recorded")
-	e.RecordFailingRelay("eth_call", nil)
+	e.RecordFailingRelay("eth_call", nil, evidenceTimeout)
 	require.Empty(t, e.HealthSnapshot().RelayProbeMethod, "empty payload is not recorded")
-	e.RecordFailingRelay("eth_call", make([]byte, maxRelayProbePayloadBytes+1))
+	e.RecordFailingRelay("eth_call", make([]byte, maxRelayProbePayloadBytes+1), evidenceTimeout)
 	require.Empty(t, e.HealthSnapshot().RelayProbeMethod, "oversized payload is dropped, not truncated")
 
-	// Rolling: the newest eligible failure wins.
-	e.RecordFailingRelay("eth_call", evidencePayload)
-	e.RecordFailingRelay("eth_getLogs", []byte(`{"method":"eth_getLogs"}`))
+	// Rolling: the newest eligible failure wins — payload, timeout, and a fresh attempt budget.
+	e.RecordFailingRelay("eth_call", evidencePayload, evidenceTimeout)
+	e.RecordFailingRelay("eth_getLogs", []byte(`{"method":"eth_getLogs"}`), 25*time.Second)
 	require.Equal(t, "eth_getLogs", e.HealthSnapshot().RelayProbeMethod)
 
 	// The stored payload is a copy: mutating the caller's buffer must not corrupt the evidence.
 	buf := []byte(`{"method":"eth_call","id":1}`)
-	e.RecordFailingRelay("eth_call", buf)
+	e.RecordFailingRelay("eth_call", buf, 25*time.Second)
 	buf[0] = 'X'
 	disableAt(t, e, probeBase)
 	require.False(t, healthyPoll(e, probeBase.Add(time.Second), 1))
 	// K=1 → streak satisfied on the first poll; candidate payload must be the original bytes.
-	_, payload, ok := e.PendingRelayProbe(1)
+	_, payload, relayTimeout, ok := e.PendingRelayProbe(1)
 	require.True(t, ok)
 	require.Equal(t, byte('{'), payload[0], "recorded payload is a copy, immune to caller mutation")
+	require.Equal(t, 25*time.Second, relayTimeout, "the newest recording's timeout wins with it")
 
 	// And the returned payload is a copy too: mutating it must not corrupt the stored evidence.
 	payload[0] = 'Y'
-	_, again, ok := e.PendingRelayProbe(1)
+	_, again, _, ok := e.PendingRelayProbe(1)
 	require.True(t, ok)
 	require.Equal(t, byte('{'), again[0], "PendingRelayProbe returns a copy, not the stored buffer")
 }
@@ -207,4 +213,97 @@ func TestRelayProbe_ConfirmIsIdempotentAgainstRaces(t *testing.T) {
 	e2.mu.RLock()
 	require.Equal(t, uint64(0), e2.reenableProbeFlaps, "a stale probe failure must not escalate an enabled endpoint")
 	e2.mu.RUnlock()
+
+	// And RelayProbeInconclusive too.
+	e3 := recordedDisabledEndpoint(t)
+	require.True(t, e3.ResetHealth())
+	e3.RelayProbeInconclusive()
+	require.Zero(t, e3.HealthSnapshot().RelayProbeAttempts, "a stale inconclusive verdict must not charge an enabled endpoint")
+}
+
+// earnReplayCandidacy feeds distinct healthy polls (advancing *pollSec each time) until the
+// endpoint's current effective streak (reEnableAfterK << flaps) is satisfied and it becomes a
+// replay candidate. Fails the test if candidacy is not reached within a generous poll budget —
+// which is exactly the permanent-park bug this file's escape-hatch tests exist to prevent.
+func earnReplayCandidacy(t *testing.T, e *Endpoint, k uint64, pollSec *int) {
+	t.Helper()
+	for polls := 0; polls < 64; polls++ {
+		*pollSec++
+		require.False(t, healthyPoll(e, probeBase.Add(time.Duration(*pollSec)*time.Second), k),
+			"polls alone must never re-enable while evidence is recorded")
+		if _, _, _, ok := e.PendingRelayProbe(k); ok {
+			return
+		}
+	}
+	t.Fatal("endpoint never became a replay candidate — the gate is parking it")
+}
+
+// TestRelayProbe_EvidenceDroppedAfterMaxFailedReplays is the bounded-escape guarantee the review
+// asked for: evidence whose replay NEVER passes (a request that is simply too expensive for this
+// endpoint, pruned state, a broken recorded timeout) must not park the endpoint until the epoch
+// reset. After maxRelayProbeAttempts consecutive failed replays the evidence is dropped and the
+// endpoint re-enables through the poll-only path — still with the trial refusal budget bounding
+// client exposure.
+func TestRelayProbe_EvidenceDroppedAfterMaxFailedReplays(t *testing.T) {
+	const k = 2
+	e := recordedDisabledEndpoint(t)
+	pollSec := 0
+
+	// Every replay attempt fails; each must consume one unit of the attempt budget and keep the
+	// endpoint disabled until the budget is exhausted.
+	for attempt := uint64(1); attempt <= maxRelayProbeAttempts; attempt++ {
+		earnReplayCandidacy(t, e, k, &pollSec)
+		e.RelayProbeFailed()
+		require.False(t, e.Enabled)
+		if attempt < maxRelayProbeAttempts {
+			require.NotEmpty(t, e.HealthSnapshot().RelayProbeMethod, "evidence is kept while the attempt budget lasts")
+			require.Equal(t, attempt, e.HealthSnapshot().RelayProbeAttempts)
+		}
+	}
+	require.Empty(t, e.HealthSnapshot().RelayProbeMethod,
+		"the final failed replay drops the evidence — the gate must not outlive its attempt budget")
+
+	// Poll-only fallback: the (escalated) streak alone now re-enables — the endpoint ESCAPES
+	// without an epoch reset, carrying the trial budget.
+	for polls := 0; polls < 64 && !e.IsEnabled(); polls++ {
+		pollSec++
+		healthyPoll(e, probeBase.Add(time.Duration(pollSec)*time.Second), k)
+	}
+	require.True(t, e.IsEnabled(), "after the evidence is dropped, poll hysteresis alone must re-enable the endpoint")
+	e.mu.RLock()
+	require.Equal(t, uint64(MaxConsecutiveConnectionAttempts-probeReenableTrialBudget), e.ConnectionRefusals,
+		"the fallback re-enable still carries only the trial budget")
+	e.mu.RUnlock()
+}
+
+// TestRelayProbe_InconclusiveResetsStreakWithoutEscalation: an inconclusive replay (rate-limited,
+// unclassifiable reply) paces the next attempt by resetting the streak but must NOT escalate the
+// flap hysteresis — nothing was demonstrated about the relay path. It still consumes the attempt
+// budget, so permanently unjudgeable evidence is eventually dropped (poll-only fallback) instead
+// of degrading the gate to "never confirm".
+func TestRelayProbe_InconclusiveResetsStreakWithoutEscalation(t *testing.T) {
+	const k = 2
+	e := recordedDisabledEndpoint(t)
+	pollSec := 0
+
+	for attempt := uint64(1); attempt <= maxRelayProbeAttempts; attempt++ {
+		earnReplayCandidacy(t, e, k, &pollSec)
+		e.RelayProbeInconclusive()
+		require.False(t, e.Enabled, "inconclusive must not confirm recovery")
+		if _, _, _, ok := e.PendingRelayProbe(k); ok {
+			t.Fatal("inconclusive must reset the streak — the next replay is paced by a re-earned streak")
+		}
+		e.mu.RLock()
+		require.Equal(t, uint64(0), e.reenableProbeFlaps, "inconclusive proves no relay-path failure — no flap escalation")
+		e.mu.RUnlock()
+	}
+	require.Empty(t, e.HealthSnapshot().RelayProbeMethod,
+		"repeated inconclusive replays drop the evidence — the gate must not silently become 'never confirm'")
+
+	// Poll-only fallback re-enables at the UNescalated K: no flaps were charged.
+	for i := 1; i <= k; i++ {
+		pollSec++
+		healthyPoll(e, probeBase.Add(time.Duration(pollSec)*time.Second), k)
+	}
+	require.True(t, e.IsEnabled(), "poll-only fallback after inconclusive replays re-enables at base K")
 }

--- a/protocol/lavasession/endpoint_relay_probe_test.go
+++ b/protocol/lavasession/endpoint_relay_probe_test.go
@@ -1,0 +1,210 @@
+package lavasession
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// MAG-2550 — relay-probe recovery evidence. A disable episode that recorded a failing READ-ONLY
+// relay (RecordFailingRelay) gates the probe re-enable: poll hysteresis alone no longer flips the
+// endpoint back on, because the poll method and the failing relay method measure different things.
+// The prober must replay the recorded request and report ConfirmRelayRecovery / RelayProbeFailed.
+// These tests pin that two-step contract and the trial-budget/escalation semantics around it.
+
+// evidence is the canonical recorded failing request used across these tests.
+var evidencePayload = []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"to":"0x0"},"latest"]}`)
+
+func recordedDisabledEndpoint(t *testing.T) *Endpoint {
+	t.Helper()
+	e := &Endpoint{NetworkAddress: "http://ep:8545", Enabled: true}
+	e.RecordFailingRelay("eth_call", evidencePayload)
+	disableAt(t, e, probeBase)
+	return e
+}
+
+// TestRelayProbe_GatesReEnableUntilConfirmed is the headline MAG-2550 behavior: with recorded
+// relay evidence, ANY number of healthy polls holds the endpoint disabled; the endpoint becomes a
+// replay candidate at the hysteresis threshold; and only ConfirmRelayRecovery (a successful
+// replay) completes the re-enable — with the trial refusal budget, and the evidence cleared for
+// the next episode.
+func TestRelayProbe_GatesReEnableUntilConfirmed(t *testing.T) {
+	const k = 3
+	e := recordedDisabledEndpoint(t)
+
+	// Far more distinct healthy polls than K: the gate must hold every single one.
+	for i := 1; i <= k+5; i++ {
+		require.False(t, healthyPoll(e, probeBase.Add(time.Duration(i)*time.Second), k),
+			"healthy polls must never re-enable an endpoint whose disable episode recorded a failing relay")
+		require.False(t, e.Enabled)
+	}
+
+	// The endpoint is a replay candidate carrying the exact recorded request.
+	method, payload, ok := e.PendingRelayProbe(k)
+	require.True(t, ok, "poll hysteresis satisfied + recorded evidence → replay candidate")
+	require.Equal(t, "eth_call", method)
+	require.Equal(t, evidencePayload, payload)
+
+	// A successful replay completes the two-step re-enable.
+	require.True(t, e.ConfirmRelayRecovery())
+	require.True(t, e.Enabled)
+	e.mu.RLock()
+	require.Equal(t, uint64(MaxConsecutiveConnectionAttempts-probeReenableTrialBudget), e.ConnectionRefusals,
+		"a replay-confirmed re-enable still carries only the trial budget — one replayed request is not real traffic")
+	require.True(t, e.probeReenabled, "a replay-confirmed re-enable is still probe-granted until real traffic validates it")
+	e.mu.RUnlock()
+	require.Empty(t, e.HealthSnapshot().RelayProbeMethod, "the episode's evidence is cleared on re-enable")
+
+	// Cleared evidence means the NEXT disable episode (if transport-fault-only) is poll-gated only.
+	disableAt(t, e, probeBase.Add(100*time.Second))
+	_, _, ok = e.PendingRelayProbe(k)
+	require.False(t, ok, "no recorded evidence → no replay candidacy")
+}
+
+// TestRelayProbe_NotPendingBeforeHysteresisOrWhileEnabled: candidacy requires ALL of disabled +
+// evidence + satisfied streak — it is derived state, not a latch.
+func TestRelayProbe_NotPendingBeforeHysteresis(t *testing.T) {
+	const k = 3
+	e := recordedDisabledEndpoint(t)
+
+	_, _, ok := e.PendingRelayProbe(k)
+	require.False(t, ok, "no candidacy before any healthy poll")
+
+	for i := 1; i < k; i++ {
+		require.False(t, healthyPoll(e, probeBase.Add(time.Duration(i)*time.Second), k))
+		_, _, ok = e.PendingRelayProbe(k)
+		require.False(t, ok, "no candidacy before the full poll hysteresis (streak %d < K=%d)", i, k)
+	}
+
+	// An ENABLED endpoint is never a candidate, even with stale evidence fields.
+	enabled := &Endpoint{NetworkAddress: "http://ep:8545", Enabled: true}
+	enabled.RecordFailingRelay("eth_call", evidencePayload)
+	_, _, ok = enabled.PendingRelayProbe(k)
+	require.False(t, ok, "an enabled endpoint is never a replay candidate")
+}
+
+// TestRelayProbe_FailedReplayResetsStreakAndEscalates: a failed replay proves poll-healthy /
+// relay-broken WITHOUT client traffic — the streak resets (pacing: one replay per earned streak)
+// and the flap escalation advances, so the next replay needs K<<1 distinct polls.
+func TestRelayProbe_FailedReplayResetsStreakAndEscalates(t *testing.T) {
+	const k = 3
+	e := recordedDisabledEndpoint(t)
+
+	for i := 1; i <= k; i++ {
+		require.False(t, healthyPoll(e, probeBase.Add(time.Duration(i)*time.Second), k))
+	}
+	_, _, ok := e.PendingRelayProbe(k)
+	require.True(t, ok)
+
+	e.RelayProbeFailed()
+	require.False(t, e.Enabled, "a failed replay keeps the endpoint disabled")
+	_, _, ok = e.PendingRelayProbe(k)
+	require.False(t, ok, "a failed replay resets the streak — candidacy must be re-earned")
+	e.mu.RLock()
+	require.Equal(t, uint64(1), e.reenableProbeFlaps, "a failed replay escalates the flap counter without client exposure")
+	e.mu.RUnlock()
+
+	// K more distinct polls are NOT enough anymore — the threshold escalated to K<<1.
+	for i := 1; i <= k; i++ {
+		require.False(t, healthyPoll(e, probeBase.Add(time.Duration(k+i)*time.Second), k))
+	}
+	_, _, ok = e.PendingRelayProbe(k)
+	require.False(t, ok, "after a failed replay the next candidacy needs the escalated K<<1 streak")
+
+	// The escalated streak completes → candidate again; this time the replay succeeds.
+	for i := 1; i <= k; i++ {
+		require.False(t, healthyPoll(e, probeBase.Add(time.Duration(2*k+i)*time.Second), k))
+	}
+	_, _, ok = e.PendingRelayProbe(k)
+	require.True(t, ok, "the escalated streak re-earns candidacy")
+	require.True(t, e.ConfirmRelayRecovery())
+	require.True(t, e.Enabled)
+}
+
+// TestRelayProbe_FailedPollWithdrawsCandidacy: candidacy is derived from the live streak, so a
+// failed poll AFTER the threshold was reached withdraws it until the streak is re-earned — the
+// prober never replays against an endpoint whose polls just went unhealthy again.
+func TestRelayProbe_FailedPollWithdrawsCandidacy(t *testing.T) {
+	const k = 2
+	e := recordedDisabledEndpoint(t)
+
+	require.False(t, healthyPoll(e, probeBase.Add(1*time.Second), k))
+	require.False(t, healthyPoll(e, probeBase.Add(2*time.Second), k))
+	_, _, ok := e.PendingRelayProbe(k)
+	require.True(t, ok)
+
+	require.False(t, e.RecordProbeVerdict(probeBase.Add(3*time.Second), false, k), "a failed poll")
+	_, _, ok = e.PendingRelayProbe(k)
+	require.False(t, ok, "a failed poll withdraws replay candidacy")
+}
+
+// TestRecordFailingRelay_Guards: empty method, empty payload, and oversized payloads are dropped;
+// eligible evidence is rolling (newest wins) and the stored payload is a copy of the caller's
+// buffer, immune to later mutation on either side.
+func TestRecordFailingRelay_Guards(t *testing.T) {
+	e := &Endpoint{NetworkAddress: "http://ep:8545", Enabled: true}
+
+	e.RecordFailingRelay("", evidencePayload)
+	require.Empty(t, e.HealthSnapshot().RelayProbeMethod, "empty method is not recorded")
+	e.RecordFailingRelay("eth_call", nil)
+	require.Empty(t, e.HealthSnapshot().RelayProbeMethod, "empty payload is not recorded")
+	e.RecordFailingRelay("eth_call", make([]byte, maxRelayProbePayloadBytes+1))
+	require.Empty(t, e.HealthSnapshot().RelayProbeMethod, "oversized payload is dropped, not truncated")
+
+	// Rolling: the newest eligible failure wins.
+	e.RecordFailingRelay("eth_call", evidencePayload)
+	e.RecordFailingRelay("eth_getLogs", []byte(`{"method":"eth_getLogs"}`))
+	require.Equal(t, "eth_getLogs", e.HealthSnapshot().RelayProbeMethod)
+
+	// The stored payload is a copy: mutating the caller's buffer must not corrupt the evidence.
+	buf := []byte(`{"method":"eth_call","id":1}`)
+	e.RecordFailingRelay("eth_call", buf)
+	buf[0] = 'X'
+	disableAt(t, e, probeBase)
+	require.False(t, healthyPoll(e, probeBase.Add(time.Second), 1))
+	// K=1 → streak satisfied on the first poll; candidate payload must be the original bytes.
+	_, payload, ok := e.PendingRelayProbe(1)
+	require.True(t, ok)
+	require.Equal(t, byte('{'), payload[0], "recorded payload is a copy, immune to caller mutation")
+
+	// And the returned payload is a copy too: mutating it must not corrupt the stored evidence.
+	payload[0] = 'Y'
+	_, again, ok := e.PendingRelayProbe(1)
+	require.True(t, ok)
+	require.Equal(t, byte('{'), again[0], "PendingRelayProbe returns a copy, not the stored buffer")
+}
+
+// TestRelayProbe_EvidenceClearedOnResetHealth: the epoch/debug reset path (ResetHealth) re-enables
+// and clears the episode's evidence like every other re-enable, so a later unrelated disable
+// episode is not held hostage by stale evidence from a previous one.
+func TestRelayProbe_EvidenceClearedOnResetHealth(t *testing.T) {
+	const k = 2
+	e := recordedDisabledEndpoint(t)
+	require.True(t, e.ResetHealth())
+	require.True(t, e.Enabled)
+	require.Empty(t, e.HealthSnapshot().RelayProbeMethod, "ResetHealth clears the episode's evidence")
+
+	// The next disable episode (no evidence recorded) re-enables on poll hysteresis alone.
+	disableAt(t, e, probeBase.Add(100*time.Second))
+	require.False(t, healthyPoll(e, probeBase.Add(101*time.Second), k))
+	require.True(t, healthyPoll(e, probeBase.Add(102*time.Second), k),
+		"an evidence-free episode keeps the poll-only re-enable path")
+}
+
+// TestRelayProbe_ConfirmIsIdempotentAgainstRaces: ConfirmRelayRecovery on an endpoint something
+// else already re-enabled (straggler relay's ResetHealth, epoch reset) reports false — the
+// re-enable is counted exactly once.
+func TestRelayProbe_ConfirmIsIdempotentAgainstRaces(t *testing.T) {
+	e := recordedDisabledEndpoint(t)
+	require.True(t, e.ResetHealth(), "something else re-enables first")
+	require.False(t, e.ConfirmRelayRecovery(), "confirm on an already-enabled endpoint is a no-op")
+
+	// RelayProbeFailed after a racing re-enable is likewise inert.
+	e2 := recordedDisabledEndpoint(t)
+	require.True(t, e2.ResetHealth())
+	e2.RelayProbeFailed()
+	e2.mu.RLock()
+	require.Equal(t, uint64(0), e2.reenableProbeFlaps, "a stale probe failure must not escalate an enabled endpoint")
+	e2.mu.RUnlock()
+}

--- a/protocol/rpcsmartrouter/debug_server_test.go
+++ b/protocol/rpcsmartrouter/debug_server_test.go
@@ -573,7 +573,7 @@ func TestDebugProbeLoop_ReportsCycleStats(t *testing.T) {
 	var offsetNano atomic.Int64
 	server := &RPCSmartRouterServer{listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"}}
 	server.probeStats.setInterval(5 * time.Second)
-	server.probeStats.recordCycle(time.Now(), 7*time.Millisecond, 4, 1, 2)
+	server.probeStats.recordCycle(time.Now(), 7*time.Millisecond, 4, 1, 2, 1)
 
 	router := &RPCSmartRouter{
 		rpcServers: map[string]*RPCSmartRouterServer{

--- a/protocol/rpcsmartrouter/error_mapper.go
+++ b/protocol/rpcsmartrouter/error_mapper.go
@@ -74,6 +74,21 @@ func classifyEndpointHealth(classified *common.LavaError, isClientCancellation b
 	if isClientCancellation {
 		return false, false
 	}
+	// Unsupported-method responses — the method is absent from the node's API surface
+	// (NODE_METHOD_NOT_FOUND / NODE_UNIMPLEMENTED / ...) or present but disabled on this
+	// specific node (NODE_METHOD_NOT_SUPPORTED) — are per-method capability gaps, not
+	// endpoint faults: the node answered, it just won't serve this method. They must not
+	// climb toward the disable threshold (clients hammering one unsupported method would
+	// otherwise disable an endpoint that is healthy for everything else, feeding the
+	// MAG-2550 disable/re-enable flap) and, being pre-MarkUnhealthy, they are never
+	// recorded as relay-probe recovery evidence either. The non-retryable variants already
+	// landed in the default arm below; this makes the rule explicit and extends it to the
+	// retryable NODE_METHOD_NOT_SUPPORTED, which previously marked unhealthy. No backoff:
+	// the endpoint is neither broken nor busy — steering THIS request to a different
+	// provider is the relay processor's job (Retryable=true), not backoff's.
+	if classified.SubCategory.IsUnsupportedMethod() || classified.Code == common.LavaErrorNodeMethodNotSupported.Code {
+		return false, false
+	}
 	switch {
 	case classified.Category == common.CategoryInternal:
 		return true, true

--- a/protocol/rpcsmartrouter/error_mapper_test.go
+++ b/protocol/rpcsmartrouter/error_mapper_test.go
@@ -291,6 +291,27 @@ func TestClassifyEndpointHealth_ExternalNonRetryable(t *testing.T) {
 	}
 }
 
+func TestClassifyEndpointHealth_UnsupportedMethodNeverPoisonsHealth(t *testing.T) {
+	// GIVEN any unsupported-method classification — the method is absent from the node's API
+	// surface, OR present but disabled on this specific node (NODE_METHOD_NOT_SUPPORTED, which is
+	// Retryable and previously fell into the unhealthy arm)
+	// WHEN the relay fails
+	// THEN the endpoint is neither marked unhealthy nor backed off: a per-method capability gap is
+	// not an endpoint fault, and it must not feed the MAG-2550 disable/re-enable flap.
+	unsupported := []*common.LavaError{
+		common.LavaErrorNodeMethodNotFound,
+		common.LavaErrorNodeMethodNotSupported, // Retryable=true — the regression this test pins
+		common.LavaErrorNodeUnimplemented,
+		common.LavaErrorNodeEndpointNotFound,
+		common.LavaErrorNodeMethodNotAllowed,
+	}
+	for _, le := range unsupported {
+		unhealthy, backoff := classifyEndpointHealth(le, false)
+		assert.False(t, unhealthy, "%s should NOT mark unhealthy (capability gap, not endpoint fault)", le.Name)
+		assert.False(t, backoff, "%s should NOT request backoff (endpoint is neither broken nor busy)", le.Name)
+	}
+}
+
 func TestClassifyEndpointHealth_Nil(t *testing.T) {
 	// GIVEN a nil classification
 	// WHEN health is evaluated

--- a/protocol/rpcsmartrouter/probe_loop_test.go
+++ b/protocol/rpcsmartrouter/probe_loop_test.go
@@ -259,16 +259,17 @@ func TestProbeCycleCore_ReturnsCycleCounts(t *testing.T) {
 	}
 
 	// Fresh baseline → sync fed for both providers, nothing omitted.
-	scored, reEnabled, syncOmitted := runProbeCycleCore(
+	scored, reEnabled, syncOmitted, evidenceGated := runProbeCycleCore(
 		endpoints, healthy, 1000, true,
 		provideroptimizer.SyncReference{ConsensusConfigured: true, Block: 1000, Time: now, Fresh: true},
 		now, probeCfg(), &recordingAppender{}, nil, nil)
 	require.Equal(t, 2, scored, "both endpoints scored")
 	require.Equal(t, 0, reEnabled, "already-enabled endpoints are never re-enabled")
 	require.Equal(t, 0, syncOmitted, "fresh baseline → no sync omitted")
+	require.Equal(t, 0, evidenceGated, "no endpoint holds relay evidence")
 
 	// No baseline → F5: sync omitted for every provider sample.
-	_, _, syncOmitted = runProbeCycleCore(
+	_, _, syncOmitted, _ = runProbeCycleCore(
 		endpoints, healthy, 0, false,
 		provideroptimizer.SyncReference{ConsensusConfigured: true},
 		now, probeCfg(), &recordingAppender{}, nil, nil)
@@ -290,7 +291,7 @@ func TestProbeCycleCore_CountsReEnable(t *testing.T) {
 		getObs := func(string) (endpointstate.EndpointObservation, bool) {
 			return freshObs(1000, now.Add(-time.Second), pollTime, 20*time.Millisecond), true
 		}
-		_, reEnabled, _ := runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{}, now, probeCfg(), nil, nil, nil)
+		_, reEnabled, _, _ := runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{}, now, probeCfg(), nil, nil, nil)
 		lastReEnabled = reEnabled
 		if i < K {
 			require.Equal(t, 0, reEnabled, "no re-enable before the K-th distinct healthy poll")

--- a/protocol/rpcsmartrouter/probe_loop_test.go
+++ b/protocol/rpcsmartrouter/probe_loop_test.go
@@ -97,7 +97,7 @@ func TestProbeCycle_ReEnablesRecoveredEndpoint(t *testing.T) {
 		getObs := func(string) (endpointstate.EndpointObservation, bool) {
 			return freshObs(1000, now.Add(-time.Second), pollTime, 20*time.Millisecond), true
 		}
-		runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{}, now, probeCfg(), nil, onRecover)
+		runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{}, now, probeCfg(), nil, onRecover, nil)
 	}
 
 	// K-1 distinct polls: still disabled, no recovery callback.
@@ -131,7 +131,7 @@ func TestProbeCycle_FailedPollDoesNotReEnable(t *testing.T) {
 	}
 	var recovered []string
 	for i := 0; i < 10; i++ {
-		runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{}, now, probeCfg(), nil, func(p string) { recovered = append(recovered, p) })
+		runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{}, now, probeCfg(), nil, func(p string) { recovered = append(recovered, p) }, nil)
 	}
 	require.False(t, dc.Endpoint.Enabled, "a failed last poll must never re-enable")
 	require.Empty(t, recovered)
@@ -149,7 +149,7 @@ func TestProbeCycle_StaleEndpointStaysDisabled(t *testing.T) {
 		return endpointstate.EndpointObservation{LatestBlock: 1000, ObservedAt: now.Add(-60 * time.Second)}, true
 	}
 	for i := 0; i < 10; i++ {
-		runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{}, now, probeCfg(), nil, nil)
+		runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{}, now, probeCfg(), nil, nil, nil)
 	}
 	require.False(t, dc.Endpoint.Enabled, "a still-stale endpoint must not be re-enabled")
 }
@@ -177,7 +177,7 @@ func TestProbeCycle_OneSamplePerProvider(t *testing.T) {
 
 	rec := &recordingAppender{}
 	ref := provideroptimizer.SyncReference{ConsensusConfigured: true, Block: 1000, Time: now, Fresh: true}
-	runProbeCycleCore(endpoints, getObs, 1000, true, ref, now, probeCfg(), rec, nil)
+	runProbeCycleCore(endpoints, getObs, 1000, true, ref, now, probeCfg(), rec, nil, nil)
 
 	require.Len(t, rec.calls, 1, "exactly one QoS sample per provider per cycle (rule E2)")
 	require.Equal(t, "provider1", rec.calls[0].provider)
@@ -198,7 +198,7 @@ func TestProbeCycle_NoBaselineOmitsSync(t *testing.T) {
 	endpoints := []*lavasession.EndpointWithDirectConnection{ep("http://a:8545", "provider1", true)}
 	rec := &recordingAppender{}
 	// hasBaseline=false → the prober must not set hasSync.
-	runProbeCycleCore(endpoints, getObs, 0, false, provideroptimizer.SyncReference{ConsensusConfigured: true}, now, probeCfg(), rec, nil)
+	runProbeCycleCore(endpoints, getObs, 0, false, provideroptimizer.SyncReference{ConsensusConfigured: true}, now, probeCfg(), rec, nil, nil)
 
 	require.Len(t, rec.calls, 1)
 	require.Equal(t, 1.0, rec.calls[0].availability)
@@ -217,7 +217,7 @@ func TestProbeCycle_CoversBackupsAndMultipleProviders(t *testing.T) {
 		ep("http://b:8545", "backup-provider", true), // GetAllDirectRPCEndpoints includes backups
 	}
 	rec := &recordingAppender{}
-	runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{}, now, probeCfg(), rec, nil)
+	runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{}, now, probeCfg(), rec, nil, nil)
 
 	require.Len(t, rec.calls, 2, "both the regular and backup providers get a sample")
 	seen := map[string]bool{}
@@ -237,7 +237,7 @@ func TestProbeCycle_NoObservationIsUnhealthy(t *testing.T) {
 	}
 	endpoints := []*lavasession.EndpointWithDirectConnection{ep("http://a:8545", "provider1", true)}
 	rec := &recordingAppender{}
-	runProbeCycleCore(endpoints, getObs, 0, false, provideroptimizer.SyncReference{}, now, probeCfg(), rec, nil)
+	runProbeCycleCore(endpoints, getObs, 0, false, provideroptimizer.SyncReference{}, now, probeCfg(), rec, nil, nil)
 
 	require.Len(t, rec.calls, 1)
 	require.Equal(t, 0.0, rec.calls[0].availability, "an unobserved endpoint scores unhealthy")
@@ -262,7 +262,7 @@ func TestProbeCycleCore_ReturnsCycleCounts(t *testing.T) {
 	scored, reEnabled, syncOmitted := runProbeCycleCore(
 		endpoints, healthy, 1000, true,
 		provideroptimizer.SyncReference{ConsensusConfigured: true, Block: 1000, Time: now, Fresh: true},
-		now, probeCfg(), &recordingAppender{}, nil)
+		now, probeCfg(), &recordingAppender{}, nil, nil)
 	require.Equal(t, 2, scored, "both endpoints scored")
 	require.Equal(t, 0, reEnabled, "already-enabled endpoints are never re-enabled")
 	require.Equal(t, 0, syncOmitted, "fresh baseline → no sync omitted")
@@ -271,7 +271,7 @@ func TestProbeCycleCore_ReturnsCycleCounts(t *testing.T) {
 	_, _, syncOmitted = runProbeCycleCore(
 		endpoints, healthy, 0, false,
 		provideroptimizer.SyncReference{ConsensusConfigured: true},
-		now, probeCfg(), &recordingAppender{}, nil)
+		now, probeCfg(), &recordingAppender{}, nil, nil)
 	require.Equal(t, 2, syncOmitted, "no fresh baseline → both providers' sync omitted (F5)")
 }
 
@@ -290,7 +290,7 @@ func TestProbeCycleCore_CountsReEnable(t *testing.T) {
 		getObs := func(string) (endpointstate.EndpointObservation, bool) {
 			return freshObs(1000, now.Add(-time.Second), pollTime, 20*time.Millisecond), true
 		}
-		_, reEnabled, _ := runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{}, now, probeCfg(), nil, nil)
+		_, reEnabled, _ := runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{}, now, probeCfg(), nil, nil, nil)
 		lastReEnabled = reEnabled
 		if i < K {
 			require.Equal(t, 0, reEnabled, "no re-enable before the K-th distinct healthy poll")

--- a/protocol/rpcsmartrouter/recovery_probe.go
+++ b/protocol/rpcsmartrouter/recovery_probe.go
@@ -1,0 +1,128 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/chainlib"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+)
+
+// This file is the MAG-2550 recovery-probe pair: the relay path RECORDS the failing read-only
+// request when an endpoint is marked unhealthy (recordRelayProbeEvidence), and the probe loop
+// REPLAYS it before re-enabling the disabled endpoint (replayFailingRelay). Together they close
+// the evidence gap that caused the disable/re-enable flap: the poll method (eth_blockNumber) and
+// the failing relay method (e.g. eth_call) measure different things, so healthy polls alone must
+// never re-enable an endpoint whose relay path was the thing that broke.
+
+// relayProbeTimeout bounds one replay of the recorded failing request. Deliberately generous
+// relative to the probe cadence: the replay runs at most once per earned poll-hysteresis streak
+// per disabled endpoint, off the data plane, and a slow-but-correct answer is still recovery
+// evidence.
+const relayProbeTimeout = 10 * time.Second
+
+// relayProbeFunc replays a disabled endpoint's recorded failing request and reports whether it no
+// longer produces a health-affecting failure. Injected into runProbeCycleCore so the pure cycle
+// body stays testable without network I/O.
+type relayProbeFunc func(ep *lavasession.EndpointWithDirectConnection, method string, payload []byte) bool
+
+// recordRelayProbeEvidence stores the failing request on the endpoint as replayable recovery
+// evidence (Endpoint.RecordFailingRelay), called just before MarkUnhealthy on a health-affecting
+// relay failure. Eligibility gates, in order:
+//   - JSON-RPC interface only: the raw POST body is fully self-contained, so replaying the exact
+//     bytes through DirectRPCConnection.SendRequest reproduces the request faithfully. REST/gRPC
+//     requests carry out-of-band routing (URL path, method descriptors) and fall back to the
+//     poll-only re-enable path with its trial budget.
+//   - Read-only methods only: a write (Stateful == CONSISTENCY_SELECT_ALL_PROVIDERS) must never be
+//     re-broadcast as a health check, subscriptions don't fit a one-shot replay, and hanging APIs
+//     would stall the probe cycle. Writes are also broadcast to all providers on the client path,
+//     so a write-broken provider cannot single-handedly fail a client anyway.
+//
+// Unsupported-method responses never reach this function at all: classifyEndpointHealth returns
+// shouldMarkUnhealthy=false for them, so they neither disable the endpoint nor pollute the
+// recorded evidence.
+func (rpcss *RPCSmartRouterServer) recordRelayProbeEvidence(endpoint *lavasession.Endpoint, chainMessage chainlib.ChainMessage, requestData []byte) {
+	if endpoint == nil || chainMessage == nil {
+		return
+	}
+	if rpcss.listenEndpoint.ApiInterface != spectypes.APIInterfaceJsonRPC {
+		return
+	}
+	if chainlib.GetStateful(chainMessage) == common.CONSISTENCY_SELECT_ALL_PROVIDERS {
+		return
+	}
+	if chainlib.IsHangingApi(chainMessage) {
+		return
+	}
+	if chainlib.IsFunctionTagOfType(chainMessage, spectypes.FUNCTION_TAG_SUBSCRIBE) {
+		return
+	}
+	endpoint.RecordFailingRelay(chainMessage.GetApi().Name, requestData)
+}
+
+// replayFailingRelay sends the recorded failing request through the endpoint's own direct
+// connection and judges the outcome by the SAME classification rules the relay path uses to mark
+// endpoints unhealthy. "Success" therefore means exactly: this request no longer produces a
+// health-affecting failure. A user-level node error (e.g. an execution revert) counts as
+// recovered — the transport and the method handler answered — while 5xx, timeouts, connection
+// errors, and health-affecting node errors keep the endpoint disabled. A 429 is treated as
+// failure: a rate-limited replay never exercised the failing handler, so it proves nothing either
+// way and the probe simply retries after the next earned poll streak.
+func (rpcss *RPCSmartRouterServer) replayFailingRelay(ep *lavasession.EndpointWithDirectConnection, method string, payload []byte) bool {
+	if ep == nil || ep.DirectConnection == nil || len(payload) == 0 {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), relayProbeTimeout)
+	defer cancel()
+	resp, err := ep.DirectConnection.SendRequest(ctx, payload, nil)
+
+	chainFamily := common.ChainFamily(-1)
+	if family, ok := common.GetChainFamily(rpcss.listenEndpoint.ChainID); ok {
+		chainFamily = family
+	}
+
+	if err != nil {
+		// HTTP-status errors mirror the relay path's status rule (5xx unhealthy except 501,
+		// which is a capability answer, not a fault).
+		if httpErr, ok := err.(*lavasession.HTTPStatusError); ok {
+			if httpErr.StatusCode == http.StatusTooManyRequests {
+				return false // busy: the failing handler was never exercised — no evidence
+			}
+			unhealthy, _ := classifyHTTPStatus(httpErr.StatusCode)
+			return !unhealthy || httpErr.StatusCode == http.StatusNotImplemented
+		}
+		classified, _ := classifyDirectRPCError(err, chainFamily, common.TransportJsonRPC)
+		if classified.IsRateLimited() {
+			return false
+		}
+		unhealthy, _ := classifyEndpointHealth(classified, false)
+		return !unhealthy
+	}
+	if resp == nil {
+		return false
+	}
+
+	// Transport-level success. A JSON-RPC node error can still ride an HTTP 200 body — classify it
+	// with the same registry the relay path uses. Batch replies (JSON arrays) don't match the
+	// single-object shape and fall through to success: the transport answered, which is all a
+	// multi-request payload can prove per-replay.
+	var nodeErr struct {
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if len(resp.Data) > 0 && json.Unmarshal(resp.Data, &nodeErr) == nil && nodeErr.Error != nil {
+		classified := common.ClassifyError(nil, chainFamily, common.TransportJsonRPC, nodeErr.Error.Code, nodeErr.Error.Message)
+		if classified.IsRateLimited() {
+			return false
+		}
+		unhealthy, _ := classifyEndpointHealth(classified, false)
+		return !unhealthy
+	}
+	return true
+}

--- a/protocol/rpcsmartrouter/recovery_probe.go
+++ b/protocol/rpcsmartrouter/recovery_probe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/magma-Devs/smart-router/protocol/chainlib"
@@ -19,20 +20,91 @@ import (
 // the failing relay method (e.g. eth_call) measure different things, so healthy polls alone must
 // never re-enable an endpoint whose relay path was the thing that broke.
 
-// relayProbeTimeout bounds one replay of the recorded failing request. Deliberately generous
-// relative to the probe cadence: the replay runs at most once per earned poll-hysteresis streak
-// per disabled endpoint, off the data plane, and a slow-but-correct answer is still recovery
-// evidence.
-const relayProbeTimeout = 10 * time.Second
+// minRelayProbeTimeout floors one replay's budget. The effective budget is the RECORDED relay
+// timeout — the spec/CU-derived budget the request actually failed under, carried with the
+// evidence — never less than this floor, and extended by the endpoint's own NodeUrl.Timeout
+// exactly like the relay path (LowerContextTimeoutWithDuration). A flat probe timeout below the
+// relay path's would fail every slow-but-recovered heavy method (eth_getLogs, debug_trace*)
+// forever, holding a healthy endpoint out of rotation until the epoch reset.
+const minRelayProbeTimeout = 10 * time.Second
 
-// relayProbeFunc replays a disabled endpoint's recorded failing request and reports whether it no
-// longer produces a health-affecting failure. Injected into runProbeCycleCore so the pure cycle
-// body stays testable without network I/O.
-type relayProbeFunc func(ep *lavasession.EndpointWithDirectConnection, method string, payload []byte) bool
+// relayProbeVerdict is the replay judge's three-way outcome. The state machine treats them very
+// differently: recovered completes the two-step re-enable; still-failing resets the streak AND
+// escalates the flap hysteresis (a relay-path failure was demonstrated); inconclusive resets the
+// streak WITHOUT escalating (nothing was demonstrated either way). Both non-recovered verdicts
+// consume one replay attempt of the evidence, which is dropped after maxRelayProbeAttempts —
+// the bounded escape to the poll-only path.
+type relayProbeVerdict int
+
+const (
+	relayProbeRecovered relayProbeVerdict = iota
+	relayProbeStillFailing
+	relayProbeInconclusive
+)
+
+// relayProbeFunc replays a disabled endpoint's recorded failing request under the recorded relay
+// timeout and judges the outcome. Injected into runProbeCycleCore (via relayProbeRunner) so the
+// pure cycle body stays testable without network I/O.
+type relayProbeFunc func(ep *lavasession.EndpointWithDirectConnection, method string, payload []byte, relayTimeout time.Duration) relayProbeVerdict
+
+// relayProbeRunner executes replays for the probe cycle WITHOUT blocking it. The probe loop is a
+// single serial ticker that also feeds every provider's QoS sample; a replay can legitimately run
+// tens of seconds (heavy recorded methods), and a provider-wide recovery makes several endpoints
+// replay candidates in the same cycle — run inline they would serialize to N×timeout, starving
+// the QoS feed and silently dropping ticks. So launch() runs each replay on its own goroutine
+// (async=false runs inline, for deterministic tests) and applies the verdict on completion via
+// the endpoint's own thread-safe transitions (ConfirmRelayRecovery / RelayProbeFailed /
+// RelayProbeInconclusive, all inert against racing re-enables). inFlight guarantees at most ONE
+// outstanding replay per endpoint: candidacy is re-derived every cycle while the streak holds, so
+// without the guard each 5s tick would stack another replay of the same evidence.
+type relayProbeRunner struct {
+	probe relayProbeFunc
+	async bool
+
+	mu       sync.Mutex
+	inFlight map[string]struct{} // keyed by Endpoint.NetworkAddress
+}
+
+// launch runs one replay for the endpoint keyed by key, unless one is already outstanding.
+func (r *relayProbeRunner) launch(key string, run func()) {
+	r.mu.Lock()
+	if _, busy := r.inFlight[key]; busy {
+		r.mu.Unlock()
+		return
+	}
+	if r.inFlight == nil {
+		r.inFlight = make(map[string]struct{})
+	}
+	r.inFlight[key] = struct{}{}
+	r.mu.Unlock()
+
+	wrapped := func() {
+		defer func() {
+			r.mu.Lock()
+			delete(r.inFlight, key)
+			r.mu.Unlock()
+		}()
+		run()
+	}
+	if r.async {
+		go wrapped()
+		return
+	}
+	wrapped()
+}
 
 // recordRelayProbeEvidence stores the failing request on the endpoint as replayable recovery
 // evidence (Endpoint.RecordFailingRelay), called just before MarkUnhealthy on a health-affecting
-// relay failure. Eligibility gates, in order:
+// relay failure. relayTimeout is the relay path's effective budget for this request, recorded so
+// the replay judges under the same budget the request failed with.
+//
+// NOTE the eligibility gates below are about the SHAPE of the request, never the CAUSE of the
+// failure: any health-affecting failure of an eligible request records evidence — 5xx storms,
+// timeouts, and transport faults included (they all carry a valid chainMessage). On a JSON-RPC
+// router this makes recording the COMMON disable path; the poll-only fallback is the exception
+// (REST/gRPC interfaces, writes, subscriptions, hanging APIs, batches, oversized payloads) plus
+// episodes whose evidence was dropped after maxRelayProbeAttempts non-recovered replays.
+// Eligibility gates, in order:
 //   - JSON-RPC interface only: the raw POST body is fully self-contained, so replaying the exact
 //     bytes through DirectRPCConnection.SendRequest reproduces the request faithfully. REST/gRPC
 //     requests carry out-of-band routing (URL path, method descriptors) and fall back to the
@@ -41,11 +113,17 @@ type relayProbeFunc func(ep *lavasession.EndpointWithDirectConnection, method st
 //     re-broadcast as a health check, subscriptions don't fit a one-shot replay, and hanging APIs
 //     would stall the probe cycle. Writes are also broadcast to all providers on the client path,
 //     so a write-broken provider cannot single-handedly fail a client anyway.
+//   - No batches (top-level JSON arrays): a batch reply cannot be judged by the single-response
+//     health classification, so a batch replay could only ever prove transport success — no more
+//     than the poll it is meant to improve on. Recording it would make the gate a silent no-op;
+//     falling back to the poll-only path says what it means. (This also keeps the synthesized
+//     unbounded a+SEP+b batch method name out of the evidence — see 6fef8e0 for the metrics-label
+//     twin of that problem.)
 //
 // Unsupported-method responses never reach this function at all: classifyEndpointHealth returns
 // shouldMarkUnhealthy=false for them, so they neither disable the endpoint nor pollute the
 // recorded evidence.
-func (rpcss *RPCSmartRouterServer) recordRelayProbeEvidence(endpoint *lavasession.Endpoint, chainMessage chainlib.ChainMessage, requestData []byte) {
+func (rpcss *RPCSmartRouterServer) recordRelayProbeEvidence(endpoint *lavasession.Endpoint, chainMessage chainlib.ChainMessage, requestData []byte, relayTimeout time.Duration) {
 	if endpoint == nil || chainMessage == nil {
 		return
 	}
@@ -61,22 +139,49 @@ func (rpcss *RPCSmartRouterServer) recordRelayProbeEvidence(endpoint *lavasessio
 	if chainlib.IsFunctionTagOfType(chainMessage, spectypes.FUNCTION_TAG_SUBSCRIBE) {
 		return
 	}
-	endpoint.RecordFailingRelay(chainMessage.GetApi().Name, requestData)
+	if isBatchPayload(requestData) {
+		return
+	}
+	endpoint.RecordFailingRelay(chainMessage.GetApi().Name, requestData, relayTimeout)
+}
+
+// isBatchPayload reports whether the raw JSON-RPC POST body is a batch — a top-level JSON array.
+func isBatchPayload(data []byte) bool {
+	for _, b := range data {
+		switch b {
+		case ' ', '\t', '\r', '\n':
+			continue
+		default:
+			return b == '['
+		}
+	}
+	return false
 }
 
 // replayFailingRelay sends the recorded failing request through the endpoint's own direct
 // connection and judges the outcome by the SAME classification rules the relay path uses to mark
-// endpoints unhealthy. "Success" therefore means exactly: this request no longer produces a
-// health-affecting failure. A user-level node error (e.g. an execution revert) counts as
-// recovered — the transport and the method handler answered — while 5xx, timeouts, connection
-// errors, and health-affecting node errors keep the endpoint disabled. A 429 is treated as
-// failure: a rate-limited replay never exercised the failing handler, so it proves nothing either
-// way and the probe simply retries after the next earned poll streak.
-func (rpcss *RPCSmartRouterServer) replayFailingRelay(ep *lavasession.EndpointWithDirectConnection, method string, payload []byte) bool {
+// endpoints unhealthy. The budget mirrors the relay path too: the recorded relay timeout (floored
+// at minRelayProbeTimeout) extended by the endpoint's NodeUrl.Timeout override, so a request that
+// was failing under N seconds is judged under N seconds — never a tighter probe-only deadline.
+//
+// The three verdicts:
+//   - recovered: the request no longer produces a health-affecting failure. A user-level node
+//     error (e.g. an execution revert) counts — the transport and the method handler answered.
+//   - still-failing: a health-affecting failure the relay path would disable on (5xx except 501,
+//     timeouts, connection errors, health-affecting node errors).
+//   - inconclusive: the replay proved nothing either way — rate-limited (the failing handler was
+//     never exercised), an unclassifiable HTTP status (auth drift, proxy 4xx), or an unparseable
+//     body on transport success (a proxy's HTML error page). Failing OPEN here would degrade the
+//     gate to "always confirm" with no signal; failing CLOSED would escalate the flap hysteresis
+//     on evidence of nothing. Inconclusive does neither.
+func (rpcss *RPCSmartRouterServer) replayFailingRelay(ep *lavasession.EndpointWithDirectConnection, method string, payload []byte, relayTimeout time.Duration) relayProbeVerdict {
 	if ep == nil || ep.DirectConnection == nil || len(payload) == 0 {
-		return false
+		return relayProbeInconclusive
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), relayProbeTimeout)
+	if relayTimeout < minRelayProbeTimeout {
+		relayTimeout = minRelayProbeTimeout
+	}
+	ctx, cancel := ep.DirectConnection.GetNodeUrl().LowerContextTimeoutWithDuration(context.Background(), relayTimeout)
 	defer cancel()
 	resp, err := ep.DirectConnection.SendRequest(ctx, payload, nil)
 
@@ -87,42 +192,58 @@ func (rpcss *RPCSmartRouterServer) replayFailingRelay(ep *lavasession.EndpointWi
 
 	if err != nil {
 		// HTTP-status errors mirror the relay path's status rule (5xx unhealthy except 501,
-		// which is a capability answer, not a fault).
+		// which is a capability answer, not a fault). Statuses the relay path would NOT disable
+		// on (unrecognized 4xx: auth drift, a proxy in the way) prove nothing about the recorded
+		// failure — inconclusive, never "recovered".
 		if httpErr, ok := err.(*lavasession.HTTPStatusError); ok {
-			if httpErr.StatusCode == http.StatusTooManyRequests {
-				return false // busy: the failing handler was never exercised — no evidence
+			switch {
+			case httpErr.StatusCode == http.StatusTooManyRequests:
+				return relayProbeInconclusive // busy: the failing handler was never exercised
+			case httpErr.StatusCode == http.StatusNotImplemented:
+				return relayProbeRecovered // capability answer, not a fault
+			default:
+				if unhealthy, _ := classifyHTTPStatus(httpErr.StatusCode); unhealthy {
+					return relayProbeStillFailing
+				}
+				return relayProbeInconclusive
 			}
-			unhealthy, _ := classifyHTTPStatus(httpErr.StatusCode)
-			return !unhealthy || httpErr.StatusCode == http.StatusNotImplemented
 		}
 		classified, _ := classifyDirectRPCError(err, chainFamily, common.TransportJsonRPC)
 		if classified.IsRateLimited() {
-			return false
+			return relayProbeInconclusive
 		}
-		unhealthy, _ := classifyEndpointHealth(classified, false)
-		return !unhealthy
+		if unhealthy, _ := classifyEndpointHealth(classified, false); unhealthy {
+			return relayProbeStillFailing
+		}
+		// The relay path would not have disabled on this error — the health-affecting failure is
+		// gone, which is exactly what the gate needs to know.
+		return relayProbeRecovered
 	}
 	if resp == nil {
-		return false
+		return relayProbeInconclusive
 	}
 
 	// Transport-level success. A JSON-RPC node error can still ride an HTTP 200 body — classify it
-	// with the same registry the relay path uses. Batch replies (JSON arrays) don't match the
-	// single-object shape and fall through to success: the transport answered, which is all a
-	// multi-request payload can prove per-replay.
+	// with the same registry the relay path uses. A body that does not parse as a single JSON-RPC
+	// object (empty, a proxy's HTML error page, a stray batch array — batches are never recorded)
+	// cannot be judged: inconclusive, not success.
 	var nodeErr struct {
 		Error *struct {
 			Code    int    `json:"code"`
 			Message string `json:"message"`
 		} `json:"error"`
 	}
-	if len(resp.Data) > 0 && json.Unmarshal(resp.Data, &nodeErr) == nil && nodeErr.Error != nil {
+	if len(resp.Data) == 0 || json.Unmarshal(resp.Data, &nodeErr) != nil {
+		return relayProbeInconclusive
+	}
+	if nodeErr.Error != nil {
 		classified := common.ClassifyError(nil, chainFamily, common.TransportJsonRPC, nodeErr.Error.Code, nodeErr.Error.Message)
 		if classified.IsRateLimited() {
-			return false
+			return relayProbeInconclusive
 		}
-		unhealthy, _ := classifyEndpointHealth(classified, false)
-		return !unhealthy
+		if unhealthy, _ := classifyEndpointHealth(classified, false); unhealthy {
+			return relayProbeStillFailing
+		}
 	}
-	return true
+	return relayProbeRecovered
 }

--- a/protocol/rpcsmartrouter/recovery_probe_test.go
+++ b/protocol/rpcsmartrouter/recovery_probe_test.go
@@ -1,0 +1,270 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/magma-Devs/smart-router/protocol/chainlib"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/endpointstate"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// MAG-2550 — the recovery-probe pair: recordRelayProbeEvidence (relay path, eligibility) and
+// replayFailingRelay (probe loop, judge), plus the probe-cycle integration of the two-step
+// re-enable (gate → replay → confirm/fail).
+
+// ---------------------------------------------------------------------------
+// Probe-cycle integration: gate → replay → confirm / fail
+// ---------------------------------------------------------------------------
+
+var testEvidence = []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[]}`)
+
+// relayProbeRecorder is a fake relayProbeFunc that records invocations and returns a scripted
+// verdict per call.
+type relayProbeRecorder struct {
+	verdicts []bool // consumed in order; the last value repeats
+	calls    int
+	method   string
+	payload  []byte
+}
+
+func (r *relayProbeRecorder) probe(ep *lavasession.EndpointWithDirectConnection, method string, payload []byte) bool {
+	r.calls++
+	r.method = method
+	r.payload = payload
+	idx := r.calls - 1
+	if idx >= len(r.verdicts) {
+		idx = len(r.verdicts) - 1
+	}
+	return r.verdicts[idx]
+}
+
+// TestProbeCycle_RelayEvidenceGatesReEnableUntilReplayPasses: an endpoint whose disable episode
+// recorded a failing relay is NOT re-enabled by poll hysteresis alone — the cycle replays the
+// recorded request at the threshold, and only a passing replay re-enables (counting as the
+// cycle's re-enable and restoring routing).
+func TestProbeCycle_RelayEvidenceGatesReEnableUntilReplayPasses(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	dc := ep("http://ep:8545", "provider1", false)
+	dc.Endpoint.RecordFailingRelay("eth_call", testEvidence)
+	endpoints := []*lavasession.EndpointWithDirectConnection{dc}
+
+	probe := &relayProbeRecorder{verdicts: []bool{true}}
+	var recovered []string
+	cycle := func(i int) int {
+		pollTime := base.Add(time.Duration(i) * time.Second)
+		now := pollTime.Add(time.Millisecond)
+		getObs := func(string) (endpointstate.EndpointObservation, bool) {
+			return freshObs(1000, now.Add(-time.Second), pollTime, 20*time.Millisecond), true
+		}
+		_, reEnabled, _ := runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{},
+			now, probeCfg(), nil, func(p string) { recovered = append(recovered, p) }, probe.probe)
+		return reEnabled
+	}
+
+	K := int(probeCfg().ReEnableHysteresis)
+	for i := 1; i < K; i++ {
+		require.Equal(t, 0, cycle(i))
+		require.Zero(t, probe.calls, "no replay before the poll hysteresis is earned")
+		require.False(t, dc.Endpoint.Enabled)
+	}
+	// The K-th cycle replays the recorded request and, on success, re-enables in the same cycle.
+	require.Equal(t, 1, cycle(K), "a passing replay counts as the cycle's re-enable")
+	require.Equal(t, 1, probe.calls, "exactly one replay at the threshold")
+	require.Equal(t, "eth_call", probe.method)
+	require.Equal(t, testEvidence, probe.payload, "the replay receives the exact recorded request")
+	require.True(t, dc.Endpoint.Enabled)
+	require.Equal(t, []string{"provider1"}, recovered, "a replay-confirmed recovery restores routing (F2)")
+}
+
+// TestProbeCycle_FailedReplayKeepsDisabledAndPacesRetries: a failing replay keeps the endpoint
+// disabled, resets the streak, and escalates — the next replay happens only after the escalated
+// K<<1 streak is re-earned, NOT on every cycle.
+func TestProbeCycle_FailedReplayKeepsDisabledAndPacesRetries(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	dc := ep("http://ep:8545", "provider1", false)
+	dc.Endpoint.RecordFailingRelay("eth_call", testEvidence)
+	endpoints := []*lavasession.EndpointWithDirectConnection{dc}
+
+	probe := &relayProbeRecorder{verdicts: []bool{false, true}}
+	cycle := func(i int) int {
+		pollTime := base.Add(time.Duration(i) * time.Second)
+		now := pollTime.Add(time.Millisecond)
+		getObs := func(string) (endpointstate.EndpointObservation, bool) {
+			return freshObs(1000, now.Add(-time.Second), pollTime, 20*time.Millisecond), true
+		}
+		_, reEnabled, _ := runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{},
+			now, probeCfg(), nil, nil, probe.probe)
+		return reEnabled
+	}
+
+	K := int(probeCfg().ReEnableHysteresis)
+	for i := 1; i <= K; i++ {
+		require.Equal(t, 0, cycle(i), "a failing replay must not re-enable")
+	}
+	require.Equal(t, 1, probe.calls, "one replay at the threshold, which failed")
+	require.False(t, dc.Endpoint.Enabled)
+
+	// The next K cycles re-earn only the BASE streak — below the escalated K<<1 → no replay yet.
+	for i := K + 1; i <= 2*K; i++ {
+		require.Equal(t, 0, cycle(i))
+	}
+	require.Equal(t, 1, probe.calls, "no replay until the escalated K<<1 streak is re-earned (pacing)")
+
+	// Completing the escalated streak triggers the second replay, which passes → re-enabled.
+	var last int
+	for i := 2*K + 1; i <= 3*K; i++ {
+		last = cycle(i)
+	}
+	require.Equal(t, 2, probe.calls, "second replay exactly when the escalated streak completes")
+	require.Equal(t, 1, last, "the passing replay's cycle reports the re-enable")
+	require.True(t, dc.Endpoint.Enabled)
+}
+
+// TestProbeCycle_NilRelayProbeFallsBackToPollOnly: without replay wiring (nil relayProbe — tests,
+// degraded setups) recorded evidence must not park the endpoint forever; the cycle falls back to
+// poll-only evidence like the legacy path.
+func TestProbeCycle_NilRelayProbeFallsBackToPollOnly(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	dc := ep("http://ep:8545", "provider1", false)
+	dc.Endpoint.RecordFailingRelay("eth_call", testEvidence)
+	endpoints := []*lavasession.EndpointWithDirectConnection{dc}
+
+	K := int(probeCfg().ReEnableHysteresis)
+	for i := 1; i <= K; i++ {
+		pollTime := base.Add(time.Duration(i) * time.Second)
+		now := pollTime.Add(time.Millisecond)
+		getObs := func(string) (endpointstate.EndpointObservation, bool) {
+			return freshObs(1000, now.Add(-time.Second), pollTime, 20*time.Millisecond), true
+		}
+		runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{}, now, probeCfg(), nil, nil, nil)
+	}
+	require.True(t, dc.Endpoint.Enabled, "nil relayProbe falls back to poll-only re-enable instead of parking the endpoint")
+}
+
+// ---------------------------------------------------------------------------
+// replayFailingRelay — the judge
+// ---------------------------------------------------------------------------
+
+// fakeDirectConn is a scriptable DirectRPCConnection for the replay judge.
+type fakeDirectConn struct {
+	resp       *lavasession.DirectRPCResponse
+	err        error
+	gotPayload []byte
+}
+
+func (f *fakeDirectConn) SendRequest(ctx context.Context, data []byte, headers map[string]string) (*lavasession.DirectRPCResponse, error) {
+	f.gotPayload = data
+	return f.resp, f.err
+}
+func (f *fakeDirectConn) GetProtocol() lavasession.DirectRPCProtocol { return "http" }
+func (f *fakeDirectConn) Close() error                               { return nil }
+func (f *fakeDirectConn) GetURL() string                             { return "http://fake:8545" }
+func (f *fakeDirectConn) GetNodeUrl() *common.NodeUrl                { return nil }
+
+func replayServer() *RPCSmartRouterServer {
+	return &RPCSmartRouterServer{
+		listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: spectypes.APIInterfaceJsonRPC},
+	}
+}
+
+func replayWith(t *testing.T, conn *fakeDirectConn) bool {
+	t.Helper()
+	rpcss := replayServer()
+	epc := &lavasession.EndpointWithDirectConnection{
+		Endpoint:         &lavasession.Endpoint{NetworkAddress: "http://fake:8545"},
+		DirectConnection: conn,
+		ProviderAddress:  "provider1",
+	}
+	return rpcss.replayFailingRelay(epc, "eth_call", testEvidence)
+}
+
+// TestReplayFailingRelay_JudgesByHealthClassification pins the judge's contract: "pass" means the
+// request no longer produces a HEALTH-AFFECTING failure — the same rule the relay path uses to
+// mark endpoints unhealthy — not "the request returned a happy result".
+func TestReplayFailingRelay_JudgesByHealthClassification(t *testing.T) {
+	cases := []struct {
+		name string
+		conn *fakeDirectConn
+		want bool
+	}{
+		{"clean 200 result", &fakeDirectConn{resp: &lavasession.DirectRPCResponse{
+			StatusCode: 200, Data: []byte(`{"jsonrpc":"2.0","id":1,"result":"0x1"}`)}}, true},
+		{"5xx still failing", &fakeDirectConn{err: &lavasession.HTTPStatusError{StatusCode: 503, Status: "503"}}, false},
+		{"429 proves nothing", &fakeDirectConn{err: &lavasession.HTTPStatusError{StatusCode: 429, Status: "429"}}, false},
+		{"501 is a capability answer, not a fault", &fakeDirectConn{err: &lavasession.HTTPStatusError{StatusCode: 501, Status: "501"}}, true},
+		{"transport error still failing", &fakeDirectConn{err: context.DeadlineExceeded}, false},
+		{"node internal error rides HTTP 200", &fakeDirectConn{resp: &lavasession.DirectRPCResponse{
+			StatusCode: 200, Data: []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"internal error"}}`)}}, false},
+		{"unsupported method in body is not a fault", &fakeDirectConn{resp: &lavasession.DirectRPCResponse{
+			StatusCode: 200, Data: []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found"}}`)}}, true},
+		{"batch reply (JSON array) passes on transport success", &fakeDirectConn{resp: &lavasession.DirectRPCResponse{
+			StatusCode: 200, Data: []byte(`[{"jsonrpc":"2.0","id":1,"result":"0x1"}]`)}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, replayWith(t, tc.conn))
+			require.Equal(t, testEvidence, tc.conn.gotPayload, "the judge sends the exact recorded bytes")
+		})
+	}
+}
+
+func TestReplayFailingRelay_NoConnectionFails(t *testing.T) {
+	rpcss := replayServer()
+	require.False(t, rpcss.replayFailingRelay(nil, "eth_call", testEvidence))
+	require.False(t, rpcss.replayFailingRelay(&lavasession.EndpointWithDirectConnection{}, "eth_call", testEvidence))
+}
+
+// ---------------------------------------------------------------------------
+// recordRelayProbeEvidence — eligibility
+// ---------------------------------------------------------------------------
+
+func mockMessage(t *testing.T, api *spectypes.Api, parseDirective *spectypes.ParseDirective) *chainlib.MockChainMessage {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	msg := chainlib.NewMockChainMessage(ctrl)
+	msg.EXPECT().GetApi().Return(api).AnyTimes()
+	msg.EXPECT().GetParseDirective().Return(parseDirective).AnyTimes()
+	return msg
+}
+
+// TestRecordRelayProbeEvidence_Eligibility pins the recording rules: read-only JSON-RPC methods
+// are recorded; writes (stateful), subscriptions, hanging APIs, and non-JSON-RPC interfaces are
+// not — those episodes fall back to the poll-only path with its trial budget.
+func TestRecordRelayProbeEvidence_Eligibility(t *testing.T) {
+	readOnly := &spectypes.Api{Name: "eth_call"}
+	write := &spectypes.Api{Name: "eth_sendRawTransaction", Category: spectypes.SpecCategory{Stateful: common.CONSISTENCY_SELECT_ALL_PROVIDERS}}
+	hanging := &spectypes.Api{Name: "eth_newFilter", Category: spectypes.SpecCategory{HangingApi: true}}
+	subscribe := &spectypes.Api{Name: "eth_subscribe"}
+	subscribeDirective := &spectypes.ParseDirective{ApiName: "eth_subscribe", FunctionTag: spectypes.FUNCTION_TAG_SUBSCRIBE}
+
+	cases := []struct {
+		name         string
+		apiInterface string
+		msg          chainlib.ChainMessage
+		wantRecorded bool
+	}{
+		{"read-only jsonrpc method is recorded", spectypes.APIInterfaceJsonRPC, mockMessage(t, readOnly, nil), true},
+		{"write method never recorded", spectypes.APIInterfaceJsonRPC, mockMessage(t, write, nil), false},
+		{"hanging api never recorded", spectypes.APIInterfaceJsonRPC, mockMessage(t, hanging, nil), false},
+		{"subscription never recorded", spectypes.APIInterfaceJsonRPC, mockMessage(t, subscribe, subscribeDirective), false},
+		{"non-jsonrpc interface never recorded", spectypes.APIInterfaceRest, mockMessage(t, readOnly, nil), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rpcss := &RPCSmartRouterServer{
+				listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: tc.apiInterface},
+			}
+			endpoint := &lavasession.Endpoint{NetworkAddress: "http://ep:8545", Enabled: true}
+			rpcss.recordRelayProbeEvidence(endpoint, tc.msg, testEvidence)
+			recorded := endpoint.HealthSnapshot().RelayProbeMethod != ""
+			require.Equal(t, tc.wantRecorded, recorded)
+		})
+	}
+}

--- a/protocol/rpcsmartrouter/recovery_probe_test.go
+++ b/protocol/rpcsmartrouter/recovery_probe_test.go
@@ -2,6 +2,7 @@ package rpcsmartrouter
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,8 +17,9 @@ import (
 )
 
 // MAG-2550 — the recovery-probe pair: recordRelayProbeEvidence (relay path, eligibility) and
-// replayFailingRelay (probe loop, judge), plus the probe-cycle integration of the two-step
-// re-enable (gate → replay → confirm/fail).
+// replayFailingRelay (probe loop, three-way judge), plus the probe-cycle integration of the
+// two-step re-enable (gate → replay → confirm / still-failing / inconclusive) through the
+// relayProbeRunner (replays off the cycle, single-flight per endpoint).
 
 // ---------------------------------------------------------------------------
 // Probe-cycle integration: gate → replay → confirm / fail
@@ -25,19 +27,23 @@ import (
 
 var testEvidence = []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[]}`)
 
+const testEvidenceTimeout = 15 * time.Second
+
 // relayProbeRecorder is a fake relayProbeFunc that records invocations and returns a scripted
 // verdict per call.
 type relayProbeRecorder struct {
-	verdicts []bool // consumed in order; the last value repeats
+	verdicts []relayProbeVerdict // consumed in order; the last value repeats
 	calls    int
 	method   string
 	payload  []byte
+	timeout  time.Duration
 }
 
-func (r *relayProbeRecorder) probe(ep *lavasession.EndpointWithDirectConnection, method string, payload []byte) bool {
+func (r *relayProbeRecorder) probe(ep *lavasession.EndpointWithDirectConnection, method string, payload []byte, relayTimeout time.Duration) relayProbeVerdict {
 	r.calls++
 	r.method = method
 	r.payload = payload
+	r.timeout = relayTimeout
 	idx := r.calls - 1
 	if idx >= len(r.verdicts) {
 		idx = len(r.verdicts) - 1
@@ -45,40 +51,52 @@ func (r *relayProbeRecorder) probe(ep *lavasession.EndpointWithDirectConnection,
 	return r.verdicts[idx]
 }
 
+// syncRunner wraps a recorder in a relayProbeRunner that executes inline (async=false), so the
+// cycle tests stay deterministic while exercising the same launch path production uses.
+func syncRunner(probe *relayProbeRecorder) *relayProbeRunner {
+	return &relayProbeRunner{probe: probe.probe}
+}
+
 // TestProbeCycle_RelayEvidenceGatesReEnableUntilReplayPasses: an endpoint whose disable episode
 // recorded a failing relay is NOT re-enabled by poll hysteresis alone — the cycle replays the
-// recorded request at the threshold, and only a passing replay re-enables (counting as the
-// cycle's re-enable and restoring routing).
+// recorded request (with its recorded timeout) at the threshold, and only a passing replay
+// re-enables and restores routing. Replay-granted re-enables complete on the replayer, so they are
+// NOT part of the cycle's synchronous reEnabled count.
 func TestProbeCycle_RelayEvidenceGatesReEnableUntilReplayPasses(t *testing.T) {
 	base := time.Unix(1_700_000_000, 0)
 	dc := ep("http://ep:8545", "provider1", false)
-	dc.Endpoint.RecordFailingRelay("eth_call", testEvidence)
+	dc.Endpoint.RecordFailingRelay("eth_call", testEvidence, testEvidenceTimeout)
 	endpoints := []*lavasession.EndpointWithDirectConnection{dc}
 
-	probe := &relayProbeRecorder{verdicts: []bool{true}}
+	probe := &relayProbeRecorder{verdicts: []relayProbeVerdict{relayProbeRecovered}}
+	runner := syncRunner(probe)
 	var recovered []string
-	cycle := func(i int) int {
+	cycle := func(i int) (reEnabled, evidenceGated int) {
 		pollTime := base.Add(time.Duration(i) * time.Second)
 		now := pollTime.Add(time.Millisecond)
 		getObs := func(string) (endpointstate.EndpointObservation, bool) {
 			return freshObs(1000, now.Add(-time.Second), pollTime, 20*time.Millisecond), true
 		}
-		_, reEnabled, _ := runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{},
-			now, probeCfg(), nil, func(p string) { recovered = append(recovered, p) }, probe.probe)
-		return reEnabled
+		_, reEnabled, _, evidenceGated = runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{},
+			now, probeCfg(), nil, func(p string) { recovered = append(recovered, p) }, runner)
+		return reEnabled, evidenceGated
 	}
 
 	K := int(probeCfg().ReEnableHysteresis)
 	for i := 1; i < K; i++ {
-		require.Equal(t, 0, cycle(i))
+		reEnabled, evidenceGated := cycle(i)
+		require.Zero(t, reEnabled)
+		require.Equal(t, 1, evidenceGated, "a disabled endpoint holding evidence is reported as gated")
 		require.Zero(t, probe.calls, "no replay before the poll hysteresis is earned")
 		require.False(t, dc.Endpoint.Enabled)
 	}
-	// The K-th cycle replays the recorded request and, on success, re-enables in the same cycle.
-	require.Equal(t, 1, cycle(K), "a passing replay counts as the cycle's re-enable")
+	// The K-th cycle replays the recorded request; the (inline) recovered verdict re-enables.
+	reEnabled, _ := cycle(K)
+	require.Zero(t, reEnabled, "replay-granted re-enables are applied by the replayer, not counted as the cycle's synchronous re-enable")
 	require.Equal(t, 1, probe.calls, "exactly one replay at the threshold")
 	require.Equal(t, "eth_call", probe.method)
 	require.Equal(t, testEvidence, probe.payload, "the replay receives the exact recorded request")
+	require.Equal(t, testEvidenceTimeout, probe.timeout, "the replay receives the recorded relay timeout")
 	require.True(t, dc.Endpoint.Enabled)
 	require.Equal(t, []string{"provider1"}, recovered, "a replay-confirmed recovery restores routing (F2)")
 }
@@ -89,51 +107,156 @@ func TestProbeCycle_RelayEvidenceGatesReEnableUntilReplayPasses(t *testing.T) {
 func TestProbeCycle_FailedReplayKeepsDisabledAndPacesRetries(t *testing.T) {
 	base := time.Unix(1_700_000_000, 0)
 	dc := ep("http://ep:8545", "provider1", false)
-	dc.Endpoint.RecordFailingRelay("eth_call", testEvidence)
+	dc.Endpoint.RecordFailingRelay("eth_call", testEvidence, testEvidenceTimeout)
 	endpoints := []*lavasession.EndpointWithDirectConnection{dc}
 
-	probe := &relayProbeRecorder{verdicts: []bool{false, true}}
-	cycle := func(i int) int {
+	probe := &relayProbeRecorder{verdicts: []relayProbeVerdict{relayProbeStillFailing, relayProbeRecovered}}
+	runner := syncRunner(probe)
+	cycle := func(i int) {
 		pollTime := base.Add(time.Duration(i) * time.Second)
 		now := pollTime.Add(time.Millisecond)
 		getObs := func(string) (endpointstate.EndpointObservation, bool) {
 			return freshObs(1000, now.Add(-time.Second), pollTime, 20*time.Millisecond), true
 		}
-		_, reEnabled, _ := runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{},
-			now, probeCfg(), nil, nil, probe.probe)
-		return reEnabled
+		runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{},
+			now, probeCfg(), nil, nil, runner)
 	}
 
 	K := int(probeCfg().ReEnableHysteresis)
 	for i := 1; i <= K; i++ {
-		require.Equal(t, 0, cycle(i), "a failing replay must not re-enable")
+		cycle(i)
 	}
 	require.Equal(t, 1, probe.calls, "one replay at the threshold, which failed")
-	require.False(t, dc.Endpoint.Enabled)
+	require.False(t, dc.Endpoint.Enabled, "a failing replay must not re-enable")
 
 	// The next K cycles re-earn only the BASE streak — below the escalated K<<1 → no replay yet.
 	for i := K + 1; i <= 2*K; i++ {
-		require.Equal(t, 0, cycle(i))
+		cycle(i)
 	}
 	require.Equal(t, 1, probe.calls, "no replay until the escalated K<<1 streak is re-earned (pacing)")
 
 	// Completing the escalated streak triggers the second replay, which passes → re-enabled.
-	var last int
 	for i := 2*K + 1; i <= 3*K; i++ {
-		last = cycle(i)
+		cycle(i)
 	}
 	require.Equal(t, 2, probe.calls, "second replay exactly when the escalated streak completes")
-	require.Equal(t, 1, last, "the passing replay's cycle reports the re-enable")
 	require.True(t, dc.Endpoint.Enabled)
 }
 
-// TestProbeCycle_NilRelayProbeFallsBackToPollOnly: without replay wiring (nil relayProbe — tests,
+// TestProbeCycle_InconclusiveReplayRetriesAtBaseStreak: an inconclusive replay paces the next
+// attempt (streak reset) but does NOT escalate — the second replay is due after the BASE K streak,
+// not K<<1. This is the observable difference between still-failing and inconclusive.
+func TestProbeCycle_InconclusiveReplayRetriesAtBaseStreak(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	dc := ep("http://ep:8545", "provider1", false)
+	dc.Endpoint.RecordFailingRelay("eth_call", testEvidence, testEvidenceTimeout)
+	endpoints := []*lavasession.EndpointWithDirectConnection{dc}
+
+	probe := &relayProbeRecorder{verdicts: []relayProbeVerdict{relayProbeInconclusive, relayProbeRecovered}}
+	runner := syncRunner(probe)
+	cycle := func(i int) {
+		pollTime := base.Add(time.Duration(i) * time.Second)
+		now := pollTime.Add(time.Millisecond)
+		getObs := func(string) (endpointstate.EndpointObservation, bool) {
+			return freshObs(1000, now.Add(-time.Second), pollTime, 20*time.Millisecond), true
+		}
+		runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{},
+			now, probeCfg(), nil, nil, runner)
+	}
+
+	K := int(probeCfg().ReEnableHysteresis)
+	for i := 1; i <= K; i++ {
+		cycle(i)
+	}
+	require.Equal(t, 1, probe.calls, "one replay at the threshold, inconclusive")
+	require.False(t, dc.Endpoint.Enabled, "inconclusive must not re-enable")
+
+	// No escalation: the BASE K streak earns the next replay, which passes.
+	for i := K + 1; i <= 2*K; i++ {
+		cycle(i)
+	}
+	require.Equal(t, 2, probe.calls, "inconclusive does not escalate — the second replay is due after the base K streak")
+	require.True(t, dc.Endpoint.Enabled)
+}
+
+// TestProbeCycle_AsyncReplayDoesNotBlockTheCycle pins the review's scheduling complaint: the cycle
+// must return while a slow replay is still running (the probe loop also feeds every provider's
+// QoS), the verdict lands on the replayer's goroutine, and the single-flight guard keeps
+// subsequent cycles from stacking a second replay of the same evidence.
+func TestProbeCycle_AsyncReplayDoesNotBlockTheCycle(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	dc := ep("http://ep:8545", "provider1", false)
+	dc.Endpoint.RecordFailingRelay("eth_call", testEvidence, testEvidenceTimeout)
+	endpoints := []*lavasession.EndpointWithDirectConnection{dc}
+
+	release := make(chan struct{})
+	var calls atomic.Int32
+	runner := &relayProbeRunner{
+		async: true,
+		probe: func(*lavasession.EndpointWithDirectConnection, string, []byte, time.Duration) relayProbeVerdict {
+			calls.Add(1)
+			<-release
+			return relayProbeRecovered
+		},
+	}
+	cycle := func(i int) {
+		pollTime := base.Add(time.Duration(i) * time.Second)
+		now := pollTime.Add(time.Millisecond)
+		getObs := func(string) (endpointstate.EndpointObservation, bool) {
+			return freshObs(1000, now.Add(-time.Second), pollTime, 20*time.Millisecond), true
+		}
+		runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{},
+			now, probeCfg(), nil, nil, runner)
+	}
+
+	K := int(probeCfg().ReEnableHysteresis)
+	for i := 1; i <= K; i++ {
+		cycle(i) // the K-th cycle launches the replay and MUST return while it blocks
+	}
+	require.Eventually(t, func() bool { return calls.Load() == 1 }, time.Second, time.Millisecond,
+		"the replay was launched off the cycle")
+	require.False(t, dc.Endpoint.Enabled, "no verdict yet — the endpoint stays disabled while the replay runs")
+
+	// Further cycles while the replay is outstanding: candidacy holds, but single-flight
+	// suppresses a second launch.
+	for i := K + 1; i <= K+3; i++ {
+		cycle(i)
+	}
+	require.Equal(t, int32(1), calls.Load(), "one outstanding replay per endpoint, never stacked per tick")
+
+	close(release)
+	require.Eventually(t, func() bool { return dc.Endpoint.IsEnabled() }, time.Second, time.Millisecond,
+		"the recovered verdict re-enables on the replayer's goroutine")
+}
+
+// TestRelayProbeRunner_SingleFlightPerKey: the guard is per endpoint key, released on completion.
+func TestRelayProbeRunner_SingleFlightPerKey(t *testing.T) {
+	r := &relayProbeRunner{async: true}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var ran atomic.Int32
+
+	r.launch("ep1", func() { close(started); <-release; ran.Add(1) })
+	<-started
+	r.launch("ep1", func() { ran.Add(1) }) // suppressed: ep1 already in flight
+	r.launch("ep2", func() { ran.Add(1) }) // independent key: runs
+
+	require.Eventually(t, func() bool { return ran.Load() == 1 }, time.Second, time.Millisecond, "only ep2 ran while ep1 was in flight")
+	close(release)
+	require.Eventually(t, func() bool { return ran.Load() == 2 }, time.Second, time.Millisecond)
+
+	// ep1's slot is free again after completion.
+	r.launch("ep1", func() { ran.Add(1) })
+	require.Eventually(t, func() bool { return ran.Load() == 3 }, time.Second, time.Millisecond, "completion releases the key")
+}
+
+// TestProbeCycle_NilRelayProbeFallsBackToPollOnly: without replay wiring (nil replayer — tests,
 // degraded setups) recorded evidence must not park the endpoint forever; the cycle falls back to
 // poll-only evidence like the legacy path.
 func TestProbeCycle_NilRelayProbeFallsBackToPollOnly(t *testing.T) {
 	base := time.Unix(1_700_000_000, 0)
 	dc := ep("http://ep:8545", "provider1", false)
-	dc.Endpoint.RecordFailingRelay("eth_call", testEvidence)
+	dc.Endpoint.RecordFailingRelay("eth_call", testEvidence, testEvidenceTimeout)
 	endpoints := []*lavasession.EndpointWithDirectConnection{dc}
 
 	K := int(probeCfg().ReEnableHysteresis)
@@ -145,7 +268,7 @@ func TestProbeCycle_NilRelayProbeFallsBackToPollOnly(t *testing.T) {
 		}
 		runProbeCycleCore(endpoints, getObs, 1000, true, provideroptimizer.SyncReference{}, now, probeCfg(), nil, nil, nil)
 	}
-	require.True(t, dc.Endpoint.Enabled, "nil relayProbe falls back to poll-only re-enable instead of parking the endpoint")
+	require.True(t, dc.Endpoint.Enabled, "nil replayer falls back to poll-only re-enable instead of parking the endpoint")
 }
 
 // ---------------------------------------------------------------------------
@@ -157,10 +280,14 @@ type fakeDirectConn struct {
 	resp       *lavasession.DirectRPCResponse
 	err        error
 	gotPayload []byte
+	gotTimeout time.Duration // remaining context budget observed by the request
 }
 
 func (f *fakeDirectConn) SendRequest(ctx context.Context, data []byte, headers map[string]string) (*lavasession.DirectRPCResponse, error) {
 	f.gotPayload = data
+	if deadline, ok := ctx.Deadline(); ok {
+		f.gotTimeout = time.Until(deadline)
+	}
 	return f.resp, f.err
 }
 func (f *fakeDirectConn) GetProtocol() lavasession.DirectRPCProtocol { return "http" }
@@ -174,7 +301,7 @@ func replayServer() *RPCSmartRouterServer {
 	}
 }
 
-func replayWith(t *testing.T, conn *fakeDirectConn) bool {
+func replayWith(t *testing.T, conn *fakeDirectConn) relayProbeVerdict {
 	t.Helper()
 	rpcss := replayServer()
 	epc := &lavasession.EndpointWithDirectConnection{
@@ -182,30 +309,39 @@ func replayWith(t *testing.T, conn *fakeDirectConn) bool {
 		DirectConnection: conn,
 		ProviderAddress:  "provider1",
 	}
-	return rpcss.replayFailingRelay(epc, "eth_call", testEvidence)
+	return rpcss.replayFailingRelay(epc, "eth_call", testEvidence, testEvidenceTimeout)
 }
 
-// TestReplayFailingRelay_JudgesByHealthClassification pins the judge's contract: "pass" means the
-// request no longer produces a HEALTH-AFFECTING failure — the same rule the relay path uses to
-// mark endpoints unhealthy — not "the request returned a happy result".
+// TestReplayFailingRelay_JudgesByHealthClassification pins the judge's three-way contract:
+// "recovered" means the request no longer produces a HEALTH-AFFECTING failure — the same rule the
+// relay path uses to mark endpoints unhealthy; "still-failing" means it still does; and anything
+// the judge cannot classify (rate limits, unrecognized 4xx, unparseable bodies) is INCONCLUSIVE —
+// never silently "recovered" (the fail-open the review flagged), never an escalating failure.
 func TestReplayFailingRelay_JudgesByHealthClassification(t *testing.T) {
 	cases := []struct {
 		name string
 		conn *fakeDirectConn
-		want bool
+		want relayProbeVerdict
 	}{
 		{"clean 200 result", &fakeDirectConn{resp: &lavasession.DirectRPCResponse{
-			StatusCode: 200, Data: []byte(`{"jsonrpc":"2.0","id":1,"result":"0x1"}`)}}, true},
-		{"5xx still failing", &fakeDirectConn{err: &lavasession.HTTPStatusError{StatusCode: 503, Status: "503"}}, false},
-		{"429 proves nothing", &fakeDirectConn{err: &lavasession.HTTPStatusError{StatusCode: 429, Status: "429"}}, false},
-		{"501 is a capability answer, not a fault", &fakeDirectConn{err: &lavasession.HTTPStatusError{StatusCode: 501, Status: "501"}}, true},
-		{"transport error still failing", &fakeDirectConn{err: context.DeadlineExceeded}, false},
+			StatusCode: 200, Data: []byte(`{"jsonrpc":"2.0","id":1,"result":"0x1"}`)}}, relayProbeRecovered},
+		{"5xx still failing", &fakeDirectConn{err: &lavasession.HTTPStatusError{StatusCode: 503, Status: "503"}}, relayProbeStillFailing},
+		{"429 proves nothing", &fakeDirectConn{err: &lavasession.HTTPStatusError{StatusCode: 429, Status: "429"}}, relayProbeInconclusive},
+		{"501 is a capability answer, not a fault", &fakeDirectConn{err: &lavasession.HTTPStatusError{StatusCode: 501, Status: "501"}}, relayProbeRecovered},
+		{"404 proves nothing (auth drift, proxy in the way)", &fakeDirectConn{err: &lavasession.HTTPStatusError{StatusCode: 404, Status: "404"}}, relayProbeInconclusive},
+		{"401 proves nothing", &fakeDirectConn{err: &lavasession.HTTPStatusError{StatusCode: 401, Status: "401"}}, relayProbeInconclusive},
+		{"transport error still failing", &fakeDirectConn{err: context.DeadlineExceeded}, relayProbeStillFailing},
 		{"node internal error rides HTTP 200", &fakeDirectConn{resp: &lavasession.DirectRPCResponse{
-			StatusCode: 200, Data: []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"internal error"}}`)}}, false},
+			StatusCode: 200, Data: []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"internal error"}}`)}}, relayProbeStillFailing},
 		{"unsupported method in body is not a fault", &fakeDirectConn{resp: &lavasession.DirectRPCResponse{
-			StatusCode: 200, Data: []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found"}}`)}}, true},
-		{"batch reply (JSON array) passes on transport success", &fakeDirectConn{resp: &lavasession.DirectRPCResponse{
-			StatusCode: 200, Data: []byte(`[{"jsonrpc":"2.0","id":1,"result":"0x1"}]`)}}, true},
+			StatusCode: 200, Data: []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found"}}`)}}, relayProbeRecovered},
+		{"unparseable 200 body (proxy HTML page) proves nothing", &fakeDirectConn{resp: &lavasession.DirectRPCResponse{
+			StatusCode: 200, Data: []byte(`<html><body>Bad Gateway</body></html>`)}}, relayProbeInconclusive},
+		{"empty 200 body proves nothing", &fakeDirectConn{resp: &lavasession.DirectRPCResponse{
+			StatusCode: 200, Data: nil}}, relayProbeInconclusive},
+		{"batch reply (JSON array) cannot be judged", &fakeDirectConn{resp: &lavasession.DirectRPCResponse{
+			StatusCode: 200, Data: []byte(`[{"jsonrpc":"2.0","id":1,"result":"0x1"}]`)}}, relayProbeInconclusive},
+		{"nil response with nil error proves nothing", &fakeDirectConn{}, relayProbeInconclusive},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -215,10 +351,45 @@ func TestReplayFailingRelay_JudgesByHealthClassification(t *testing.T) {
 	}
 }
 
-func TestReplayFailingRelay_NoConnectionFails(t *testing.T) {
+// TestReplayFailingRelay_UsesRecordedTimeout pins the review's timeout complaint: the replay's
+// budget is the RECORDED relay timeout (what the request actually failed under), floored at
+// minRelayProbeTimeout — never a tighter probe-only constant that would fail every
+// slow-but-recovered heavy method forever.
+func TestReplayFailingRelay_UsesRecordedTimeout(t *testing.T) {
 	rpcss := replayServer()
-	require.False(t, rpcss.replayFailingRelay(nil, "eth_call", testEvidence))
-	require.False(t, rpcss.replayFailingRelay(&lavasession.EndpointWithDirectConnection{}, "eth_call", testEvidence))
+	mkEp := func(conn *fakeDirectConn) *lavasession.EndpointWithDirectConnection {
+		return &lavasession.EndpointWithDirectConnection{
+			Endpoint:         &lavasession.Endpoint{NetworkAddress: "http://fake:8545"},
+			DirectConnection: conn,
+			ProviderAddress:  "provider1",
+		}
+	}
+	okResp := func() *lavasession.DirectRPCResponse {
+		return &lavasession.DirectRPCResponse{StatusCode: 200, Data: []byte(`{"jsonrpc":"2.0","id":1,"result":"0x1"}`)}
+	}
+
+	// A heavy method recorded with a 25s relay budget is judged under ~25s.
+	conn := &fakeDirectConn{resp: okResp()}
+	rpcss.replayFailingRelay(mkEp(conn), "eth_getLogs", testEvidence, 25*time.Second)
+	require.InDelta(t, (25 * time.Second).Seconds(), conn.gotTimeout.Seconds(), 2.0,
+		"the replay context carries the recorded relay budget")
+
+	// No recorded budget (0) floors at minRelayProbeTimeout, as does a shorter one.
+	conn = &fakeDirectConn{resp: okResp()}
+	rpcss.replayFailingRelay(mkEp(conn), "eth_call", testEvidence, 0)
+	require.InDelta(t, minRelayProbeTimeout.Seconds(), conn.gotTimeout.Seconds(), 2.0,
+		"a missing recorded budget falls back to the floor")
+
+	conn = &fakeDirectConn{resp: okResp()}
+	rpcss.replayFailingRelay(mkEp(conn), "eth_call", testEvidence, time.Second)
+	require.InDelta(t, minRelayProbeTimeout.Seconds(), conn.gotTimeout.Seconds(), 2.0,
+		"a recorded budget below the floor is raised to it")
+}
+
+func TestReplayFailingRelay_NoConnectionIsInconclusive(t *testing.T) {
+	rpcss := replayServer()
+	require.Equal(t, relayProbeInconclusive, rpcss.replayFailingRelay(nil, "eth_call", testEvidence, testEvidenceTimeout))
+	require.Equal(t, relayProbeInconclusive, rpcss.replayFailingRelay(&lavasession.EndpointWithDirectConnection{}, "eth_call", testEvidence, testEvidenceTimeout))
 }
 
 // ---------------------------------------------------------------------------
@@ -234,27 +405,35 @@ func mockMessage(t *testing.T, api *spectypes.Api, parseDirective *spectypes.Par
 	return msg
 }
 
-// TestRecordRelayProbeEvidence_Eligibility pins the recording rules: read-only JSON-RPC methods
-// are recorded; writes (stateful), subscriptions, hanging APIs, and non-JSON-RPC interfaces are
-// not — those episodes fall back to the poll-only path with its trial budget.
+// TestRecordRelayProbeEvidence_Eligibility pins the recording rules: single read-only JSON-RPC
+// requests are recorded (with the relay path's effective timeout); writes (stateful),
+// subscriptions, hanging APIs, batches, and non-JSON-RPC interfaces are not — those episodes fall
+// back to the poll-only path with its trial budget. NOTE the gates are about request SHAPE, never
+// failure CAUSE: 5xx storms and transport faults record like any other health-affecting failure.
 func TestRecordRelayProbeEvidence_Eligibility(t *testing.T) {
 	readOnly := &spectypes.Api{Name: "eth_call"}
 	write := &spectypes.Api{Name: "eth_sendRawTransaction", Category: spectypes.SpecCategory{Stateful: common.CONSISTENCY_SELECT_ALL_PROVIDERS}}
 	hanging := &spectypes.Api{Name: "eth_newFilter", Category: spectypes.SpecCategory{HangingApi: true}}
 	subscribe := &spectypes.Api{Name: "eth_subscribe"}
 	subscribeDirective := &spectypes.ParseDirective{ApiName: "eth_subscribe", FunctionTag: spectypes.FUNCTION_TAG_SUBSCRIBE}
+	batched := &spectypes.Api{Name: "eth_call" + chainlib.SEP + "eth_getLogs"}
 
 	cases := []struct {
 		name         string
 		apiInterface string
 		msg          chainlib.ChainMessage
+		payload      []byte
 		wantRecorded bool
 	}{
-		{"read-only jsonrpc method is recorded", spectypes.APIInterfaceJsonRPC, mockMessage(t, readOnly, nil), true},
-		{"write method never recorded", spectypes.APIInterfaceJsonRPC, mockMessage(t, write, nil), false},
-		{"hanging api never recorded", spectypes.APIInterfaceJsonRPC, mockMessage(t, hanging, nil), false},
-		{"subscription never recorded", spectypes.APIInterfaceJsonRPC, mockMessage(t, subscribe, subscribeDirective), false},
-		{"non-jsonrpc interface never recorded", spectypes.APIInterfaceRest, mockMessage(t, readOnly, nil), false},
+		{"read-only jsonrpc method is recorded", spectypes.APIInterfaceJsonRPC, mockMessage(t, readOnly, nil), testEvidence, true},
+		{"write method never recorded", spectypes.APIInterfaceJsonRPC, mockMessage(t, write, nil), testEvidence, false},
+		{"hanging api never recorded", spectypes.APIInterfaceJsonRPC, mockMessage(t, hanging, nil), testEvidence, false},
+		{"subscription never recorded", spectypes.APIInterfaceJsonRPC, mockMessage(t, subscribe, subscribeDirective), testEvidence, false},
+		{"non-jsonrpc interface never recorded", spectypes.APIInterfaceRest, mockMessage(t, readOnly, nil), testEvidence, false},
+		{"batch (JSON array body) never recorded", spectypes.APIInterfaceJsonRPC, mockMessage(t, batched, nil),
+			[]byte(`[{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[]}]`), false},
+		{"batch with leading whitespace never recorded", spectypes.APIInterfaceJsonRPC, mockMessage(t, batched, nil),
+			[]byte("  \n\t[{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_call\",\"params\":[]}]"), false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -262,7 +441,7 @@ func TestRecordRelayProbeEvidence_Eligibility(t *testing.T) {
 				listenEndpoint: &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: tc.apiInterface},
 			}
 			endpoint := &lavasession.Endpoint{NetworkAddress: "http://ep:8545", Enabled: true}
-			rpcss.recordRelayProbeEvidence(endpoint, tc.msg, testEvidence)
+			rpcss.recordRelayProbeEvidence(endpoint, tc.msg, tc.payload, testEvidenceTimeout)
 			recorded := endpoint.HealthSnapshot().RelayProbeMethod != ""
 			require.Equal(t, tc.wantRecorded, recorded)
 		})

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -1199,6 +1199,12 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 						"LatestBlock":              obs.LatestBlock,
 						"ObservedAt":               debugTimeRFC3339(obs.ObservedAt),
 						"Source":                   obs.Source.String(),
+						// The MAG-2550 replay gate, made visible: a disabled endpoint with a
+						// RelayProbeMethod is held pending a successful replay of that method (or
+						// the attempt-budget fallback) — NOT merely earning its poll streak.
+						"RelayProbeMethod":   health.RelayProbeMethod,
+						"RelayProbeAttempts": health.RelayProbeAttempts,
+						"ReenableProbeFlaps": health.ReenableProbeFlaps,
 						// PollIntervalMs is the live dedicated-poll cadence: base when healthy,
 						// exponentialBackoff-stretched when the endpoint has been failing. This is the
 						// observable /debug/reset-probe-backoff returns to base (MAG-2395).
@@ -1308,6 +1314,13 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 					"EndpointsScored":     s.EndpointsScored,
 					"ReEnabledCount":      s.ReEnabledCount,
 					"SyncOmittedCount":    s.SyncOmittedCount,
+					// MAG-2550 replay-gate telemetry: how many disabled endpoints are held on
+					// recorded relay evidence, and the cumulative replay outcomes.
+					"EvidenceGatedCount":  s.EvidenceGatedCount,
+					"ReplaysAttempted":    s.ReplaysAttempted,
+					"ReplaysRecovered":    s.ReplaysRecovered,
+					"ReplaysStillFailing": s.ReplaysStillFailing,
+					"ReplaysInconclusive": s.ReplaysInconclusive,
 				})
 			}
 			deps.router.mu.Unlock()

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2386,6 +2386,7 @@ func (rpcss *RPCSmartRouterServer) runProbeCycle(appender probeQoSAppender, cfg 
 		rpcss.endpointChainTrackerManager.GetObservation,
 		baseline, hasBaseline, syncRef, startedAt, cfg, appender,
 		rpcss.sessionManager.RestoreRecoveredProvider,
+		rpcss.replayFailingRelay,
 	)
 	rpcss.probeStats.recordCycle(startedAt, time.Since(startedAt), scored, reEnabled, syncOmitted)
 }
@@ -2409,6 +2410,7 @@ func runProbeCycleCore(
 	cfg probing.VerdictConfig,
 	appender probeQoSAppender,
 	onRecover func(provider string),
+	relayProbe relayProbeFunc,
 ) (scored, reEnabled, syncOmitted int) {
 	// One verdict per endpoint (regular + backup), grouped by provider for the single-sample rule.
 	verdictsByProvider := make(map[string][]probing.EndpointVerdict)
@@ -2426,6 +2428,23 @@ func runProbeCycleCore(
 			reEnabled++
 			if onRecover != nil {
 				onRecover(ep.ProviderAddress)
+			}
+		} else if method, payload, ok := ep.Endpoint.PendingRelayProbe(cfg.ReEnableHysteresis); ok {
+			// Two-step re-enable (MAG-2550): poll hysteresis is satisfied but this disable episode
+			// recorded a failing read-only relay, so RecordProbeVerdict held the re-enable. Replay
+			// the recorded request through the endpoint's own connection — outside any endpoint
+			// lock — and re-enable only when it no longer produces a health-affecting failure. A
+			// nil relayProbe (tests / degraded wiring) falls back to poll-only evidence rather
+			// than parking the endpoint forever.
+			if relayProbe == nil || relayProbe(ep, method, payload) {
+				if ep.Endpoint.ConfirmRelayRecovery() {
+					reEnabled++
+					if onRecover != nil {
+						onRecover(ep.ProviderAddress)
+					}
+				}
+			} else {
+				ep.Endpoint.RelayProbeFailed()
 			}
 		}
 		verdictsByProvider[ep.ProviderAddress] = append(verdictsByProvider[ep.ProviderAddress], verdict)
@@ -3645,8 +3664,11 @@ func (rpcss *RPCSmartRouterServer) relayInnerDirect(
 		var shouldMarkUnhealthy bool
 		shouldMarkUnhealthy, needsBackoff = classifyEndpointHealth(classified, isClientCancel)
 
-		// Apply health tracking based on error classification
+		// Apply health tracking based on error classification. The failing request is recorded
+		// FIRST (read-only methods only) so that if this failure crosses the disable threshold,
+		// the disable episode carries its replayable recovery evidence (MAG-2550).
 		if shouldMarkUnhealthy && targetEndpoint != nil {
+			rpcss.recordRelayProbeEvidence(targetEndpoint, chainMessage, originalRequestData)
 			targetEndpoint.MarkUnhealthy()
 			rpcss.smartRouterEndpointMetrics.SetEndpointOverallHealth(rpcss.listenEndpoint.ChainID, rpcss.listenEndpoint.ApiInterface, endpointName, false)
 		}
@@ -3670,6 +3692,7 @@ func (rpcss *RPCSmartRouterServer) relayInnerDirect(
 		needsBackoff = needsBackoffHTTP
 
 		if shouldMarkUnhealthy && targetEndpoint != nil {
+			rpcss.recordRelayProbeEvidence(targetEndpoint, chainMessage, originalRequestData)
 			targetEndpoint.MarkUnhealthy()
 			rpcss.smartRouterEndpointMetrics.SetEndpointOverallHealth(rpcss.listenEndpoint.ChainID, rpcss.listenEndpoint.ApiInterface, endpointName, false)
 			utils.LavaFormatDebug("endpoint returned error status",

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -90,6 +90,11 @@ type RPCSmartRouterServer struct {
 	// (MAG-2202 endpoint 4). Written off the data plane by runProbeCycle; read by the debug handler.
 	probeStats probeLoopStats
 
+	// probeReplayer executes MAG-2550 recovery replays off the probe loop (one goroutine per
+	// replay, at most one outstanding per endpoint). Initialized once in runProbeLoop; nil until
+	// then, which runProbeCycleCore treats as "no replay wiring" (poll-only fallback).
+	probeReplayer *relayProbeRunner
+
 	// Cached API names of the two tip-defining spec methods (GET_BLOCKNUM / GET_BLOCK_BY_NUM), resolved
 	// once on the first relay via tipApiNamesOnce. tipBlockFromRelay runs on every successful relay;
 	// resolving the tag→ApiName mapping per call took the shared chainParser RWLock twice
@@ -2260,6 +2265,18 @@ type probeLoopStats struct {
 	endpointsScored  int       // endpoints scored in the last cycle
 	reEnabledCount   int       // endpoints the probe re-enabled in the last cycle (F1)
 	syncOmittedCount int       // providers whose last-cycle QoS sample fed no sync evidence (F5)
+	// evidenceGatedCount is how many disabled endpoints held recorded relay evidence in the last
+	// cycle (MAG-2550) — endpoints that will need a successful replay (or the attempt-budget
+	// fallback) before re-enabling. Without this a replay-held endpoint is indistinguishable from
+	// one still earning its poll streak.
+	evidenceGatedCount int
+	// Cumulative MAG-2550 replay outcomes (counted per completed replay, on the replayer's
+	// goroutine). replaysRecovered approximates replay-granted re-enables — the re-enable happens
+	// on the replayer's goroutine, outside any cycle, so it is never part of reEnabledCount.
+	replaysAttempted    uint64
+	replaysRecovered    uint64
+	replaysStillFailing uint64
+	replaysInconclusive uint64
 }
 
 // setInterval publishes the effective probe cadence. Called once at loop start.
@@ -2270,7 +2287,7 @@ func (s *probeLoopStats) setInterval(d time.Duration) {
 }
 
 // recordCycle overwrites the last-cycle snapshot and bumps the completed-cycle counter.
-func (s *probeLoopStats) recordCycle(startedAt time.Time, dur time.Duration, scored, reEnabled, syncOmitted int) {
+func (s *probeLoopStats) recordCycle(startedAt time.Time, dur time.Duration, scored, reEnabled, syncOmitted, evidenceGated int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.cyclesCompleted++
@@ -2279,6 +2296,23 @@ func (s *probeLoopStats) recordCycle(startedAt time.Time, dur time.Duration, sco
 	s.endpointsScored = scored
 	s.reEnabledCount = reEnabled
 	s.syncOmittedCount = syncOmitted
+	s.evidenceGatedCount = evidenceGated
+}
+
+// countReplay records one completed MAG-2550 recovery replay. Called from the replayer's
+// goroutine, so it takes the stats lock rather than assuming the cycle's context.
+func (s *probeLoopStats) countReplay(verdict relayProbeVerdict) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.replaysAttempted++
+	switch verdict {
+	case relayProbeRecovered:
+		s.replaysRecovered++
+	case relayProbeStillFailing:
+		s.replaysStillFailing++
+	case relayProbeInconclusive:
+		s.replaysInconclusive++
+	}
 }
 
 // probeLoopSnapshot is the read-only view the /debug/probe-loop handler emits per chain.
@@ -2290,6 +2324,11 @@ type probeLoopSnapshot struct {
 	EndpointsScored     int
 	ReEnabledCount      int
 	SyncOmittedCount    int
+	EvidenceGatedCount  int
+	ReplaysAttempted    uint64
+	ReplaysRecovered    uint64
+	ReplaysStillFailing uint64
+	ReplaysInconclusive uint64
 }
 
 // snapshot returns a consistent copy of the stats under the lock (no mutex in the returned value).
@@ -2304,6 +2343,11 @@ func (s *probeLoopStats) snapshot() probeLoopSnapshot {
 		EndpointsScored:     s.endpointsScored,
 		ReEnabledCount:      s.reEnabledCount,
 		SyncOmittedCount:    s.syncOmittedCount,
+		EvidenceGatedCount:  s.evidenceGatedCount,
+		ReplaysAttempted:    s.replaysAttempted,
+		ReplaysRecovered:    s.replaysRecovered,
+		ReplaysStillFailing: s.replaysStillFailing,
+		ReplaysInconclusive: s.replaysInconclusive,
 	}
 }
 
@@ -2347,6 +2391,17 @@ func (rpcss *RPCSmartRouterServer) runProbeLoop(ctx context.Context, cadence tim
 	// Publish the effective cadence for /debug/probe-loop (CycleIntervalMs) before the first tick,
 	// so the endpoint reports the interval even before a cycle has completed.
 	rpcss.probeStats.setInterval(cadence)
+	// The replay judge is wrapped with the stats counter so every replay outcome is visible in
+	// /debug/probe-loop (attempted/recovered/still-failing/inconclusive) — a feature that can hold
+	// an endpoint out of rotation must be observable in production, not only in one log line.
+	rpcss.probeReplayer = &relayProbeRunner{
+		async: true,
+		probe: func(ep *lavasession.EndpointWithDirectConnection, method string, payload []byte, relayTimeout time.Duration) relayProbeVerdict {
+			verdict := rpcss.replayFailingRelay(ep, method, payload, relayTimeout)
+			rpcss.probeStats.countReplay(verdict)
+			return verdict
+		},
+	}
 	// The optimizer's AppendProbeData is optional (inline assertion) so the loop degrades to
 	// re-enable-only if a future optimizer lacks it, rather than failing to start.
 	appender, _ := rpcss.sessionManager.GetProviderOptimizer().(probeQoSAppender)
@@ -2381,14 +2436,14 @@ func (rpcss *RPCSmartRouterServer) runProbeCycle(appender probeQoSAppender, cfg 
 		}
 	}
 	startedAt := time.Now()
-	scored, reEnabled, syncOmitted := runProbeCycleCore(
+	scored, reEnabled, syncOmitted, evidenceGated := runProbeCycleCore(
 		rpcss.sessionManager.GetAllDirectRPCEndpoints(),
 		rpcss.endpointChainTrackerManager.GetObservation,
 		baseline, hasBaseline, syncRef, startedAt, cfg, appender,
 		rpcss.sessionManager.RestoreRecoveredProvider,
-		rpcss.replayFailingRelay,
+		rpcss.probeReplayer,
 	)
-	rpcss.probeStats.recordCycle(startedAt, time.Since(startedAt), scored, reEnabled, syncOmitted)
+	rpcss.probeStats.recordCycle(startedAt, time.Since(startedAt), scored, reEnabled, syncOmitted, evidenceGated)
 }
 
 // runProbeCycleCore is the pure probe-cycle body (no rpcss fields), so it is testable with
@@ -2397,9 +2452,13 @@ func (rpcss *RPCSmartRouterServer) runProbeCycle(appender probeQoSAppender, cfg 
 // (rule E2). A nil appender still performs the re-enable (QoS feed simply skipped).
 //
 // Returns the per-cycle telemetry for /debug/probe-loop (MAG-2202 endpoint 4): scored = endpoints
-// that received a verdict; reEnabled = endpoints the probe re-enabled this cycle (F1); syncOmitted =
-// providers whose QoS sample fed NO sync evidence (F5: no fresh consensus baseline, or no block in
-// the sample). syncOmitted is 0 when appender is nil (no QoS feed happens, so nothing is omitted).
+// that received a verdict; reEnabled = endpoints the probe re-enabled SYNCHRONOUSLY this cycle
+// (poll-only path — replay-granted re-enables complete on the replayer's goroutine and are
+// visible in probeLoopStats' replay counters instead); syncOmitted = providers whose QoS sample
+// fed NO sync evidence (F5: no fresh consensus baseline, or no block in the sample); evidenceGated
+// = disabled endpoints currently holding recorded relay evidence, i.e. endpoints that will require
+// a successful replay (or the attempt-budget fallback) to re-enable. syncOmitted is 0 when
+// appender is nil (no QoS feed happens, so nothing is omitted).
 func runProbeCycleCore(
 	endpoints []*lavasession.EndpointWithDirectConnection,
 	getObservation func(url string) (endpointstate.EndpointObservation, bool),
@@ -2410,8 +2469,8 @@ func runProbeCycleCore(
 	cfg probing.VerdictConfig,
 	appender probeQoSAppender,
 	onRecover func(provider string),
-	relayProbe relayProbeFunc,
-) (scored, reEnabled, syncOmitted int) {
+	replayer *relayProbeRunner,
+) (scored, reEnabled, syncOmitted, evidenceGated int) {
 	// One verdict per endpoint (regular + backup), grouped by provider for the single-sample rule.
 	verdictsByProvider := make(map[string][]probing.EndpointVerdict)
 	for _, ep := range endpoints {
@@ -2419,6 +2478,9 @@ func runProbeCycleCore(
 			continue
 		}
 		scored++
+		if snap := ep.Endpoint.HealthSnapshot(); !snap.Enabled && snap.RelayProbeMethod != "" {
+			evidenceGated++
+		}
 		obs, _ := getObservation(ep.Endpoint.NetworkAddress)
 		verdict := probing.RenderEndpointVerdict(obs, baseline, hasBaseline, now, cfg)
 		// Proactive re-enable from POST-DISABLE successful-poll evidence only (F1). RecordProbeVerdict
@@ -2429,14 +2491,16 @@ func runProbeCycleCore(
 			if onRecover != nil {
 				onRecover(ep.ProviderAddress)
 			}
-		} else if method, payload, ok := ep.Endpoint.PendingRelayProbe(cfg.ReEnableHysteresis); ok {
+		} else if method, payload, relayTimeout, ok := ep.Endpoint.PendingRelayProbe(cfg.ReEnableHysteresis); ok {
 			// Two-step re-enable (MAG-2550): poll hysteresis is satisfied but this disable episode
 			// recorded a failing read-only relay, so RecordProbeVerdict held the re-enable. Replay
-			// the recorded request through the endpoint's own connection — outside any endpoint
-			// lock — and re-enable only when it no longer produces a health-affecting failure. A
-			// nil relayProbe (tests / degraded wiring) falls back to poll-only evidence rather
-			// than parking the endpoint forever.
-			if relayProbe == nil || relayProbe(ep, method, payload) {
+			// the recorded request through the endpoint's own connection and re-enable only when it
+			// no longer produces a health-affecting failure. The replayer runs the replay OFF this
+			// loop (its own goroutine, at most one outstanding per endpoint) so a slow replay never
+			// starves the cycle's QoS feed; the verdict is applied on completion through the
+			// endpoint's race-safe transitions. A nil replayer (tests / degraded wiring) falls back
+			// to poll-only evidence rather than parking the endpoint forever.
+			if replayer == nil || replayer.probe == nil {
 				if ep.Endpoint.ConfirmRelayRecovery() {
 					reEnabled++
 					if onRecover != nil {
@@ -2444,14 +2508,26 @@ func runProbeCycleCore(
 					}
 				}
 			} else {
-				ep.Endpoint.RelayProbeFailed()
+				target := ep
+				replayer.launch(target.Endpoint.NetworkAddress, func() {
+					switch replayer.probe(target, method, payload, relayTimeout) {
+					case relayProbeRecovered:
+						if target.Endpoint.ConfirmRelayRecovery() && onRecover != nil {
+							onRecover(target.ProviderAddress)
+						}
+					case relayProbeStillFailing:
+						target.Endpoint.RelayProbeFailed()
+					case relayProbeInconclusive:
+						target.Endpoint.RelayProbeInconclusive()
+					}
+				})
 			}
 		}
 		verdictsByProvider[ep.ProviderAddress] = append(verdictsByProvider[ep.ProviderAddress], verdict)
 	}
 
 	if appender == nil {
-		return scored, reEnabled, syncOmitted // re-enable still happened above; QoS feed unavailable
+		return scored, reEnabled, syncOmitted, evidenceGated // re-enable still happened above; QoS feed unavailable
 	}
 	for provider, verdicts := range verdictsByProvider {
 		sample, ok := probing.AggregateProviderSample(verdicts)
@@ -2466,7 +2542,7 @@ func runProbeCycleCore(
 		}
 		appender.AppendProbeData(provider, sample.Availability, sample.Latency, sample.HasLatency, sample.Block, hasSync, syncRef)
 	}
-	return scored, reEnabled, syncOmitted
+	return scored, reEnabled, syncOmitted, evidenceGated
 }
 
 // onTipObservation is the EndpointMonitor's OnTipObservation hook: it feeds every positive
@@ -3668,7 +3744,7 @@ func (rpcss *RPCSmartRouterServer) relayInnerDirect(
 		// FIRST (read-only methods only) so that if this failure crosses the disable threshold,
 		// the disable episode carries its replayable recovery evidence (MAG-2550).
 		if shouldMarkUnhealthy && targetEndpoint != nil {
-			rpcss.recordRelayProbeEvidence(targetEndpoint, chainMessage, originalRequestData)
+			rpcss.recordRelayProbeEvidence(targetEndpoint, chainMessage, originalRequestData, relayTimeout)
 			targetEndpoint.MarkUnhealthy()
 			rpcss.smartRouterEndpointMetrics.SetEndpointOverallHealth(rpcss.listenEndpoint.ChainID, rpcss.listenEndpoint.ApiInterface, endpointName, false)
 		}
@@ -3692,7 +3768,7 @@ func (rpcss *RPCSmartRouterServer) relayInnerDirect(
 		needsBackoff = needsBackoffHTTP
 
 		if shouldMarkUnhealthy && targetEndpoint != nil {
-			rpcss.recordRelayProbeEvidence(targetEndpoint, chainMessage, originalRequestData)
+			rpcss.recordRelayProbeEvidence(targetEndpoint, chainMessage, originalRequestData, relayTimeout)
 			targetEndpoint.MarkUnhealthy()
 			rpcss.smartRouterEndpointMetrics.SetEndpointOverallHealth(rpcss.listenEndpoint.ChainID, rpcss.listenEndpoint.ApiInterface, endpointName, false)
 			utils.LavaFormatDebug("endpoint returned error status",


### PR DESCRIPTION
## Summary

Fixes [MAG-2550](https://magmadevs.atlassian.net/browse/MAG-2550): a provider whose polls succeed but whose relays keep failing was re-enabled on poll evidence alone (~3 healthy `eth_blockNumber` polls), then failed a fresh 50-request budget of real client traffic before re-disabling — flapping indefinitely. The root cause is an evidence mismatch: the re-enable signal (cheap polls) and the disable trigger (real relay failures) measure different things, so no amount of poll hysteresis can prove the relay path recovered.

## What changed

**Record/replay recovery evidence** — the relay path records the failing request on the endpoint just before `MarkUnhealthy` (`Endpoint.RecordFailingRelay`), together with the relay path's **effective timeout** for that request, so the replay judges under the budget the request actually failed with (floored at 10s, extended by the endpoint's own `NodeUrl.Timeout` — exactly like the relay path). Eligibility is about the **shape** of the request, never the cause of the failure: single read-only JSON-RPC requests only — never writes (`Stateful == CONSISTENCY_SELECT_ALL_PROVIDERS` — those are broadcast to all providers anyway), never subscriptions, hanging APIs, batches (a batch reply can't be judged by single-response health classification), or oversized payloads. On a JSON-RPC router this makes recording the **common** disable path — 5xx storms and transport faults record too; the poll-only fallback covers the exceptions above plus non-JSON-RPC interfaces.

**Two-step re-enable with a three-way judge** — when a disable episode carries recorded evidence, `RecordProbeVerdict` holds the re-enable at the poll-hysteresis threshold. The probe loop replays the exact recorded request through the endpoint's own connection and judges by the same health-classification rules the relay path uses, with three outcomes:
- **recovered** — no health-affecting failure (user-level node errors count as answered) → completes the re-enable (`ConfirmRelayRecovery`);
- **still-failing** — a failure the relay path would disable on (5xx except 501, timeouts, transport faults, health-affecting node errors) → resets the streak and escalates the flap hysteresis (`RelayProbeFailed`) — proving poll-healthy/relay-broken **without exposing a single client request**;
- **inconclusive** — the replay proved nothing either way (429, unrecognized 4xx such as auth drift or an interfering proxy, unparseable 200 bodies) → neither confirms nor escalates (`RelayProbeInconclusive`); it only resets the streak to pace the next attempt.

**Bounded escape hatch** — every non-recovered replay consumes one unit of a per-evidence attempt budget (`maxRelayProbeAttempts = 3`). Exhausting it **drops the evidence** and the episode falls back to the poll-only re-enable path, so evidence whose replay can never pass (too expensive for that endpoint, pruned state, permanently unjudgeable replies) can never park an otherwise-healthy endpoint until the epoch reset. The trial budget still bounds client exposure after the fallback.

**Replays never block the prober** — the probe loop is a single serial ticker that also feeds every provider's QoS sample, so replays run on their own goroutines (`relayProbeRunner`, single-flight per endpoint) and the verdict is applied on completion through the endpoint's race-safe transitions.

**Trial refusal budget** — probe-granted re-enables carry a 3-consecutive-failure trial budget instead of a full `MaxConsecutiveConnectionAttempts` (50) reset, shrinking each residual flap cycle's client exposure ~16x. A successful real relay (`ResetHealth`) restores the full budget.

**Unsupported methods never poison health** — method-not-found / unimplemented / and the *retryable* `NODE_METHOD_NOT_SUPPORTED` (method disabled on this specific node, which previously marked unhealthy) no longer count toward the disable threshold and are never recorded as recovery evidence: a per-method capability gap is not an endpoint fault.

**Observability** — `/debug/endpoint-state` rows now expose `RelayProbeMethod` / `RelayProbeAttempts` / `ReenableProbeFlaps` (a held endpoint is distinguishable from one still earning its streak, and you can see *what* must replay); `/debug/probe-loop` exposes `EvidenceGatedCount` plus cumulative `ReplaysAttempted` / `ReplaysRecovered` / `ReplaysStillFailing` / `ReplaysInconclusive`.

## Testing

- New unit tests: `endpoint_relay_probe_test.go` (gate/confirm/fail/inconclusive/trial-budget state machine, evidence-drop escape hatch — a gated endpoint provably escapes without an epoch reset), `recovery_probe_test.go` (probe-cycle integration, three-way replay judge incl. fail-open cases, recorded-timeout plumbing and floor, async non-blocking cycle, single-flight guard, batch/whitespace-batch recording eligibility), plus `classifyEndpointHealth` unsupported-method cases.
- Updated existing hysteresis tests for the trial-budget semantics.
- Full suites pass under `-race`: `protocol/lavasession`, `protocol/rpcsmartrouter`, `protocol/probing`, `protocol/common`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MAG-2550]: https://magmadevs.atlassian.net/browse/MAG-2550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


Jira ticket: MAG-2550
