### PR TITLE
fix(rpcsmartrouter): stop relay-race cancellations penalising endpoint health and QoS

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -73,7 +73,7 @@ They split into **endpoint-scoped** (`rpc_endpoint_*`) and **router-scoped**
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
 | `rpc_endpoint_total_relays_serviced` | Counter | `spec`, `apiInterface`, `endpoint_id`, `function` | Relays successfully served by this endpoint. |
-| `rpc_endpoint_total_errored` | Counter | `spec`, `apiInterface`, `endpoint_id`, `function` | Errored relays for this endpoint. Excludes relays the router cancelled — see `rpc_endpoint_total_cancelled`. |
+| `rpc_endpoint_total_errored` | Counter | `spec`, `apiInterface`, `endpoint_id`, `function` | Errored relays for this endpoint. Excludes relays the router itself cancelled — see `rpc_endpoint_total_cancelled`. |
 | `rpc_endpoint_total_cancelled` | Counter | `spec`, `apiInterface`, `endpoint_id`, `function` | Relays the router aborted before completion: relay-race losers on stateful broadcasts, and client disconnects. **Not an endpoint fault** — excluded from `rpc_endpoint_total_errored` and from QoS/availability scoring. |
 | `rpc_endpoint_requests_in_flight` | Gauge | `spec`, `apiInterface`, `endpoint_id`, `function` | Relays currently in flight to this endpoint. |
 | `rpc_endpoint_end_to_end_latency_milliseconds` | Histogram | `spec`, `apiInterface`, `endpoint_id`, `function` | End-to-end latency per function for this endpoint. |
@@ -81,18 +81,25 @@ They split into **endpoint-scoped** (`rpc_endpoint_*`) and **router-scoped**
 | `rpc_endpoint_overall_health_breakdown` | Gauge | `spec`, `apiInterface` | Aggregate health per chain/interface. |
 | `rpc_endpoint_selection_score` | Gauge | `spec`, `apiInterface`, `endpoint_id`, `score_type` | Selection scores by `score_type` (availability / latency / sync / stake / composite). |
 | `rpc_endpoint_latest_block` | Gauge | `spec`, `apiInterface`, `endpoint_id` | Latest block reported by the endpoint. |
-
-> **Reading cancelled relays.** A write (`stateful: 1`, e.g. `eth_sendRawTransaction`) is
-> broadcast to every endpoint; the first response wins and the rest are cancelled. So a
-> healthy endpoint on write-heavy traffic will show a high `rpc_endpoint_total_cancelled`
-> rate by design — roughly `(N-1)/N` of broadcasts, for N endpoints. That is the number to
-> watch when tuning broadcast fan-out, not a fault signal. Cancelled relays still decrement
-> `rpc_endpoint_requests_in_flight`, and never move the `smartrouter_requests_*` group, so
-> `requests_total == requests_success + requests_failed` remains exact.
 | `rpc_endpoint_fetch_latest_fails` | Counter | `spec`, `apiInterface`, `endpoint_id` | Failed latest-block fetches. |
 | `rpc_endpoint_fetch_block_fails` | Counter | `spec`, `apiInterface`, `endpoint_id` | Failed specific-block fetches. |
 | `rpc_endpoint_fetch_latest_success` | Counter | `spec`, `apiInterface`, `endpoint_id` | Successful latest-block fetches. |
 | `rpc_endpoint_fetch_block_success` | Counter | `spec`, `apiInterface`, `endpoint_id` | Successful specific-block fetches. |
+
+> **Reading cancelled relays.** A stateful method (`stateful: 1` in the spec — e.g.
+> `eth_sendRawTransaction`, Solana `sendTransaction`) is broadcast to *every* endpoint; the
+> first response wins and the rest are cancelled. A healthy endpoint under write traffic will
+> therefore show a high `rpc_endpoint_total_cancelled` rate **by design** — with N endpoints,
+> roughly `(N-1)/N` of every broadcast. That is the number to watch when tuning broadcast
+> fan-out; it is not a fault signal.
+>
+> The two counters partition the non-success outcomes: `total_errored` is the endpoint's
+> fault, `total_cancelled` is ours. Cancelled relays still decrement
+> `rpc_endpoint_requests_in_flight`, and never move the `smartrouter_requests_*` family, so
+> `requests_total == requests_success + requests_failed` remains exact.
+>
+> Measured on a 3-endpoint SOLANAT router (MAG-2648): 90 stateful broadcasts produced 103
+> serviced + 167 cancelled = 270 relays = 90 × 3, with zero errored.
 
 ### Optimizer
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -73,13 +73,22 @@ They split into **endpoint-scoped** (`rpc_endpoint_*`) and **router-scoped**
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
 | `rpc_endpoint_total_relays_serviced` | Counter | `spec`, `apiInterface`, `endpoint_id`, `function` | Relays successfully served by this endpoint. |
-| `rpc_endpoint_total_errored` | Counter | `spec`, `apiInterface`, `endpoint_id`, `function` | Errored relays for this endpoint. |
+| `rpc_endpoint_total_errored` | Counter | `spec`, `apiInterface`, `endpoint_id`, `function` | Errored relays for this endpoint. Excludes relays the router cancelled — see `rpc_endpoint_total_cancelled`. |
+| `rpc_endpoint_total_cancelled` | Counter | `spec`, `apiInterface`, `endpoint_id`, `function` | Relays the router aborted before completion: relay-race losers on stateful broadcasts, and client disconnects. **Not an endpoint fault** — excluded from `rpc_endpoint_total_errored` and from QoS/availability scoring. |
 | `rpc_endpoint_requests_in_flight` | Gauge | `spec`, `apiInterface`, `endpoint_id`, `function` | Relays currently in flight to this endpoint. |
 | `rpc_endpoint_end_to_end_latency_milliseconds` | Histogram | `spec`, `apiInterface`, `endpoint_id`, `function` | End-to-end latency per function for this endpoint. |
 | `rpc_endpoint_overall_health` | Gauge | `spec`, `apiInterface`, `endpoint_id` | Endpoint health (1 healthy / 0 unhealthy). |
 | `rpc_endpoint_overall_health_breakdown` | Gauge | `spec`, `apiInterface` | Aggregate health per chain/interface. |
 | `rpc_endpoint_selection_score` | Gauge | `spec`, `apiInterface`, `endpoint_id`, `score_type` | Selection scores by `score_type` (availability / latency / sync / stake / composite). |
 | `rpc_endpoint_latest_block` | Gauge | `spec`, `apiInterface`, `endpoint_id` | Latest block reported by the endpoint. |
+
+> **Reading cancelled relays.** A write (`stateful: 1`, e.g. `eth_sendRawTransaction`) is
+> broadcast to every endpoint; the first response wins and the rest are cancelled. So a
+> healthy endpoint on write-heavy traffic will show a high `rpc_endpoint_total_cancelled`
+> rate by design — roughly `(N-1)/N` of broadcasts, for N endpoints. That is the number to
+> watch when tuning broadcast fan-out, not a fault signal. Cancelled relays still decrement
+> `rpc_endpoint_requests_in_flight`, and never move the `smartrouter_requests_*` group, so
+> `requests_total == requests_success + requests_failed` remains exact.
 | `rpc_endpoint_fetch_latest_fails` | Counter | `spec`, `apiInterface`, `endpoint_id` | Failed latest-block fetches. |
 | `rpc_endpoint_fetch_block_fails` | Counter | `spec`, `apiInterface`, `endpoint_id` | Failed specific-block fetches. |
 | `rpc_endpoint_fetch_latest_success` | Counter | `spec`, `apiInterface`, `endpoint_id` | Successful latest-block fetches. |

--- a/protocol/common/error_cause_test.go
+++ b/protocol/common/error_cause_test.go
@@ -115,3 +115,67 @@ func TestIsClientCancellation(t *testing.T) {
 		assert.False(t, IsClientCancellation(context.Canceled, nil))
 	})
 }
+
+// Nil-guard coverage. Raised in review of PR #252: the `As` method added by MAG-2648 was
+// the new surface — returning true with a nil *LavaError both hands the caller a nil and
+// halts errors.As before it can reach a real one deeper in the chain. Error/Is/Unwrap had
+// the same unguarded dereference (pre-existing), and Error's failure mode is a panic
+// inside a logging call.
+//
+// The constructors always set LavaErr today, so every case here is latent. They are pinned
+// anyway: this type exists because a silently unreachable resolution path was expensive.
+func TestLavaWrappedError_NilLavaErrIsSafe(t *testing.T) {
+	bare := &LavaWrappedError{Context: "some context"}
+
+	t.Run("Error does not panic", func(t *testing.T) {
+		require.NotPanics(t, func() { _ = bare.Error() })
+		assert.Equal(t, "some context", bare.Error())
+	})
+
+	t.Run("Error with no context does not panic", func(t *testing.T) {
+		empty := &LavaWrappedError{}
+		require.NotPanics(t, func() { _ = empty.Error() })
+	})
+
+	t.Run("Is reports no match instead of panicking", func(t *testing.T) {
+		require.NotPanics(t, func() { _ = errors.Is(bare, LavaErrorContextCanceled) })
+		assert.False(t, errors.Is(bare, LavaErrorContextCanceled))
+	})
+
+	t.Run("As declines instead of yielding a nil", func(t *testing.T) {
+		var le *LavaError
+		require.NotPanics(t, func() { _ = errors.As(bare, &le) })
+		assert.False(t, errors.As(bare, &le), "As must not claim a match it cannot satisfy")
+		assert.Nil(t, le, "target must be left untouched")
+	})
+
+	t.Run("As does not halt the walk to a real LavaError deeper in the chain", func(t *testing.T) {
+		// The failure this guard exists for: an unguarded As returns true at the outer
+		// wrapper, so errors.As stops and never reaches the resolvable inner one.
+		inner := NewLavaError(LavaErrorChainNonceTooLow, "inner")
+		outer := &LavaWrappedError{Context: "outer", cause: inner}
+
+		var le *LavaError
+		require.True(t, errors.As(outer, &le), "the walk must continue past a LavaErr-less wrapper")
+		assert.Equal(t, LavaErrorChainNonceTooLow.Code, le.Code)
+	})
+
+	t.Run("Unwrap yields no typed nil", func(t *testing.T) {
+		// A typed nil here would be a non-nil error interface holding a nil *LavaError,
+		// and the next errors.Is would call LavaError.Is on a nil receiver.
+		require.NotPanics(t, func() { _ = errors.Unwrap(bare) })
+		assert.Nil(t, errors.Unwrap(bare))
+		require.NotPanics(t, func() { _ = errors.Is(bare, LavaErrorUnknown) })
+	})
+}
+
+func TestLavaWrappedError_NilReceiverIsSafe(t *testing.T) {
+	var nilWrapped *LavaWrappedError
+	require.NotPanics(t, func() { _ = nilWrapped.Error() })
+	require.NotPanics(t, func() { _ = nilWrapped.Is(LavaErrorUnknown) })
+	require.NotPanics(t, func() { _ = nilWrapped.Unwrap() })
+
+	var le *LavaError
+	require.NotPanics(t, func() { _ = nilWrapped.As(&le) })
+	assert.False(t, nilWrapped.As(&le))
+}

--- a/protocol/common/error_cause_test.go
+++ b/protocol/common/error_cause_test.go
@@ -1,0 +1,122 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// MAG-2648. LavaWrappedError used to discard the error it was built from, keeping only
+// its text. Every sentinel check past the classification boundary therefore failed —
+// most consequentially IsClientCancellation, which made the relay-race carve-out dead
+// code. These tests pin the four resolution paths that must all hold at once.
+
+func TestLavaErrorWrapping_AllPathsResolve(t *testing.T) {
+	cause := &url.Error{Op: "Post", URL: "http://node:8545", Err: context.Canceled}
+	wrapped := NewLavaErrorWrapping(LavaErrorContextCanceled, cause)
+
+	t.Run("cause sentinel is reachable", func(t *testing.T) {
+		assert.True(t, errors.Is(wrapped, context.Canceled))
+	})
+
+	t.Run("lava error still matches by code", func(t *testing.T) {
+		assert.True(t, errors.Is(wrapped, LavaErrorContextCanceled))
+	})
+
+	t.Run("lava error still resolves via As", func(t *testing.T) {
+		var le *LavaError
+		require.True(t, errors.As(wrapped, &le))
+		assert.Equal(t, LavaErrorContextCanceled.Code, le.Code)
+	})
+
+	t.Run("wrapper type resolves via As", func(t *testing.T) {
+		var lwe *LavaWrappedError
+		require.True(t, errors.As(wrapped, &lwe))
+		assert.Equal(t, LavaErrorContextCanceled.Code, lwe.LavaErr.Code)
+	})
+
+	t.Run("typed cause resolves via As", func(t *testing.T) {
+		var ue *url.Error
+		require.True(t, errors.As(wrapped, &ue))
+		assert.Equal(t, "Post", ue.Op)
+	})
+
+	t.Run("errors.Unwrap stays non-nil", func(t *testing.T) {
+		// The singular errors.Unwrap must keep working — utils/score walks chains with it,
+		// and it returns nil for multi-unwrap types. This is why Unwrap is not []error.
+		assert.NotNil(t, errors.Unwrap(wrapped))
+	})
+
+	t.Run("message shape is unchanged", func(t *testing.T) {
+		// Must still read as "<cause text>: <description>", the shape
+		// NewLavaError(classified, err.Error()) produced.
+		assert.Contains(t, wrapped.Error(), cause.Error())
+		assert.Contains(t, wrapped.Error(), LavaErrorContextCanceled.Description)
+	})
+}
+
+// The causeless constructor must behave exactly as it did before this change — three
+// existing tests in chainlib and this package depend on it.
+func TestLavaErrorWrapping_NoCauseIsUnchanged(t *testing.T) {
+	wrapped := NewLavaError(LavaErrorChainNonceTooLow, "context")
+
+	assert.Equal(t, LavaErrorChainNonceTooLow, errors.Unwrap(wrapped))
+	assert.True(t, errors.Is(wrapped, LavaErrorChainNonceTooLow))
+	assert.False(t, errors.Is(wrapped, context.Canceled))
+
+	var le *LavaError
+	require.True(t, errors.As(wrapped, &le))
+	assert.Equal(t, LavaErrorChainNonceTooLow.Code, le.Code)
+}
+
+func TestLavaErrorWrapping_NilCause(t *testing.T) {
+	wrapped := NewLavaErrorWrapping(LavaErrorUnknown, nil)
+	require.NotNil(t, wrapped)
+	assert.True(t, errors.Is(wrapped, LavaErrorUnknown))
+	assert.NotNil(t, errors.Unwrap(wrapped))
+}
+
+// IsClientCancellation had no test at all, which is the second half of why MAG-2648
+// survived: the branch it guards was tested, the predicate feeding it never was.
+func TestIsClientCancellation(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	liveCtx := context.Background()
+
+	t.Run("raw cancellation on a cancelled context", func(t *testing.T) {
+		assert.True(t, IsClientCancellation(context.Canceled, cancelledCtx))
+	})
+
+	t.Run("classified cancellation on a cancelled context", func(t *testing.T) {
+		cause := &url.Error{Op: "Post", URL: "http://node:8545", Err: context.Canceled}
+		wrapped := NewLavaErrorWrapping(LavaErrorContextCanceled, cause)
+		assert.True(t, IsClientCancellation(wrapped, cancelledCtx))
+	})
+
+	t.Run("cancellation on a live context is not a client cancellation", func(t *testing.T) {
+		// The conjunction guards against a provider-emitted cancellation being read as ours.
+		assert.False(t, IsClientCancellation(context.Canceled, liveCtx))
+	})
+
+	t.Run("a node that says the words is not a cancellation", func(t *testing.T) {
+		// The doc block on IsClientCancellation promises this specifically.
+		nodeErr := fmt.Errorf("rpc error: code = Canceled desc = context canceled")
+		assert.False(t, IsClientCancellation(nodeErr, cancelledCtx),
+			"a remote error whose TEXT says 'context canceled' carries no sentinel and must not match")
+	})
+
+	t.Run("deadline is not a cancellation", func(t *testing.T) {
+		assert.False(t, IsClientCancellation(context.DeadlineExceeded, cancelledCtx),
+			"a timeout is an endpoint fault and must still be penalised")
+	})
+
+	t.Run("nil inputs", func(t *testing.T) {
+		assert.False(t, IsClientCancellation(nil, cancelledCtx))
+		assert.False(t, IsClientCancellation(context.Canceled, nil))
+	})
+}

--- a/protocol/common/error_cause_test.go
+++ b/protocol/common/error_cause_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// MAG-2648. LavaWrappedError used to discard the error it was built from, keeping only
-// its text. Every sentinel check past the classification boundary therefore failed —
-// most consequentially IsClientCancellation, which made the relay-race carve-out dead
-// code. These tests pin the four resolution paths that must all hold at once.
+// MAG-2648. LavaWrappedError used to discard the error it was built from, keeping only its
+// text. Every sentinel check past the classification boundary therefore failed — most
+// consequentially IsClientCancellation, which made the relay-race carve-out dead code.
+// These tests pin the resolution paths that must all hold at once.
 
 func TestLavaErrorWrapping_AllPathsResolve(t *testing.T) {
 	cause := &url.Error{Op: "Post", URL: "http://node:8545", Err: context.Canceled}
@@ -23,45 +23,37 @@ func TestLavaErrorWrapping_AllPathsResolve(t *testing.T) {
 	t.Run("cause sentinel is reachable", func(t *testing.T) {
 		assert.True(t, errors.Is(wrapped, context.Canceled))
 	})
-
 	t.Run("lava error still matches by code", func(t *testing.T) {
 		assert.True(t, errors.Is(wrapped, LavaErrorContextCanceled))
 	})
-
 	t.Run("lava error still resolves via As", func(t *testing.T) {
 		var le *LavaError
 		require.True(t, errors.As(wrapped, &le))
 		assert.Equal(t, LavaErrorContextCanceled.Code, le.Code)
 	})
-
 	t.Run("wrapper type resolves via As", func(t *testing.T) {
 		var lwe *LavaWrappedError
 		require.True(t, errors.As(wrapped, &lwe))
 		assert.Equal(t, LavaErrorContextCanceled.Code, lwe.LavaErr.Code)
 	})
-
 	t.Run("typed cause resolves via As", func(t *testing.T) {
 		var ue *url.Error
 		require.True(t, errors.As(wrapped, &ue))
 		assert.Equal(t, "Post", ue.Op)
 	})
-
 	t.Run("errors.Unwrap stays non-nil", func(t *testing.T) {
 		// The singular errors.Unwrap must keep working — utils/score walks chains with it,
 		// and it returns nil for multi-unwrap types. This is why Unwrap is not []error.
 		assert.NotNil(t, errors.Unwrap(wrapped))
 	})
-
 	t.Run("message shape is unchanged", func(t *testing.T) {
-		// Must still read as "<cause text>: <description>", the shape
-		// NewLavaError(classified, err.Error()) produced.
 		assert.Contains(t, wrapped.Error(), cause.Error())
 		assert.Contains(t, wrapped.Error(), LavaErrorContextCanceled.Description)
 	})
 }
 
-// The causeless constructor must behave exactly as it did before this change — three
-// existing tests in chainlib and this package depend on it.
+// The causeless constructor must behave exactly as before — chainlib and this package
+// both have tests that depend on it.
 func TestLavaErrorWrapping_NoCauseIsUnchanged(t *testing.T) {
 	wrapped := NewLavaError(LavaErrorChainNonceTooLow, "context")
 
@@ -81,6 +73,17 @@ func TestLavaErrorWrapping_NilCause(t *testing.T) {
 	assert.NotNil(t, errors.Unwrap(wrapped))
 }
 
+// Collateral guard: wrapping a cause must not let an UNRELATED LavaError code match.
+// The Is method compares codes, and the cause chain must not create false positives.
+func TestLavaErrorWrapping_DoesNotOvermatch(t *testing.T) {
+	cause := &url.Error{Op: "Post", URL: "http://node:8545", Err: context.Canceled}
+	wrapped := NewLavaErrorWrapping(LavaErrorContextCanceled, cause)
+
+	assert.False(t, errors.Is(wrapped, LavaErrorChainNonceTooLow))
+	assert.False(t, errors.Is(wrapped, LavaErrorNodeRateLimited))
+	assert.False(t, errors.Is(wrapped, context.DeadlineExceeded))
+}
+
 // IsClientCancellation had no test at all, which is the second half of why MAG-2648
 // survived: the branch it guards was tested, the predicate feeding it never was.
 func TestIsClientCancellation(t *testing.T) {
@@ -91,30 +94,22 @@ func TestIsClientCancellation(t *testing.T) {
 	t.Run("raw cancellation on a cancelled context", func(t *testing.T) {
 		assert.True(t, IsClientCancellation(context.Canceled, cancelledCtx))
 	})
-
 	t.Run("classified cancellation on a cancelled context", func(t *testing.T) {
 		cause := &url.Error{Op: "Post", URL: "http://node:8545", Err: context.Canceled}
-		wrapped := NewLavaErrorWrapping(LavaErrorContextCanceled, cause)
-		assert.True(t, IsClientCancellation(wrapped, cancelledCtx))
+		assert.True(t, IsClientCancellation(NewLavaErrorWrapping(LavaErrorContextCanceled, cause), cancelledCtx))
 	})
-
 	t.Run("cancellation on a live context is not a client cancellation", func(t *testing.T) {
-		// The conjunction guards against a provider-emitted cancellation being read as ours.
 		assert.False(t, IsClientCancellation(context.Canceled, liveCtx))
 	})
-
 	t.Run("a node that says the words is not a cancellation", func(t *testing.T) {
-		// The doc block on IsClientCancellation promises this specifically.
 		nodeErr := fmt.Errorf("rpc error: code = Canceled desc = context canceled")
 		assert.False(t, IsClientCancellation(nodeErr, cancelledCtx),
 			"a remote error whose TEXT says 'context canceled' carries no sentinel and must not match")
 	})
-
 	t.Run("deadline is not a cancellation", func(t *testing.T) {
 		assert.False(t, IsClientCancellation(context.DeadlineExceeded, cancelledCtx),
 			"a timeout is an endpoint fault and must still be penalised")
 	})
-
 	t.Run("nil inputs", func(t *testing.T) {
 		assert.False(t, IsClientCancellation(nil, cancelledCtx))
 		assert.False(t, IsClientCancellation(context.Canceled, nil))

--- a/protocol/common/error_registry.go
+++ b/protocol/common/error_registry.go
@@ -537,7 +537,18 @@ type LavaWrappedError struct {
 	cause error
 }
 
+// Every method below guards e.LavaErr. The constructors always set it today, so these are
+// latent — but a nil there fails in three different ways (Error panics inside a logging
+// call, Is silently mismatches, As hands back a nil AND halts the walk), and this type's
+// whole reason for existing is that a quietly unreachable resolution path is expensive.
+
 func (e *LavaWrappedError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.LavaErr == nil {
+		return e.Context
+	}
 	if e.Context != "" {
 		return fmt.Sprintf("%s: %s", e.Context, e.LavaErr.Description)
 	}
@@ -545,6 +556,9 @@ func (e *LavaWrappedError) Error() string {
 }
 
 func (e *LavaWrappedError) Is(target error) bool {
+	if e == nil || e.LavaErr == nil {
+		return false
+	}
 	if t, ok := target.(*LavaError); ok {
 		return e.LavaErr.Code == t.Code
 	}
@@ -563,8 +577,16 @@ func (e *LavaWrappedError) Is(target error) bool {
 // form preserves that traversal; the LavaErr branch it displaces stays reachable
 // through Is and As below, so nothing loses a path.
 func (e *LavaWrappedError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
 	if e.cause != nil {
 		return e.cause
+	}
+	if e.LavaErr == nil {
+		// Returning a typed nil here would hand back a non-nil error interface holding a
+		// nil *LavaError, and the next errors.Is would call LavaError.Is on a nil receiver.
+		return nil
 	}
 	return e.LavaErr
 }
@@ -572,7 +594,13 @@ func (e *LavaWrappedError) Unwrap() error {
 // As keeps the *LavaError reachable via errors.As even when Unwrap yields the cause
 // instead. Without this, retaining a cause would quietly remove a resolution path that
 // worked before — the same species of silent reachability loss this fix exists to undo.
+// Guarding on nil is load-bearing, not defensive noise: returning true with a nil
+// *LavaError would both hand the caller a nil AND stop errors.As walking to a real one
+// deeper in the chain — strictly worse than never matching.
 func (e *LavaWrappedError) As(target any) bool {
+	if e == nil || e.LavaErr == nil {
+		return false
+	}
 	if t, ok := target.(**LavaError); ok {
 		*t = e.LavaErr
 		return true

--- a/protocol/common/error_registry.go
+++ b/protocol/common/error_registry.go
@@ -528,6 +528,13 @@ func isRetryable(code uint32) bool {
 type LavaWrappedError struct {
 	LavaErr *LavaError
 	Context string
+	// cause is the error this classification was derived from, retained so sentinel
+	// checks (errors.Is(err, context.Canceled), net.Error, syscall errnos) still work
+	// on the far side of classification. Constructing with NewLavaError leaves it nil
+	// and only the Context string survives — which is exactly how the relay-race
+	// cancellation carve-out silently died (MAG-2648). Prefer NewLavaErrorWrapping
+	// whenever the original error is in hand.
+	cause error
 }
 
 func (e *LavaWrappedError) Error() string {
@@ -544,14 +551,53 @@ func (e *LavaWrappedError) Is(target error) bool {
 	return false
 }
 
+// Unwrap returns the original cause when one was retained, else the classification.
+//
+// Returning e.LavaErr unconditionally was the MAG-2648 bug: the cause's sentinel
+// (context.Canceled) became unreachable, so the relay-race carve-out could never fire.
+//
+// The multi-error form (Unwrap() []error) looks like the tidier fix and is NOT used
+// here on purpose: errors.Unwrap — the singular one — is documented to return nil for
+// multi-unwrap types, which would silently break every caller walking a chain with it,
+// including the sentinel walker in utils/score/score_errors.go. Keeping the singular
+// form preserves that traversal; the LavaErr branch it displaces stays reachable
+// through Is and As below, so nothing loses a path.
 func (e *LavaWrappedError) Unwrap() error {
+	if e.cause != nil {
+		return e.cause
+	}
 	return e.LavaErr
+}
+
+// As keeps the *LavaError reachable via errors.As even when Unwrap yields the cause
+// instead. Without this, retaining a cause would quietly remove a resolution path that
+// worked before — the same species of silent reachability loss this fix exists to undo.
+func (e *LavaWrappedError) As(target any) bool {
+	if t, ok := target.(**LavaError); ok {
+		*t = e.LavaErr
+		return true
+	}
+	return false
 }
 
 // NewLavaError creates an error that wraps a LavaError with optional context.
 // Supports errors.Is(err, LavaErrorSomething) matching by code.
+//
+// This constructor keeps no cause, so sentinel checks against the underlying error
+// will NOT match. Use NewLavaErrorWrapping when the original error is available.
 func NewLavaError(lavaErr *LavaError, context string) error {
 	return &LavaWrappedError{LavaErr: lavaErr, Context: context}
+}
+
+// NewLavaErrorWrapping is NewLavaError that retains the original error, so both
+// errors.Is(err, LavaErrorSomething) and errors.Is(err, <sentinel of the cause>)
+// resolve. The Context string is derived from the cause, preserving the message
+// shape NewLavaError(classified, err.Error()) produced.
+func NewLavaErrorWrapping(lavaErr *LavaError, cause error) error {
+	if cause == nil {
+		return &LavaWrappedError{LavaErr: lavaErr}
+	}
+	return &LavaWrappedError{LavaErr: lavaErr, Context: cause.Error(), cause: cause}
 }
 
 func IsInternal(code uint32) bool {

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -1938,14 +1938,14 @@ func (csm *ConsumerSessionManager) blockProvider(ctx context.Context, address st
 	return nil
 }
 
-// OnSessionDiscarded releases a session that was selected but intentionally
-// dropped before any relay was dispatched. It returns the reserved compute
-// units and unlocks the session without recording a QoS failure or adding a
-// consecutive provider error: no upstream request was made, so availability
-// was not actually tested.
-func (csm *ConsumerSessionManager) OnSessionDiscarded(consumerSession *SingleConsumerSession, reason error) error {
+// releaseWithoutPenalty is the shared body of the two "this told us nothing about the
+// provider" release paths. It returns the reserved compute units and unlocks the session,
+// deliberately recording NO QoS failure, NO consecutive provider error, and NO optimizer
+// availability sample. caller names the entry point so a lock-order violation still
+// reports the site that caused it.
+func (csm *ConsumerSessionManager) releaseWithoutPenalty(consumerSession *SingleConsumerSession, reason error, caller string) error {
 	if err := consumerSession.VerifyLock(); err != nil {
-		return fmt.Errorf("OnSessionDiscarded, consumerSession.lock must be locked before accessing this method: %w", err)
+		return fmt.Errorf("%s, consumerSession.lock must be locked before accessing this method: %w", caller, err)
 	}
 
 	cuToDecrease := consumerSession.LatestRelayCu
@@ -1954,6 +1954,34 @@ func (csm *ConsumerSessionManager) OnSessionDiscarded(consumerSession *SingleCon
 	consumerSession.Free(reason)
 
 	return parentConsumerSessionsWithProvider.decreaseUsedComputeUnits(cuToDecrease)
+}
+
+// OnSessionDiscarded releases a session that was selected but intentionally
+// dropped before any relay was dispatched. It returns the reserved compute
+// units and unlocks the session without recording a QoS failure or adding a
+// consecutive provider error: no upstream request was made, so availability
+// was not actually tested.
+func (csm *ConsumerSessionManager) OnSessionDiscarded(consumerSession *SingleConsumerSession, reason error) error {
+	return csm.releaseWithoutPenalty(consumerSession, reason, "OnSessionDiscarded")
+}
+
+// OnSessionCancelled releases a session whose relay WAS dispatched but was then cancelled
+// by us — a relay-race loser on a stateful broadcast, or a client that hung up — rather
+// than answered or failed by the endpoint (MAG-2648).
+//
+// It shares OnSessionDiscarded's accounting, and for the same reason: the endpoint's
+// availability was never actually tested. It was mid-flight and we told it to stop. Routing
+// these through OnSessionFailure is the bug — that path calls AddFailedRelay (which lands
+// in the availability ratio), appends a consecutive error, and feeds the optimizer an
+// availability sample of 0, penalising a node that did nothing wrong. On a broadcast the
+// fastest node wins and EVERY other healthy node takes that hit, so the damage is
+// structural rather than correlated with node quality.
+//
+// It is a separate name from OnSessionDiscarded on purpose: "discarded" means never sent,
+// and a reader at the call site needs to be able to tell those apart even though the
+// bookkeeping is identical today.
+func (csm *ConsumerSessionManager) OnSessionCancelled(consumerSession *SingleConsumerSession, reason error) error {
+	return csm.releaseWithoutPenalty(consumerSession, reason, "OnSessionCancelled")
 }
 
 // Report session failure, mark it as blocked from future usages, report if timeout happened.

--- a/protocol/lavasession/on_session_cancelled_test.go
+++ b/protocol/lavasession/on_session_cancelled_test.go
@@ -50,14 +50,11 @@ func TestOnSessionCancelledReturnsReservationWithoutPenalty(t *testing.T) {
 		require.Zero(t, session.LatestRelayCu)
 		require.Zero(t, usedProviders.CurrentlyUsed())
 	})
-
 	t.Run("no blame recorded", func(t *testing.T) {
 		require.Empty(t, session.ConsecutiveErrors,
 			"a relay we cancelled ourselves must not count as a provider failure")
-		require.False(t, session.BlockListed,
-			"a race loser must never be blocklisted")
+		require.False(t, session.BlockListed, "a race loser must never be blocklisted")
 	})
-
 	t.Run("session is reusable", func(t *testing.T) {
 		blocked, ok := session.TryUseSession()
 		require.False(t, blocked)
@@ -66,9 +63,9 @@ func TestOnSessionCancelledReturnsReservationWithoutPenalty(t *testing.T) {
 	})
 }
 
-// The QoS report is what drives the availability ratio the customer saw collapse. A
-// cancelled relay must leave both the answered and the total counts untouched — counting
-// it as "total but not answered" is precisely what dragged availability toward zero.
+// The QoS report drives the availability ratio the customer saw collapse. A cancelled
+// relay must leave both counts untouched — counting it as "total but not answered" is
+// precisely what dragged availability toward zero.
 func TestOnSessionCancelledLeavesQoSUntouched(t *testing.T) {
 	csm, _, session, usedProviders, routerKey := newCancellableTestSession(t, "provider-qos")
 	usedProviders.ReleaseFromLatestBatch("provider-qos", routerKey, context.Canceled)
@@ -84,7 +81,7 @@ func TestOnSessionCancelledLeavesQoSUntouched(t *testing.T) {
 	require.Equal(t, answeredBefore, csm.qosManager.GetAnsweredRelays(epoch, session.SessionId))
 }
 
-// Contrast test: a genuine failure must still be penalised, so the carve-out cannot be
+// COLLATERAL GUARD: a genuine failure must still be penalised, so the carve-out cannot be
 // accused of hiding real faults.
 func TestOnSessionFailureStillRecordsPenalty(t *testing.T) {
 	csm, _, session, usedProviders, routerKey := newCancellableTestSession(t, "provider-real-fault")
@@ -99,4 +96,17 @@ func TestOnSessionFailureStillRecordsPenalty(t *testing.T) {
 		"a real failure must still count against availability")
 	require.NotEmpty(t, session.ConsecutiveErrors,
 		"a real failure must still accumulate consecutive errors")
+}
+
+// COLLATERAL GUARD: OnSessionDiscarded now delegates to the shared helper. Its original
+// contract — release without penalty for a never-dispatched relay — must be unchanged.
+func TestOnSessionDiscardedUnchangedAfterRefactor(t *testing.T) {
+	csm, parent, session, usedProviders, routerKey := newCancellableTestSession(t, "provider-discard")
+	usedProviders.ReleaseFromLatestBatch("provider-discard", routerKey, ConsistencyPreValidationError)
+
+	require.NoError(t, csm.OnSessionDiscarded(session, ConsistencyPreValidationError))
+	require.Zero(t, parent.atomicReadUsedComputeUnits())
+	require.Zero(t, session.LatestRelayCu)
+	require.Empty(t, session.ConsecutiveErrors)
+	require.Zero(t, usedProviders.CurrentlyUsed())
 }

--- a/protocol/lavasession/on_session_cancelled_test.go
+++ b/protocol/lavasession/on_session_cancelled_test.go
@@ -1,0 +1,102 @@
+package lavasession
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// MAG-2648. A relay-race loser was routed through OnSessionFailure, which records a QoS
+// failure and feeds the optimizer an availability sample of 0. On a stateful broadcast the
+// fastest node wins and every other healthy node takes that hit, so the penalty is
+// structural rather than correlated with node quality. OnSessionCancelled is the release
+// path that does the bookkeeping without the blame.
+
+func newCancellableTestSession(t *testing.T, address string) (*ConsumerSessionManager, *ConsumerSessionsWithProvider, *SingleConsumerSession, *UsedProviders, RouterKey) {
+	t.Helper()
+
+	csm := CreateConsumerSessionManager()
+	usedProviders := NewUsedProviders(nil)
+	parent := &ConsumerSessionsWithProvider{
+		PublicLavaAddress: address,
+		MaxComputeUnits:   100,
+		UsedComputeUnits:  10,
+		// OnSessionFailure's metrics publish reads Endpoints[0]; OnSessionCancelled never
+		// reaches it, but the contrast test below exercises the failure path too.
+		Endpoints: []*Endpoint{{NetworkAddress: "http://" + address + ":8545"}},
+	}
+	session := &SingleConsumerSession{Parent: parent}
+
+	blocked, ok := session.TryUseSession()
+	require.False(t, blocked)
+	require.True(t, ok)
+
+	routerKey := NewRouterKey(nil)
+	require.NoError(t, session.SetUsageForSession(10, nil, usedProviders, routerKey))
+	usedProviders.AddUsed(ConsumerSessionsMap{address: &SessionInfo{Session: session}}, nil)
+
+	return csm, parent, session, usedProviders, routerKey
+}
+
+func TestOnSessionCancelledReturnsReservationWithoutPenalty(t *testing.T) {
+	csm, parent, session, usedProviders, routerKey := newCancellableTestSession(t, "provider-race-loser")
+	usedProviders.ReleaseFromLatestBatch("provider-race-loser", routerKey, context.Canceled)
+
+	require.NoError(t, csm.OnSessionCancelled(session, context.Canceled))
+
+	t.Run("cleanup happened", func(t *testing.T) {
+		require.Zero(t, parent.atomicReadUsedComputeUnits(), "reserved CU must be returned")
+		require.Zero(t, session.LatestRelayCu)
+		require.Zero(t, usedProviders.CurrentlyUsed())
+	})
+
+	t.Run("no blame recorded", func(t *testing.T) {
+		require.Empty(t, session.ConsecutiveErrors,
+			"a relay we cancelled ourselves must not count as a provider failure")
+		require.False(t, session.BlockListed,
+			"a race loser must never be blocklisted")
+	})
+
+	t.Run("session is reusable", func(t *testing.T) {
+		blocked, ok := session.TryUseSession()
+		require.False(t, blocked)
+		require.True(t, ok)
+		session.Free(nil)
+	})
+}
+
+// The QoS report is what drives the availability ratio the customer saw collapse. A
+// cancelled relay must leave both the answered and the total counts untouched — counting
+// it as "total but not answered" is precisely what dragged availability toward zero.
+func TestOnSessionCancelledLeavesQoSUntouched(t *testing.T) {
+	csm, _, session, usedProviders, routerKey := newCancellableTestSession(t, "provider-qos")
+	usedProviders.ReleaseFromLatestBatch("provider-qos", routerKey, context.Canceled)
+
+	epoch := csm.atomicReadCurrentEpoch()
+	totalBefore := csm.qosManager.GetTotalRelays(epoch, session.SessionId)
+	answeredBefore := csm.qosManager.GetAnsweredRelays(epoch, session.SessionId)
+
+	require.NoError(t, csm.OnSessionCancelled(session, context.Canceled))
+
+	require.Equal(t, totalBefore, csm.qosManager.GetTotalRelays(epoch, session.SessionId),
+		"a cancelled relay must not increment totalRelays — that is what lowers availability")
+	require.Equal(t, answeredBefore, csm.qosManager.GetAnsweredRelays(epoch, session.SessionId))
+}
+
+// Contrast test: a genuine failure must still be penalised, so the carve-out cannot be
+// accused of hiding real faults.
+func TestOnSessionFailureStillRecordsPenalty(t *testing.T) {
+	csm, _, session, usedProviders, routerKey := newCancellableTestSession(t, "provider-real-fault")
+	usedProviders.ReleaseFromLatestBatch("provider-real-fault", routerKey, nil)
+
+	epoch := csm.atomicReadCurrentEpoch()
+	totalBefore := csm.qosManager.GetTotalRelays(epoch, session.SessionId)
+
+	require.NoError(t, csm.OnSessionFailure(session, context.DeadlineExceeded))
+
+	require.Greater(t, csm.qosManager.GetTotalRelays(epoch, session.SessionId), totalBefore,
+		"a real failure must still count against availability")
+	require.NotEmpty(t, session.ConsecutiveErrors,
+		"a real failure must still accumulate consecutive errors")
+}

--- a/protocol/metrics/batch_method_label_test.go
+++ b/protocol/metrics/batch_method_label_test.go
@@ -229,7 +229,7 @@ func TestRecordDirectRelayEndCollapsesBatchLabel(t *testing.T) {
 
 	for size := 2; size <= 40; size++ {
 		apiName := joinedBatchName(append(repeatMethod("eth_call", size), "eth_getBalance")...)
-		m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", apiName, 10, true, &RelayMetrics{IsBatch: true})
+		m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", apiName, 10, RelayOutcomeSuccess, &RelayMetrics{IsBatch: true})
 	}
 
 	require.Equal(t, 1, testutil.CollectAndCount(m.routerRequestsTotal),
@@ -249,7 +249,7 @@ func TestRecordDirectRelayEndObservesBatchSizeOnce(t *testing.T) {
 	m := newSmartRouterForBatchLabelTest()
 	apiName := joinedBatchName(repeatMethod("eth_call", 5)...)
 
-	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", apiName, 10, true, &RelayMetrics{IsBatch: true})
+	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", apiName, 10, RelayOutcomeSuccess, &RelayMetrics{IsBatch: true})
 
 	count, sum := histogramTotals(t, m.batchSize)
 	require.Equal(t, uint64(1), count, "one relay must produce exactly one batch-size observation")
@@ -262,7 +262,7 @@ func TestRecordDirectRelayEndObservesBatchSizeOnce(t *testing.T) {
 func TestRecordDirectRelayEndSkipsBatchSizeForSingleMethods(t *testing.T) {
 	m := newSmartRouterForBatchLabelTest()
 
-	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_call", 10, true, &RelayMetrics{IsBatch: true})
+	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_call", 10, RelayOutcomeSuccess, &RelayMetrics{IsBatch: true})
 
 	count, _ := histogramTotals(t, m.batchSize)
 	require.Equal(t, uint64(0), count)
@@ -278,7 +278,7 @@ func TestInFlightGaugeReturnsToZeroForBatches(t *testing.T) {
 	apiName := joinedBatchName(append(repeatMethod("eth_call", 7), "eth_getLogs")...)
 
 	m.RecordDirectRelayStart("ETH1", "jsonrpc", "ep1", apiName)
-	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", apiName, 10, true, &RelayMetrics{IsBatch: true})
+	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", apiName, 10, RelayOutcomeSuccess, &RelayMetrics{IsBatch: true})
 
 	registry := prometheus.NewPedanticRegistry()
 	require.NoError(t, registry.Register(m.endpointInFlight))

--- a/protocol/metrics/cancelled_relay_metrics_test.go
+++ b/protocol/metrics/cancelled_relay_metrics_test.go
@@ -15,33 +15,25 @@ func cancelledTestLabels() map[string]string {
 }
 
 // The trap this fix had to route around: the in-flight gauge is incremented at relay
-// start, and RecordDirectRelayEnd is the only thing that decrements it. Skipping the
-// call for cancelled relays — the naive fix — leaks the gauge one per race loser.
+// start, and RecordDirectRelayEnd is the only thing that decrements it. Skipping the call
+// for cancelled relays — the naive fix — leaks the gauge one per race loser.
 func TestCancelledRelay_InFlightGaugeReturnsToZero(t *testing.T) {
 	m := newSmartRouterForRequestGroupTest()
-	labels := cancelledTestLabels()
-
 	for i := 0; i < 25; i++ {
 		m.RecordDirectRelayStart("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction")
 		m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction", 5, RelayOutcomeCancelled, &RelayMetrics{IsWrite: true})
 	}
-
-	require.Equal(t, float64(0), testutil.ToFloat64(m.endpointInFlight.WithLabelValues(labels)),
+	require.Equal(t, float64(0), testutil.ToFloat64(m.endpointInFlight.WithLabelValues(cancelledTestLabels())),
 		"every cancelled relay must still decrement the in-flight gauge")
 }
 
-// Mixed traffic must also balance — the winner and the losers of the same broadcast.
 func TestCancelledRelay_InFlightBalancesAcrossMixedOutcomes(t *testing.T) {
 	m := newSmartRouterForRequestGroupTest()
-	labels := cancelledTestLabels()
-
-	outcomes := []RelayOutcome{RelayOutcomeSuccess, RelayOutcomeCancelled, RelayOutcomeCancelled, RelayOutcomeCancelled, RelayOutcomeError}
-	for _, outcome := range outcomes {
+	for _, outcome := range []RelayOutcome{RelayOutcomeSuccess, RelayOutcomeCancelled, RelayOutcomeCancelled, RelayOutcomeCancelled, RelayOutcomeError} {
 		m.RecordDirectRelayStart("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction")
 		m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction", 5, outcome, &RelayMetrics{IsWrite: true})
 	}
-
-	require.Equal(t, float64(0), testutil.ToFloat64(m.endpointInFlight.WithLabelValues(labels)))
+	require.Equal(t, float64(0), testutil.ToFloat64(m.endpointInFlight.WithLabelValues(cancelledTestLabels())))
 }
 
 // The customer-visible symptom: errored relays were almost all eth_sendRawTransaction.
@@ -53,15 +45,13 @@ func TestCancelledRelay_DoesNotCountAsErrored(t *testing.T) {
 		m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction", 5, RelayOutcomeCancelled, &RelayMetrics{IsWrite: true})
 	}
 
-	require.Equal(t, float64(0), testutil.ToFloat64(m.endpointTotalErrored.WithLabelValues(labels)),
-		"cancelled relays must not inflate rpc_endpoint_total_errored")
-	require.Equal(t, float64(10), testutil.ToFloat64(m.endpointTotalCancelled.WithLabelValues(labels)),
-		"cancelled relays must remain visible in their own counter")
-	require.Equal(t, float64(0), testutil.ToFloat64(m.endpointTotalRelaysServiced.WithLabelValues(labels)),
-		"a cancelled relay was not serviced either")
+	require.Equal(t, float64(0), testutil.ToFloat64(m.endpointTotalErrored.WithLabelValues(labels)))
+	require.Equal(t, float64(10), testutil.ToFloat64(m.endpointTotalCancelled.WithLabelValues(labels)))
+	require.Equal(t, float64(0), testutil.ToFloat64(m.endpointTotalRelaysServiced.WithLabelValues(labels)))
 }
 
-// A real error must still be counted — the carve-out must not swallow genuine faults.
+// COLLATERAL GUARD: a real error must still be counted as errored. If this ever fails the
+// fix is hiding genuine faults, which is worse than the bug it replaced.
 func TestErroredRelay_StillCountsAsErrored(t *testing.T) {
 	m := newSmartRouterForRequestGroupTest()
 	labels := cancelledTestLabels()
@@ -72,37 +62,71 @@ func TestErroredRelay_StillCountsAsErrored(t *testing.T) {
 	require.Equal(t, float64(0), testutil.ToFloat64(m.endpointTotalCancelled.WithLabelValues(labels)))
 }
 
-// requests_total == requests_success + requests_failed must stay a true invariant, so a
-// cancelled relay moves none of the router request-group counters.
-func TestCancelledRelay_LeavesRequestGroupCountersUntouched(t *testing.T) {
+// COLLATERAL GUARD: success accounting is untouched by the signature change.
+func TestSuccessRelay_StillCountsAsServiced(t *testing.T) {
+	m := newSmartRouterForRequestGroupTest()
+	labels := cancelledTestLabels()
+	reqLabels := []string{"ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction"}
+
+	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction", 5, RelayOutcomeSuccess, &RelayMetrics{IsWrite: true})
+
+	require.Equal(t, float64(1), testutil.ToFloat64(m.endpointTotalRelaysServiced.WithLabelValues(labels)))
+	require.Equal(t, float64(0), testutil.ToFloat64(m.endpointTotalErrored.WithLabelValues(labels)))
+	require.Equal(t, float64(1), testutil.ToFloat64(m.routerRequestsTotal.WithLabelValues(reqLabels...)))
+	require.Equal(t, float64(1), testutil.ToFloat64(m.routerRequestsSuccess.WithLabelValues(reqLabels...)))
+	require.Equal(t, float64(1), testutil.ToFloat64(m.routerRequestsWrite.WithLabelValues(reqLabels...)))
+}
+
+// requests_total == requests_success + requests_failed is a documented invariant
+// (docs/METRICS.md). A cancelled relay moves none of them, which is what keeps it exact.
+func TestCancelledRelay_PreservesRequestGroupInvariant(t *testing.T) {
 	m := newSmartRouterForRequestGroupTest()
 	reqLabels := []string{"ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction"}
 
-	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction", 5, RelayOutcomeCancelled, &RelayMetrics{IsWrite: true})
+	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction", 5, RelayOutcomeSuccess, &RelayMetrics{IsWrite: true})
+	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction", 5, RelayOutcomeError, &RelayMetrics{IsWrite: true})
+	for i := 0; i < 8; i++ {
+		m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction", 5, RelayOutcomeCancelled, &RelayMetrics{IsWrite: true})
+	}
 
-	require.Equal(t, float64(0), testutil.ToFloat64(m.routerRequestsTotal.WithLabelValues(reqLabels...)))
-	require.Equal(t, float64(0), testutil.ToFloat64(m.routerRequestsSuccess.WithLabelValues(reqLabels...)))
-	require.Equal(t, float64(0), testutil.ToFloat64(m.routerRequestsFailed.WithLabelValues(reqLabels...)))
-	require.Equal(t, float64(0), testutil.ToFloat64(m.routerRequestsWrite.WithLabelValues(reqLabels...)))
+	total := testutil.ToFloat64(m.routerRequestsTotal.WithLabelValues(reqLabels...))
+	success := testutil.ToFloat64(m.routerRequestsSuccess.WithLabelValues(reqLabels...))
+	failed := testutil.ToFloat64(m.routerRequestsFailed.WithLabelValues(reqLabels...))
+
+	require.Equal(t, float64(2), total, "only completed relays enter the request-group family")
+	require.Equal(t, success+failed, total, "requests_total must equal success + failed")
 }
 
-// A cancelled relay never finished, so its latency carries no information and must not
-// be observed — otherwise the race-loser cancel time would drag the endpoint's latency
-// distribution toward zero.
+// A cancelled relay never finished, so its latency carries no information and must not be
+// observed — otherwise cancel timings would drag the endpoint's distribution toward zero.
 func TestCancelledRelay_DoesNotObserveLatency(t *testing.T) {
 	m := newSmartRouterForRequestGroupTest()
-
 	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction", 5, RelayOutcomeCancelled, &RelayMetrics{IsWrite: true})
+	require.Equal(t, 0, testutil.CollectAndCount(m.endpointEndToEndLatency))
 
-	require.Equal(t, 0, testutil.CollectAndCount(m.endpointEndToEndLatency),
-		"no latency sample may be recorded for a relay that never completed")
+	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction", 5, RelayOutcomeSuccess, &RelayMetrics{IsWrite: true})
+	require.Equal(t, 1, testutil.CollectAndCount(m.endpointEndToEndLatency),
+		"a completed relay must still be observed")
 }
 
-// The nil-manager guard must survive the signature change.
 func TestCancelledRelay_NilManager(t *testing.T) {
 	var m *SmartRouterMetricsManager
 	require.NotPanics(t, func() {
 		m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "method", 10, RelayOutcomeCancelled, &RelayMetrics{})
 		m.AddEndpointRelayCancelled("ETH1", "jsonrpc", "ep1", "method")
 	})
+}
+
+// PR #242 interaction: batch method labels must still be collapsed on the cancelled path,
+// or a cancelled batch would reintroduce the unbounded-cardinality leak that PR fixed.
+func TestCancelledRelay_StillNormalisesBatchLabel(t *testing.T) {
+	m := newSmartRouterForRequestGroupTest()
+	m.batchSignatures = newBatchSignatureRegistry()
+
+	raw := "eth_call&eth_call&eth_getBalance"
+	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", raw, 5, RelayOutcomeCancelled, &RelayMetrics{IsBatch: true})
+
+	collapsed := map[string]string{"spec": "ETH1", "apiInterface": "jsonrpc", "endpoint_id": "ep1", "function": "batch:eth_call+eth_getBalance"}
+	require.Equal(t, float64(1), testutil.ToFloat64(m.endpointTotalCancelled.WithLabelValues(collapsed)),
+		"the cancelled path must collapse batch labels like every other recorder")
 }

--- a/protocol/metrics/cancelled_relay_metrics_test.go
+++ b/protocol/metrics/cancelled_relay_metrics_test.go
@@ -1,0 +1,108 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// MAG-2648. A relay-race loser must balance the in-flight gauge and land in its own
+// counter, without polluting the error counter or the router request-group counters.
+
+func cancelledTestLabels() map[string]string {
+	return map[string]string{"spec": "ETH1", "apiInterface": "jsonrpc", "endpoint_id": "ep1", "function": "eth_sendRawTransaction"}
+}
+
+// The trap this fix had to route around: the in-flight gauge is incremented at relay
+// start, and RecordDirectRelayEnd is the only thing that decrements it. Skipping the
+// call for cancelled relays — the naive fix — leaks the gauge one per race loser.
+func TestCancelledRelay_InFlightGaugeReturnsToZero(t *testing.T) {
+	m := newSmartRouterForRequestGroupTest()
+	labels := cancelledTestLabels()
+
+	for i := 0; i < 25; i++ {
+		m.RecordDirectRelayStart("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction")
+		m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction", 5, RelayOutcomeCancelled, &RelayMetrics{IsWrite: true})
+	}
+
+	require.Equal(t, float64(0), testutil.ToFloat64(m.endpointInFlight.WithLabelValues(labels)),
+		"every cancelled relay must still decrement the in-flight gauge")
+}
+
+// Mixed traffic must also balance — the winner and the losers of the same broadcast.
+func TestCancelledRelay_InFlightBalancesAcrossMixedOutcomes(t *testing.T) {
+	m := newSmartRouterForRequestGroupTest()
+	labels := cancelledTestLabels()
+
+	outcomes := []RelayOutcome{RelayOutcomeSuccess, RelayOutcomeCancelled, RelayOutcomeCancelled, RelayOutcomeCancelled, RelayOutcomeError}
+	for _, outcome := range outcomes {
+		m.RecordDirectRelayStart("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction")
+		m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction", 5, outcome, &RelayMetrics{IsWrite: true})
+	}
+
+	require.Equal(t, float64(0), testutil.ToFloat64(m.endpointInFlight.WithLabelValues(labels)))
+}
+
+// The customer-visible symptom: errored relays were almost all eth_sendRawTransaction.
+func TestCancelledRelay_DoesNotCountAsErrored(t *testing.T) {
+	m := newSmartRouterForRequestGroupTest()
+	labels := cancelledTestLabels()
+
+	for i := 0; i < 10; i++ {
+		m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction", 5, RelayOutcomeCancelled, &RelayMetrics{IsWrite: true})
+	}
+
+	require.Equal(t, float64(0), testutil.ToFloat64(m.endpointTotalErrored.WithLabelValues(labels)),
+		"cancelled relays must not inflate rpc_endpoint_total_errored")
+	require.Equal(t, float64(10), testutil.ToFloat64(m.endpointTotalCancelled.WithLabelValues(labels)),
+		"cancelled relays must remain visible in their own counter")
+	require.Equal(t, float64(0), testutil.ToFloat64(m.endpointTotalRelaysServiced.WithLabelValues(labels)),
+		"a cancelled relay was not serviced either")
+}
+
+// A real error must still be counted — the carve-out must not swallow genuine faults.
+func TestErroredRelay_StillCountsAsErrored(t *testing.T) {
+	m := newSmartRouterForRequestGroupTest()
+	labels := cancelledTestLabels()
+
+	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction", 5, RelayOutcomeError, &RelayMetrics{IsWrite: true})
+
+	require.Equal(t, float64(1), testutil.ToFloat64(m.endpointTotalErrored.WithLabelValues(labels)))
+	require.Equal(t, float64(0), testutil.ToFloat64(m.endpointTotalCancelled.WithLabelValues(labels)))
+}
+
+// requests_total == requests_success + requests_failed must stay a true invariant, so a
+// cancelled relay moves none of the router request-group counters.
+func TestCancelledRelay_LeavesRequestGroupCountersUntouched(t *testing.T) {
+	m := newSmartRouterForRequestGroupTest()
+	reqLabels := []string{"ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction"}
+
+	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction", 5, RelayOutcomeCancelled, &RelayMetrics{IsWrite: true})
+
+	require.Equal(t, float64(0), testutil.ToFloat64(m.routerRequestsTotal.WithLabelValues(reqLabels...)))
+	require.Equal(t, float64(0), testutil.ToFloat64(m.routerRequestsSuccess.WithLabelValues(reqLabels...)))
+	require.Equal(t, float64(0), testutil.ToFloat64(m.routerRequestsFailed.WithLabelValues(reqLabels...)))
+	require.Equal(t, float64(0), testutil.ToFloat64(m.routerRequestsWrite.WithLabelValues(reqLabels...)))
+}
+
+// A cancelled relay never finished, so its latency carries no information and must not
+// be observed — otherwise the race-loser cancel time would drag the endpoint's latency
+// distribution toward zero.
+func TestCancelledRelay_DoesNotObserveLatency(t *testing.T) {
+	m := newSmartRouterForRequestGroupTest()
+
+	m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "eth_sendRawTransaction", 5, RelayOutcomeCancelled, &RelayMetrics{IsWrite: true})
+
+	require.Equal(t, 0, testutil.CollectAndCount(m.endpointEndToEndLatency),
+		"no latency sample may be recorded for a relay that never completed")
+}
+
+// The nil-manager guard must survive the signature change.
+func TestCancelledRelay_NilManager(t *testing.T) {
+	var m *SmartRouterMetricsManager
+	require.NotPanics(t, func() {
+		m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "method", 10, RelayOutcomeCancelled, &RelayMetrics{})
+		m.AddEndpointRelayCancelled("ETH1", "jsonrpc", "ep1", "method")
+	})
+}

--- a/protocol/metrics/request_group_metrics_test.go
+++ b/protocol/metrics/request_group_metrics_test.go
@@ -20,6 +20,7 @@ func newSmartRouterForRequestGroupTest() *SmartRouterMetricsManager {
 		endpointInFlight:            NewMappedLabelsGaugeVec(MappedLabelsMetricOpts{Name: "t_sr_inflight", Labels: funcLabels}),
 		endpointTotalRelaysServiced: NewMappedLabelsCounterVec(MappedLabelsMetricOpts{Name: "t_sr_relays", Labels: funcLabels}),
 		endpointTotalErrored:        NewMappedLabelsCounterVec(MappedLabelsMetricOpts{Name: "t_sr_errored", Labels: funcLabels}),
+		endpointTotalCancelled:      NewMappedLabelsCounterVec(MappedLabelsMetricOpts{Name: "t_sr_cancelled", Labels: funcLabels}),
 		endpointEndToEndLatency:     prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "t_sr_latency"}, endpointLabels),
 		// Request-group counters under test
 		routerRequestsTotal:      prometheus.NewCounterVec(prometheus.CounterOpts{Name: "t_sr_req_total"}, reqLabels),
@@ -55,7 +56,11 @@ func newSmartRouterRequestGroupRunner() *requestGroupRunner {
 	m := newSmartRouterForRequestGroupTest()
 	return &requestGroupRunner{
 		invoke: func(r RelayMetrics, e error) {
-			m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", r.ApiMethod, 10, e == nil, &r)
+			outcome := RelayOutcomeSuccess
+			if e != nil {
+				outcome = RelayOutcomeError
+			}
+			m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", r.ApiMethod, 10, outcome, &r)
 		},
 		labels:  func(method string) []string { return []string{"ETH1", "jsonrpc", "ep1", method} },
 		total:   m.routerRequestsTotal,
@@ -167,6 +172,6 @@ func TestSetRelayMetrics(t *testing.T) {
 func TestSmartRouterRecordDirectRelayEnd_NilManager(t *testing.T) {
 	var m *SmartRouterMetricsManager
 	require.NotPanics(t, func() {
-		m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "method", 10, true, &RelayMetrics{})
+		m.RecordDirectRelayEnd("ETH1", "jsonrpc", "ep1", "method", 10, RelayOutcomeSuccess, &RelayMetrics{})
 	})
 }

--- a/protocol/metrics/smartrouter_metrics_manager.go
+++ b/protocol/metrics/smartrouter_metrics_manager.go
@@ -46,6 +46,7 @@ type SmartRouterMetricsManager struct {
 	// Endpoint-scoped metrics (labels: spec, apiInterface, endpoint_id, function)
 	endpointTotalRelaysServiced *MappedLabelsCounterVec  // rpc_endpoint_total_relays_serviced
 	endpointTotalErrored        *MappedLabelsCounterVec  // rpc_endpoint_total_errored
+	endpointTotalCancelled      *MappedLabelsCounterVec  // rpc_endpoint_total_cancelled
 	endpointEndToEndLatency     *prometheus.HistogramVec // rpc_endpoint_end_to_end_latency_milliseconds
 	endpointInFlight            *MappedLabelsGaugeVec    // rpc_endpoint_requests_in_flight
 
@@ -192,6 +193,13 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	endpointTotalErrored := NewMappedLabelsCounterVec(MappedLabelsMetricOpts{
 		Name:       "rpc_endpoint_total_errored",
 		Help:       "Total errored relays for this RPC endpoint, by function.",
+		Labels:     endpointFunctionLabels,
+		Registerer: prometheus.DefaultRegisterer,
+	})
+
+	endpointTotalCancelled := NewMappedLabelsCounterVec(MappedLabelsMetricOpts{
+		Name:       "rpc_endpoint_total_cancelled",
+		Help:       "Relays cancelled by the router before completion, by function — relay-race losers on stateful broadcasts, and client disconnects. NOT an endpoint fault: these are deliberately excluded from rpc_endpoint_total_errored and from QoS/availability scoring. A high rate here is normal on write-heavy traffic (one winner, N-1 cancelled) and is the signal for tuning broadcast fan-out.",
 		Labels:     endpointFunctionLabels,
 		Registerer: prometheus.DefaultRegisterer,
 	})
@@ -588,6 +596,7 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 		// Endpoint-scoped (with function)
 		endpointTotalRelaysServiced: endpointTotalRelaysServiced,
 		endpointTotalErrored:        endpointTotalErrored,
+		endpointTotalCancelled:      endpointTotalCancelled,
 		endpointEndToEndLatency:     endpointEndToEndLatency,
 		endpointInFlight:            endpointInFlight,
 
@@ -790,6 +799,18 @@ func (m *SmartRouterMetricsManager) AddEndpointRelayServiced(spec, apiInterface,
 	function = m.normalizeMethodLabel(spec, function)
 	labels := map[string]string{"spec": spec, "apiInterface": apiInterface, "endpoint_id": endpointID, "function": function}
 	m.endpointTotalRelaysServiced.WithLabelValues(labels).Inc()
+}
+
+// AddEndpointRelayCancelled increments the cancelled counter for an endpoint and function.
+// Cancelled means WE stopped the relay — a relay-race loser or a client disconnect — so it
+// is deliberately not an error (MAG-2648).
+func (m *SmartRouterMetricsManager) AddEndpointRelayCancelled(spec, apiInterface, endpointID, function string) {
+	if m == nil {
+		return
+	}
+	function = m.normalizeMethodLabel(spec, function)
+	labels := map[string]string{"spec": spec, "apiInterface": apiInterface, "endpoint_id": endpointID, "function": function}
+	m.endpointTotalCancelled.WithLabelValues(labels).Inc()
 }
 
 // AddEndpointRelayErrored increments the error counter for an endpoint and function
@@ -1031,20 +1052,52 @@ func (m *SmartRouterMetricsManager) RecordDirectRelayStart(spec, apiInterface, e
 	m.AddEndpointInFlightRequest(spec, apiInterface, endpointID, function)
 }
 
+// RelayOutcome is how a direct relay ended. It is three-valued rather than a success
+// bool because "cancelled" is neither (MAG-2648): the router aborted the relay itself —
+// a relay-race loser on a stateful broadcast, or a client that hung up — so the endpoint
+// neither served nor failed it, and must not be scored either way.
+type RelayOutcome int
+
+const (
+	RelayOutcomeSuccess RelayOutcome = iota
+	RelayOutcomeError
+	// RelayOutcomeCancelled: we stopped it. Records the in-flight decrement and the
+	// cancelled counter, and nothing else.
+	RelayOutcomeCancelled
+)
+
 // RecordDirectRelayEnd records the end of an in-flight request and updates metrics.
 // relay carries the request classification (IsWrite/IsArchive/IsDebugTrace/IsBatch)
 // that the call site should populate on the shared RelayMetrics before calling here.
-func (m *SmartRouterMetricsManager) RecordDirectRelayEnd(spec, apiInterface, endpointID, function string, latencyMs float64, success bool, relay *RelayMetrics) {
+//
+// Every outcome — including cancelled — MUST reach the in-flight decrement below, which
+// pairs the increment from RecordDirectRelayStart. Returning early for cancelled relays
+// would leak rpc_endpoint_requests_in_flight upward forever, one per race loser.
+func (m *SmartRouterMetricsManager) RecordDirectRelayEnd(spec, apiInterface, endpointID, function string, latencyMs float64, outcome RelayOutcome, relay *RelayMetrics) {
 	if m == nil {
 		return
 	}
 	// Observe the batch's element count BEFORE collapsing the label, and do it only
 	// here: this is the single once-per-completed-relay entry point, so the other
 	// recorders normalize without observing and a batch is counted exactly once.
-	m.observeBatchSize(spec, apiInterface, function)
+	// A cancelled relay never completed, so it is not observed.
+	if outcome != RelayOutcomeCancelled {
+		m.observeBatchSize(spec, apiInterface, function)
+	}
 	function = m.normalizeMethodLabel(spec, function)
 
 	m.SubEndpointInFlightRequest(spec, apiInterface, endpointID, function)
+
+	// A cancelled relay stops here: the in-flight gauge is balanced and the cancellation
+	// is counted, but no latency is observed (the relay never finished, so the number is
+	// meaningless) and none of the router request-group counters move — that keeps
+	// requests_total == requests_success + requests_failed a true invariant.
+	if outcome == RelayOutcomeCancelled {
+		m.AddEndpointRelayCancelled(spec, apiInterface, endpointID, function)
+		return
+	}
+
+	success := outcome == RelayOutcomeSuccess
 
 	if success {
 		m.RecordRelaySuccess(spec, apiInterface, endpointID, function, latencyMs)

--- a/protocol/rpcsmartrouter/error_mapper.go
+++ b/protocol/rpcsmartrouter/error_mapper.go
@@ -37,7 +37,11 @@ func classifyDirectRPCError(err error, chainFamily common.ChainFamily, transport
 	errorCode, errorMessage := chainlib.ExtractNodeErrorDetails(err)
 	classified := common.ClassifyError(connError, chainFamily, transport, errorCode, errorMessage)
 
-	return classified, common.NewLavaError(classified, err.Error())
+	// Wrap rather than flatten: the returned error must keep the original reachable so
+	// errors.Is still resolves its sentinel downstream. Flattening to err.Error() here
+	// is what severed context.Canceled and left the relay-race carve-out at the endpoint
+	// health decision permanently false (MAG-2648).
+	return classified, common.NewLavaErrorWrapping(classified, err)
 }
 
 // classifyAndWrap is a convenience that calls classifyDirectRPCError and returns

--- a/protocol/rpcsmartrouter/relay_race_cancellation_test.go
+++ b/protocol/rpcsmartrouter/relay_race_cancellation_test.go
@@ -3,7 +3,9 @@ package rpcsmartrouter
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,94 +14,118 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
 )
 
-// raceLoserError builds the error a relay-race loser actually produces: net/http
-// returns a *url.Error carrying context.Canceled, and DoHTTPRequest wraps it with %w
-// (direct_rpc_connection.go), so the sentinel is intact when it reaches classification.
 func raceLoserError() error {
+	// net/http returns a *url.Error carrying context.Canceled; DoHTTPRequest wraps it
+	// with %w, so the sentinel is intact when it reaches classification.
 	return &url.Error{Op: "Post", URL: "http://bor-internal:8545", Err: context.Canceled}
 }
 
 // TestRaceLoser_SurvivesClassification is the regression test for MAG-2648.
 //
-// The pre-existing carve-out test (TestClassifyEndpointHealth_ClientCancellationCarvesOut)
-// passes isClientCancellation as a literal `true`, so it verifies the branch but never
-// that the flag is ever computed true on the real path. It stayed green for the entire
-// life of the bug. This test starts from a real transport error and drives it through the
-// actual wrapping the relay path performs.
+// The pre-existing carve-out test passes isClientCancellation as a literal `true`, so it
+// verifies the branch but never that the flag is ever computed true on the real path. It
+// stayed green for the entire life of the bug. This starts from a real transport error and
+// drives it through the actual wrapping the relay path performs.
 func TestRaceLoser_SurvivesClassification(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // a sibling relay won the race
 
 	transportErr := raceLoserError()
-
-	// Precondition: before classification the sentinel is reachable.
-	require.True(t, errors.Is(transportErr, context.Canceled))
 	require.True(t, common.IsClientCancellation(transportErr, ctx),
 		"precondition: the raw transport error IS a client cancellation")
 
-	// Exactly what SendDirectRelay returns (direct_rpc_relay.go).
 	wrapped := classifyAndWrap(transportErr, common.ChainFamily(-1), common.TransportJsonRPC)
 
 	t.Run("classification is still correct", func(t *testing.T) {
-		classified := extractLavaError(wrapped)
-		require.NotNil(t, classified)
-		require.Equal(t, common.LavaErrorContextCanceled.Code, classified.Code)
+		require.Equal(t, common.LavaErrorContextCanceled.Code, extractLavaError(wrapped).Code)
 	})
-
 	t.Run("sentinel survives wrapping", func(t *testing.T) {
-		require.True(t, errors.Is(wrapped, context.Canceled),
-			"the cause must stay reachable through LavaWrappedError")
+		require.True(t, errors.Is(wrapped, context.Canceled))
 	})
-
 	t.Run("carve-out fires", func(t *testing.T) {
 		require.True(t, common.IsClientCancellation(wrapped, ctx))
 	})
-
 	t.Run("endpoint is not blamed", func(t *testing.T) {
-		classified := extractLavaError(wrapped)
-		isClientCancel := common.IsClientCancellation(wrapped, ctx)
-
-		markUnhealthy, backoff := classifyEndpointHealth(classified, isClientCancel)
+		markUnhealthy, backoff := classifyEndpointHealth(extractLavaError(wrapped), common.IsClientCancellation(wrapped, ctx))
 		require.False(t, markUnhealthy, "a relay-race loser must not mark the endpoint unhealthy")
-		require.False(t, backoff, "a relay-race loser must not trigger backoff")
+		require.False(t, backoff)
 	})
 }
 
-// TestClassification_PreservesOtherSentinels guards the general property, not just the
-// context.Canceled case: whatever sentinel the cause carries must remain reachable.
+// COLLATERAL GUARD — the most important test in this file.
+//
+// The fix must not swallow genuine faults. Every error below is a real endpoint problem
+// and must still mark the endpoint unhealthy, even while the context is cancelled (which
+// is the state a race loser is in). If any of these stop being penalised, the fix has
+// traded a false-positive bug for a much worse false-negative one.
+func TestGenuineFaults_StillPenalised(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"connection refused", &url.Error{Op: "Post", URL: "http://n:8545", Err: syscall.ECONNREFUSED}},
+		{"connection reset", &url.Error{Op: "Post", URL: "http://n:8545", Err: syscall.ECONNRESET}},
+		{"host unreachable", &url.Error{Op: "Post", URL: "http://n:8545", Err: syscall.EHOSTUNREACH}},
+		{"deadline exceeded", &url.Error{Op: "Post", URL: "http://n:8545", Err: context.DeadlineExceeded}},
+		{"eof", fmt.Errorf("http request failed: %w", errors.New("EOF"))},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wrapped := classifyAndWrap(tc.err, common.ChainFamily(-1), common.TransportJsonRPC)
+
+			require.False(t, common.IsClientCancellation(wrapped, cancelledCtx),
+				"%s must NOT be mistaken for a client cancellation even on a cancelled ctx", tc.name)
+
+			markUnhealthy, backoff := classifyEndpointHealth(
+				extractLavaError(wrapped),
+				common.IsClientCancellation(wrapped, cancelledCtx),
+			)
+			require.True(t, markUnhealthy, "%s must still mark the endpoint unhealthy", tc.name)
+			require.True(t, backoff, "%s must still trigger backoff", tc.name)
+		})
+	}
+}
+
+// Rate limiting keeps its distinct treatment: healthy but busy — backoff without
+// marking unhealthy. The new cancellation branch must not have collapsed this case.
+func TestRateLimit_StillHealthyButBusy(t *testing.T) {
+	markUnhealthy, backoff := classifyEndpointHealth(common.LavaErrorNodeRateLimited, false)
+	require.False(t, markUnhealthy, "a rate-limited endpoint is healthy, just busy")
+	require.True(t, backoff)
+}
+
+// Cross-validation stragglers run on a WithoutCancel context (MAG-2187), so a batch
+// cancel must NOT make them look cancelled — they should complete and be scored normally.
+func TestCrossValidationStraggler_NotSeenAsCancelled(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	detached := context.WithoutCancel(parent)
+	cancel() // batch cancel fires; the detached straggler must be unaffected
+
+	require.NoError(t, detached.Err(), "precondition: WithoutCancel survives the parent cancel")
+
+	wrapped := classifyAndWrap(raceLoserError(), common.ChainFamily(-1), common.TransportJsonRPC)
+	require.False(t, common.IsClientCancellation(wrapped, detached),
+		"a detached CV straggler must not be classified as a client cancellation")
+}
+
+// Sentinels other than context.Canceled must remain reachable through classification —
+// the wrapping change is general, not special-cased to one error.
 func TestClassification_PreservesOtherSentinels(t *testing.T) {
 	t.Run("deadline exceeded", func(t *testing.T) {
 		cause := &url.Error{Op: "Post", URL: "http://bor:8545", Err: context.DeadlineExceeded}
 		wrapped := classifyAndWrap(cause, common.ChainFamily(-1), common.TransportJsonRPC)
-
 		require.True(t, errors.Is(wrapped, context.DeadlineExceeded))
 		require.Equal(t, common.LavaErrorContextDeadline.Code, extractLavaError(wrapped).Code)
 	})
-
 	t.Run("typed http status error stays reachable", func(t *testing.T) {
 		cause := &lavasession.HTTPStatusError{StatusCode: 503, Status: "503"}
 		wrapped := classifyAndWrap(cause, common.ChainFamily(-1), common.TransportJsonRPC)
-
 		var httpErr *lavasession.HTTPStatusError
 		require.True(t, errors.As(wrapped, &httpErr))
 		require.Equal(t, 503, httpErr.StatusCode)
 	})
-}
-
-// TestDeadlineIsNotCarvedOut pins the deliberate asymmetry: a timeout is NOT a client
-// cancellation. A slow or unreachable endpoint must still be penalised, otherwise this
-// fix would paper over real faults.
-func TestDeadlineIsNotCarvedOut(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cause := &url.Error{Op: "Post", URL: "http://bor:8545", Err: context.DeadlineExceeded}
-	wrapped := classifyAndWrap(cause, common.ChainFamily(-1), common.TransportJsonRPC)
-
-	require.False(t, common.IsClientCancellation(wrapped, ctx),
-		"a deadline on a live context is an endpoint fault, not a cancellation")
-
-	markUnhealthy, backoff := classifyEndpointHealth(extractLavaError(wrapped), false)
-	require.True(t, markUnhealthy, "timeouts must still mark the endpoint unhealthy")
-	require.True(t, backoff)
 }

--- a/protocol/rpcsmartrouter/relay_race_cancellation_test.go
+++ b/protocol/rpcsmartrouter/relay_race_cancellation_test.go
@@ -1,0 +1,105 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+)
+
+// raceLoserError builds the error a relay-race loser actually produces: net/http
+// returns a *url.Error carrying context.Canceled, and DoHTTPRequest wraps it with %w
+// (direct_rpc_connection.go), so the sentinel is intact when it reaches classification.
+func raceLoserError() error {
+	return &url.Error{Op: "Post", URL: "http://bor-internal:8545", Err: context.Canceled}
+}
+
+// TestRaceLoser_SurvivesClassification is the regression test for MAG-2648.
+//
+// The pre-existing carve-out test (TestClassifyEndpointHealth_ClientCancellationCarvesOut)
+// passes isClientCancellation as a literal `true`, so it verifies the branch but never
+// that the flag is ever computed true on the real path. It stayed green for the entire
+// life of the bug. This test starts from a real transport error and drives it through the
+// actual wrapping the relay path performs.
+func TestRaceLoser_SurvivesClassification(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // a sibling relay won the race
+
+	transportErr := raceLoserError()
+
+	// Precondition: before classification the sentinel is reachable.
+	require.True(t, errors.Is(transportErr, context.Canceled))
+	require.True(t, common.IsClientCancellation(transportErr, ctx),
+		"precondition: the raw transport error IS a client cancellation")
+
+	// Exactly what SendDirectRelay returns (direct_rpc_relay.go).
+	wrapped := classifyAndWrap(transportErr, common.ChainFamily(-1), common.TransportJsonRPC)
+
+	t.Run("classification is still correct", func(t *testing.T) {
+		classified := extractLavaError(wrapped)
+		require.NotNil(t, classified)
+		require.Equal(t, common.LavaErrorContextCanceled.Code, classified.Code)
+	})
+
+	t.Run("sentinel survives wrapping", func(t *testing.T) {
+		require.True(t, errors.Is(wrapped, context.Canceled),
+			"the cause must stay reachable through LavaWrappedError")
+	})
+
+	t.Run("carve-out fires", func(t *testing.T) {
+		require.True(t, common.IsClientCancellation(wrapped, ctx))
+	})
+
+	t.Run("endpoint is not blamed", func(t *testing.T) {
+		classified := extractLavaError(wrapped)
+		isClientCancel := common.IsClientCancellation(wrapped, ctx)
+
+		markUnhealthy, backoff := classifyEndpointHealth(classified, isClientCancel)
+		require.False(t, markUnhealthy, "a relay-race loser must not mark the endpoint unhealthy")
+		require.False(t, backoff, "a relay-race loser must not trigger backoff")
+	})
+}
+
+// TestClassification_PreservesOtherSentinels guards the general property, not just the
+// context.Canceled case: whatever sentinel the cause carries must remain reachable.
+func TestClassification_PreservesOtherSentinels(t *testing.T) {
+	t.Run("deadline exceeded", func(t *testing.T) {
+		cause := &url.Error{Op: "Post", URL: "http://bor:8545", Err: context.DeadlineExceeded}
+		wrapped := classifyAndWrap(cause, common.ChainFamily(-1), common.TransportJsonRPC)
+
+		require.True(t, errors.Is(wrapped, context.DeadlineExceeded))
+		require.Equal(t, common.LavaErrorContextDeadline.Code, extractLavaError(wrapped).Code)
+	})
+
+	t.Run("typed http status error stays reachable", func(t *testing.T) {
+		cause := &lavasession.HTTPStatusError{StatusCode: 503, Status: "503"}
+		wrapped := classifyAndWrap(cause, common.ChainFamily(-1), common.TransportJsonRPC)
+
+		var httpErr *lavasession.HTTPStatusError
+		require.True(t, errors.As(wrapped, &httpErr))
+		require.Equal(t, 503, httpErr.StatusCode)
+	})
+}
+
+// TestDeadlineIsNotCarvedOut pins the deliberate asymmetry: a timeout is NOT a client
+// cancellation. A slow or unreachable endpoint must still be penalised, otherwise this
+// fix would paper over real faults.
+func TestDeadlineIsNotCarvedOut(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cause := &url.Error{Op: "Post", URL: "http://bor:8545", Err: context.DeadlineExceeded}
+	wrapped := classifyAndWrap(cause, common.ChainFamily(-1), common.TransportJsonRPC)
+
+	require.False(t, common.IsClientCancellation(wrapped, ctx),
+		"a deadline on a live context is an endpoint fault, not a cancellation")
+
+	markUnhealthy, backoff := classifyEndpointHealth(extractLavaError(wrapped), false)
+	require.True(t, markUnhealthy, "timeouts must still mark the endpoint unhealthy")
+	require.True(t, backoff)
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -1758,17 +1758,34 @@ func (rpcss *RPCSmartRouterServer) sendRelayToDirectEndpoints(
 				analytics,
 			)
 
+			// Did WE stop this relay? On a stateful broadcast every endpoint is queried and the
+			// first answer cancels the rest, so N-1 goroutines land here holding context.Canceled
+			// through no fault of their endpoint. Same for a client that hung up. Resolved once,
+			// here, and reused by both the metric outcome and the session release below so the two
+			// can never disagree about what happened (MAG-2648).
+			//
+			// goroutineCtx is the right context to ask: for cross-validation it is derived from a
+			// WithoutCancel parent, so a detached straggler is correctly NOT seen as cancelled.
+			isClientCancel := err != nil && common.IsClientCancellation(err, goroutineCtx)
+
 			if rpcss.smartRouterEndpointMetrics != nil {
 				// analytics is read-only here (classification flags set once pre-launch, Success set
 				// once in SendParsedRelay), so this per-endpoint metric is safe from a detached
-				// straggler goroutine; per-relay success is passed explicitly (err == nil).
+				// straggler goroutine; the per-relay outcome is passed explicitly.
+				outcome := metrics.RelayOutcomeSuccess
+				switch {
+				case isClientCancel:
+					outcome = metrics.RelayOutcomeCancelled
+				case err != nil:
+					outcome = metrics.RelayOutcomeError
+				}
 				rpcss.smartRouterEndpointMetrics.RecordDirectRelayEnd(
 					rpcss.listenEndpoint.ChainID,
 					rpcss.listenEndpoint.ApiInterface,
 					endpointAddress,
 					apiMethod,
 					float64(relayLatency.Milliseconds()),
-					err == nil,
+					outcome,
 					analytics,
 				)
 			}
@@ -1808,7 +1825,21 @@ func (rpcss *RPCSmartRouterServer) sendRelayToDirectEndpoints(
 			statusCode := localRelayResult.StatusCode
 			shouldFailSession := err != nil || statusCode >= 500 || statusCode == 429
 
-			if !shouldFailSession {
+			if isClientCancel {
+				// We cancelled it, so the endpoint's availability was never actually tested —
+				// release the session and return its CU without a QoS penalty (MAG-2648).
+				// Routing this through OnSessionFailure is the bug: it feeds AddFailedRelay and
+				// the optimizer an availability sample of 0, and on a broadcast that lands on
+				// every healthy node except the single fastest one.
+				//
+				// This branch precedes the shouldFailSession test on purpose — a cancelled relay
+				// always has err != nil, so it would otherwise be swallowed by the failure arm.
+				if errSession := rpcss.sessionManager.OnSessionCancelled(singleConsumerSession, err); errSession != nil {
+					utils.LavaFormatWarning("OnSessionCancelled failed for direct RPC", errSession,
+						utils.LogAttr("GUID", goroutineCtx),
+					)
+				}
+			} else if !shouldFailSession {
 				// Success or client error (4xx except 429) - update session as success.
 				// targetEndpoint / directConn were resolved and the tracker ensured before
 				// dispatch (above), so harvestGen is the generation captured pre-relay.

--- a/scripts/check_solana_balance.sh
+++ b/scripts/check_solana_balance.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Check the SOL balance of one or more Solana addresses.
+#
+# Queries the getBalance JSON-RPC method (result.value is lamports;
+# 1 SOL = 1_000_000_000 lamports). Prefers the `solana` CLI if installed,
+# otherwise falls back to a direct curl RPC call (no dependencies).
+#
+# Usage:
+#   ./check_solana_balance.sh <ADDRESS> [<ADDRESS> ...]                 # via Smart Router
+#   RPC_URL=https://api.testnet.solana.com ./check_solana_balance.sh <ADDRESS>  # direct testnet
+#   RPC_URL=https://api.devnet.solana.com ./check_solana_balance.sh <ADDRESS>   # direct devnet
+#
+# Default target is the local Smart Router (so reads are exercised through it).
+set -euo pipefail
+
+RPC_URL="${RPC_URL:-http://127.0.0.1:3360}"
+
+if [[ "$#" -lt 1 ]]; then
+    echo "Usage: $0 <SOLANA_ADDRESS> [<SOLANA_ADDRESS> ...]" >&2
+    echo "  (optionally set RPC_URL=... ; default: $RPC_URL)" >&2
+    exit 1
+fi
+
+echo "============================================"
+echo "Solana balance check"
+echo "RPC: $RPC_URL"
+echo "============================================"
+echo ""
+
+# Basic base58 sanity check (Solana addresses are 32-44 base58 chars, no 0OIl).
+is_valid_address() {
+    [[ "$1" =~ ^[1-9A-HJ-NP-Za-km-z]{32,44}$ ]]
+}
+
+# lamports -> SOL with 9 decimals, without floating-point drift (awk).
+lamports_to_sol() {
+    awk "BEGIN{printf \"%.9f\", $1 / 1000000000}"
+}
+
+check_one() {
+    local addr="$1"
+    echo "Address: $addr"
+
+    if ! is_valid_address "$addr"; then
+        echo "  SKIPPED: not a valid base58 Solana address."
+        echo ""
+        return
+    fi
+
+    if command -v solana >/dev/null 2>&1; then
+        # CLI prints e.g. "1.5 SOL"; --output prints lamports when piped, so keep human form.
+        local out
+        if out=$(solana balance "$addr" --url "$RPC_URL" 2>&1); then
+            echo "  Balance: $out"
+        else
+            echo "  ERROR querying balance: $out"
+        fi
+        echo ""
+        return
+    fi
+
+    if ! command -v curl >/dev/null 2>&1; then
+        echo "  ERROR: need either 'solana' or 'curl' on PATH." >&2
+        echo ""
+        return
+    fi
+
+    # Don't let a connection failure (curl exit != 0) abort the whole run under set -e.
+    local resp rc=0
+    resp=$(curl -s --max-time 20 "$RPC_URL" \
+        -X POST -H 'Content-Type: application/json' \
+        -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getBalance\",\"params\":[\"$addr\"]}") || rc=$?
+
+    if [[ "$rc" -ne 0 || -z "$resp" ]]; then
+        echo "  ERROR: could not reach RPC at $RPC_URL (curl exit $rc)."
+        echo "         Is the Smart Router running? Start it: scripts/pre_setups/init_smartrouter_sol.sh"
+        echo "         Or query a cluster directly: RPC_URL=https://api.testnet.solana.com $0 $addr"
+        echo ""
+        return
+    fi
+
+    # Echo the raw JSON-RPC response so the caller can see exactly what the endpoint returned.
+    echo "  RPC response: $resp"
+
+    if [[ "$resp" == *'"error"'* ]]; then
+        echo "  ERROR: $resp"
+        echo ""
+        return
+    fi
+
+    # result.value holds the lamport balance.
+    local lamports
+    lamports=$(printf '%s' "$resp" | sed -n 's/.*"value":\([0-9]*\).*/\1/p')
+
+    if [[ -z "$lamports" ]]; then
+        echo "  Unexpected response: $resp"
+        echo ""
+        return
+    fi
+
+    echo "  Balance: $(lamports_to_sol "$lamports") SOL ($lamports lamports)"
+    if [[ "$lamports" == "0" ]]; then
+        echo "  Note: 0 balance — account is empty or has never been funded on this cluster."
+    fi
+    echo ""
+}
+
+for addr in "$@"; do
+    check_one "$addr"
+done
+
+echo "============================================"
+echo "Done."
+echo "============================================"

--- a/scripts/transfer_sol_example.sh
+++ b/scripts/transfer_sol_example.sh
@@ -1,0 +1,267 @@
+#!/bin/bash
+# Transfer SOL from one account to another.
+#
+# Defaults are wired to the requested transfer (0.05 SOL between two addresses),
+# but all values can be overridden via flags/env. The signing keypair (private
+# key) for the SENDER must be supplied.
+#
+# SECURITY WARNING: a private key passed as a CLI argument is visible in your
+# shell history and in `ps`. Prefer PRIVATE_KEY env var or a keypair file.
+#
+# Backends (auto-detected): prefers the `solana` CLI; otherwise builds, signs,
+# and submits a legacy transaction with Node (native ed25519, zero deps).
+#
+# Usage:
+#   ./transfer_sol.sh <PRIVATE_KEY>                 # uses built-in from/to/amount
+#   PRIVATE_KEY=... ./transfer_sol.sh               # key via env (safer)
+#   ./transfer_sol.sh --from ADDR --to ADDR --amount 0.05 <PRIVATE_KEY>
+#   ./transfer_sol.sh --dry-run <PRIVATE_KEY>       # build+sign, DO NOT broadcast
+#   RPC_URL=https://api.devnet.solana.com ./transfer_sol.sh <PRIVATE_KEY>
+#
+# PRIVATE_KEY may be base58 (Phantom export) or a JSON byte array ([12,34,...]).
+set -euo pipefail
+
+FROM="${FROM:-DFagbpsNcfmDMYjR5FS9o5E79e1puWF1sSdHkR9eVaPU}"
+TO="${TO:-4YPYNbYdSUBbVtiyGznEePpHBoRiGRP2ZMwk5dnuYjcb}"
+AMOUNT_SOL="${AMOUNT_SOL:-0.05}"
+RPC_URL="${RPC_URL:-http://127.0.0.1:3360}"   # default: local Smart Router (proxies testnet)
+# Explorer links can't infer the cluster from a localhost router URL; override if needed.
+CLUSTER="${CLUSTER:-testnet}"
+PRIVATE_KEY="${PRIVATE_KEY:-}"
+DRY_RUN="${DRY_RUN:-0}"
+
+# --- parse flags; first non-flag positional is the private key ---
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --from)    FROM="$2"; shift 2 ;;
+        --to)      TO="$2"; shift 2 ;;
+        --amount)  AMOUNT_SOL="$2"; shift 2 ;;
+        --rpc)     RPC_URL="$2"; shift 2 ;;
+        --dry-run) DRY_RUN="1"; shift ;;
+        -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+        *)         PRIVATE_KEY="$1"; shift ;;
+    esac
+done
+
+if [[ -z "$PRIVATE_KEY" ]]; then
+    echo "ERROR: sender private key required (CLI arg or PRIVATE_KEY env)." >&2
+    echo "       Run with --help for usage." >&2
+    exit 1
+fi
+
+echo "============================================"
+echo "Transfer SOL"
+echo "============================================"
+echo "From:    $FROM"
+echo "To:      $TO"
+echo "Amount:  $AMOUNT_SOL SOL"
+echo "RPC:     $RPC_URL"
+[[ "$DRY_RUN" == "1" ]] && echo "Mode:    DRY RUN (build + sign only, no broadcast)"
+echo "============================================"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Backend 1: solana CLI (canonical)
+# ---------------------------------------------------------------------------
+if command -v solana >/dev/null 2>&1; then
+    echo "(using solana CLI)"
+    KEYFILE=$(mktemp)
+    trap 'rm -f "$KEYFILE"' EXIT
+    # Normalize the key into an id.json (JSON byte array) the CLI understands.
+    if [[ "$PRIVATE_KEY" == \[* ]]; then
+        printf '%s' "$PRIVATE_KEY" > "$KEYFILE"
+    else
+        # base58 -> JSON array via node (CLI keygen can't import base58 directly).
+        PRIVATE_KEY="$PRIVATE_KEY" node -e '
+          const A="123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+          let b=[0]; for(const c of process.env.PRIVATE_KEY){const p=A.indexOf(c);
+            if(p<0)throw new Error("bad base58");let car=p;
+            for(let j=0;j<b.length;j++){car+=b[j]*58;b[j]=car&255;car=Math.floor(car/256);}
+            while(car>0){b.push(car&255);car=Math.floor(car/256);}}
+          for(let i=0;i<process.env.PRIVATE_KEY.length&&process.env.PRIVATE_KEY[i]==="1";i++)b.push(0);
+          process.stdout.write(JSON.stringify(b.reverse()));' > "$KEYFILE"
+    fi
+    if [[ "$DRY_RUN" == "1" ]]; then
+        solana transfer --from "$KEYFILE" "$TO" "$AMOUNT_SOL" --url "$RPC_URL" \
+            --allow-unfunded-recipient --fee-payer "$KEYFILE" --dump-transaction-message --sign-only
+    else
+        solana transfer --from "$KEYFILE" "$TO" "$AMOUNT_SOL" --url "$RPC_URL" \
+            --allow-unfunded-recipient --fee-payer "$KEYFILE"
+    fi
+    exit $?
+fi
+
+# ---------------------------------------------------------------------------
+# Backend 2: Node (build + sign + send a legacy transaction, zero deps)
+# ---------------------------------------------------------------------------
+echo "(solana CLI not found — using node native ed25519 signer)"
+echo ""
+
+FROM="$FROM" TO="$TO" AMOUNT_SOL="$AMOUNT_SOL" RPC_URL="$RPC_URL" CLUSTER="$CLUSTER" \
+PRIVATE_KEY="$PRIVATE_KEY" DRY_RUN="$DRY_RUN" node - <<'NODE'
+const crypto = require('crypto');
+
+const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+function b58decode(str) {
+  let bytes = [0];
+  for (const c of str) {
+    const p = ALPHABET.indexOf(c);
+    if (p < 0) throw new Error('invalid base58 char: ' + c);
+    let carry = p;
+    for (let j = 0; j < bytes.length; j++) {
+      carry += bytes[j] * 58;
+      bytes[j] = carry & 0xff;
+      carry = Math.floor(carry / 256);
+    }
+    while (carry > 0) { bytes.push(carry & 0xff); carry = Math.floor(carry / 256); }
+  }
+  for (let i = 0; i < str.length && str[i] === '1'; i++) bytes.push(0);
+  return Buffer.from(bytes.reverse());
+}
+
+function b58encode(buf) {
+  let zeros = 0;
+  while (zeros < buf.length && buf[zeros] === 0) zeros++;
+  const digits = [0];
+  for (let i = zeros; i < buf.length; i++) {
+    let carry = buf[i];
+    for (let j = 0; j < digits.length; j++) {
+      carry += digits[j] << 8;
+      digits[j] = carry % 58;
+      carry = (carry / 58) | 0;
+    }
+    while (carry > 0) { digits.push(carry % 58); carry = (carry / 58) | 0; }
+  }
+  let out = '1'.repeat(zeros);
+  for (let k = digits.length - 1; k >= 0; k--) out += ALPHABET[digits[k]];
+  return out;
+}
+
+// compact-u16 (shortvec) length prefix used by Solana for arrays.
+function encodeLength(len) {
+  const out = [];
+  let rem = len;
+  for (;;) {
+    let elem = rem & 0x7f;
+    rem >>= 7;
+    if (rem === 0) { out.push(elem); break; }
+    out.push(elem | 0x80);
+  }
+  return Buffer.from(out);
+}
+
+// Parse base58 or JSON-array secret into {seed(32), pub(32)}.
+function parseSecret(raw) {
+  raw = raw.trim();
+  let secret = raw.startsWith('[') ? Buffer.from(JSON.parse(raw)) : b58decode(raw);
+  if (secret.length === 64) return { seed: secret.subarray(0, 32), pub: secret.subarray(32, 64) };
+  if (secret.length === 32) {
+    const der = Buffer.concat([Buffer.from('302e020100300506032b657004220420', 'hex'), secret]);
+    const sk = crypto.createPrivateKey({ key: der, format: 'der', type: 'pkcs8' });
+    const x = crypto.createPublicKey(sk).export({ format: 'jwk' }).x;
+    return { seed: secret, pub: Buffer.from(x, 'base64url') };
+  }
+  throw new Error('private key must decode to 32 or 64 bytes, got ' + secret.length);
+}
+
+function signerFromSeed(seed) {
+  const der = Buffer.concat([Buffer.from('302e020100300506032b657004220420', 'hex'), seed]);
+  return crypto.createPrivateKey({ key: der, format: 'der', type: 'pkcs8' });
+}
+
+async function rpc(url, method, params) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  });
+  const json = await res.json();
+  if (json.error) throw new Error(`${method} RPC error: ${JSON.stringify(json.error)}`);
+  return json.result;
+}
+
+(async () => {
+  const { FROM, TO, AMOUNT_SOL, RPC_URL, PRIVATE_KEY, DRY_RUN } = process.env;
+  const dryRun = DRY_RUN === '1';
+
+  const { seed, pub } = parseSecret(PRIVATE_KEY);
+  const fromPubkey = b58decode(FROM);
+  const toPubkey = b58decode(TO);
+  const systemProgram = Buffer.alloc(32); // all-zeros = System Program
+
+  // Safety: the supplied key must actually control the --from address.
+  if (b58encode(pub) !== FROM) {
+    throw new Error(`private key does not match --from address.\n  key pubkey: ${b58encode(pub)}\n  --from:     ${FROM}`);
+  }
+
+  const lamports = BigInt(Math.round(parseFloat(AMOUNT_SOL) * 1e9));
+  if (lamports <= 0n) throw new Error('amount must be > 0');
+
+  // SystemProgram::Transfer instruction data: u32 index(2) + u64 lamports (LE).
+  const data = Buffer.alloc(12);
+  data.writeUInt32LE(2, 0);
+  data.writeBigUInt64LE(lamports, 4);
+
+  // Account keys ordered: writable-signer, writable-nonsigner, readonly-nonsigner.
+  const keys = [fromPubkey, toPubkey, systemProgram];
+  const header = Buffer.from([1, 0, 1]); // reqSigs=1, roSigned=0, roUnsigned=1
+
+  // Recent blockhash (finalized) — the tx's "valid until" anchor.
+  let blockhashB58;
+  if (dryRun) {
+    try {
+      blockhashB58 = (await rpc(RPC_URL, 'getLatestBlockhash', [{ commitment: 'finalized' }])).value.blockhash;
+    } catch (e) {
+      // Dry run can proceed offline with a placeholder blockhash just to exercise signing.
+      console.log('  (dry-run: could not fetch blockhash, using zero placeholder — ' + e.message + ')');
+      blockhashB58 = b58encode(Buffer.alloc(32));
+    }
+  } else {
+    blockhashB58 = (await rpc(RPC_URL, 'getLatestBlockhash', [{ commitment: 'finalized' }])).value.blockhash;
+  }
+  const recentBlockhash = b58decode(blockhashB58);
+
+  // --- serialize the message ---
+  const instr = Buffer.concat([
+    Buffer.from([2]),                 // programIdIndex = system program (keys[2])
+    encodeLength(2), Buffer.from([0, 1]), // accounts: from(0), to(1)
+    encodeLength(data.length), data,
+  ]);
+  const message = Buffer.concat([
+    header,
+    encodeLength(keys.length), ...keys,
+    recentBlockhash,
+    encodeLength(1), instr,
+  ]);
+
+  // --- sign ---
+  const signer = signerFromSeed(seed);
+  const signature = crypto.sign(null, message, signer); // 64-byte ed25519 sig
+
+  // Self-check the signature against the derived public key.
+  const ok = crypto.verify(null, message, crypto.createPublicKey(signer), signature);
+  if (!ok) throw new Error('internal error: signature failed self-verification');
+
+  // --- assemble wire transaction: compact(sigs) + message ---
+  const tx = Buffer.concat([encodeLength(1), signature, message]);
+  const txBase64 = tx.toString('base64');
+
+  console.log('  Lamports:        ' + lamports.toString());
+  console.log('  Recent blockhash: ' + blockhashB58);
+  console.log('  Tx signature:    ' + b58encode(signature));
+  console.log('  Signed tx (b64): ' + txBase64);
+  console.log('');
+
+  if (dryRun) {
+    console.log('  DRY RUN: transaction built and signature self-verified. NOT broadcast.');
+    return;
+  }
+
+  const sig = await rpc(RPC_URL, 'sendTransaction', [txBase64, { encoding: 'base64' }]);
+  console.log('  ✅ Broadcast. Signature: ' + sig);
+  const cluster = process.env.CLUSTER || 'testnet';
+  console.log('  Explorer: https://explorer.solana.com/tx/' + sig +
+    (cluster === 'mainnet' ? '' : '?cluster=' + cluster));
+})().catch((e) => { console.error('  ERROR: ' + e.message); process.exit(1); });
+NODE


### PR DESCRIPTION
# Description

A stateful method (`stateful: 1` in the spec — `eth_sendRawTransaction`, Solana
`sendTransaction`) is broadcast to **every** endpoint. The first response wins and the
router cancels the rest. Those cancelled relays were being recorded as **endpoint
failures** at three independent sites.

On a broadcast the fastest node wins and every *other* healthy node takes the hit, so the
penalty is structural rather than correlated with node quality. Reported by a customer on
Polygon: healthy internal Bor endpoints flipping available/unavailable 30–110×/3h with
availability scores at 0.0–0.4, while block lag was 0 and sync ~0.99.

**Nothing was broken for clients** — the winning relay always succeeded. The damage was to
the router's own endpoint scoring and to every dashboard built on the error metrics.

## Root cause

A carve-out for exactly this case already existed at one of the three sites and had never
worked. `classifyDirectRPCError` rebuilt the error from `err.Error()` — a plain string —
so `LavaWrappedError` carried no cause:

```go
return classified, common.NewLavaError(classified, err.Error())
//                                                 ^^^^^^^^^^^ flattened
```

`errors.Is(err, context.Canceled)` was therefore always false, `IsClientCancellation`
always returned false, and `classifyEndpointHealth` fell through to the
`CategoryInternal` arm → `MarkUnhealthy()` + backoff.

The classification itself was correct (`PROTOCOL_CONTEXT_CANCELED`) — only the sentinel
needed by the carve-out was lost.

## Approach

Restore the signal at the root, then honour it at all three sites.

**1. Keep the cause** (`error_registry.go`, `error_mapper.go`)

`LavaWrappedError` gains a `cause`, `Unwrap` returns it, and a new `As` keeps the
`*LavaError` reachable. One call site switches to `NewLavaErrorWrapping`.

The singular `Unwrap() error` is deliberate. `Unwrap() []error` is the tidier-looking form
and is **wrong here**: `errors.Unwrap` is documented to return nil for multi-unwrap types,
which breaks three existing tests and the chain walker in `utils/score/score_errors.go`.
The comment in the code explains this so a future refactor does not silently reintroduce
the bug.

This change alone revives the health carve-out with no edit to `classifyEndpointHealth`.

**2. Release the session without blaming it** (`consumer_session_manager.go`)

New `OnSessionCancelled`, sharing a private helper with the existing `OnSessionDiscarded`
— which already had exactly this accounting, on exactly this reasoning ("no upstream
request was made, so availability was not actually tested"). A race loser is the same
category: dispatched, but no verdict about the endpoint was obtained.

**3. A third relay outcome** (`smartrouter_metrics_manager.go`)

`RecordDirectRelayEnd` takes a `RelayOutcome` (success / error / cancelled) instead of a
success bool. Two words of vocabulary were not enough for three real outcomes.

### The trap that shapes 2 and 3

Neither call could simply be skipped for a cancelled relay, because **both do cleanup as
well as blame**:

- `RecordDirectRelayEnd` also decrements the in-flight gauge that `RecordDirectRelayStart`
  incremented. Skipping it leaks `rpc_endpoint_requests_in_flight` upward forever, one per
  race loser.
- `OnSessionFailure` also frees the session and returns its compute units. Skipping it
  leaks sessions until the provider stops being granted new ones.

Each needed a third path that keeps the cleanup and drops only the penalty.
`TestCancelledRelay_InFlightGaugeReturnsToZero` pins the naive fix out of existence.

## New metric

| Metric | Type | Labels | Description |
| --- | --- | --- | --- |
| `rpc_endpoint_total_cancelled` | Counter | `spec`, `apiInterface`, `endpoint_id`, `function` | Relays the router aborted before completion — race losers on stateful broadcasts, and client disconnects. Not an endpoint fault. |

A separate counter rather than silence: dropping these entirely would hide the broadcast
cancel rate, which is the number you need to tune fan-out. Documented in `docs/METRICS.md`
with the expected `(N-1)/N` rate on write traffic.

## Behaviour changes reviewers should know about

- **`rpc_endpoint_total_errored` will drop sharply on write-heavy specs.** That volume
  moves to `rpc_endpoint_total_cancelled`. This is the fix working, but it will look like
  a measurement break on a dashboard.
- **`smartrouter_requests_*` no longer counts cancelled relays.** For a stateful broadcast
  to N endpoints, `requests_total` now counts completed relays rather than all dispatched
  ones. This preserves `requests_total == requests_success + requests_failed` exactly, at
  the cost of lower write-method request counts.
- **Client disconnects are fixed as a side effect.** They ride the same
  `IsClientCancellation` rule, which is correct — a user hanging up is not an endpoint
  fault. It means the error-rate drop is not limited to broadcast traffic.
- **Cancelled relays no longer record latency.** A cancel timing measures "time until the
  winner returned", not that endpoint's performance, and would have dragged the slowest
  endpoints' distributions toward zero.

## Verification

### Live A/B on a 3-endpoint SOLANAT router

Same server, same config, same 90 stateful broadcasts. Only the binary changed. All three
`direct-rpc` entries pointed at the **same upstream URL**, so latency and sync were
identical and the only variable was which endpoint answered first.

| Measurement | Before | After |
| --- | --- | --- |
| `rpc_endpoint_total_errored` | **160** | **0** |
| `rpc_endpoint_total_cancelled` | *(did not exist)* | 167 |
| `selection_score{availability}` | 0.00 / 0.00 / 0.00 | 0.93 / 0.90 / 0.94 |
| `selection_score{sync}` | 1.00 / 1.00 / 1.00 | 1.00 / 1.00 / 1.00 |
| `rpc_endpoint_overall_health` flips | 28 | 0 (723 samples) |
| `rpc_endpoint_requests_in_flight` | 0 | 0 |
| Client-visible failures | 0 / 91 | 0 / 90 |

Accounting balances on both sides: `serviced + (errored | cancelled) == 90 × 3 == 270`.

### Genuine faults are still penalised

The obvious risk in a fix like this is trading a false-positive for a much worse
false-negative. Verified two ways:

- **Live:** a deliberately broken 4th endpoint (a proxy killed mid-run) took **17 errors**
  and went unhealthy, while the three healthy endpoints took **0** in the same run.
- **Unit:** `TestGenuineFaults_StillPenalised` asserts connection refused / reset / host
  unreachable / deadline / EOF all still mark the endpoint unhealthy **while the context
  is cancelled** — the exact state a race loser is in.

Also pinned: rate limiting keeps its "healthy but busy" treatment, `OnSessionFailure`
still records QoS penalties, and cross-validation stragglers on `WithoutCancel` contexts
are correctly *not* treated as cancelled.

### Test plan

- 24 new/updated tests across `common`, `metrics`, `lavasession`, `rpcsmartrouter`
- `go build ./...`, `go vet ./...`, `gofmt`: clean
- Full suite: **32 packages, 0 failures**
- `-race` on the changed packages: no races in this change. One pre-existing flake
  (`TestHappyFlow`, `relays_monitor_test.go`) reproduces identically on clean `main` —
  confirmed by running `main` 10× (2 failures) vs this branch 7× (2 failures)
- Review note (avitenzer, 2026-08-05): two more pre-existing flakes reproduce on clean
  `main` in full-package `lavasession` runs — `TestCheckAndUnblock_BackupUnblockedWhenHealthy`
  and `TestEndpointHealthRecovery` (both pass in isolation; confirmed flaky in a clean `main`
  worktree, so not introduced by this branch)

### Why the previous tests missed this

`TestClassifyEndpointHealth_ClientCancellationCarvesOut` passes
`isClientCancellation` as a literal `true`. It verifies the branch but never whether the
flag is ever computed true on the real path, so it stayed green for the entire life of the
bug. `IsClientCancellation` itself had no test at all. Both are now covered from a real
transport error forward.

## Known gap — this fix is HTTP-only

**The gRPC transport still has this bug, with an inverted and worse failure mode.**

`handleGRPCError` rebuilds the error as `GRPCStatusError{Code, Message}` with no cause,
and grpc-go's `status.Error(codes.Canceled, ...)` does not wrap `context.Canceled` either.
Because `codes.Canceled` is 1 (below the `>= 13` node-error threshold) the consumption arm
returns a nil error, so a cancelled gRPC relay is recorded as a **success** — including a
fabricated latency sample and an active `ResetHealth()`.

Confirmed by driving the real code path. Affects the seven specs with a `grpc`
apiInterface (Cosmos family + Lava). Not fixed here because it needs its own change and
its own verification; tracked with a full plan in the ticket.

## Follow-up

From code review, tracked separately:

- **gRPC transport** (above) — highest priority
- Race losers still appear in the client's errored-providers metadata
- `rpc_endpoint_total_cancelled` merges race losers with client disconnects; needs a
  `reason` label to separate them
- Client-disconnected requests are now invisible in `smartrouter_requests_*`
- Nil guards on `LavaWrappedError`
- Adjacent pre-existing bug: gRPC `DeadlineExceeded` is also recorded as a success

## Files most worth reviewing

1. `protocol/common/error_registry.go` — the root fix; read the `Unwrap` comment
2. `protocol/rpcsmartrouter/rpcsmartrouter_server.go` — the two call sites; note that the
   `isClientCancel` branch must precede the `shouldFailSession` test
3. `protocol/metrics/smartrouter_metrics_manager.go` — the in-flight decrement must run
   for every outcome

---

## Jira ticket

Jira ticket: MAG-2648

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

