### PR TITLE
docs(secondary-cache): retire references to the deleted design doc

### DIFF
--- a/config/smartrouter_examples/smartrouter_eth_two_tier.yml
+++ b/config/smartrouter_examples/smartrouter_eth_two_tier.yml
@@ -1,0 +1,51 @@
+# Smart Router Direct RPC Configuration — Ethereum with a two-tier cache
+# Mode: Direct connections to Ethereum JSON-RPC endpoints (no Lava providers!)
+#
+# Same as smartrouter_eth_cached.yml, plus a read-only SECONDARY cache tier
+# (docs/SECONDARY-CACHE.md): consulted when the primary produces no hit, before
+# falling through to upstreams. Both addresses live in the config file — an
+# explicitly-passed flag outranks the YAML value in viper.
+#
+# Run it with BOTH cache overlays (which start the two cache services):
+#   SR_CONFIG=config/smartrouter_examples/smartrouter_eth_two_tier.yml \
+#     docker compose -f docker/docker-compose.yml \
+#                    -f docker/docker-compose.cache.yml \
+#                    -f docker/docker-compose.secondary-cache.yml up --build
+#
+# Both caches start empty; to see a secondary hit, seed cache-secondary first
+# (see the docker/docker-compose.secondary-cache.yml header).
+
+# Primary cache (the `smart-router cache` sidecar from the cache overlay).
+cache-be: "cache:20100"
+
+# Read-only secondary tier (the cache-secondary service from the
+# secondary-cache overlay). The router never writes it.
+secondary-cache-be: "cache-secondary:20100"
+secondary-cache-timeout: 100ms # per-lookup budget; exceeded = miss
+
+# Prometheus metrics (scrape at http://<host>:7779/metrics). Set to
+# "disabled" to turn off.
+metrics-listen-address: "0.0.0.0:7779"
+
+endpoints:
+  - listen-address: "0.0.0.0:3360"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    network-address: "0.0.0.0:3360"
+
+direct-rpc:
+  # Endpoint 1 — PublicNode (HTTP + WS)
+  - name: "eth-publicnode"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://ethereum-rpc.publicnode.com"
+      - url: "wss://ethereum-rpc.publicnode.com"
+
+  # Endpoint 2 — Tenderly public gateway (HTTP + WS)
+  - name: "eth-tenderly"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "https://mainnet.gateway.tenderly.co"
+      - url: "wss://mainnet.gateway.tenderly.co"

--- a/docker/docker-compose.secondary-cache.yml
+++ b/docker/docker-compose.secondary-cache.yml
@@ -1,6 +1,6 @@
 # Secondary-cache overlay — layer on top of docker-compose.yml AND the cache
 # overlay to add a SECOND cache service, read through the router's read-only
-# secondary tier (docs/SECONDARY-CACHE-DESIGN.md):
+# secondary tier (docs/SECONDARY-CACHE.md):
 #
 #   SR_CONFIG=config/smartrouter_examples/smartrouter_eth_two_tier.yml \
 #     docker compose -f docker/docker-compose.yml \

--- a/docs/LOCAL-COMPOSE.md
+++ b/docs/LOCAL-COMPOSE.md
@@ -81,7 +81,7 @@ it (see `smartrouter_eth_cached.yml`) and run it with the overlay.
 
 ## Enabling a read-only secondary cache
 
-The optional secondary tier (docs/SECONDARY-CACHE-DESIGN.md) is a second cache
+The optional secondary tier (docs/SECONDARY-CACHE.md) is a second cache
 service the router only ever **reads**, consulted when the primary produces no
 hit, before falling through to upstreams. Layer the second overlay on top of
 the cache one and declare both addresses in the config — same

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -238,7 +238,7 @@ Once it is non-zero they are lossy — some batch types are being merged into `b
 > percentiles, since misses return faster than hits — while timeouts now appear
 > as a bounded tail instead of being invisible). The secondary tier
 > (`cache_tier="secondary"`) appears only when `secondary-cache-be` is
-> configured; see `docs/SECONDARY-CACHE-DESIGN.md` §12.
+> configured; see `docs/SECONDARY-CACHE.md`.
 
 #### CSM state-store sizes (diagnostics)
 

--- a/ecosystem/cache/is_node_error_roundtrip_test.go
+++ b/ecosystem/cache/is_node_error_roundtrip_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// These tests lock the entry-kind contract from docs/SECONDARY-CACHE-DESIGN.md §7:
+// These tests lock the entry-kind contract of the cache protocol:
 // RelayCacheSet.IsNodeError must survive storage and come back on GetRelay via
 // CacheRelayReply.IsNodeError. Before this, the flag only selected the write TTL and
 // was lost, so a reader (e.g. secondary-cache backfill) could not tell a cached node

--- a/ecosystem/cache/seen_block_validation_test.go
+++ b/ecosystem/cache/seen_block_validation_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Pins the server-side validation the exact-key backfill fix depends on
-// (docs/SECONDARY-CACHE-DESIGN.md §6): GetRelay rejects a hit whose stored
+// Pins the server-side validation the exact-key backfill fix depends on:
+// GetRelay rejects a hit whose stored
 // SeenBlock (= max(Response.LatestBlock, SET SeenBlock)) is below
 // min(GET SeenBlock, GET RequestedBlock). A backfill SET at key N that carries
 // SeenBlock=N-1 with an unparsable Reply.LatestBlock=0 is therefore invisible to

--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -65,8 +65,7 @@ const (
 // the router substitutes the current request's GUID for the placeholder before
 // serving. No producer exists in this repository — the constants preserve byte-exact
 // compatibility with entries written by other lineages, and are the fallback signal
-// for entry kind when a cache backend predates CacheRelayReply.IsNodeError
-// (docs/SECONDARY-CACHE-DESIGN.md §7).
+// for entry kind when a cache backend predates CacheRelayReply.IsNodeError.
 const (
 	CachedErrorGUIDKeyPrefix   = `"Error_GUID":"`
 	CachedErrorGUIDPlaceholder = CachedErrorGUIDKeyPrefix + `CACHED_ERROR"`

--- a/protocol/metrics/cache_metrics_test.go
+++ b/protocol/metrics/cache_metrics_test.go
@@ -24,7 +24,7 @@ func newSmartRouterForCacheTest() *SmartRouterMetricsManager {
 	}
 }
 
-// ---- outcome-aware, per-tier recording (docs/SECONDARY-CACHE-DESIGN.md §12) ----
+// ---- outcome-aware, per-tier recording (docs/METRICS.md#cache) ----
 
 func TestSmartRouterRecordCacheResult_HitPerTier(t *testing.T) {
 	m := newSmartRouterForCacheTest()

--- a/protocol/metrics/cache_outcome.go
+++ b/protocol/metrics/cache_outcome.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// Cache tier and lookup-outcome label values (docs/SECONDARY-CACHE-DESIGN.md §12).
+// Cache tier and lookup-outcome label values (docs/METRICS.md#cache).
 // Both are closed enums: cache_tier distinguishes the primary cache from the
 // optional read-only secondary, and outcome splits the former catch-all "failed"
 // classification so operators can tell a clean miss from a broken or slow tier.

--- a/protocol/metrics/smartrouter_metrics_manager.go
+++ b/protocol/metrics/smartrouter_metrics_manager.go
@@ -1168,7 +1168,7 @@ func (m *SmartRouterMetricsManager) RecordCacheResult(chainId, apiInterface, met
 		m.cacheFailedTotalMetric.WithLabelValues(chainId, apiInterface, method, cacheTier, outcome).Inc()
 	}
 	// Every attempted lookup is observed — hit-only latency hid exactly the tail
-	// that matters for a network-hop tier (docs/SECONDARY-CACHE-DESIGN.md §12).
+	// that matters for a network-hop tier.
 	m.cacheLatencyHistogram.WithLabelValues(chainId, apiInterface, method, cacheTier).Observe(latencyMs)
 }
 

--- a/protocol/performance/cache_reader.go
+++ b/protocol/performance/cache_reader.go
@@ -7,7 +7,7 @@ import (
 )
 
 // CacheReader is the read-only surface of a cache backend. The secondary cache
-// (docs/SECONDARY-CACHE-DESIGN.md §9) is held behind this interface so writes
+// (docs/SECONDARY-CACHE.md) is held behind this interface so writes
 // (SetEntry) and flushes (Flush) on it are compile-time errors — the read-only
 // guarantee is structural, not conventional. It doubles as the unit-test seam:
 // tests inject a fake CacheReader instead of standing up a gRPC cache server.

--- a/protocol/performance/common.go
+++ b/protocol/performance/common.go
@@ -5,16 +5,16 @@ import "time"
 const (
 	CacheFlagName = "cache-be"
 
-	// Secondary cache tier (docs/SECONDARY-CACHE-DESIGN.md): an optional read-only
+	// Secondary cache tier (docs/SECONDARY-CACHE.md): an optional read-only
 	// fallback cache queried when the primary produces no hit, before provider
 	// fall-through. Independent of the primary — valid with cache-be unset, and it
-	// keeps serving while the primary is down (§5).
+	// keeps serving while the primary is down.
 	SecondaryCacheFlagName        = "secondary-cache-be"
 	SecondaryCacheTimeoutFlagName = "secondary-cache-timeout"
 	SecondaryCacheModeFlagName    = "secondary-cache-mode"
 
 	// SecondaryCacheModeReadOnly is the only access mode v1 accepts; read-write is
-	// reserved for a future iteration (design §16).
+	// reserved for a future iteration.
 	SecondaryCacheModeReadOnly = "read-only"
 
 	// DefaultSecondaryCacheTimeout mirrors the primary lookup budget

--- a/protocol/performance/sanitize.go
+++ b/protocol/performance/sanitize.go
@@ -5,7 +5,7 @@ import (
 )
 
 // SanitizeForeignCacheReply strips identity-bearing data from a cache reply that
-// crossed a trust boundary — the secondary cache (docs/SECONDARY-CACHE-DESIGN.md §4).
+// crossed a trust boundary — the secondary cache (docs/SECONDARY-CACHE.md).
 // Entries in a foreign cache may have been written by other router versions or other
 // software lineages, and RelayReply.Metadata carries arbitrary upstream HTTP/gRPC
 // response headers (X-Provider-ID, Via, Server, ...) that no denylist can be proven

--- a/protocol/performance/sanitize_test.go
+++ b/protocol/performance/sanitize_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The drop-everything policy from docs/SECONDARY-CACHE-DESIGN.md §4: a foreign cache
+// The drop-everything policy: a foreign cache
 // entry's Metadata is arbitrary upstream response metadata and cannot be proven
 // identity-free by any denylist, so all of it goes — including names this router has
 // never heard of. Payload fields that carry the response itself survive untouched.

--- a/protocol/performance/secondary_config.go
+++ b/protocol/performance/secondary_config.go
@@ -6,7 +6,7 @@ import (
 )
 
 // SecondaryCacheConfig carries the operator-provided secondary cache settings
-// (docs/SECONDARY-CACHE-DESIGN.md §11).
+// (docs/SECONDARY-CACHE.md).
 type SecondaryCacheConfig struct {
 	Address string
 	Timeout time.Duration
@@ -18,12 +18,12 @@ func (c SecondaryCacheConfig) Enabled() bool {
 	return c.Address != ""
 }
 
-// Validate applies the startup rules from docs/SECONDARY-CACHE-DESIGN.md §11.
+// Validate applies the secondary-cache startup rules (docs/SECONDARY-CACHE.md).
 // A hard error fails startup; warnings are logged and startup proceeds.
 // timeoutSet/modeSet distinguish an explicitly provided flag/YAML value from the
 // default — secondary options without an address are a deployment mistake, not a
 // configuration. primaryAddress feeds the two advisory warnings: secondary-only is
-// explicitly allowed (§5) but warned about (no backfill), and secondary == primary
+// explicitly allowed but warned about (no backfill), and secondary == primary
 // is legal but almost certainly unintended.
 func (c SecondaryCacheConfig) Validate(primaryAddress string, timeoutSet, modeSet bool) (warnings []string, err error) {
 	if !c.Enabled() {

--- a/protocol/performance/secondary_config_test.go
+++ b/protocol/performance/secondary_config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Startup validation rules from docs/SECONDARY-CACHE-DESIGN.md §11 (T9).
+// Startup validation rules (docs/SECONDARY-CACHE.md).
 func TestSecondaryCacheConfigValidate(t *testing.T) {
 	valid := SecondaryCacheConfig{Address: "cache-shared:20100", Timeout: 75 * time.Millisecond, Mode: SecondaryCacheModeReadOnly}
 

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -214,7 +214,7 @@ type RPCSmartRouter struct {
 type rpcSmartRouterStartOptions struct {
 	rpcEndpoints             []*lavasession.RPCEndpoint
 	cache                    *performance.Cache
-	secondaryCache           performance.CacheReader // optional read-only fallback tier (docs/SECONDARY-CACHE-DESIGN.md); nil when unconfigured
+	secondaryCache           performance.CacheReader // optional read-only fallback tier (docs/SECONDARY-CACHE.md); nil when unconfigured
 	secondaryCacheTimeout    time.Duration
 	strategy                 provideroptimizer.Strategy
 	analyticsServerAddresses AnalyticsServerAddresses
@@ -2511,8 +2511,8 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 				}
 			}
 
-			// Optional read-only secondary cache tier (docs/SECONDARY-CACHE-DESIGN.md §11).
-			// Deliberately independent of the primary (§5): valid with cache-be unset.
+			// Optional read-only secondary cache tier (docs/SECONDARY-CACHE.md).
+			// Deliberately independent of the primary: valid with cache-be unset.
 			secondaryCacheConfig := performance.SecondaryCacheConfig{
 				Address: viper.GetString(performance.SecondaryCacheFlagName),
 				Timeout: viper.GetDuration(performance.SecondaryCacheTimeoutFlagName),
@@ -2540,7 +2540,7 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 					utils.LavaFormatInfo("secondary cache service connected", utils.Attribute{Key: "address", Value: secondaryCacheConfig.Address})
 				}
 				secondaryCacheReader = secondaryCache
-				// Startup visibility (design §11 / PRD nice-to-have): one line with the
+				// Startup visibility (PRD nice-to-have): one line with the
 				// full secondary configuration.
 				utils.LavaFormatInfo("secondary cache configured",
 					utils.Attribute{Key: "address", Value: secondaryCacheConfig.Address},
@@ -2666,7 +2666,7 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	cmdRPCSmartRouter.Flags().Int(performance.PyroscopeBlockProfileRateFlagName, performance.DefaultBlockProfileRate, "block profile rate in nanoseconds (1 records all blocking events)")
 	cmdRPCSmartRouter.Flags().String(performance.PyroscopeTagsFlagName, "", "comma-separated list of tags in key=value format (e.g., instance=router-1,region=us-east)")
 	cmdRPCSmartRouter.Flags().String(performance.CacheFlagName, "", "address for a cache server to improve performance")
-	cmdRPCSmartRouter.Flags().String(performance.SecondaryCacheFlagName, "", "address for an optional read-only secondary cache, queried when the primary cache produces no hit (docs/SECONDARY-CACHE-DESIGN.md)")
+	cmdRPCSmartRouter.Flags().String(performance.SecondaryCacheFlagName, "", "address for an optional read-only secondary cache, queried when the primary cache produces no hit (docs/SECONDARY-CACHE.md)")
 	cmdRPCSmartRouter.Flags().Duration(performance.SecondaryCacheTimeoutFlagName, performance.DefaultSecondaryCacheTimeout, "per-lookup time budget for the secondary cache; an exceeded lookup is treated as a miss")
 	cmdRPCSmartRouter.Flags().String(performance.SecondaryCacheModeFlagName, performance.SecondaryCacheModeReadOnly, "secondary cache access mode; only read-only is supported")
 	cmdRPCSmartRouter.Flags().Int(relaycore.ConsistencyBlockGapFactorFlagName, 0, "consistency-relief: widen the consistency endpoint-lag gate (blockLagForQosSync x factor; default 2). Allowed [2,8]; out-of-range reverts to default.")

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -70,7 +70,7 @@ type RPCSmartRouterServer struct {
 	initialized          atomic.Bool
 	enableSelectionStats bool // feature flag to enable selection stats header
 
-	// Optional read-only secondary cache tier (docs/SECONDARY-CACHE-DESIGN.md §9);
+	// Optional read-only secondary cache tier (docs/SECONDARY-CACHE.md);
 	// nil when unconfigured. Typed as the narrow CacheReader so SetEntry/Flush are
 	// compile-time errors — read-only is structural, not conventional.
 	secondaryCache        performance.CacheReader
@@ -2963,7 +2963,7 @@ func (rpcss *RPCSmartRouterServer) tryCacheWrite(
 }
 
 // tryCacheWriteResolved is tryCacheWrite with an optional pre-resolved cache-key
-// block (docs/SECONDARY-CACHE-DESIGN.md §6). resolvedBlock == nil preserves the
+// block. resolvedBlock == nil preserves the
 // legacy resolution (Reply.LatestBlock → SeenBlock → skip). A non-nil resolvedBlock
 // carries the exact block that produced a secondary-cache hit, so the backfill SET
 // lands on the identical server-side key (hash ‖ block) — re-deriving it here could
@@ -3069,7 +3069,7 @@ func (rpcss *RPCSmartRouterServer) tryCacheWriteResolved(
 	// This must match the logic in cache lookup (sendRelayToEndpoint) to ensure cache hits
 	requestedBlockForCache := requestedBlock
 	if resolvedBlock != nil && *resolvedBlock >= 0 {
-		// Exact-key backfill (§6): the caller proved this block is the server-side
+		// Exact-key backfill: the caller proved this block is the server-side
 		// key that hit — trust it over re-derivation.
 		requestedBlockForCache = *resolvedBlock
 	} else if requestedBlock == spectypes.LATEST_BLOCK {
@@ -3091,7 +3091,7 @@ func (rpcss *RPCSmartRouterServer) tryCacheWriteResolved(
 	// Get seen block
 	seenBlock := relayData.SeenBlock
 	if resolvedBlock != nil && *resolvedBlock > seenBlock {
-		// Exact-key backfill (§6): the cache server validates hits against the
+		// Exact-key backfill: the cache server validates hits against the
 		// stored max(SeenBlock, Reply.LatestBlock) — a follow-up GET at key N with
 		// SeenBlock=N rejects an entry stored with SeenBlock=N-1 as "smaller than
 		// our expectations" (ecosystem/cache/handlers.go GetRelay), which would make
@@ -3224,7 +3224,7 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 	crossValidationParams := relayProcessor.GetCrossValidationParams()
 
 	// Cache lookup: bypass rules are evaluated once for both tiers; each tier is then
-	// attempted iff it is itself active (docs/SECONDARY-CACHE-DESIGN.md §5) — a
+	// attempted iff it is itself active — a
 	// healthy secondary keeps serving while the primary is down or unconfigured.
 	crossValidationEnabled := selection == relaycore.CrossValidation && crossValidationParams != nil
 	primaryCacheActive := rpcss.cache.CacheActive()
@@ -3411,10 +3411,10 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 						latestBlockHashRequested, earliestBlockHashRequested = rpcss.getEarliestBlockHashRequestedFromCacheReply(cacheReply)
 						utils.LavaFormatTrace("[Archive Debug] Reading block hashes from cache", utils.LogAttr("latestBlockHashRequested", latestBlockHashRequested), utils.LogAttr("earliestBlockHashRequested", earliestBlockHashRequested), utils.LogAttr("GUID", ctx))
 					}
-					// Secondary tier (design §5): consulted whenever the primary produced no
-					// hit — including primary inactive or unconfigured. A hit is sanitized,
-					// served, and backfilled through the populator; a miss still contributes
-					// block-hash→height data to the merge (§8).
+					// Secondary tier (docs/SECONDARY-CACHE.md): consulted whenever the primary
+					// produced no hit — including primary inactive or unconfigured. A hit is
+					// sanitized, served, and backfilled through the populator; a miss still
+					// contributes block-hash→height data to the merge.
 					if secondaryCacheActive {
 						served, secondaryCacheReply := rpcss.trySecondaryCacheLookup(ctx, protocolMessage, localRelayData, relayProcessor, analytics, hashKey, outputFormatter, requestedBlockForCache)
 						if served {

--- a/protocol/rpcsmartrouter/secondary_cache.go
+++ b/protocol/rpcsmartrouter/secondary_cache.go
@@ -26,26 +26,27 @@ func (rpcss *RPCSmartRouterServer) secondaryCacheActive() bool {
 }
 
 // trySecondaryCacheLookup queries the read-only secondary cache tier
-// (docs/SECONDARY-CACHE-DESIGN.md §5). It runs only when the primary produced no hit
+// (docs/SECONDARY-CACHE.md). It runs only when the primary produced no hit
 // (miss, error, timeout, or primary inactive/unconfigured). On a hit it sanitizes a
-// private copy of the entry (§4 — the secondary is a cross-zone trust boundary),
+// private copy of the entry (the secondary is a cross-zone trust boundary),
 // serves it exactly like a primary hit, and backfills the primary through the
-// populator with the exact block that hit (§6) — unless the entry is a cached node
-// error (§7), which is served but never re-written as a success. Every error,
+// populator with the exact block that hit — unless the entry is a cached node
+// error, which is served but never re-written as a success. Every error,
 // timeout, or malformed entry degrades to a miss; this tier can never fail a request.
 //
 // Returns served=true when the response was set on the relay processor, plus the raw
-// reply so a miss can still contribute block-hash→height data to the §8 merge.
+// reply so a miss can still contribute block-hash→height data to the
+// mergeBlockHashHeights fold.
 //
 // Deliberate differences from the primary lookup:
 //   - SharedStateId is empty and the reply's SeenBlock is never fed to
 //     adoptSharedStateTip: shared-state tip exchange is fleet-scoped, and a
-//     foreign-zone cache is not this router's fleet (§5, T13).
+//     foreign-zone cache is not this router's fleet.
 //   - The lookup runs under the operator-configured secondary-cache-timeout rather
 //     than the primary's fixed budget.
 //   - Every attempted lookup is recorded with cache_tier=secondary and its outcome
 //     (hit|miss|error|timeout) in the smartrouter_cache_* series and on its own
-//     smartrouter.CacheLookup span (design §12). Router request counters
+//     smartrouter.CacheLookup span. Router request counters
 //     (RecordCacheHitRequest, provider_address="Cached") fire for a hit on either
 //     tier, unchanged in shape.
 func (rpcss *RPCSmartRouterServer) trySecondaryCacheLookup(
@@ -69,7 +70,7 @@ func (rpcss *RPCSmartRouterServer) trySecondaryCacheLookup(
 		ChainId:               chainId,
 		BlockHash:             nil,
 		Finalized:             false, // same as the primary: the server searches both stores
-		SharedStateId:         "",    // never join a foreign fleet's shared state (§5)
+		SharedStateId:         "",    // never join a foreign fleet's shared state
 		SeenBlock:             localRelayData.SeenBlock,
 		BlocksHashesToHeights: rpcss.newBlocksHashesToHeightsSliceFromRequestedBlockHashes(protocolMessage.GetRequestedBlocksHashes()),
 	})
@@ -81,8 +82,8 @@ func (rpcss *RPCSmartRouterServer) trySecondaryCacheLookup(
 	cacheSpan.End()
 	go rpcss.smartRouterEndpointMetrics.RecordCacheResult(chainId, apiInterface, protocolMessage.GetApi().GetName(), metrics.CacheTierSecondary, outcome, latencyMs)
 	if !hit {
-		// miss, error, and timeout all degrade to a miss (§5); the reply may still
-		// carry block-hash→height data worth merging (§8)
+		// miss, error, and timeout all degrade to a miss; the reply may still
+		// carry block-hash→height data worth merging
 		utils.LavaFormatDebug("secondary cache lookup produced no hit",
 			utils.LogAttr("GUID", ctx),
 			utils.LogAttr("requestedBlockForCache", requestedBlockForCache),
@@ -92,7 +93,7 @@ func (rpcss *RPCSmartRouterServer) trySecondaryCacheLookup(
 		return false, cacheReply
 	}
 
-	// Trust boundary (§4): work on a private copy and strip identity-bearing data
+	// Trust boundary: work on a private copy and strip identity-bearing data
 	// before the entry is served or backfilled. The sanitized copy is the ONLY copy
 	// used from here on.
 	copyReply := &pairingtypes.RelayReply{}
@@ -106,7 +107,7 @@ func (rpcss *RPCSmartRouterServer) trySecondaryCacheLookup(
 	copyReply.Data = outputFormatter(copyReply.Data)
 
 	// Entry kind must be decided BEFORE the GUID substitution below erases the legacy
-	// placeholder (§7): explicit flag from newer backends, placeholder heuristic for
+	// placeholder: explicit flag from newer backends, placeholder heuristic for
 	// older ones.
 	replyDataStr := string(copyReply.Data)
 	isNodeError := cacheReply.GetIsNodeError() || strings.Contains(replyDataStr, common.CachedErrorGUIDPlaceholder)
@@ -117,7 +118,7 @@ func (rpcss *RPCSmartRouterServer) trySecondaryCacheLookup(
 		}
 	}
 
-	// Original upstream status, when the entry's writer recorded it (§7). Zero is the
+	// Original upstream status, when the entry's writer recorded it. Zero is the
 	// legacy "unknown" and keeps today's assume-success serving; a real stored status
 	// flows through RelayResult so the populator's own 429/504/non-2xx checks decide
 	// backfill eligibility instead of a hardcoded 200 making them unreachable.
@@ -140,18 +141,18 @@ func (rpcss *RPCSmartRouterServer) trySecondaryCacheLookup(
 		ProviderInfo: common.ProviderInfo{ProviderAddress: ""}, // rendered as "Cached", same as a primary hit
 	}
 
-	// Backfill (§6): the populator owns ALL eligibility — node-error, status-code,
+	// Backfill: the populator owns ALL eligibility — node-error, status-code,
 	// stateful, NOT_APPLICABLE, finalization — so this call is unconditional and the
-	// checks see the entry's real state (§7). It runs BEFORE SetResponse so the
+	// checks see the entry's real state. It runs BEFORE SetResponse so the
 	// populator's synchronous deep copy cannot race the response path's later header
 	// appends; the actual SET stays async inside the populator. When the primary is
-	// inactive the populator skips itself (§5 secondary-only topology).
+	// inactive the populator skips itself (secondary-only topology).
 	rpcss.tryCacheWriteResolved(ctx, protocolMessage, &relayResult, &requestedBlockForCache)
 
 	// Same MAG-2160 rule as primary hits: a cached reply's LatestBlock is the block
 	// that was current when the entry was written, not a fresh chain-head
 	// observation — it never feeds tip state. The reply's SeenBlock is likewise
-	// dropped here (T13), not adopted.
+	// dropped here, not adopted.
 	relayProcessor.SetResponse(&relaycore.RelayResponse{
 		RelayResult: relayResult,
 		Err:         nil,
@@ -176,7 +177,7 @@ func (rpcss *RPCSmartRouterServer) trySecondaryCacheLookup(
 }
 
 // mergeBlockHashHeights merges the block-hash→height scalars harvested from the
-// primary and secondary miss replies (docs/SECONDARY-CACHE-DESIGN.md §8):
+// primary and secondary miss replies:
 // information is merged, never overwritten. The earliest is the minimum valid
 // height, the latest the maximum, and a reply without mappings (NOT_APPLICABLE,
 // negative) cannot erase the other tier's values. Conflicting heights for the same

--- a/protocol/rpcsmartrouter/secondary_cache_test.go
+++ b/protocol/rpcsmartrouter/secondary_cache_test.go
@@ -30,7 +30,7 @@ import (
 // Harness
 // ---------------------------------------------------------------------------
 
-// fakeCacheReader is the CacheReader test seam (design §9): canned reply/error,
+// fakeCacheReader is the CacheReader test seam: canned reply/error,
 // optional context-respecting delay, and a recording of every GetEntry request so
 // tests can assert what crossed the trust boundary (SharedStateId, blocks, ...).
 type fakeCacheReader struct {
@@ -175,10 +175,10 @@ func directGet(rcs *ecocache.RelayerCacheServer, hashKey []byte, block, seenBloc
 }
 
 // ---------------------------------------------------------------------------
-// Behavioral tests (design §14)
+// Behavioral tests
 // ---------------------------------------------------------------------------
 
-// T1 + T16: a secondary hit serves the caller with no primary configured at all —
+// A secondary hit serves the caller with no primary configured at all —
 // and the request-side contract holds: exactly one lookup, SharedStateId empty
 // (never join a foreign fleet's shared state), Finalized=false, the resolved block.
 func TestSecondaryCacheHitServesWithoutPrimary(t *testing.T) {
@@ -202,12 +202,12 @@ func TestSecondaryCacheHitServesWithoutPrimary(t *testing.T) {
 
 	gets := fake.recorded()
 	require.Len(t, gets, 1)
-	require.Equal(t, "", gets[0].SharedStateId, "secondary GET must never carry SharedStateId (design §5)")
+	require.Equal(t, "", gets[0].SharedStateId, "secondary GET must never carry SharedStateId")
 	require.False(t, gets[0].Finalized)
 	require.Equal(t, int64(100), gets[0].RequestedBlock)
 }
 
-// T5: timeout and transport errors both degrade to a miss within the configured
+// Timeout and transport errors both degrade to a miss within the configured
 // budget — the tier can never fail or stall a request.
 func TestSecondaryCacheTimeoutAndErrorAreMisses(t *testing.T) {
 	chainParser, protocolMessage := buildRestProtocolMessage(t, context.Background(), 100)
@@ -229,7 +229,7 @@ func TestSecondaryCacheTimeoutAndErrorAreMisses(t *testing.T) {
 	})
 }
 
-// T2 — the exact-key backfill blocker regression, through REAL cache-server
+// The exact-key backfill blocker regression, through REAL cache-server
 // validation. Scenario: ParseRelay stamped SeenBlock=99, the guarded tip advanced
 // to 100 by lookup time (requestedBlockForCache=100), and the cached entry has
 // Reply.LatestBlock=0 (an eth_call-style reply with no parsable height). The
@@ -268,7 +268,7 @@ func TestSecondaryHitBackfillsPrimaryWithExactKeyAndValidSeenBlock(t *testing.T)
 	require.False(t, reply.GetIsNodeError())
 }
 
-// T12: cached node errors — explicit flag and legacy placeholder — are served but
+// Cached node errors — explicit flag and legacy placeholder — are served but
 // NEVER backfilled, and the rejection is the populator's own node-error check (the
 // RelayResult carries IsNodeError; there is no pre-filter in the secondary path).
 func TestSecondaryCachedNodeErrorsServeButNeverBackfill(t *testing.T) {
@@ -314,9 +314,9 @@ func TestSecondaryCachedNodeErrorsServeButNeverBackfill(t *testing.T) {
 	}
 }
 
-// T11 — full-path poisoned-entry test: foreign signatures and ARBITRARY foreign
+// Full-path poisoned-entry test: foreign signatures and ARBITRARY foreign
 // metadata (names no denylist could enumerate) appear neither in the served result
-// nor in the primary backfill payload. Drop-all policy from design §4.
+// nor in the primary backfill payload — the drop-all sanitization policy.
 func TestSecondaryPoisonedEntrySanitizedForCallerAndBackfill(t *testing.T) {
 	primary, rcs := startCacheServerForTest(t)
 	chainParser, protocolMessage := buildRestProtocolMessage(t, context.Background(), 100)
@@ -368,7 +368,7 @@ func TestSecondaryPoisonedEntrySanitizedForCallerAndBackfill(t *testing.T) {
 	require.Equal(t, payload, stored.GetReply().Data)
 }
 
-// T13: the secondary reply's SeenBlock is never adopted into ChainState, even with
+// The secondary reply's SeenBlock is never adopted into ChainState, even with
 // shared-state mode on — shared-state tip exchange is fleet-scoped and a foreign
 // cache is not this router's fleet.
 func TestSecondarySeenBlockNeverAdoptedIntoChainState(t *testing.T) {
@@ -388,14 +388,14 @@ func TestSecondarySeenBlockNeverAdoptedIntoChainState(t *testing.T) {
 	require.True(t, served)
 
 	_, ok := rpcss.chainState.GetLatestBlock()
-	require.False(t, ok, "foreign SeenBlock must never reach ChainState (design §5, T13)")
+	require.False(t, ok, "foreign SeenBlock must never reach ChainState")
 }
 
 // ---------------------------------------------------------------------------
-// Configuration wiring (design §11, T8) — through the real cobra command's flags
+// Configuration wiring — through the real cobra command's flags
 // and the same viper mechanics the RunE uses (BindPFlags + optional YAML config).
 // Environment variables are intentionally NOT bound anywhere in this repo, which is
-// why the design scopes configuration to flags and YAML.
+// why configuration is scoped to flags and YAML.
 // ---------------------------------------------------------------------------
 
 func TestSecondaryCacheFlagAndYamlWiring(t *testing.T) {
@@ -433,7 +433,7 @@ func TestSecondaryCacheFlagAndYamlWiring(t *testing.T) {
 // Pure helpers
 // ---------------------------------------------------------------------------
 
-// Block-hash→height merge semantics from docs/SECONDARY-CACHE-DESIGN.md §8 (T14):
+// Block-hash→height merge semantics:
 // merged, never overwritten — earliest is the minimum valid height, latest the
 // maximum, and a reply without mappings (NOT_APPLICABLE) cannot erase the other
 // tier's values.
@@ -463,7 +463,7 @@ func TestMergeBlockHashHeights(t *testing.T) {
 }
 
 // The secondary tier must be skipped cleanly in every unconfigured/disconnected
-// state (design §5): nil interface, and an interface wrapping a typed-nil concrete
+// state: nil interface, and an interface wrapping a typed-nil concrete
 // client (the wiring hands over a nil *performance.Cache when disabled).
 func TestSecondaryCacheActiveNilSafety(t *testing.T) {
 	rpcss := &RPCSmartRouterServer{}

--- a/protocol/tracing/span_helpers.go
+++ b/protocol/tracing/span_helpers.go
@@ -168,7 +168,7 @@ func RecordCacheResult(ctx context.Context, span trace.Span, cacheTier, outcome 
 		// cache.hit mirrors every lookup (last write wins, so a primary miss
 		// followed by a secondary hit leaves true); cache.tier is stamped only by
 		// the tier that actually served, so the parent answers "which cache?"
-		// without a child-span walk (docs/SECONDARY-CACHE-DESIGN.md §12).
+		// without a child-span walk.
 		relaySpan.SetAttributes(attribute.Bool(attrCacheHit, hit))
 		if hit {
 			relaySpan.SetAttributes(attribute.String(attrCacheTier, cacheTier))

--- a/protocol/tracing/span_names.go
+++ b/protocol/tracing/span_names.go
@@ -48,7 +48,7 @@ const (
 	// Cache attributes.
 	attrCacheHit       = "cache.hit"
 	attrCacheLatencyMs = "cache.latency_ms"
-	attrCacheTier      = "cache.tier"    // primary | secondary (docs/SECONDARY-CACHE-DESIGN.md §12)
+	attrCacheTier      = "cache.tier"    // primary | secondary
 	attrCacheOutcome   = "cache.outcome" // hit | miss | error | timeout
 
 	// Session attributes.

--- a/scripts/pre_setups/init_smartrouter_eth_secondary_cache.sh
+++ b/scripts/pre_setups/init_smartrouter_eth_secondary_cache.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Two-zone secondary-cache integration lane (docs/SECONDARY-CACHE-DESIGN.md §14).
+# Two-zone secondary-cache integration lane (docs/SECONDARY-CACHE.md).
 #
 # Reproduces the PRD's Kraken topology on one machine:
 #

--- a/types/relay/cache_test.go
+++ b/types/relay/cache_test.go
@@ -10,7 +10,7 @@ import (
 // The cache wire types are hand-written structs serialized as JSON, so cross-version
 // compatibility rests on encoding/json semantics: absent fields decode to zero values
 // and unknown fields are ignored. These tests lock both directions for the
-// CacheRelayReply.IsNodeError extension (docs/SECONDARY-CACHE-DESIGN.md §7): an old
+// CacheRelayReply.IsNodeError extension: an old
 // cache server's reply (no is_node_error) must decode to false, and a newer peer's
 // extra fields must not break this reader.
 


### PR DESCRIPTION
## What

`docs/SECONDARY-CACHE-DESIGN.md` was removed in 350c349, but ~30 references to it (and to its `§N` sections / `T1–T16` test-matrix IDs) remained across code comments, test comments, the `--secondary-cache-be` flag help text, `docs/METRICS.md`, `docs/LOCAL-COMPOSE.md`, the compose overlay, and the two-zone lane script. This stacks on #248 and cleans them all up before the RESP-cache work adds more references on top.

## How

- **Redirect**: pointers that name a doc for further reading now cite the surviving customer-facing `docs/SECONDARY-CACHE.md`; metrics-related ones cite `docs/METRICS.md#cache`.
- **Inline**: comments that cited a deleted `§N` for a rule they already state are now self-contained (the comment is the spec); orphaned design test-matrix IDs (`T8`, `T13`, …) are dropped from test comments and assertion messages.
- **Untouched**: the `T1–T4`/`T10`/`T11` refs in `chainstate`/`endpointstate`/`endpointtip` come from the MAG-2160 decisions log — a different lineage — and are left alone.
- **New file**: `config/smartrouter_examples/smartrouter_eth_two_tier.yml` — both `docker/docker-compose.secondary-cache.yml` and `LOCAL-COMPOSE.md` instruct running with it, but it never existed. Derived from `smartrouter_eth_cached.yml`; force-added past the examples-dir gitignore like the other curated examples.

Comment/doc-only plus one example config — **no behavior change**.

## Verification

- `git grep SECONDARY-CACHE-DESIGN` → empty; no orphaned `§`/`T` refs remain in the secondary-cache files
- `go build ./...` clean; edited files pass `gofmt`
- `go test ./ecosystem/cache/... ./types/relay/... ./protocol/performance/... ./protocol/metrics/... ./protocol/tracing/...` and the rpcsmartrouter `Secondary|MergeBlockHash` suite — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)