### PR TITLE
feat(smart-router/debug): add POST /debug/poll-now (MAG-2649)

### DIFF
--- a/protocol/chaintracker/chain_tracker.go
+++ b/protocol/chaintracker/chain_tracker.go
@@ -47,6 +47,11 @@ type IChainTracker interface {
 	// only (MAG-2395).
 	CurrentPollInterval() time.Duration
 
+	// PollNow runs ONE dedicated poll cycle immediately — the same cycle the cadence timer runs —
+	// and returns once its result has been recorded (debug trigger for /debug/poll-now, MAG-2649).
+	// Cadence is untouched: it neither consumes nor advances the failure backoff.
+	PollNow(ctx context.Context) error
+
 	// StartAndServe starts the chain tracker and serves gRPC if configured
 	StartAndServe(ctx context.Context) error
 
@@ -160,6 +165,20 @@ type ChainTracker struct {
 	// reschedule the next poll at base cadence. Buffered(1) with a non-blocking send in
 	// ResetBackoff, so /debug/reset-probe-backoff never blocks on the poll goroutine (MAG-2395).
 	resetBackoffCh chan struct{}
+	// pollNowCh hands an out-of-band "poll right now" request to the poll goroutine, which runs the
+	// ordinary cycle and replies when its result is recorded (MAG-2649 / /debug/poll-now). It is
+	// UNBUFFERED and handled by the same select as the timer, which is the point: the cycle keeps
+	// exactly ONE writer, so the unlocked single-goroutine state it mutates (relaySkipsSinceRealPoll
+	// here, blockCheckpoint in fetchAllPreviousBlocks) is never raced by a debug caller.
+	pollNowCh chan pollNowRequest
+}
+
+// pollNowRequest is one PollNow trigger in flight to the poll goroutine. resp is buffered(1) so
+// the goroutine's reply never blocks it, even when the requester has already abandoned the wait
+// on a cancelled context. There is no context here on purpose: the poll goroutine bounds the
+// fetch with the TRACKER's context (see the pollNowCh case in start), exactly as the timer does.
+type pollNowRequest struct {
+	resp chan error
 }
 
 func (cs *ChainTracker) IsDummy() bool {
@@ -435,7 +454,13 @@ func (cs *ChainTracker) gotNewBlock(ctx context.Context, newLatestBlock int64) (
 // backoff (MAG-2159 follow-up). Conflating the two (skip → err==nil → "success") let every gated
 // cycle cancel a broken poll path's backoff, so a doomed poll never backed off and its recovery
 // evidence never accrued.
-func (cs *ChainTracker) fetchAllPreviousBlocksIfNecessary(ctx context.Context) (skipped bool, err error) {
+//
+// force skips the traffic-gate check so the cycle always reaches upstream. Only PollNow
+// (/debug/poll-now, MAG-2649) passes true: an on-demand trigger that silently no-ops because a
+// relay tip happens to be fresh would be useless to the caller waiting on its result. The cadence
+// timer passes false and is unaffected. It is a parameter rather than a second copy of this
+// function deliberately — one body means the forced poll IS the production poll.
+func (cs *ChainTracker) fetchAllPreviousBlocksIfNecessary(ctx context.Context, force bool) (skipped bool, err error) {
 	// Traffic gate (MAG-2159 / Topic B). When a fresh relay-harvested tip already covers this
 	// endpoint, the whole poll cycle is redundant — skip it: no FetchLatestBlockNum AND no
 	// fork-check FetchBlockHashByNum (forkChanged fetches a hash every tick, even when the block
@@ -446,7 +471,7 @@ func (cs *ChainTracker) fetchAllPreviousBlocksIfNecessary(ctx context.Context) (
 	// maxRelaySkipsBeforePoll consecutive skips we force one real poll for independent
 	// fork/liveness verification. relaySkipsSinceRealPoll is touched only by this single poll
 	// goroutine. The global tracker leaves relayTipFresh nil and never skips.
-	if cs.relayTipFresh != nil && cs.relaySkipsSinceRealPoll < cs.maxRelaySkipsBeforePoll && cs.relayTipFresh(time.Now()) {
+	if !force && cs.relayTipFresh != nil && cs.relaySkipsSinceRealPoll < cs.maxRelaySkipsBeforePoll && cs.relayTipFresh(time.Now()) {
 		cs.relaySkipsSinceRealPoll++
 		return true, nil
 	}
@@ -627,7 +652,7 @@ func (cs *ChainTracker) start(ctx context.Context, pollingTime time.Duration) er
 			case <-cs.timer.C:
 				fetchTimeout := max(10*time.Second, common.MinimumTimePerRelayDelay)
 				fetchCtx, cancel := context.WithTimeout(ctx, fetchTimeout) // protect this flow from hanging code
-				skipped, err := cs.fetchAllPreviousBlocksIfNecessary(fetchCtx)
+				skipped, err := cs.fetchAllPreviousBlocksIfNecessary(fetchCtx, false)
 				cancel()
 				// A gate skip PRESERVES fetchFails (see nextFetchFails): it proved nothing about poll
 				// health, so it must not cancel a broken poll path's backoff. The reschedule uses the
@@ -650,6 +675,34 @@ func (cs *ChainTracker) start(ctx context.Context, pollingTime time.Duration) er
 				if enoughSamples {
 					blockGapTicker.Reset(pollingTime * 10)
 				}
+			case req := <-cs.pollNowCh:
+				// /debug/poll-now (MAG-2649): run the SAME cycle the timer case above runs, right
+				// now, on this same goroutine. The caller therefore observes the real production
+				// poll — same parse, same observation/failure-streak/tip writes — with only the wait
+				// for the timer removed, and the cycle's unlocked state keeps a single writer.
+				// force=true bypasses the traffic gate (see fetchAllPreviousBlocksIfNecessary); the
+				// cycle still resets relaySkipsSinceRealPoll, because a real poll genuinely happened.
+				//
+				// Cadence is deliberately NOT touched: fetchFails is left alone and updateTimer is
+				// not called, so a forced poll never moves the schedule the cadence tests measure.
+				// This is the mirror of ResetBackoff (cadence only, data untouched). The poll's own
+				// failure counter — the observation record's ConsecutivePollFailures — is still
+				// updated, by the shared record path, exactly as on a timer-driven poll.
+				//
+				// If the timer fires while this fetch is in flight its tick is buffered and runs
+				// immediately after, producing two back-to-back polls. That is already true of any
+				// poll slower than the cadence and is harmless: each is a real, separately recorded
+				// poll.
+				//
+				// The fetch is bounded by the TRACKER's context and timeout, not the requester's:
+				// same bound as the timer case (fidelity), and a shutdown still cancels the fetch
+				// promptly. The requester's context governs only how long IT waits — a caller that
+				// gives up leaves the poll to finish and record, which is honest: it did happen.
+				fetchTimeout := max(10*time.Second, common.MinimumTimePerRelayDelay)
+				fetchCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
+				_, pollErr := cs.fetchAllPreviousBlocksIfNecessary(fetchCtx, true)
+				cancel()
+				req.resp <- pollErr // buffered(1): never blocks, even if the requester gave up
 			case <-cs.resetBackoffCh:
 				// /debug/reset-probe-backoff (MAG-2395): clear the failure backoff and reschedule the
 				// next poll at base cadence. Cadence only — block data, observations, and the
@@ -686,6 +739,41 @@ func (cs *ChainTracker) ResetBackoff() {
 	select {
 	case cs.resetBackoffCh <- struct{}{}:
 	default:
+	}
+}
+
+// PollNow runs one dedicated poll cycle immediately and returns once that poll's result has been
+// recorded — the synchronous test trigger behind /debug/poll-now (MAG-2649). It removes the wait
+// for the cadence timer and nothing else: the cycle it runs IS
+// fetchAllPreviousBlocksIfNecessary, the same function the timer calls, executed on the same poll
+// goroutine, so the parse, the observation write (block, source, failure streak, last-successful
+// stamp) and the tip update are the production ones. All of those complete before the reply is
+// sent, which is what makes "poll now, then read the result" race-free for the caller.
+//
+// The returned error is the poll's own error (a failed poll is a legitimate, recorded outcome —
+// callers that need to tell "the poll failed" from "no poll ran" should test the two sentinels
+// below with errors.Is):
+//   - ErrorPollNowNotDelivered — the poll goroutine never took the request before ctx expired:
+//     the tracker has not finished starting, is retrying its init, or has been stopped. NOTHING
+//     was polled and no observation was written.
+//   - ErrorPollNowUnsupported — this tracker cannot poll at all (DummyChainTracker).
+//
+// Deliberately NOT for cadence tests: it neither resets nor deepens the failure backoff and never
+// reschedules the timer. It does reset the traffic gate's skip budget, because it performs a real
+// poll — so it must not be called inside a test measuring the skip ceiling (MAG-2159).
+func (cs *ChainTracker) PollNow(ctx context.Context) error {
+	req := pollNowRequest{resp: make(chan error, 1)}
+	select {
+	case cs.pollNowCh <- req:
+	case <-ctx.Done():
+		return fmt.Errorf("%w: %w", ErrorPollNowNotDelivered, ctx.Err())
+	}
+	select {
+	case err := <-req.resp:
+		return err
+	case <-ctx.Done():
+		// The poll was accepted and is still running; it will finish and record on its own.
+		return fmt.Errorf("poll started but its result was not awaited: %w", ctx.Err())
 	}
 }
 
@@ -891,6 +979,7 @@ func newCustomChainTracker(chainFetcher ChainFetcher, config ChainTrackerConfig)
 		maxRelaySkipsBeforePoll: maxRelaySkips,
 		endpoint:                endpoint,
 		resetBackoffCh:          make(chan struct{}, 1),
+		pollNowCh:               make(chan pollNowRequest), // unbuffered: handled by the poll goroutine only
 	}
 	// Publish the base cadence up front so /debug/endpoint-state reports a sensible PollIntervalMs
 	// before the first poll reschedules it (0 for the legacy global tracker, which is not a

--- a/protocol/chaintracker/chain_tracker.go
+++ b/protocol/chaintracker/chain_tracker.go
@@ -52,6 +52,11 @@ type IChainTracker interface {
 	// Cadence is untouched: it neither consumes nor advances the failure backoff.
 	PollNow(ctx context.Context) error
 
+	// PollNowWithDeliveryDeadline is PollNow with a separate, usually shorter, bound on the wait for
+	// the poll goroutine to take the request — for a caller that suspects there is no goroutine to
+	// take it. resultCtx still bounds the cycle itself (MAG-2649).
+	PollNowWithDeliveryDeadline(deliveryCtx, resultCtx context.Context) error
+
 	// StartAndServe starts the chain tracker and serves gRPC if configured
 	StartAndServe(ctx context.Context) error
 
@@ -751,29 +756,54 @@ func (cs *ChainTracker) ResetBackoff() {
 // sent, which is what makes "poll now, then read the result" race-free for the caller.
 //
 // The returned error is the poll's own error (a failed poll is a legitimate, recorded outcome —
-// callers that need to tell "the poll failed" from "no poll ran" should test the two sentinels
-// below with errors.Is):
+// callers that need to tell "the poll failed" from "no poll ran" should test the sentinels below
+// with errors.Is). Each sentinel says something different about whether the caller may trust a
+// record it reads afterwards:
 //   - ErrorPollNowNotDelivered — the poll goroutine never took the request before ctx expired:
 //     the tracker has not finished starting, is retrying its init, or has been stopped. NOTHING
 //     was polled and no observation was written.
 //   - ErrorPollNowUnsupported — this tracker cannot poll at all (DummyChainTracker).
+//   - ErrorPollNowResultNotAwaited — the request WAS taken and the cycle is running, but ctx
+//     expired before it recorded. The poll completes and writes regardless; this caller simply did
+//     not witness it, so anything it reads back is the PRE-poll record. Never report this as a
+//     completed poll.
 //
 // Deliberately NOT for cadence tests: it neither resets nor deepens the failure backoff and never
 // reschedules the timer. It does reset the traffic gate's skip budget, because it performs a real
 // poll — so it must not be called inside a test measuring the skip ceiling (MAG-2159).
 func (cs *ChainTracker) PollNow(ctx context.Context) error {
+	return cs.pollNow(ctx, ctx)
+}
+
+// PollNowWithDeliveryDeadline is PollNow with the two waits bounded separately: deliveryCtx caps
+// only how long we wait for the poll goroutine to TAKE the request, and resultCtx caps the wait
+// for the cycle it then runs.
+//
+// The split exists because those two waits have unrelated natural lengths. Delivery either happens
+// in microseconds (the goroutine is at its select) or never (there is no goroutine yet), so a
+// caller that suspects the latter wants a short deadline. The cycle itself is bounded by the
+// tracker's own fetch timeout — max(10s, MinimumTimePerRelayDelay) — so applying that same short
+// deadline to the result would routinely abandon a poll that was proceeding normally, and the
+// caller would then read a pre-poll record. See EndpointMonitor.PollNow, the one caller.
+func (cs *ChainTracker) PollNowWithDeliveryDeadline(deliveryCtx, resultCtx context.Context) error {
+	return cs.pollNow(deliveryCtx, resultCtx)
+}
+
+func (cs *ChainTracker) pollNow(deliveryCtx, resultCtx context.Context) error {
 	req := pollNowRequest{resp: make(chan error, 1)}
 	select {
 	case cs.pollNowCh <- req:
-	case <-ctx.Done():
-		return fmt.Errorf("%w: %w", ErrorPollNowNotDelivered, ctx.Err())
+	case <-deliveryCtx.Done():
+		return fmt.Errorf("%w: %w", ErrorPollNowNotDelivered, deliveryCtx.Err())
 	}
 	select {
 	case err := <-req.resp:
 		return err
-	case <-ctx.Done():
-		// The poll was accepted and is still running; it will finish and record on its own.
-		return fmt.Errorf("poll started but its result was not awaited: %w", ctx.Err())
+	case <-resultCtx.Done():
+		// The poll was accepted and is still running; it will finish and record on its own. Sentinel,
+		// not a bare error: the caller has to be able to tell this from a poll that ran and failed,
+		// because the observation it can read right now is the one from BEFORE this poll.
+		return fmt.Errorf("%w: %w", ErrorPollNowResultNotAwaited, resultCtx.Err())
 	}
 }
 

--- a/protocol/chaintracker/chain_tracker_gate_test.go
+++ b/protocol/chaintracker/chain_tracker_gate_test.go
@@ -104,7 +104,7 @@ func TestTrafficGate_FullCycle_UpstreamCallCounts(t *testing.T) {
 					fetcher := &countingGateFetcher{}
 					ct := newGateTracker(t, chain.chainID, fetcher, sc.relayFresh, maxSkips)
 					for i := 0; i < cycles; i++ {
-						_, _ = ct.fetchAllPreviousBlocksIfNecessary(context.Background())
+						_, _ = ct.fetchAllPreviousBlocksIfNecessary(context.Background(), false)
 					}
 					require.Equal(t, sc.wantUpstream, fetcher.upstreamCalls(),
 						"%s/%s: total upstream calls over %d cycles", chain.name, sc.name, cycles)
@@ -126,7 +126,7 @@ func TestTrafficGate_BoundedVerification(t *testing.T) {
 	// First maxSkips cycles skip — zero upstream, and each reports skipped=true so the caller
 	// can preserve (not reset) the poll-failure backoff.
 	for i := 0; i < maxSkips; i++ {
-		skipped, err := ct.fetchAllPreviousBlocksIfNecessary(context.Background())
+		skipped, err := ct.fetchAllPreviousBlocksIfNecessary(context.Background(), false)
 		require.NoError(t, err)
 		require.True(t, skipped, "cycle %d is a gate skip, reported as such (not a successful poll)", i)
 		require.Equal(t, int32(0), fetcher.upstreamCalls(), "cycle %d must skip (no upstream)", i)
@@ -134,7 +134,7 @@ func TestTrafficGate_BoundedVerification(t *testing.T) {
 	}
 
 	// The next cycle is forced to poll for real (the fetcher errors, proving it ran upstream).
-	skipped, err := ct.fetchAllPreviousBlocksIfNecessary(context.Background())
+	skipped, err := ct.fetchAllPreviousBlocksIfNecessary(context.Background(), false)
 	require.False(t, skipped, "the forced verification cycle is a real poll, not a skip")
 	require.Error(t, err, "after maxSkips skips the cycle must force a real poll")
 	require.Equal(t, int32(1), fetcher.latestCalls.Load(), "exactly one real latest-block poll was forced")
@@ -148,7 +148,7 @@ func TestTrafficGate_NilGate_GlobalTrackerAlwaysPolls(t *testing.T) {
 	fetcher := &countingGateFetcher{}
 	ct := newGateTracker(t, "ETH1", fetcher, nil, defaultMaxRelaySkipsBeforePoll)
 	for i := 0; i < 5; i++ {
-		skipped, _ := ct.fetchAllPreviousBlocksIfNecessary(context.Background())
+		skipped, _ := ct.fetchAllPreviousBlocksIfNecessary(context.Background(), false)
 		require.False(t, skipped, "an ungated tracker never skips")
 	}
 	require.Equal(t, int32(5), fetcher.latestCalls.Load(), "an ungated tracker polls every cycle")
@@ -199,11 +199,11 @@ func TestFlatTracker_SkipsBlockGapMachinery(t *testing.T) {
 	// Drive several real block advances through the poll path. The first advance has a zero
 	// prevChangeTime (no sample either way); the rest would each append a blockEventsGap sample
 	// on a NON-flat tracker. The flat tracker must append none.
-	_, err := ct.fetchAllPreviousBlocksIfNecessary(context.Background())
+	_, err := ct.fetchAllPreviousBlocksIfNecessary(context.Background(), false)
 	require.NoError(t, err)
 	for i := 0; i < 5; i++ {
 		fetcher.block.Add(1)
-		_, err := ct.fetchAllPreviousBlocksIfNecessary(context.Background())
+		_, err := ct.fetchAllPreviousBlocksIfNecessary(context.Background(), false)
 		require.NoError(t, err)
 	}
 	require.Empty(t, ct.blockEventsGap, "a flat tracker must not accumulate block-gap samples")

--- a/protocol/chaintracker/chain_tracker_nil_oldblockcallback_test.go
+++ b/protocol/chaintracker/chain_tracker_nil_oldblockcallback_test.go
@@ -73,7 +73,7 @@ func TestFetchAllPreviousBlocksIfNecessary_UpstreamTimeoutIsHandled(t *testing.T
 		}
 	}()
 
-	gotSkipped, gotErr := cs.fetchAllPreviousBlocksIfNecessary(context.Background())
+	gotSkipped, gotErr := cs.fetchAllPreviousBlocksIfNecessary(context.Background(), false)
 	require.False(t, gotSkipped, "an upstream timeout is a real poll attempt, not a gate skip")
 	require.Error(t, gotErr, "an upstream latest-block timeout should surface as an error, not crash the router")
 	require.True(t, errors.Is(gotErr, context.DeadlineExceeded), "the returned error should preserve the upstream deadline cause")

--- a/protocol/chaintracker/dummy_chain_tracker.go
+++ b/protocol/chaintracker/dummy_chain_tracker.go
@@ -42,6 +42,12 @@ func (dct *DummyChainTracker) CurrentPollInterval() time.Duration { return 0 }
 // test that a poll completed when none can ever run here (MAG-2649).
 func (dct *DummyChainTracker) PollNow(ctx context.Context) error { return ErrorPollNowUnsupported }
 
+// PollNowWithDeliveryDeadline is unsupported for the same reason as PollNow: neither deadline can
+// matter when there is no poll loop to deliver to.
+func (dct *DummyChainTracker) PollNowWithDeliveryDeadline(deliveryCtx, resultCtx context.Context) error {
+	return ErrorPollNowUnsupported
+}
+
 // StartAndServe starts the chain tracker and serves gRPC if configured
 func (dct *DummyChainTracker) StartAndServe(ctx context.Context) error {
 	return nil

--- a/protocol/chaintracker/dummy_chain_tracker.go
+++ b/protocol/chaintracker/dummy_chain_tracker.go
@@ -37,6 +37,11 @@ func (dct *DummyChainTracker) ResetBackoff() {}
 // CurrentPollInterval is 0 for the dummy tracker; it schedules no polls.
 func (dct *DummyChainTracker) CurrentPollInterval() time.Duration { return 0 }
 
+// PollNow always fails for the dummy tracker: it has no poll loop, so there is nothing to run on
+// demand. Reporting that honestly (rather than returning nil) keeps /debug/poll-now from telling a
+// test that a poll completed when none can ever run here (MAG-2649).
+func (dct *DummyChainTracker) PollNow(ctx context.Context) error { return ErrorPollNowUnsupported }
+
 // StartAndServe starts the chain tracker and serves gRPC if configured
 func (dct *DummyChainTracker) StartAndServe(ctx context.Context) error {
 	return nil

--- a/protocol/chaintracker/errors.go
+++ b/protocol/chaintracker/errors.go
@@ -20,4 +20,12 @@ var ( // Consumer Side Errors
 	// instead of a silent nil so a /debug/poll-now caller never mistakes "nothing polls here" for a
 	// completed poll and reads a stale record as fresh (MAG-2649).
 	ErrorPollNowUnsupported = errors.New("this chain tracker does not poll, poll-now is unsupported")
+	// ErrorPollNowResultNotAwaited means the poll goroutine TOOK the request but the caller's
+	// context expired before the cycle finished recording. The poll itself is unaffected — it runs
+	// to completion and writes its observation — but this caller never saw that happen, so any
+	// record it reads back predates the poll. Distinct from ErrorPollNowNotDelivered on purpose:
+	// "a poll is running and I cannot tell you what it recorded" is a different claim from "no poll
+	// ran", and only a sentinel makes the two distinguishable to errors.Is. Both must map to
+	// "do not trust the record" at the debug boundary (MAG-2649).
+	ErrorPollNowResultNotAwaited = errors.New("poll-now started but its result was not awaited")
 )

--- a/protocol/chaintracker/errors.go
+++ b/protocol/chaintracker/errors.go
@@ -12,4 +12,12 @@ var ( // Consumer Side Errors
 	RequestedBlocksOutOfRange       = errors.New("requested blocks are outside the supported range by the state tracker")
 	ErrorFailedToFetchTooEarlyBlock = errors.New("server memory protection triggered, requested block is too early")
 	InvalidRequestedSpecificBlock   = errors.New("provided requested specific blocks for function do not compose a stored entry")
+	// ErrorPollNowNotDelivered means a PollNow request was never taken by the poll goroutine before
+	// the caller's context expired — the tracker is still starting, is retrying its init, or has
+	// stopped. No poll ran and no observation was written (MAG-2649).
+	ErrorPollNowNotDelivered = errors.New("poll-now was not picked up by the poll loop")
+	// ErrorPollNowUnsupported means the tracker cannot poll at all (DummyChainTracker). Returned
+	// instead of a silent nil so a /debug/poll-now caller never mistakes "nothing polls here" for a
+	// completed poll and reads a stale record as fresh (MAG-2649).
+	ErrorPollNowUnsupported = errors.New("this chain tracker does not poll, poll-now is unsupported")
 )

--- a/protocol/chaintracker/poll_now_internal_test.go
+++ b/protocol/chaintracker/poll_now_internal_test.go
@@ -8,6 +8,7 @@ package chaintracker
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -155,6 +156,128 @@ func TestChainTracker_PollNow_NoPollLoop_ReportsNotDelivered(t *testing.T) {
 // polls nothing must say so, never report a silent success.
 func TestDummyChainTracker_PollNow_Unsupported(t *testing.T) {
 	require.ErrorIs(t, (&DummyChainTracker{}).PollNow(context.Background()), ErrorPollNowUnsupported)
+	require.ErrorIs(t, (&DummyChainTracker{}).PollNowWithDeliveryDeadline(context.Background(), context.Background()),
+		ErrorPollNowUnsupported)
+}
+
+// TestChainTracker_PollNow_TakenButNotAwaited_IsItsOwnSentinel separates the two ways a poll-now can
+// time out. Here the request IS taken — the goroutine is at its select — and the cycle then outlives
+// the caller's budget. That must NOT surface as ErrorPollNowNotDelivered (nothing ran) and must not
+// surface as a bare error either: a bare error is indistinguishable from "the poll ran and failed
+// upstream", and the two license opposite things. Only the not-awaited sentinel tells a caller that
+// a record read now predates the poll.
+func TestChainTracker_PollNow_TakenButNotAwaited_IsItsOwnSentinel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	fetcher := newBlockingFetcher()
+	fetcher.block.Store(1000)
+	ct := newPollNowTracker(t, ctx, fetcher)
+
+	// Block the cycle mid-fetch so it cannot finish inside the caller's budget, then release it.
+	fetcher.hold.Store(true)
+	defer fetcher.release()
+
+	callerCtx, callerCancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer callerCancel()
+
+	err := ct.PollNow(callerCtx)
+	require.ErrorIs(t, err, ErrorPollNowResultNotAwaited)
+	require.NotErrorIs(t, err, ErrorPollNowNotDelivered, "the request WAS taken; only the result was not awaited")
+	require.ErrorIs(t, err, context.DeadlineExceeded, "the cause is preserved for the operator")
+	require.Equal(t, int64(1000), ct.GetAtomicLatestBlockNum(),
+		"nothing is recorded yet — which is exactly why the caller must not be told a poll completed")
+
+	// The abandoned poll is not cancelled by the caller giving up — it is bounded by the TRACKER's
+	// context. It finishes and records, which is why the caller must be told not to trust the record
+	// it can read right now rather than being told nothing happened.
+	fetcher.block.Store(1007)
+	fetcher.release()
+	require.Eventually(t, func() bool { return ct.GetAtomicLatestBlockNum() == 1007 },
+		10*time.Second, 20*time.Millisecond, "the abandoned poll still completes on the tracker's own budget")
+}
+
+// TestChainTracker_PollNowWithDeliveryDeadline_BoundsDeliveryOnly is the MAG-2649 review fix: a
+// caller that suspects there is no poll goroutine may cap the wait for one to TAKE its request
+// without also capping the cycle. Before the split, one context bounded both, so a short delivery
+// deadline silently truncated healthy polls — and the caller, holding neither sentinel, reported the
+// pre-poll record as fresh. Here the delivery deadline is far shorter than the poll: delivery
+// succeeds, the cycle is awaited on the full budget, and the poll completes normally.
+func TestChainTracker_PollNowWithDeliveryDeadline_BoundsDeliveryOnly(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	fetcher := &slowFetcher{delay: 300 * time.Millisecond}
+	fetcher.block.Store(1000)
+	ct := newPollNowTracker(t, ctx, fetcher)
+
+	fetcher.block.Store(1005)
+	deliveryCtx, cancelDelivery := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer cancelDelivery()
+
+	// 50 ms of delivery budget against a cycle that spends ~600 ms fetching.
+	require.NoError(t, ct.PollNowWithDeliveryDeadline(deliveryCtx, ctx),
+		"the delivery deadline must not reach the cycle it delivers")
+	require.Equal(t, int64(1005), ct.GetAtomicLatestBlockNum(), "the poll ran to completion and recorded")
+
+	// And it still reports non-delivery when there genuinely is no receiver.
+	unstarted := newCustomChainTracker(&advancingFetcher{}, ChainTrackerConfig{
+		BlocksToSave: 1, AverageBlockTime: time.Minute, ServerBlockMemory: 100,
+		ChainId: "ETH1", ParseDirectiveEnabled: true, FlatPollInterval: 30 * time.Second,
+	})
+	shortCtx, cancelShort := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancelShort()
+	require.ErrorIs(t, unstarted.PollNowWithDeliveryDeadline(shortCtx, ctx), ErrorPollNowNotDelivered)
+}
+
+// blockingFetcher holds FetchLatestBlockNum open until released, so a test can keep a poll cycle
+// in flight across the caller's deadline. Release is idempotent, so a test can both defer it and
+// call it explicitly.
+type blockingFetcher struct {
+	advancingFetcher
+	hold      atomic.Bool
+	releaseCh chan struct{}
+	once      sync.Once
+}
+
+func newBlockingFetcher() *blockingFetcher {
+	return &blockingFetcher{releaseCh: make(chan struct{})}
+}
+
+func (f *blockingFetcher) FetchLatestBlockNum(ctx context.Context) (int64, error) {
+	if f.hold.Load() {
+		select {
+		case <-f.releaseCh:
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		}
+	}
+	return f.advancingFetcher.FetchLatestBlockNum(ctx)
+}
+
+func (f *blockingFetcher) release() {
+	f.once.Do(func() { f.hold.Store(false); close(f.releaseCh) })
+}
+
+// slowFetcher makes every fetch take a fixed, real amount of time, so a test can compare a poll
+// cycle's duration against a deadline that is supposed to bound only the delivery before it.
+type slowFetcher struct {
+	advancingFetcher
+	delay time.Duration
+}
+
+func (f *slowFetcher) FetchLatestBlockNum(ctx context.Context) (int64, error) {
+	if err := sleepCtx(ctx, f.delay); err != nil {
+		return 0, err
+	}
+	return f.advancingFetcher.FetchLatestBlockNum(ctx)
+}
+
+func (f *slowFetcher) FetchBlockHashByNum(ctx context.Context, blockNum int64) (string, error) {
+	if err := sleepCtx(ctx, f.delay); err != nil {
+		return "", err
+	}
+	return f.advancingFetcher.FetchBlockHashByNum(ctx, blockNum)
 }
 
 // TestChainTracker_PollNow_ConcurrentTriggersAllComplete pins the queueing behaviour the debug

--- a/protocol/chaintracker/poll_now_internal_test.go
+++ b/protocol/chaintracker/poll_now_internal_test.go
@@ -1,0 +1,184 @@
+package chaintracker
+
+// Internal (white-box) tests for the MAG-2649 poll-now trigger. They assert the three properties
+// the debug endpoint's usefulness rests on: the forced poll is the REAL cycle (it advances the
+// tracker the same way a timer-driven poll does), it does not disturb the poll CADENCE, and it
+// bypasses the traffic gate so the trigger can never silently no-op.
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// failableFetcher is an advancingFetcher (chain_tracker_gate_test.go) whose fetches can be broken
+// at will, so a test can drive a healthy tracker into a FAILED poll without failing its init.
+type failableFetcher struct {
+	advancingFetcher
+	fail atomic.Bool
+}
+
+func (f *failableFetcher) FetchLatestBlockNum(ctx context.Context) (int64, error) {
+	if f.fail.Load() {
+		return 0, fmt.Errorf("injected poll failure")
+	}
+	return f.advancingFetcher.FetchLatestBlockNum(ctx)
+}
+
+func (f *failableFetcher) FetchBlockHashByNum(ctx context.Context, blockNum int64) (string, error) {
+	if f.fail.Load() {
+		return "", fmt.Errorf("injected poll failure")
+	}
+	return f.advancingFetcher.FetchBlockHashByNum(ctx, blockNum)
+}
+
+// newPollNowTracker builds a started per-endpoint tracker whose cadence is far longer than any
+// test could wait (10 minutes). Anything the tracker observes during the test therefore came from
+// a poll-now trigger, not from the timer.
+func newPollNowTracker(t *testing.T, ctx context.Context, fetcher ChainFetcher) *ChainTracker {
+	t.Helper()
+	const unreachableCadence = 10 * time.Minute
+	tracker := newCustomChainTracker(fetcher, ChainTrackerConfig{
+		BlocksToSave:          1,
+		AverageBlockTime:      2 * unreachableCadence,
+		ServerBlockMemory:     100,
+		ChainId:               "ETH1",
+		ParseDirectiveEnabled: true,
+		FlatPollInterval:      unreachableCadence,
+	})
+	ct, ok := tracker.(*ChainTracker)
+	require.True(t, ok)
+	require.NoError(t, ct.StartAndServe(ctx), "init fetch must succeed so the poll goroutine runs")
+	return ct
+}
+
+// TestChainTracker_PollNow_RunsRealCycleWithoutWaitingForTimer is the headline MAG-2649 check: on a
+// tracker whose next scheduled poll is 10 minutes out, PollNow makes the block advance land NOW —
+// and it lands through the real cycle (the tracker's own latest-block state moves, which only
+// fetchAllPreviousBlocksIfNecessary does), not through some fetch-only shortcut.
+func TestChainTracker_PollNow_RunsRealCycleWithoutWaitingForTimer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fetcher := &advancingFetcher{}
+	fetcher.block.Store(1000)
+	ct := newPollNowTracker(t, ctx, fetcher)
+	require.Equal(t, int64(1000), ct.GetAtomicLatestBlockNum(), "init seeds the tracker at the first block")
+
+	fetcher.block.Store(1005)
+
+	start := time.Now()
+	require.NoError(t, ct.PollNow(ctx))
+	require.Less(t, time.Since(start), 30*time.Second, "poll-now must not wait for the cadence timer")
+	require.Equal(t, int64(1005), ct.GetAtomicLatestBlockNum(),
+		"the forced poll ran the full cycle and advanced the tracker's latest block")
+}
+
+// TestChainTracker_PollNow_LeavesCadenceUntouched pins the deliberate limit (MAG-2649): poll-now is
+// "data only, cadence untouched" — the mirror of ResetBackoff's "cadence only, data untouched". A
+// FAILED forced poll must not stretch the poll interval, because a timer-driven failure would, and
+// tests that measure backoff growth have to stay able to measure it.
+func TestChainTracker_PollNow_LeavesCadenceUntouched(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fetcher := &failableFetcher{}
+	fetcher.block.Store(1000)
+	ct := newPollNowTracker(t, ctx, fetcher)
+	baseInterval := ct.CurrentPollInterval()
+	require.Positive(t, baseInterval)
+
+	fetcher.fail.Store(true)
+	require.Error(t, ct.PollNow(ctx), "a broken upstream surfaces as the poll's own error")
+	require.Equal(t, baseInterval, ct.CurrentPollInterval(),
+		"a failed poll-now must not deepen the failure backoff")
+
+	fetcher.fail.Store(false)
+	require.NoError(t, ct.PollNow(ctx))
+	require.Equal(t, baseInterval, ct.CurrentPollInterval(),
+		"a successful poll-now must not reschedule the timer either")
+}
+
+// TestChainTracker_PollNow_BypassesTrafficGate proves the force flag: with a permanently-fresh
+// relay tip the ordinary cycle skips (no upstream call at all), while the forced cycle polls for
+// real. Without this a poll-now issued right after a set-up relay would silently no-op — the one
+// failure mode that would make the endpoint useless. The forced poll still resets the gate's skip
+// budget, since a real poll did happen.
+func TestChainTracker_PollNow_BypassesTrafficGate(t *testing.T) {
+	fetcher := &countingGateFetcher{}
+	ct := newGateTracker(t, "ETH1", fetcher, func(time.Time) bool { return true }, defaultMaxRelaySkipsBeforePoll)
+
+	skipped, err := ct.fetchAllPreviousBlocksIfNecessary(context.Background(), false)
+	require.True(t, skipped, "a fresh relay tip skips the ordinary cycle")
+	require.NoError(t, err)
+	require.Equal(t, int32(0), fetcher.upstreamCalls(), "a skipped cycle makes no upstream call")
+	require.Equal(t, 1, ct.relaySkipsSinceRealPoll)
+
+	skipped, err = ct.fetchAllPreviousBlocksIfNecessary(context.Background(), true)
+	require.False(t, skipped, "the forced cycle is never gated")
+	require.Error(t, err, "the counting fetcher errors, proving the forced cycle reached upstream")
+	require.Equal(t, int32(1), fetcher.latestCalls.Load(), "exactly one forced latest-block poll")
+	require.Equal(t, 0, ct.relaySkipsSinceRealPoll, "a real poll restores the skip budget")
+}
+
+// TestChainTracker_PollNow_NoPollLoop_ReportsNotDelivered covers the tracker that cannot poll yet
+// (never started, still retrying its init, or stopped). The caller must get the distinct
+// "nothing ran" sentinel promptly instead of a hang or — far worse — a nil error that would let a
+// test read the untouched previous record as a fresh poll result.
+func TestChainTracker_PollNow_NoPollLoop_ReportsNotDelivered(t *testing.T) {
+	fetcher := &advancingFetcher{}
+	fetcher.block.Store(1000)
+	tracker := newCustomChainTracker(fetcher, ChainTrackerConfig{
+		BlocksToSave:          1,
+		AverageBlockTime:      time.Minute,
+		ServerBlockMemory:     100,
+		ChainId:               "ETH1",
+		ParseDirectiveEnabled: true,
+		FlatPollInterval:      30 * time.Second,
+	}) // deliberately NOT started: no poll goroutine exists
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := tracker.PollNow(ctx)
+	require.ErrorIs(t, err, ErrorPollNowNotDelivered)
+	require.ErrorIs(t, err, context.DeadlineExceeded, "the cause is preserved for the operator")
+	require.Less(t, time.Since(start), 5*time.Second, "the trigger gives up on its own deadline")
+}
+
+// TestDummyChainTracker_PollNow_Unsupported guards the honest-failure contract: a tracker that
+// polls nothing must say so, never report a silent success.
+func TestDummyChainTracker_PollNow_Unsupported(t *testing.T) {
+	require.ErrorIs(t, (&DummyChainTracker{}).PollNow(context.Background()), ErrorPollNowUnsupported)
+}
+
+// TestChainTracker_PollNow_ConcurrentTriggersAllComplete pins the queueing behaviour the debug
+// handler depends on: the poll goroutine serves triggers one at a time, and every caller gets its
+// own answer rather than one of them being dropped or blocking the loop forever.
+func TestChainTracker_PollNow_ConcurrentTriggersAllComplete(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	fetcher := &advancingFetcher{}
+	fetcher.block.Store(1000)
+	ct := newPollNowTracker(t, ctx, fetcher)
+
+	const callers = 4
+	errs := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		go func() { errs <- ct.PollNow(ctx) }()
+	}
+	for i := 0; i < callers; i++ {
+		select {
+		case err := <-errs:
+			require.NoError(t, err)
+		case <-ctx.Done():
+			t.Fatal("a concurrent poll-now trigger was never answered")
+		}
+	}
+}

--- a/protocol/endpointstate/endpoint_monitor.go
+++ b/protocol/endpointstate/endpoint_monitor.go
@@ -30,11 +30,16 @@ const (
 	defaultTrackerStartRetryMax = 30 * time.Second
 	trackerStartRetryJitterDiv  = 5
 
-	// pollNowUnstartedGrace bounds how long PollNow waits on a tracker that is not yet Polling
-	// (MAG-2649). Such a tracker has no poll goroutine to receive the trigger, so waiting out the
-	// caller's full budget only delays a verdict that will not change. Comfortably longer than the
-	// microseconds a live goroutine needs to take the send, so it never cuts short a tracker whose
-	// state merely lagged.
+	// pollNowUnstartedGrace bounds how long PollNow waits for a tracker that is not yet Polling to
+	// TAKE the trigger (MAG-2649). Such a tracker has no poll goroutine to receive it, so waiting out
+	// the caller's full budget only delays a verdict that will not change. Comfortably longer than
+	// the microseconds a live goroutine needs to take the send, so it never cuts short a tracker
+	// whose state merely lagged.
+	//
+	// Delivery only. It deliberately does NOT bound the poll cycle that follows: that is bounded by
+	// the tracker's own fetch timeout, max(10s, MinimumTimePerRelayDelay), which is several times
+	// this grace. Capping both with this value would abandon healthy polls mid-flight and leave the
+	// caller reading a pre-poll record.
 	pollNowUnstartedGrace = 2 * time.Second
 )
 
@@ -591,14 +596,21 @@ func (m *EndpointMonitor) BackoffSnapshot() map[string]time.Duration {
 // /debug/poll-now). It exists so a test can set a provider's state, trigger the poll, and read the
 // result — instead of waiting out the per-endpoint cadence (avgBlockTime/2).
 //
-// polled reports whether the poll CYCLE ACTUALLY RAN. It separates the two outcomes a caller must
-// never conflate:
+// polled reports whether THE RETURNED OBSERVATION IS THIS POLL'S. It is the caller's licence to
+// trust the record, and it separates outcomes that must never be conflated:
 //   - polled=true with a non-nil err — a real poll reached (or tried to reach) upstream and
 //     failed. The observation records that failure, exactly as a timer-driven failure would:
 //     ConsecutivePollFailures incremented, LastSuccessfulPoll untouched.
-//   - polled=false — no poll happened at all (no tracker for this URL, the tracker is still
-//     starting/retrying its init, or it is a non-polling dummy). The returned observation is
-//     whatever was already on record and says nothing about now.
+//   - polled=false — the observation predates this call and says nothing about now. Either no poll
+//     happened at all (no tracker for this URL, the tracker is still starting/retrying its init, or
+//     it is a non-polling dummy), or one was started and outlived the caller's budget. err
+//     distinguishes them; both mean the same thing about the record.
+//
+// That second case is why polled is phrased around the RECORD rather than around the cycle. A poll
+// whose result was not awaited did run — it finishes and writes on its own — but this call cannot
+// say what it wrote, and the record available now is the one from before it. Reporting that as
+// polled=true would hand a harness a pre-poll block and a pre-poll failure streak while telling it
+// both were fresh, which is precisely the confusion this endpoint exists to remove.
 //
 // The tracker's poll goroutine takes m.mu during a block-advancing cycle (newLatestCallback →
 // setTrackerState), so the lock is released BEFORE the trigger — holding it across the wait would
@@ -621,27 +633,42 @@ func (m *EndpointMonitor) PollNow(ctx context.Context, endpointURL string) (obse
 	// otherwise burn the caller's whole budget waiting for a receiver that does not exist. Cap that
 	// wait instead. Deliberately a shorter DEADLINE and not a rejection: the state can lag the
 	// goroutine by a hair (it flips to Polling just after start returns), and in that window the
-	// send is taken instantly anyway, so nothing that could have succeeded is refused. A Polling
-	// tracker keeps the full budget — it may legitimately be mid-cycle on a slow upstream.
-	attemptCtx := ctx
+	// send is taken instantly anyway, so nothing that could have succeeded is refused.
+	//
+	// The grace bounds DELIVERY ONLY. Once the goroutine has the request, the cycle it runs is
+	// bounded by the tracker's own fetch timeout — several times this grace — and is awaited on the
+	// caller's full budget, exactly as for a tracker that was already Polling. Bounding both with
+	// the grace would turn the lagging-state window into the worst outcome of all: the send taken,
+	// the poll running, and the caller timing out on a healthy cycle with a pre-poll record in hand.
+	deliveryCtx := ctx
 	if stateBefore != EndpointChainTrackerPolling {
-		var cancelAttempt context.CancelFunc
-		attemptCtx, cancelAttempt = context.WithTimeout(ctx, pollNowUnstartedGrace)
-		defer cancelAttempt()
+		var cancelDelivery context.CancelFunc
+		deliveryCtx, cancelDelivery = context.WithTimeout(ctx, pollNowUnstartedGrace)
+		defer cancelDelivery()
 	}
 
-	pollErr := tracker.PollNow(attemptCtx)
+	pollErr := tracker.PollNowWithDeliveryDeadline(deliveryCtx, ctx)
 	// Report the record either way: on a failed poll it carries the failure the caller came to
-	// observe, and on a non-delivery it is the untouched prior state.
+	// observe, and otherwise it is the prior state, flagged as such by polled=false.
 	observation, _ = m.GetObservation(endpointURL)
 
-	// Undelivered/unsupported means no cycle ran. Name the tracker's lifecycle state in the error —
-	// "retrying_start" is a diagnosis, a bare timeout is not.
-	if errors.Is(pollErr, chaintracker.ErrorPollNowNotDelivered) || errors.Is(pollErr, chaintracker.ErrorPollNowUnsupported) {
+	// Three ways to end up holding a record this call cannot vouch for. Undelivered/unsupported mean
+	// no cycle ran; not-awaited means one is running but wrote after we read. All three must report
+	// polled=false — the caller's question is "may I trust this record", not "did a goroutine move".
+	// Name the tracker's lifecycle state in the error: "retrying_start" is a diagnosis, a bare
+	// timeout is not.
+	if errors.Is(pollErr, chaintracker.ErrorPollNowNotDelivered) || errors.Is(pollErr, chaintracker.ErrorPollNowUnsupported) ||
+		errors.Is(pollErr, chaintracker.ErrorPollNowResultNotAwaited) {
 		// Read the state HERE, not before the attempt: what matters to whoever is diagnosing is the
-		// tracker's state at the moment it failed to take the request.
+		// tracker's state at the moment the attempt gave out.
 		state, _, _ := m.GetTrackerState(endpointURL)
-		return observation, false, utils.LavaFormatError("poll-now: no poll ran", pollErr,
+		message := "poll-now: no poll ran"
+		if errors.Is(pollErr, chaintracker.ErrorPollNowResultNotAwaited) {
+			// Distinct message because the operator response is distinct: nothing is wrong with the
+			// tracker, the budget was too short for this upstream.
+			message = "poll-now: a poll is running but its result was not awaited; the record below predates it"
+		}
+		return observation, false, utils.LavaFormatError(message, pollErr,
 			utils.LogAttr("endpoint", endpointURL),
 			utils.LogAttr("chainID", m.chainID),
 			utils.LogAttr("trackerState", string(state)),

--- a/protocol/endpointstate/endpoint_monitor.go
+++ b/protocol/endpointstate/endpoint_monitor.go
@@ -2,6 +2,7 @@ package endpointstate
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -28,6 +29,13 @@ const (
 	defaultTrackerStartRetryMin = time.Second
 	defaultTrackerStartRetryMax = 30 * time.Second
 	trackerStartRetryJitterDiv  = 5
+
+	// pollNowUnstartedGrace bounds how long PollNow waits on a tracker that is not yet Polling
+	// (MAG-2649). Such a tracker has no poll goroutine to receive the trigger, so waiting out the
+	// caller's full budget only delays a verdict that will not change. Comfortably longer than the
+	// microseconds a live goroutine needs to take the send, so it never cuts short a tracker whose
+	// state merely lagged.
+	pollNowUnstartedGrace = 2 * time.Second
 )
 
 type EndpointChainTrackerState string
@@ -576,6 +584,70 @@ func (m *EndpointMonitor) BackoffSnapshot() map[string]time.Duration {
 		out[url] = t.CurrentPollInterval()
 	}
 	return out
+}
+
+// PollNow forces ONE endpoint's ChainTracker to run its dedicated poll immediately and returns
+// that endpoint's observation record once the poll's result has been written (MAG-2649, behind
+// /debug/poll-now). It exists so a test can set a provider's state, trigger the poll, and read the
+// result — instead of waiting out the per-endpoint cadence (avgBlockTime/2).
+//
+// polled reports whether the poll CYCLE ACTUALLY RAN. It separates the two outcomes a caller must
+// never conflate:
+//   - polled=true with a non-nil err — a real poll reached (or tried to reach) upstream and
+//     failed. The observation records that failure, exactly as a timer-driven failure would:
+//     ConsecutivePollFailures incremented, LastSuccessfulPoll untouched.
+//   - polled=false — no poll happened at all (no tracker for this URL, the tracker is still
+//     starting/retrying its init, or it is a non-polling dummy). The returned observation is
+//     whatever was already on record and says nothing about now.
+//
+// The tracker's poll goroutine takes m.mu during a block-advancing cycle (newLatestCallback →
+// setTrackerState), so the lock is released BEFORE the trigger — holding it across the wait would
+// deadlock the monitor against its own poll loop the first time a poll observed a new block.
+func (m *EndpointMonitor) PollNow(ctx context.Context, endpointURL string) (observation EndpointObservation, polled bool, err error) {
+	m.mu.RLock()
+	tracker, exists := m.trackers[endpointURL]
+	stateBefore := m.trackerStates[endpointURL]
+	m.mu.RUnlock()
+
+	if !exists {
+		return EndpointObservation{}, false, utils.LavaFormatError("poll-now: no ChainTracker for endpoint", nil,
+			utils.LogAttr("endpoint", endpointURL),
+			utils.LogAttr("chainID", m.chainID),
+		)
+	}
+
+	// A tracker that is not yet Polling has no poll goroutine to take the request — start() spawns
+	// it only after the init fetch succeeds — so an endpoint stuck retrying a dead upstream would
+	// otherwise burn the caller's whole budget waiting for a receiver that does not exist. Cap that
+	// wait instead. Deliberately a shorter DEADLINE and not a rejection: the state can lag the
+	// goroutine by a hair (it flips to Polling just after start returns), and in that window the
+	// send is taken instantly anyway, so nothing that could have succeeded is refused. A Polling
+	// tracker keeps the full budget — it may legitimately be mid-cycle on a slow upstream.
+	attemptCtx := ctx
+	if stateBefore != EndpointChainTrackerPolling {
+		var cancelAttempt context.CancelFunc
+		attemptCtx, cancelAttempt = context.WithTimeout(ctx, pollNowUnstartedGrace)
+		defer cancelAttempt()
+	}
+
+	pollErr := tracker.PollNow(attemptCtx)
+	// Report the record either way: on a failed poll it carries the failure the caller came to
+	// observe, and on a non-delivery it is the untouched prior state.
+	observation, _ = m.GetObservation(endpointURL)
+
+	// Undelivered/unsupported means no cycle ran. Name the tracker's lifecycle state in the error —
+	// "retrying_start" is a diagnosis, a bare timeout is not.
+	if errors.Is(pollErr, chaintracker.ErrorPollNowNotDelivered) || errors.Is(pollErr, chaintracker.ErrorPollNowUnsupported) {
+		// Read the state HERE, not before the attempt: what matters to whoever is diagnosing is the
+		// tracker's state at the moment it failed to take the request.
+		state, _, _ := m.GetTrackerState(endpointURL)
+		return observation, false, utils.LavaFormatError("poll-now: no poll ran", pollErr,
+			utils.LogAttr("endpoint", endpointURL),
+			utils.LogAttr("chainID", m.chainID),
+			utils.LogAttr("trackerState", string(state)),
+		)
+	}
+	return observation, true, pollErr
 }
 
 // RemoveTracker removes and stops a ChainTracker for an endpoint.

--- a/protocol/endpointstate/poll_now_test.go
+++ b/protocol/endpointstate/poll_now_test.go
@@ -1,0 +1,264 @@
+package endpointstate
+
+// End-to-end tests for the MAG-2649 poll-now trigger, driven through a REAL ChainTracker built by
+// GetOrCreateTracker — so the production poll callbacks (observation record, endpoint tip,
+// tracker-state write) are all wired exactly as in the router.
+//
+// Two of these are load-bearing beyond their assertions:
+//   - the block ADVANCES between polls, which is what makes the tracker fire newLatestCallback →
+//     setTrackerState → m.mu.Lock() inside the poll cycle. PollNow must therefore have released the
+//     monitor lock before waiting on the tracker; a version that holds it deadlocks here and would
+//     pass against a mock returning a constant block.
+//   - the failure case asserts the observation's ConsecutivePollFailures, which is the ticket's
+//     "running count of failed polls" — recorded by the shared production path, not by poll-now.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// pollNowConn answers the two ETH poll requests (eth_blockNumber and eth_getBlockByNumber) from a
+// live block counter, so a test can move the chain forward between polls. Hashes are derived from
+// the REQUESTED block, not the current head, so re-reading an older block returns the same hash it
+// had (a head-derived hash would look like a fork on every advance). fail breaks the transport.
+type pollNowConn struct {
+	url   string
+	block atomic.Int64
+	fail  atomic.Bool
+}
+
+func (c *pollNowConn) SendRequest(ctx context.Context, data []byte, headers map[string]string) (*lavasession.DirectRPCResponse, error) {
+	if c.fail.Load() {
+		return nil, errors.New("pollNowConn: upstream unreachable")
+	}
+	request := string(data)
+	if strings.Contains(request, "eth_getBlockByNumber") {
+		return &lavasession.DirectRPCResponse{
+			Data:       []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"result":{"hash":"0x%064x"}}`, requestedBlockOf(request))),
+			StatusCode: 200,
+		}, nil
+	}
+	return &lavasession.DirectRPCResponse{
+		Data:       []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"result":"0x%x"}`, c.block.Load())),
+		StatusCode: 200,
+	}, nil
+}
+
+func (c *pollNowConn) GetProtocol() lavasession.DirectRPCProtocol {
+	return lavasession.DirectRPCProtocolHTTP
+}
+func (c *pollNowConn) Close() error                { return nil }
+func (c *pollNowConn) GetURL() string              { return c.url }
+func (c *pollNowConn) GetNodeUrl() *common.NodeUrl { return nil }
+
+// requestedBlockOf pulls the block number out of an eth_getBlockByNumber body
+// ({"params":["0x3e8", false]}). Returns 0 when it cannot be read, which still yields a stable
+// hash — the tests never depend on the value itself, only on it being per-block.
+func requestedBlockOf(request string) int64 {
+	var body struct {
+		Params []json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal([]byte(request), &body); err != nil || len(body.Params) == 0 {
+		return 0
+	}
+	var blockHex string
+	if err := json.Unmarshal(body.Params[0], &blockHex); err != nil {
+		return 0
+	}
+	block, err := strconv.ParseInt(strings.TrimPrefix(blockHex, "0x"), 16, 64)
+	if err != nil {
+		return 0
+	}
+	return block
+}
+
+// newPollNowMonitor wires a monitor + one live ETH tracker whose cadence (avgBlockTime/2 = 30 s) is
+// far beyond the test's lifetime, so nothing the test observes can come from the timer. It returns
+// once the tracker is actually polling, i.e. its init succeeded and the poll goroutine exists.
+func newPollNowMonitor(t *testing.T, ctx context.Context, url string, startBlock int64) (*EndpointMonitor, *pollNowConn) {
+	t.Helper()
+	ensureRandSeeded()
+
+	m := NewEndpointMonitor(ctx, EndpointChainTrackerConfig{
+		ChainParser:      newRealChainParser(t, "ETH1", spectypes.APIInterfaceJsonRPC),
+		ChainID:          "ETH1",
+		ApiInterface:     spectypes.APIInterfaceJsonRPC,
+		AverageBlockTime: time.Minute,
+		BlocksToSave:     1,
+	})
+	require.NotNil(t, m)
+
+	conn := &pollNowConn{url: url}
+	conn.block.Store(startBlock)
+	_, err := m.GetOrCreateTracker(&lavasession.Endpoint{NetworkAddress: url, Enabled: true}, conn)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		state, _, exists := m.GetTrackerState(url)
+		return exists && state == EndpointChainTrackerPolling
+	}, 10*time.Second, 20*time.Millisecond, "the tracker must reach its poll loop before poll-now is triggered")
+
+	return m, conn
+}
+
+// TestEndpointMonitor_PollNow_RecordsAdvancedBlockImmediately is the MAG-2649 end-to-end proof: a
+// block that appears after the last poll is observed and recorded the moment poll-now is called,
+// with the tracker's next scheduled poll still ~30 s away. It also proves the trigger records what
+// the ticket lists — block, source, and the successful-poll stamp — via the production path.
+func TestEndpointMonitor_PollNow_RecordsAdvancedBlockImmediately(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const url = "http://eth-pollnow:8545"
+	m, conn := newPollNowMonitor(t, ctx, url, 1000)
+	defer m.Stop()
+
+	before, ok := m.GetObservation(url)
+	require.True(t, ok)
+	require.Equal(t, int64(1000), before.LatestBlock, "the init poll seeds the record")
+
+	conn.block.Store(1042) // a new head arrives; nothing has polled it yet
+
+	obs, polled, err := m.PollNow(ctx, url)
+	require.NoError(t, err)
+	require.True(t, polled)
+	require.Equal(t, int64(1042), obs.LatestBlock, "poll-now observed the new head without waiting for the timer")
+	require.Equal(t, ObservationSourcePoll, obs.Source)
+	require.True(t, obs.LastSuccessfulPoll.After(before.LastSuccessfulPoll), "a successful poll re-stamps LastSuccessfulPoll")
+	require.Equal(t, 0, obs.ConsecutivePollFailures)
+	require.Empty(t, obs.LastPollError)
+}
+
+// TestEndpointMonitor_PollNow_FailedPollIsRecordedAsFailure covers the outcome a test asserting on
+// the failure streak needs: the poll RAN (polled=true) and failed, so the streak advances while the
+// last-good block and success stamp are left alone. This is the ticket's "running count of failed
+// polls", written by recordPollObservation exactly as on a timer-driven failure.
+func TestEndpointMonitor_PollNow_FailedPollIsRecordedAsFailure(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const url = "http://eth-pollnow-fail:8545"
+	m, conn := newPollNowMonitor(t, ctx, url, 2000)
+	defer m.Stop()
+
+	good, ok := m.GetObservation(url)
+	require.True(t, ok)
+
+	conn.fail.Store(true)
+	obs, polled, err := m.PollNow(ctx, url)
+	require.True(t, polled, "the cycle ran and reached upstream — it just failed there")
+	require.Error(t, err)
+	require.Equal(t, 1, obs.ConsecutivePollFailures, "the failure streak advances")
+	require.NotEmpty(t, obs.LastPollError)
+	require.Equal(t, good.LatestBlock, obs.LatestBlock, "a failed poll observes no new block")
+	require.Equal(t, good.LastSuccessfulPoll, obs.LastSuccessfulPoll, "a failed poll does not stamp success")
+
+	obs, polled, err = m.PollNow(ctx, url)
+	require.True(t, polled)
+	require.Error(t, err)
+	require.Equal(t, 2, obs.ConsecutivePollFailures, "consecutive forced failures keep accumulating")
+
+	// And recovery clears it, through the same record path.
+	conn.fail.Store(false)
+	obs, polled, err = m.PollNow(ctx, url)
+	require.NoError(t, err)
+	require.True(t, polled)
+	require.Equal(t, 0, obs.ConsecutivePollFailures, "a successful poll resets the streak")
+}
+
+// TestEndpointMonitor_PollNow_ForcesPastAFreshRelayTip composes the two halves the pytest suite
+// actually uses in sequence: serve a relay (which harvests a tip and arms the traffic gate), then
+// trigger a poll. The ordinary cycle would SKIP here — a relay-sourced tip younger than
+// relayGateFreshness suppresses it — so without the force this endpoint would return the pre-relay
+// record and the trigger would look broken. The forced poll goes upstream anyway and records.
+func TestEndpointMonitor_PollNow_ForcesPastAFreshRelayTip(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const url = "http://eth-pollnow-gated:8545"
+	m, conn := newPollNowMonitor(t, ctx, url, 3000)
+	defer m.Stop()
+
+	// A served relay harvests the current tip — exactly what the router's relay path does.
+	gen, ok := m.ObservationGeneration(url)
+	require.True(t, ok)
+	require.True(t, m.RecordRelayObservation(url, gen, 3000, time.Now()))
+	require.Condition(t, func() bool {
+		_, fresh := m.freshRelayTip(url, time.Now())
+		return fresh
+	}, "the fixture must actually arm the traffic gate, or this test proves nothing")
+
+	conn.block.Store(3050)
+
+	obs, polled, err := m.PollNow(ctx, url)
+	require.NoError(t, err)
+	require.True(t, polled, "a fresh relay tip must not turn the trigger into a silent skip")
+	require.Equal(t, int64(3050), obs.LatestBlock)
+	require.Equal(t, ObservationSourcePoll, obs.Source, "the forced poll is the source of the new tip")
+}
+
+// TestEndpointMonitor_PollNow_UnknownEndpoint: an endpoint with no ChainTracker reports "nothing
+// polled" rather than an empty success, so the debug handler can answer 404/504 honestly instead of
+// handing back a zero record that reads like a fresh poll.
+func TestEndpointMonitor_PollNow_UnknownEndpoint(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := NewEndpointMonitor(ctx, EndpointChainTrackerConfig{
+		ChainID:          "ETH1",
+		ApiInterface:     spectypes.APIInterfaceJsonRPC,
+		AverageBlockTime: time.Minute,
+		BlocksToSave:     1,
+	})
+	defer m.Stop()
+
+	obs, polled, err := m.PollNow(ctx, "http://never-registered:8545")
+	require.Error(t, err)
+	require.False(t, polled)
+	require.Equal(t, EndpointObservation{}, obs)
+}
+
+// TestEndpointMonitor_PollNow_TrackerNotPolling_NamesTheState covers the endpoint that is
+// registered but cannot poll yet (its init keeps failing, so it sits in startTrackerWithRetry). The
+// caller must learn WHY nothing ran — the tracker's lifecycle state is named in the error — instead
+// of being handed a bare timeout.
+func TestEndpointMonitor_PollNow_TrackerNotPolling_NamesTheState(t *testing.T) {
+	ensureRandSeeded()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := NewEndpointMonitor(ctx, EndpointChainTrackerConfig{
+		ChainParser:      newRealChainParser(t, "ETH1", spectypes.APIInterfaceJsonRPC),
+		ChainID:          "ETH1",
+		ApiInterface:     spectypes.APIInterfaceJsonRPC,
+		AverageBlockTime: 200 * time.Millisecond, // fail init fast rather than spacing retries out
+		BlocksToSave:     1,
+	})
+	defer m.Stop()
+
+	const url = "http://eth-pollnow-dead:8545"
+	conn := &pollNowConn{url: url}
+	conn.fail.Store(true) // every fetch fails → init never completes → no poll goroutine
+	_, err := m.GetOrCreateTracker(&lavasession.Endpoint{NetworkAddress: url, Enabled: true}, conn)
+	require.NoError(t, err)
+
+	triggerCtx, triggerCancel := context.WithTimeout(ctx, 300*time.Millisecond)
+	defer triggerCancel()
+
+	_, polled, err := m.PollNow(triggerCtx, url)
+	require.False(t, polled, "no poll can run while the tracker is still trying to start")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "trackerState", "the error names the tracker's lifecycle state")
+}

--- a/protocol/endpointstate/poll_now_test.go
+++ b/protocol/endpointstate/poll_now_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/magma-Devs/smart-router/protocol/chaintracker"
 	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
 	spectypes "github.com/magma-Devs/smart-router/types/spec"
@@ -33,13 +34,25 @@ import (
 // live block counter, so a test can move the chain forward between polls. Hashes are derived from
 // the REQUESTED block, not the current head, so re-reading an older block returns the same hash it
 // had (a head-derived hash would look like a fork on every advance). fail breaks the transport.
+// delayNanos, when set, makes every request take that long — the knob the deadline-split tests use
+// to build a poll cycle that outlives a short deadline.
 type pollNowConn struct {
-	url   string
-	block atomic.Int64
-	fail  atomic.Bool
+	url        string
+	block      atomic.Int64
+	fail       atomic.Bool
+	delayNanos atomic.Int64
 }
 
 func (c *pollNowConn) SendRequest(ctx context.Context, data []byte, headers map[string]string) (*lavasession.DirectRPCResponse, error) {
+	if delay := time.Duration(c.delayNanos.Load()); delay > 0 {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
 	if c.fail.Load() {
 		return nil, errors.New("pollNowConn: upstream unreachable")
 	}
@@ -260,5 +273,90 @@ func TestEndpointMonitor_PollNow_TrackerNotPolling_NamesTheState(t *testing.T) {
 	_, polled, err := m.PollNow(triggerCtx, url)
 	require.False(t, polled, "no poll can run while the tracker is still trying to start")
 	require.Error(t, err)
+	require.ErrorIs(t, err, chaintracker.ErrorPollNowNotDelivered, "nothing was taken, so nothing ran")
 	require.Contains(t, err.Error(), "trackerState", "the error names the tracker's lifecycle state")
+}
+
+// TestEndpointMonitor_PollNow_LaggingTrackerStateDoesNotTruncateThePoll is the MAG-2649 review
+// regression, and it covers precisely the window the unstarted-grace comment claims is safe.
+//
+// The grace fires whenever trackerStates says anything but Polling. That includes the moment right
+// after StartAndServe returns, when the poll goroutine is already at its select but the state write
+// has not landed — so the send is taken instantly and a full poll cycle then runs under the grace.
+// While one context bounded both waits, that cycle was abandoned at 2 s even though nothing was
+// wrong with it, the error carried no sentinel, and PollNow reported polled=true over the PRE-poll
+// record: a stale block and a stale failure streak, both labelled fresh. Worse than the refusal the
+// grace exists to avoid.
+//
+// The fixture forces the lagging state deliberately rather than trying to hit the real race, which
+// is microseconds wide. What it reproduces is the same code path with the same inputs.
+func TestEndpointMonitor_PollNow_LaggingTrackerStateDoesNotTruncateThePoll(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const url = "http://eth-pollnow-lagging:8545"
+	m, conn := newPollNowMonitor(t, ctx, url, 7000)
+	defer m.Stop()
+
+	// A cycle that comfortably outlives the 2 s grace: two fetches at 1.5 s each.
+	conn.delayNanos.Store(int64(1500 * time.Millisecond))
+	require.Greater(t, 2*1500*time.Millisecond, pollNowUnstartedGrace,
+		"the fixture only proves anything while the poll outlasts the grace")
+
+	// The lagging window: the goroutine is polling, the recorded state has not caught up.
+	m.mu.Lock()
+	m.trackerStates[url] = EndpointChainTrackerStarting
+	m.mu.Unlock()
+
+	conn.block.Store(7042)
+
+	obs, polled, err := m.PollNow(ctx, url)
+	require.NoError(t, err, "a healthy poll must not be cut short by a deadline meant for delivery")
+	require.True(t, polled)
+	require.Equal(t, int64(7042), obs.LatestBlock,
+		"polled=true must mean the returned record is THIS poll's, never the one from before it")
+	require.Equal(t, ObservationSourcePoll, obs.Source)
+}
+
+// TestEndpointMonitor_PollNow_ResultNotAwaited_ReportsNotPolled covers the outcome that survives the
+// deadline split: the caller's own budget really is too short for the cycle. The poll is under way
+// and will record, but this call cannot say what it recorded — so it must report polled=false.
+//
+// The alternative is the bug this pair of tests exists to prevent. polled=true alongside a PollError
+// means, per the handler's documented vocabulary, "a poll reached upstream and failed, and
+// ConsecutivePollFailures went up". A harness reading that asserts on a failure streak that was
+// never recorded, off a record that predates the call entirely.
+func TestEndpointMonitor_PollNow_ResultNotAwaited_ReportsNotPolled(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const url = "http://eth-pollnow-slow:8545"
+	m, conn := newPollNowMonitor(t, ctx, url, 8000)
+	defer m.Stop()
+
+	before, ok := m.GetObservation(url)
+	require.True(t, ok)
+
+	conn.delayNanos.Store(int64(2 * time.Second))
+	conn.block.Store(8080)
+
+	// Delivery is instant (the tracker is Polling); it is the cycle that outlives this budget.
+	shortCtx, shortCancel := context.WithTimeout(ctx, 400*time.Millisecond)
+	defer shortCancel()
+
+	obs, polled, err := m.PollNow(shortCtx, url)
+	require.False(t, polled, "an unwitnessed poll must never be reported as a completed one")
+	require.ErrorIs(t, err, chaintracker.ErrorPollNowResultNotAwaited)
+	require.NotErrorIs(t, err, chaintracker.ErrorPollNowNotDelivered, "the trigger WAS delivered")
+	require.Equal(t, before.LatestBlock, obs.LatestBlock, "the record handed back is the pre-poll one")
+	require.Equal(t, before.ConsecutivePollFailures, obs.ConsecutivePollFailures,
+		"and its failure streak is the pre-poll one too — the field a harness would have misread")
+
+	// The abandoned poll is bounded by the tracker, not the caller: it finishes and records. Proving
+	// that is what makes polled=false the honest answer rather than an under-report.
+	conn.delayNanos.Store(0)
+	require.Eventually(t, func() bool {
+		latest, found := m.GetObservation(url)
+		return found && latest.LatestBlock == 8080
+	}, 15*time.Second, 20*time.Millisecond, "the poll the caller stopped waiting for still completed")
 }

--- a/protocol/rpcsmartrouter/debug_poll_now_test.go
+++ b/protocol/rpcsmartrouter/debug_poll_now_test.go
@@ -1,0 +1,215 @@
+package rpcsmartrouter
+
+// HTTP-contract tests for POST /debug/poll-now (MAG-2649). The poll mechanics themselves are
+// proven at the layers that own them (chaintracker.TestChainTracker_PollNow_* and
+// endpointstate.TestEndpointMonitor_PollNow_*); here we pin what the test harness actually codes
+// against: the request/response shape, the status codes, and — end to end over a real HTTP
+// upstream — that a block appearing after the last poll is reflected in the response body.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/endpointstate"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	rand "github.com/magma-Devs/smart-router/utils/rand"
+	"github.com/stretchr/testify/require"
+)
+
+func postDebugJSON(mux http.Handler, path, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestDebugPollNow_MethodNotAllowed(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano})
+
+	rr := getDebugRouter(mux, "/debug/poll-now") // GET on a POST-only endpoint
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}
+
+// TestDebugPollNow_RejectsUnusableRequests: the two ways a caller can ask for nothing in
+// particular are refused up front, before any tracker is touched.
+func TestDebugPollNow_RejectsUnusableRequests(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano})
+
+	require.Equal(t, http.StatusBadRequest, postDebugJSON(mux, "/debug/poll-now", `{not json`).Code)
+	require.Equal(t, http.StatusBadRequest, postDebugJSON(mux, "/debug/poll-now", `{"chain_id":"ETH1"}`).Code,
+		"network_address is required — poll-now targets one endpoint, never 'whatever matches'")
+}
+
+// TestDebugPollNow_UnknownEndpointIs404: an address with no ChainTracker (including every address
+// on a fixture with no router wired) is a 404, not a 200 with an empty row that a harness could
+// mistake for a completed poll.
+func TestDebugPollNow_UnknownEndpointIs404(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano, router: nil})
+
+	rr := postDebugJSON(mux, "/debug/poll-now", `{"network_address":"http://not-registered:8545"}`)
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+// TestDebugPollNow_TrackerNotPollingIs504 covers the one status code with real logic behind it: an
+// endpoint whose tracker is registered but cannot poll (its upstream is dead, so init never
+// completes and no poll goroutine exists). The handler must say so in the status line AND in the
+// row — a 200 here would let a harness read an untouched record as a fresh poll result.
+func TestDebugPollNow_TrackerNotPollingIs504(t *testing.T) {
+	if !rand.Initialized() {
+		rand.InitRandomSeed()
+	}
+	ctx := t.Context()
+
+	monitor := endpointstate.NewEndpointMonitor(ctx, endpointstate.EndpointChainTrackerConfig{
+		ChainParser:      newRealChainParserForHarvest(t, "ETH1"),
+		ChainID:          "ETH1",
+		ApiInterface:     "jsonrpc",
+		AverageBlockTime: 200 * time.Millisecond, // fail init fast instead of spacing retries out
+		BlocksToSave:     1,
+	})
+	t.Cleanup(monitor.Stop)
+
+	// A closed port: registration is synchronous (so the endpoint IS resolvable), but every fetch
+	// fails, so the tracker never leaves startTrackerWithRetry and no poll goroutine exists.
+	const deadURL = "http://127.0.0.1:0"
+	directConn, err := lavasession.NewDirectRPCConnection(ctx, common.NodeUrl{Url: deadURL}, 5, "jsonrpc")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = directConn.Close() })
+	_, err = monitor.GetOrCreateTracker(&lavasession.Endpoint{NetworkAddress: deadURL, Enabled: true}, directConn)
+	require.NoError(t, err)
+
+	var offsetNano atomic.Int64
+	router := &RPCSmartRouter{
+		rpcServers: map[string]*RPCSmartRouterServer{
+			"ETH1-jsonrpc": {
+				endpointChainTrackerManager: monitor,
+				listenEndpoint:              &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"},
+			},
+		},
+	}
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano, router: router})
+
+	rr := postDebugJSON(mux, "/debug/poll-now", fmt.Sprintf(`{"network_address":%q}`, deadURL))
+	require.Equal(t, http.StatusGatewayTimeout, rr.Code, "body=%q", rr.Body.String())
+	require.Equal(t, "application/json", rr.Header().Get("Content-Type"), "the body is still JSON on the failure path")
+
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	require.Equal(t, false, rows[0]["Polled"])
+	require.NotEmpty(t, rows[0]["TriggerError"], "the row explains why no poll ran")
+	require.Equal(t, "", rows[0]["PollError"], "no poll ran, so there is no poll error to report")
+}
+
+// newPollNowUpstream serves the two ETH poll requests from a live block counter, so a test can move
+// the chain forward between polls. The block hash is derived from the REQUESTED block so re-reading
+// an older block returns the hash it already had (a head-derived hash would look like a fork).
+func newPollNowUpstream(t *testing.T, block *atomic.Int64) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Method string            `json:"method"`
+			Params []json.RawMessage `json:"params"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.Header().Set("Content-Type", "application/json")
+		if body.Method == "eth_getBlockByNumber" {
+			var blockHex string
+			if len(body.Params) > 0 {
+				_ = json.Unmarshal(body.Params[0], &blockHex)
+			}
+			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":1,"result":{"hash":"0x%064s"}}`, strings.TrimPrefix(blockHex, "0x"))
+			return
+		}
+		fmt.Fprintf(w, `{"jsonrpc":"2.0","id":1,"result":"0x%x"}`, block.Load())
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// TestDebugPollNow_PollsEndpointAndReturnsFreshRecord is the end-to-end contract check: with the
+// tracker's next scheduled poll 30 s away, a block that appears now shows up in the poll-now
+// response — proving the endpoint delivers what the ticket asks for (set up state → trigger → read,
+// no waiting) all the way through a real HTTP upstream and the real poll cycle.
+func TestDebugPollNow_PollsEndpointAndReturnsFreshRecord(t *testing.T) {
+	if !rand.Initialized() {
+		rand.InitRandomSeed()
+	}
+	ctx := t.Context()
+
+	var block atomic.Int64
+	block.Store(5000)
+	upstream := newPollNowUpstream(t, &block)
+
+	monitor := endpointstate.NewEndpointMonitor(ctx, endpointstate.EndpointChainTrackerConfig{
+		ChainParser:      newRealChainParserForHarvest(t, "ETH1"),
+		ChainID:          "ETH1",
+		ApiInterface:     "jsonrpc",
+		AverageBlockTime: time.Minute, // → a 30 s dedicated-poll cadence: nothing here comes from the timer
+		BlocksToSave:     1,
+	})
+	t.Cleanup(monitor.Stop)
+
+	directConn, err := lavasession.NewDirectRPCConnection(ctx, common.NodeUrl{Url: upstream.URL}, 5, "jsonrpc")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = directConn.Close() })
+
+	_, err = monitor.GetOrCreateTracker(&lavasession.Endpoint{NetworkAddress: upstream.URL, Enabled: true}, directConn)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		state, _, exists := monitor.GetTrackerState(upstream.URL)
+		return exists && state == endpointstate.EndpointChainTrackerPolling
+	}, 10*time.Second, 20*time.Millisecond, "the tracker must be polling before poll-now is triggered")
+
+	var offsetNano atomic.Int64
+	router := &RPCSmartRouter{
+		rpcServers: map[string]*RPCSmartRouterServer{
+			"ETH1-jsonrpc": {
+				endpointChainTrackerManager: monitor,
+				listenEndpoint:              &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"},
+			},
+			"NIL-rest": {}, // no monitor, no listen endpoint: skipped, never a panic
+		},
+	}
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano, router: router})
+
+	block.Store(5123) // a new head, which nothing has polled yet
+
+	rr := postDebugJSON(mux, "/debug/poll-now", fmt.Sprintf(`{"network_address":%q}`, upstream.URL))
+	require.Equal(t, http.StatusOK, rr.Code, "body=%q", rr.Body.String())
+	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	row := rows[0]
+	require.Equal(t, "ETH1", row["ChainID"])
+	require.Equal(t, "jsonrpc", row["ApiInterface"])
+	require.Equal(t, upstream.URL, row["NetworkAddress"])
+	require.Equal(t, true, row["Polled"])
+	require.Equal(t, "", row["PollError"])
+	require.Equal(t, "", row["TriggerError"])
+	require.Equal(t, float64(5123), row["LatestBlock"], "the response carries the block the forced poll just observed")
+	require.Equal(t, "poll", row["Source"])
+	require.Equal(t, float64(0), row["ConsecutivePollFailures"])
+	require.NotEmpty(t, row["LastSuccessfulPoll"])
+	require.NotEmpty(t, row["ObservedAt"])
+
+	// The optional filters narrow the match; a wrong chain matches nothing rather than polling the
+	// endpoint anyway.
+	rr = postDebugJSON(mux, "/debug/poll-now", fmt.Sprintf(`{"network_address":%q,"chain_id":"eth1","api_interface":"jsonrpc"}`, upstream.URL))
+	require.Equal(t, http.StatusOK, rr.Code, "chain_id/api_interface match case-insensitively")
+	rr = postDebugJSON(mux, "/debug/poll-now", fmt.Sprintf(`{"network_address":%q,"chain_id":"SOLANA"}`, upstream.URL))
+	require.Equal(t, http.StatusNotFound, rr.Code, "a filter that matches no server polls nothing")
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -1401,11 +1401,17 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 	// Body: {"network_address": "<url>"} — required; optional "chain_id" / "api_interface" narrow
 	// the match when the same URL is registered on more than one chain or interface. The response is
 	// a row per matched endpoint (see /debug/endpoint-state for the shared field vocabulary), plus:
-	//   Polled       — the poll cycle actually ran. False means nothing was polled (tracker still
-	//                  starting, retrying its init, or stopped) and the record below is stale.
+	//   Polled       — the record in this row IS this poll's, and may be trusted as fresh. False
+	//                  means the record predates the call and says nothing about now: either nothing
+	//                  was polled (tracker still starting, retrying its init, or stopped), or a poll
+	//                  was started and did not finish inside the handler's budget. Assert on this
+	//                  before reading any other field.
 	//   PollError    — the poll ran and failed upstream. That is a legitimate outcome to assert on
 	//                  (it is what increments ConsecutivePollFailures), so it answers 200, not 5xx.
-	//   TriggerError — why no poll could be started, including the tracker's lifecycle state.
+	//                  Only ever set alongside Polled=true, so the pair cannot describe a failure
+	//                  streak that was never recorded.
+	//   TriggerError — why this row carries no trustworthy record, including the tracker's lifecycle
+	//                  state. Set whenever Polled is false.
 	//
 	// Two deliberate limits, both to keep this from lying to a test:
 	//   - It bypasses the relay traffic gate, so a fresh relay tip cannot silently turn the trigger
@@ -1453,6 +1459,13 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 		// Ceiling on the whole handler: one poll is bounded by the tracker's own fetch timeout, but
 		// a request that arrives mid-cycle also waits for the in-flight poll first. Cap the sum so
 		// this can never hang a test harness; the poll itself is unaffected and still completes.
+		//
+		// Deliberately ONE budget for all matched targets rather than one each, so a multi-target
+		// address cannot multiply the worst-case hang by the number of matches. The cost is that a
+		// late target can inherit a nearly-spent budget and report Polled=false with TriggerError set
+		// — honest, and the reason PollNow reports the not-awaited case that way instead of claiming
+		// a poll it did not witness. Narrow with chain_id / api_interface when a test needs every
+		// matched endpoint to get a full budget.
 		ctx, cancel := context.WithTimeout(r.Context(), debugPollNowTimeout)
 		defer cancel()
 

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -35,6 +35,7 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcInterfaceMessages"
 	"github.com/magma-Devs/smart-router/protocol/chaintracker"
 	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/endpointstate"
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
 	"github.com/magma-Devs/smart-router/protocol/metrics"
 	"github.com/magma-Devs/smart-router/protocol/performance"
@@ -469,6 +470,13 @@ type debugMuxDeps struct {
 	cache cacheFlusher
 }
 
+// debugPollNowTimeout caps how long POST /debug/poll-now waits per request (MAG-2649). A single
+// poll is already bounded by the tracker's own fetch timeout (max(10s, MinimumTimePerRelayDelay)),
+// but a trigger arriving mid-cycle queues behind the in-flight poll first — so the ceiling is
+// roughly two fetch timeouts plus slack. Reaching it returns 504 rather than hanging the caller;
+// the poll itself, once started, still completes and records.
+const debugPollNowTimeout = 25 * time.Second
+
 // cacheFlusher is the minimal surface /debug/reset-all needs from the cache-be
 // client. *performance.Cache satisfies it; tests substitute a fake that
 // records the Flush call.
@@ -589,6 +597,55 @@ func reregisterChainTrackerRows(deps debugMuxDeps) (ensured, created int) {
 		}
 	}
 	return ensured, created
+}
+
+// pollNowTarget is one endpoint /debug/poll-now will poll: the EndpointMonitor that owns its
+// ChainTracker, plus the chain identity used to label the response row.
+type pollNowTarget struct {
+	chainID      string
+	apiInterface string
+	monitor      *endpointstate.EndpointMonitor
+}
+
+// resolvePollNowTargets finds every registered ChainTracker for networkAddress, optionally narrowed
+// by chainID / apiInterface (both optional; empty means "any", matched case-insensitively). The
+// same URL can legitimately be registered on more than one chain or interface — the endpointtip
+// store keys on all three — so this returns a slice rather than a single hit and the handler polls
+// each match.
+//
+// It resolves ONLY: the router lock is taken to walk the servers and released before any polling
+// happens. A poll can block for up to the tracker's fetch timeout, and holding router.mu across it
+// would stall epoch updates, relay bookkeeping and every other /debug endpoint for that long.
+// Nil-safe at every level so test fixtures without a wired router simply match nothing.
+func resolvePollNowTargets(deps debugMuxDeps, networkAddress, chainID, apiInterface string) []pollNowTarget {
+	if deps.router == nil || networkAddress == "" {
+		return nil
+	}
+	deps.router.mu.Lock()
+	defer deps.router.mu.Unlock()
+	targets := []pollNowTarget{}
+	for _, server := range deps.router.rpcServers {
+		if server == nil || server.endpointChainTrackerManager == nil || server.listenEndpoint == nil {
+			continue
+		}
+		if chainID != "" && !strings.EqualFold(chainID, server.listenEndpoint.ChainID) {
+			continue
+		}
+		if apiInterface != "" && !strings.EqualFold(apiInterface, server.listenEndpoint.ApiInterface) {
+			continue
+		}
+		// Only servers that actually track this URL — otherwise a multi-chain router would answer
+		// with a row of "no tracker" noise per unrelated chain.
+		if _, ok := server.endpointChainTrackerManager.GetTracker(networkAddress); !ok {
+			continue
+		}
+		targets = append(targets, pollNowTarget{
+			chainID:      server.listenEndpoint.ChainID,
+			apiInterface: server.listenEndpoint.ApiInterface,
+			monitor:      server.endpointChainTrackerManager,
+		})
+	}
+	return targets
 }
 
 // setAllChainStateDebugOffset shifts every per-server ChainState's effective clock by offset, aging
@@ -1324,6 +1381,117 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 				})
 			}
 			deps.router.mu.Unlock()
+		}
+		writeDebugRows(w, rows)
+	})
+
+	// POST /debug/poll-now — force ONE endpoint's ChainTracker to run its dedicated poll right now,
+	// and answer only once that poll's result has been recorded (MAG-2649). Without it a test that
+	// checks what a poll records has to sit out the per-endpoint cadence (avgBlockTime/2 — ~6 s on
+	// Ethereum) before it can look; with it the sequence becomes set up state → trigger → read.
+	//
+	// Fidelity is the whole point: this triggers the production poll cycle
+	// (chaintracker.ChainTracker.PollNow → fetchAllPreviousBlocksIfNecessary) on the tracker's own
+	// poll goroutine — the same function the cadence timer calls. Nothing about the poll is
+	// reimplemented here, so what the caller reads back is real router behavior with only the wait
+	// removed: same parse, same observation write (LatestBlock/Source, ConsecutivePollFailures,
+	// LastSuccessfulPoll), same endpoint-tip and per-chain tip updates, all completed before this
+	// handler responds.
+	//
+	// Body: {"network_address": "<url>"} — required; optional "chain_id" / "api_interface" narrow
+	// the match when the same URL is registered on more than one chain or interface. The response is
+	// a row per matched endpoint (see /debug/endpoint-state for the shared field vocabulary), plus:
+	//   Polled       — the poll cycle actually ran. False means nothing was polled (tracker still
+	//                  starting, retrying its init, or stopped) and the record below is stale.
+	//   PollError    — the poll ran and failed upstream. That is a legitimate outcome to assert on
+	//                  (it is what increments ConsecutivePollFailures), so it answers 200, not 5xx.
+	//   TriggerError — why no poll could be started, including the tracker's lifecycle state.
+	//
+	// Two deliberate limits, both to keep this from lying to a test:
+	//   - It bypasses the relay traffic gate, so a fresh relay tip cannot silently turn the trigger
+	//     into a no-op — but it therefore resets the gate's skip budget. Do not call it from a test
+	//     that measures poll cadence, the idle-poll ceiling, the gate's skip behaviour, or failure
+	//     backoff growth; those must measure real elapsed time (the poll's cadence state is
+	//     untouched here precisely so they stay measurable).
+	//   - It records ONE endpoint's poll. The per-chain consensus baseline is recomputed on its own
+	//     tick, so /debug/chain-state's ConsensusBaseline is NOT guaranteed to have moved when this
+	//     returns; the endpoint's own record and the chain's ObservedTip are.
+	//
+	// One consequence worth knowing before writing a test against it: a head moved BACKWARD is not
+	// visible here. The poll runs and is recorded, but the endpoint tip is block-monotonic — a lower
+	// block is held off as a late straggler until the stored tip goes stale (StalenessWindow, ~120 s
+	// on Ethereum) — and the tracker does not walk its own head down either. So a setup that rewinds
+	// a simulator's head and then triggers a poll reads back the previous, higher block. That is the
+	// production anti-flap rule faithfully applied, not a failed trigger.
+	mux.HandleFunc("/debug/poll-now", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST only", http.StatusMethodNotAllowed)
+			return
+		}
+		// Same 1 KiB cap as the other JSON debug handlers: the body is three short strings.
+		r.Body = http.MaxBytesReader(w, r.Body, 1024)
+		var body struct {
+			NetworkAddress string `json:"network_address"`
+			ChainID        string `json:"chain_id"`
+			ApiInterface   string `json:"api_interface"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid JSON", http.StatusBadRequest)
+			return
+		}
+		if body.NetworkAddress == "" {
+			http.Error(w, "network_address is required", http.StatusBadRequest)
+			return
+		}
+
+		targets := resolvePollNowTargets(deps, body.NetworkAddress, body.ChainID, body.ApiInterface)
+		if len(targets) == 0 {
+			http.Error(w, "no ChainTracker registered for that endpoint", http.StatusNotFound)
+			return
+		}
+
+		// Ceiling on the whole handler: one poll is bounded by the tracker's own fetch timeout, but
+		// a request that arrives mid-cycle also waits for the in-flight poll first. Cap the sum so
+		// this can never hang a test harness; the poll itself is unaffected and still completes.
+		ctx, cancel := context.WithTimeout(r.Context(), debugPollNowTimeout)
+		defer cancel()
+
+		rows := []map[string]any{}
+		polledAny := false
+		for _, target := range targets {
+			start := time.Now()
+			obs, polled, err := target.monitor.PollNow(ctx, body.NetworkAddress)
+			row := map[string]any{
+				"ChainID":                 target.chainID,
+				"ApiInterface":            target.apiInterface,
+				"NetworkAddress":          body.NetworkAddress,
+				"Polled":                  polled,
+				"DurationMs":              time.Since(start).Milliseconds(),
+				"PollError":               "",
+				"TriggerError":            "",
+				"LatestBlock":             obs.LatestBlock,
+				"ObservedAt":              debugTimeRFC3339(obs.ObservedAt),
+				"Source":                  obs.Source.String(),
+				"ConsecutivePollFailures": obs.ConsecutivePollFailures,
+				"LastSuccessfulPoll":      debugTimeRFC3339(obs.LastSuccessfulPoll),
+			}
+			switch {
+			case polled:
+				polledAny = true
+				if err != nil {
+					row["PollError"] = err.Error()
+				}
+			case err != nil:
+				row["TriggerError"] = err.Error()
+			}
+			rows = append(rows, row)
+		}
+		// Every matched endpoint failed to even start a poll: say so in the status line as well as
+		// the rows, so a harness that only checks the code does not read "nothing happened" as
+		// success.
+		if !polledAny {
+			w.Header().Set("Content-Type", "application/json") // must precede WriteHeader
+			w.WriteHeader(http.StatusGatewayTimeout)
 		}
 		writeDebugRows(w, rows)
 	})

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -474,7 +474,8 @@ type debugMuxDeps struct {
 // poll is already bounded by the tracker's own fetch timeout (max(10s, MinimumTimePerRelayDelay)),
 // but a trigger arriving mid-cycle queues behind the in-flight poll first — so the ceiling is
 // roughly two fetch timeouts plus slack. Reaching it returns 504 rather than hanging the caller;
-// the poll itself, once started, still completes and records.
+// the poll itself, once started, still completes and records — the response simply cannot report
+// what it recorded, which is why that case answers Polled=false rather than claiming the poll.
 const debugPollNowTimeout = 25 * time.Second
 
 // cacheFlusher is the minimal surface /debug/reset-all needs from the cache-be
@@ -1423,12 +1424,19 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 	//     tick, so /debug/chain-state's ConsensusBaseline is NOT guaranteed to have moved when this
 	//     returns; the endpoint's own record and the chain's ObservedTip are.
 	//
-	// One consequence worth knowing before writing a test against it: a head moved BACKWARD is not
-	// visible here. The poll runs and is recorded, but the endpoint tip is block-monotonic — a lower
-	// block is held off as a late straggler until the stored tip goes stale (StalenessWindow, ~120 s
-	// on Ethereum) — and the tracker does not walk its own head down either. So a setup that rewinds
-	// a simulator's head and then triggers a poll reads back the previous, higher block. That is the
-	// production anti-flap rule faithfully applied, not a failed trigger.
+	// Two consequences worth knowing before writing a test against it.
+	//
+	// Assert Polled before reading any other field in a row. A false Polled with a "not awaited"
+	// TriggerError is not a broken tracker: the poll is running and will record, this response just
+	// could not wait for it. Retry, or narrow the match with chain_id / api_interface so fewer
+	// endpoints share the budget — do not treat it as an endpoint fault.
+	//
+	// A head moved BACKWARD is not visible here. The poll runs and is recorded, but the endpoint tip
+	// is block-monotonic — a lower block is held off as a late straggler until the stored tip goes
+	// stale (StalenessWindow, ~120 s on Ethereum) — and the tracker does not walk its own head down
+	// either. So a setup that rewinds a simulator's head and then triggers a poll reads back the
+	// previous, higher block. That is the production anti-flap rule faithfully applied, not a failed
+	// trigger.
 	mux.HandleFunc("/debug/poll-now", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "POST only", http.StatusMethodNotAllowed)
@@ -1499,9 +1507,15 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 			}
 			rows = append(rows, row)
 		}
-		// Every matched endpoint failed to even start a poll: say so in the status line as well as
-		// the rows, so a harness that only checks the code does not read "nothing happened" as
-		// success.
+		// No matched endpoint produced a record this response can vouch for: say so in the status
+		// line as well as the rows, so a harness that only checks the code does not read "nothing
+		// usable happened" as success.
+		//
+		// 504 covers two causes, and TriggerError is what separates them — the code alone must not be
+		// read as "the tracker is broken". Either no poll could be STARTED (still starting, retrying
+		// its init, stopped — the lifecycle state is named), or one was started and outlived the
+		// budget above, which says nothing about the tracker and everything about the upstream's
+		// latency or the budget being shared across matched targets.
 		if !polledAny {
 			w.Header().Set("Content-Type", "application/json") // must precede WriteHeader
 			w.WriteHeader(http.StatusGatewayTimeout)


### PR DESCRIPTION
# Description

Adds `POST /debug/poll-now`: force ONE endpoint's ChainTracker to run its dedicated poll right now, and answer only once that poll's result has been recorded.

The automation suite can only observe what a ChainTracker records after a poll by waiting out real clock time — ~6.5 s for the per-endpoint cadence on Ethereum, ~30 s for a warm-up that waits on a forced poll, and the poll-settle half of the ~130 s staleness check. Nothing could make a poll happen sooner. With this, a test becomes: set up state → trigger → read.

## Jira ticket

Jira ticket: MAG-2649

---

## How it works

Fidelity is the whole point, so the trigger is thin. `ChainTracker.PollNow` hands a request to the tracker's **own poll goroutine** over an unbuffered channel; that goroutine runs `fetchAllPreviousBlocksIfNecessary` — the same function the cadence timer calls, with the same fetch timeout — and replies when it returns. Nothing is reimplemented: the parse, the observation write (`LatestBlock`/`Source`, `ConsecutivePollFailures`, `LastSuccessfulPoll`), the endpoint tip and the per-chain tip are the production ones, and all complete before the reply — which is what makes the caller's subsequent read race-free.

**Running it on the poll goroutine is not incidental.** The cycle mutates `relaySkipsSinceRealPoll` and `blockCheckpoint` unlocked, on a single-writer assumption, so calling it from the HTTP goroutine would be a real data race. For the same reason `EndpointMonitor.PollNow` copies the tracker pointer and releases `m.mu` **before** waiting: the cycle takes `m.mu` itself when it observes a new block (`newLatestCallback` → `setTrackerState`), so holding it across the wait deadlocks.

## Two deliberate behaviours

- **Forces past the relay traffic gate** — via a `force` parameter on the production function rather than a second copy of it. Otherwise a poll-now issued right after a set-up relay would silently no-op inside the freshness window (`relayGateFreshness` = `averageBlockTime`, 12 s on ETH) and hand the caller a stale record. It still resets the gate's skip budget, because a real poll did happen.
- **Leaves cadence alone** — `fetchFails` is untouched and the timer is never rescheduled, so a forced poll cannot move the schedule that the cadence, idle-ceiling, gate and backoff tests measure in real time. The mirror of `/debug/reset-probe-backoff` ("cadence only, data untouched").

Note the **two distinct failure counters**: the tracker-local `fetchFails` (cadence backoff — untouched here) and the observation's `ConsecutivePollFailures`, which is what the ticket means by "the running count of failed polls" and **is** updated, by the shared record path.

## `Polled` is a claim about the record, not about the goroutine

The endpoint's entire value is that a harness can trust what it reads back, so the one field everything else hangs off is `Polled`: **this row's observation is this poll's**. It is false whenever the response cannot vouch for the record — and the record handed back is then the prior one, explicitly stale.

That phrasing matters because "a poll ran" and "I can tell you what it recorded" are not the same claim. A poll whose result outlives the caller's budget *does* run — it is bounded by the tracker's context, not the requester's, so it finishes and writes regardless — but this response read the record before it landed. Reporting that as `Polled: true` would hand back a pre-poll block **and a pre-poll failure streak** while labelling both fresh, which is exactly the confusion the endpoint exists to remove.

Three sentinels make the causes distinguishable to `errors.Is`, and all three map to `Polled: false`:

| Sentinel | Meaning |
| --- | --- |
| `ErrorPollNowNotDelivered` | the poll goroutine never took the request — tracker still starting, retrying its init, or stopped. Nothing ran and nothing was written. |
| `ErrorPollNowUnsupported` | this tracker cannot poll at all (`DummyChainTracker`). |
| `ErrorPollNowResultNotAwaited` | the request **was** taken and the cycle is running, but it outlived the caller's budget. The poll completes and records on its own; this response simply did not witness it. |

## Deadlines: delivery and result are bounded separately

A tracker that is not yet `polling` has no goroutine to receive the trigger, so waiting out the full 25 s handler budget only delays a verdict that will not change. `EndpointMonitor.PollNow` therefore caps that wait at 2 s (`pollNowUnstartedGrace`) — a shorter deadline, not a rejection, so a state that merely lags the goroutine can never refuse a poll that would have worked.

**That grace bounds delivery only.** `ChainTracker.PollNowWithDeliveryDeadline` takes the two contexts separately, because the two waits have unrelated natural lengths: delivery either happens in microseconds (the goroutine is at its select) or never (there is no goroutine), while the cycle behind it is bounded by the tracker's own fetch timeout, `max(10s, MinimumTimePerRelayDelay)` — several times the grace. Capping both with the grace would abandon healthy polls mid-flight and leave the caller holding a pre-poll record.

## API

`POST /debug/poll-now` with `{"network_address": "<url>"}` (required; optional `chain_id` / `api_interface` narrow the match when the same URL is registered on more than one chain or interface). Response is a row per matched endpoint, sharing `/debug/endpoint-state`'s field vocabulary plus `Polled`, `PollError`, `TriggerError`, `DurationMs`.

| Status | Meaning |
| --- | --- |
| 200 | at least one matched endpoint returned a record this response can vouch for — including when the poll reached upstream and **failed** (`PollError` set), which is exactly what a test asserting on the failure streak needs |
| 400 | unusable request (bad JSON, missing `network_address`) |
| 404 | no ChainTracker serves that address |
| 504 | no matched endpoint produced a trustworthy record. **`TriggerError`, not the status code, says why** — either no poll could be started (the tracker's lifecycle state is named, since `retrying_start` is a diagnosis and a bare timeout is not), or a poll was started and outlived the budget. The second is not an endpoint fault. |

`PollError` is only ever set alongside `Polled: true`, so the pair can never describe a failure streak that was not actually recorded.

The 25 s budget is **shared across all matched targets** rather than granted per target, so a multi-target address cannot multiply the worst-case hang by the number of matches. The cost is that a late target can inherit a nearly-spent budget and answer `Polled: false` — honest, and the reason the not-awaited case is reported that way instead of claiming a poll it did not witness. Narrow with `chain_id` / `api_interface` when a test needs every matched endpoint to get a full budget.

Debug-only needs no new flag: the whole `/debug` mux exists only under `--debug-address`. SVM is covered by construction — the poll goes through `iChainFetcherWrapper` and the `PollObserver` hook.

## Most critical files to review

- `protocol/chaintracker/chain_tracker.go` — the new `pollNowCh` case in the poll loop, `PollNow` / `PollNowWithDeliveryDeadline`, and the `force` parameter.
- `protocol/endpointstate/endpoint_monitor.go` — `PollNow`, the delivery-only grace, and the lock release that avoids the deadlock described above.
- `protocol/rpcsmartrouter/rpcsmartrouter.go` — the handler and `resolvePollNowTargets` (resolves under `router.mu`, releases it before polling).

## Testing

`go test -race` across `chaintracker`, `endpointstate` and `rpcsmartrouter`, including an end-to-end handler test over a real HTTP upstream.

Four tests are load-bearing beyond their assertions:
- the endpointstate test drives an **advancing** block, which is what makes the cycle fire `newLatestCallback` → `m.mu.Lock()`. A constant-block mock would pass against a version that deadlocks.
- a **relay-then-poll-now** test — the pytest suite's actual sequence — proves the gate bypass end to end through the channel, not just by calling the cycle directly.
- `TestEndpointMonitor_PollNow_LaggingTrackerStateDoesNotTruncateThePoll` forces the lagging-state window deterministically (the real race is microseconds wide) and drives a poll longer than the grace, asserting the **fresh** block comes back.
- `TestEndpointMonitor_PollNow_ResultNotAwaited_ReportsNotPolled` asserts `Polled: false` and an unchanged pre-poll failure streak, then waits for the abandoned poll to land — proving `Polled: false` is honest rather than an under-report.

Both of the last two were verified against the previous behaviour: with the fix reverted they fail, with it in place they pass.

**Pre-existing, unrelated:** three `chaintracker` tests (`TestChainTrackerCallbacks`, `TestChainTrackerFetchSpreadAcrossPollingTime`, `TestChainTrackerPollingTimeUpdate`) fail under `-race` on a `smallestBlockGap` / `blockEventsGap` race in the legacy adaptive cadence. Reproduced on a clean `origin/main` and again with this branch's later commits stashed. Untouched here; worth its own ticket.

## Notes for whoever writes the pytest side

All documented in the handler's doc comment:
- **Assert `Polled` before reading any other field in a row.** A false `Polled` with a "not awaited" `TriggerError` is not a broken tracker — the poll is running and will record, the response just could not wait for it. Retry, or narrow with `chain_id` / `api_interface` so fewer endpoints share the budget.
- The per-chain consensus baseline is recomputed on its own tick — assert on `ObservedTip`, not `/debug/chain-state`'s `ConsensusBaseline`, right after a poll-now.
- A head moved **backward** will not be visible: the endpoint tip is block-monotonic and holds a lower block as a late straggler until the stored tip goes stale (`StalenessWindow`, ~120 s on ETH), and the tracker does not walk its own head down. That is the production anti-flap rule faithfully applied, not a failed trigger.
- Do **not** use this endpoint for tests that measure poll cadence, the idle-poll ceiling, the gate's skip behaviour, or backoff growth — per the ticket's Caution, those must measure real elapsed time.

---

## Author Checklist

* [x] read the contribution guide
* [x] included the correct type prefix in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change — n/a, additive debug-only endpoint
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests
* [x] updated the relevant documentation or specification, including comments for documenting Go code — Go doc comments on every new symbol; CHANGELOG is generated at release time from commit subjects, so not hand-edited here
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

* [ ] confirmed the correct type prefix in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
