### PR TITLE
fix(rpcsmartrouter): reject a nil upstream subscription instead of panicking (MAG-2685)

### DIFF
--- a/protocol/chainlib/chainproxy/rpcclient/subscription.go
+++ b/protocol/chainlib/chainproxy/rpcclient/subscription.go
@@ -256,13 +256,25 @@ func newClientSubscription(c *Client, namespace string, channel reflect.Value) *
 // error has occurred.
 //
 // The error channel is closed when Unsubscribe is called on the subscription.
+//
+// A nil receiver yields a nil channel rather than panicking. Subscribe can hand back a nil
+// subscription alongside a nil error when the upstream answers with a JSON-RPC error object,
+// and callers routinely park this in an interface — where a nil check on the interface value
+// cannot detect it. Receiving from the nil channel simply never fires, which is the correct
+// behaviour for a subscription that was never established. See MAG-2685.
 func (sub *ClientSubscription) Err() <-chan error {
+	if sub == nil {
+		return nil
+	}
 	return sub.err
 }
 
 // Unsubscribe unsubscribes the notification and closes the error channel.
-// It can safely be called more than once.
+// It can safely be called more than once, and is a no-op on a nil receiver (see Err).
 func (sub *ClientSubscription) Unsubscribe() {
+	if sub == nil {
+		return
+	}
 	sub.errOnce.Do(func() {
 		// IMPORTANT: must never block forever.
 		// If Unsubscribe is called before the subscription forwarding goroutine (sub.run) is started,

--- a/protocol/chainlib/chainproxy/rpcclient/subscription_test.go
+++ b/protocol/chainlib/chainproxy/rpcclient/subscription_test.go
@@ -210,3 +210,34 @@ func TestClientSubscription_ErrChannelBehavior(t *testing.T) {
 	_, ok = <-sub.Err()
 	require.False(t, ok, "can read from closed error channel multiple times")
 }
+
+// TestClientSubscription_NilReceiverIsSafe is the rpcclient half of the MAG-2685 regression.
+//
+// Client.Subscribe returns (nil subscription, response, NIL error) when the upstream answers a
+// subscribe with a JSON-RPC error object. Callers park that nil in an interface, where a nil
+// check on the interface value cannot see it, and then call Err() — which dereferenced the nil
+// receiver and panicked, taking the router process down.
+//
+// Err() must yield a nil channel (a case that never fires, correct for a subscription that was
+// never established) and Unsubscribe() must be a no-op, rather than panicking.
+func TestClientSubscription_NilReceiverIsSafe(t *testing.T) {
+	var sub *ClientSubscription
+
+	require.NotPanics(t, func() {
+		ch := sub.Err()
+		require.Nil(t, ch, "Err() on a nil receiver must return a nil channel, not panic")
+
+		// Receiving from a nil channel blocks forever, so it must never be the only ready
+		// case. Prove it simply never fires rather than panicking or yielding a value.
+		select {
+		case <-ch:
+			t.Fatal("nil Err() channel must never become ready")
+		case <-time.After(50 * time.Millisecond):
+		}
+	}, "Err() must tolerate a nil receiver")
+
+	require.NotPanics(t, func() {
+		sub.Unsubscribe()
+		sub.Unsubscribe() // idempotent, as on a real subscription
+	}, "Unsubscribe() must tolerate a nil receiver")
+}

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
@@ -1148,6 +1148,20 @@ func (dwsm *DirectWSSubscriptionManager) createUpstreamSubscription(
 		return nil, nil, nil, fmt.Errorf("upstream subscribe failed: %w", err)
 	}
 
+	// Subscribe reports "upstream answered with a JSON-RPC error object" as (nil, resp, nil)
+	// — a nil subscription with a NIL error, so the check above does not catch it. That is a
+	// failed subscribe, not a successful one: returning it would hand a nil
+	// *rpcclient.ClientSubscription to listenForUpstreamMessages, which stores it in an
+	// upstreamErrSource interface (non-nil interface, nil pointer) and dereferences it on
+	// upstreamSub.Err() — panicking and taking the process down. Surface the node's error
+	// to the caller instead. See MAG-2685.
+	if sub == nil {
+		if firstMsg != nil && firstMsg.Error != nil {
+			return nil, nil, nil, fmt.Errorf("upstream rejected subscribe: %w", firstMsg.Error)
+		}
+		return nil, nil, nil, fmt.Errorf("upstream subscribe returned no subscription")
+	}
+
 	return sub, firstMsg, msgChan, nil
 }
 

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
@@ -2365,6 +2365,75 @@ type fakeUpstreamErrSource struct{ ch chan error }
 
 func (f fakeUpstreamErrSource) Err() <-chan error { return f.ch }
 
+// TestListenForUpstreamMessages_NilUpstreamSubDoesNotPanic is the regression for MAG-2685.
+//
+// rpcclient.Client.Subscribe returns (nil subscription, response, NIL error) when the upstream
+// answers a subscribe with a JSON-RPC error object — e.g. author_submitAndWatchExtrinsic with an
+// invalid extrinsic. createUpstreamSubscription only checked the error, so the nil subscription
+// reached listenForUpstreamMessages, which parks it in an upstreamErrSource interface. That is a
+// NON-nil interface wrapping a nil pointer, so no `== nil` check catches it, and the select's
+// upstreamSub.Err() dereferenced the nil receiver: the router panicked and the container exited
+// with code 2. Remote-triggerable by any client sending a subscribe the upstream rejects.
+//
+// createUpstreamSubscription now rejects a nil subscription, and Err() tolerates a nil receiver.
+// This test drives the second layer directly: the listener must survive a typed-nil subscription
+// and exit cleanly through its context rather than panicking.
+func TestListenForUpstreamMessages_NilUpstreamSubDoesNotPanic(t *testing.T) {
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc", "ETH", "jsonrpc",
+		[]*common.NodeUrl{{Url: "wss://test.example.com"}},
+		nil, nil, nil,
+	)
+
+	subCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const hp = "hp-nil-upstream-sub"
+	activeSub := &directActiveSubscription{
+		upstreamID:       "0xnil-sub",
+		hashedParams:     hp,
+		connectedClients: map[string]*common.SafeChannelSender[*pairingtypes.RelayReply]{},
+		clientRouterIDs:  map[string]string{},
+		ctx:              subCtx,
+		cancel:           cancel,
+		closeSubChan:     make(chan struct{}),
+		messagesChan:     make(chan *rpcclient.JsonrpcMessage, 1),
+	}
+
+	manager.lock.Lock()
+	manager.activeSubscriptions[hp] = activeSub
+	manager.lock.Unlock()
+
+	// A typed nil, exactly as createUpstreamSubscription used to hand back.
+	var nilSub *rpcclient.ClientSubscription
+	var upstreamSub upstreamErrSource = nilSub
+	// Plain `== nil` is the check a caller would naturally reach for, and it does NOT catch
+	// this — the interface carries a type, so it compares non-nil even though the pointer
+	// inside is nil. (testify's NotNil disagrees: it unwraps via reflection. The Go-level
+	// comparison below is the semantics that actually let the nil through to Err().)
+	require.False(t, upstreamSub == nil,
+		"a typed nil yields an interface that `== nil` reports as non-nil — precisely why a nil guard cannot catch this")
+
+	// A panic here crashes the test binary, which is the assertion. Before the fix this
+	// panicked immediately on upstreamSub.Err().
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		manager.listenForUpstreamMessages(subCtx, hp, activeSub, upstreamSub)
+	}()
+
+	// Err() on a nil receiver yields a nil channel, so that select case never fires and the
+	// listener parks on its other cases. Cancelling the context must still unwind it.
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listenForUpstreamMessages did not return within 2s after context cancel")
+	}
+}
+
 // TestUnsubscribe_StillRejectsForeignSubscription confirms the upstream-id fallback does NOT
 // open a hole that lets one client unsubscribe another client's shared subscription.
 func TestUnsubscribe_StillRejectsForeignSubscription(t *testing.T) {


### PR DESCRIPTION
# Description

A client subscribe request that the upstream answers with a JSON-RPC **error object** caused a nil-pointer dereference that panicked the router and exited the container with code 2. It was remote-triggerable: any WS client could reach it by sending a subscribe the upstream rejects.

## Jira ticket

Jira ticket: MAG-2685

## Root cause

`rpcclient.Client.Subscribe` has a deliberate path returning a **nil subscription with a nil error** when the upstream replies with a JSON-RPC error object (`client.go:541-544`):

```go
resp, err := op.wait(ctx, c)
// In the case of response containing the error message, we want to return it to the user as-is
if err != nil && resp != nil && resp.Error != nil {
    return nil, resp, nil          // nil sub, NIL error
}
```

`createUpstreamSubscription` only guarded on `err`, so the nil passed through as a *successful* subscribe. It then reached `listenForUpstreamMessages`, which holds it in an `upstreamErrSource` **interface** — a non-nil interface wrapping a nil pointer, so no `== nil` check can detect it — and dereferenced it at `case err := <-upstreamSub.Err():`. `Err()` was `return sub.err` with no nil-receiver guard.

Not specific to Substrate or to `submitAndWatch`; any api-interface and any subscribe method reaching this path was affected. `author_submitAndWatchExtrinsic` with an invalid extrinsic is simply the easiest way to make a node return an error object.

## The fix

**`createUpstreamSubscription`** now treats a nil subscription as a failed subscribe and surfaces the node's own error, so the client learns *why* it was refused instead of getting a silently dead subscription. `JsonError` implements `error`, so `%w` carries the upstream message through.

**`ClientSubscription.Err()` / `Unsubscribe()`** additionally tolerate a nil receiver. `Err()` returns a nil channel — a select case that never fires, which is correct for a subscription that was never established, and cannot wedge the listener since its other cases still work. This also closes a **second** unguarded dereference at `direct_ws_subscription_manager.go:638` (`upstreamSub.Unsubscribe()` on the `createSubscriptionReply` failure path), and stops the crash being reintroduced by a future caller.

## Most critical files to review

- `protocol/rpcsmartrouter/direct_ws_subscription_manager.go` — the primary guard
- `protocol/chainlib/chainproxy/rpcclient/subscription.go` — nil-receiver tolerance

## Testing

The regression test was verified to **fail without the fix** — with the `Err()` guard removed it reproduces the production panic exactly:

```
panic: runtime error: invalid memory address or nil pointer dereference
FAIL	github.com/magma-Devs/smart-router/protocol/rpcsmartrouter
```

With the fix restored it passes. Full suites on both touched packages, no `-run` filter:

```
go build ./...                        OK
go vet   (both packages)              OK
rpcclient          full package       ok    1.1s
rpcsmartrouter     full package       ok   87.5s
```

Nothing regressed, including the pre-existing `TestListenForUpstreamMessages_ReconnectSkipsCleanup`, which covers the same function.

One note for reviewers: the new test asserts on `upstreamSub == nil` rather than `require.NotNil`. Testify unwraps typed nils via reflection and reports this value as nil, while Go's own comparison reports it non-nil — and it is precisely that gap which let the nil reach `Err()`.

## Not covered

`createUpstreamSubscription` has no direct unit test because `conn.GetClient()` returns a concrete `*rpcclient.Client`; faking `Subscribe` would need an interface extraction that felt out of scope for a crash fix. The two tests cover the panic site and the guards.

## Provenance

Surfaced by the lava-specs spec-pipeline Phase 8 probe on Magma-Devs/lava-specs#106 (Paseo Asset Hub testnet), which probed `author_submitAndWatchExtrinsic` over `ws://localhost:3360/ws` with `["0x00"]`. Ten of twelve subscribe probes in the same session were unaffected — they succeeded, so a real subscription came back.

Worth re-probing `transactionWatch_v1_submitAndWatch` on that PR once this lands; it is currently `NOT_RETESTED` because it was skipped to avoid re-triggering this crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
