### PR TITLE
feat(smart-router/debug): add GET /debug/provider-scores (MAG-2707)

### DIFF
--- a/protocol/metrics/consumer_optimizer_qos_client.go
+++ b/protocol/metrics/consumer_optimizer_qos_client.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -220,7 +221,16 @@ func (coqc *ConsumerOptimizerQoSClient) getLastRNGValue(chainId, providerAddress
 	return 0
 }
 
-func (coqc *ConsumerOptimizerQoSClient) appendOptimizerQoSReport(report *OptimizerQoSReport, chainId string, epoch uint64) OptimizerQoSReportToSend {
+// buildOptimizerQoSReport assembles the wire form of one provider's report. It is PURE: it reads
+// the counter maps (caller must hold at least the read lock) and writes nothing, emits nothing.
+//
+// Split out from appendOptimizerQoSReport (MAG-2707) so the read-only snapshot path can reuse the
+// exact same assembly — including sanitizeFloat on every float — without the usage-sink emit that
+// belongs to the periodic sampler alone. Two properties depend on going through here rather than
+// marshalling a raw OptimizerQoSReport: NaN/Inf are neutralised (encoding/json ERRORS on NaN, and a
+// debug handler that has already written its status line cannot take that back), and the enrichment
+// (stake, selection counters, node-error rate) is applied identically to both paths.
+func (coqc *ConsumerOptimizerQoSClient) buildOptimizerQoSReport(report *OptimizerQoSReport, chainId string, epoch uint64) OptimizerQoSReportToSend {
 	// must be called under read lock
 	// Use sanitizeFloat to prevent NaN/Inf values in JSON output
 	optimizerQoSReportToSend := OptimizerQoSReportToSend{
@@ -255,9 +265,19 @@ func (coqc *ConsumerOptimizerQoSClient) appendOptimizerQoSReport(report *Optimiz
 		StakeContribution:        sanitizeFloat(report.StakeContribution),
 	}
 
-	// Fire the report at the usage sink (OTel). Non-blocking; NoopUsageSink
-	// when OTel emission is disabled. The in-memory reportsToSend cache
-	// (built by the caller) still feeds the Prometheus /metrics endpoint.
+	return optimizerQoSReportToSend
+}
+
+// appendOptimizerQoSReport builds a report AND fires it at the usage sink (OTel). Non-blocking;
+// NoopUsageSink when OTel emission is disabled. The in-memory reportsToSend cache (built by the
+// caller) still feeds the Prometheus /metrics endpoint.
+//
+// The emit is why this wrapper exists separately from buildOptimizerQoSReport: it is the periodic
+// sampler's step, and a read-only caller (SnapshotReports) must not perform it — a debug read that
+// published usage events would double-count every dashboard fed by the sink.
+func (coqc *ConsumerOptimizerQoSClient) appendOptimizerQoSReport(report *OptimizerQoSReport, chainId string, epoch uint64) OptimizerQoSReportToSend {
+	// must be called under read lock
+	optimizerQoSReportToSend := coqc.buildOptimizerQoSReport(report, chainId, epoch)
 	coqc.usageSink.EmitOptimizerQoS(optimizerQoSReportToSend)
 	return optimizerQoSReportToSend
 }
@@ -284,6 +304,85 @@ func (coqc *ConsumerOptimizerQoSClient) getReportsFromOptimizers() []OptimizerQo
 		}
 	}
 	return reportsToSend
+}
+
+// OptimizerScoresSnapshot is one on-demand read of the per-provider quality scores (MAG-2707).
+//
+// It carries the facts a caller needs to tell "here are the scores" apart from "the scores could
+// not be obtained", without this package deciding what that means over HTTP:
+//   - Reports — one entry per (chain, provider) that produced scores. A provider that exists but
+//     has not been sampled yet is a legitimate entry with zero scores, NOT an omission.
+//   - ChainsRegistered — chains that have an optimizer registered (after the filter).
+//   - ChainsUnavailable — registered chains that produced NO rows because no providers are known
+//     for them yet (the stake map is empty). The periodic sampler skips these silently; a reader
+//     must not, or an unpopulated router is indistinguishable from a healthy one with no traffic.
+type OptimizerScoresSnapshot struct {
+	Reports           []OptimizerQoSReportToSend
+	ChainsRegistered  []string
+	ChainsUnavailable []string
+}
+
+// SnapshotReports computes the CURRENT per-provider quality scores on demand and returns them
+// without publishing anything (MAG-2707, behind /debug/provider-scores).
+//
+// It runs the same enumeration the periodic sampler runs — same optimizers, same provider set, same
+// CalculateQoSScoresForMetrics call, same report assembly — so a reader sees the very numbers
+// selection uses. Two deliberate differences from getReportsFromOptimizers:
+//
+//   - It does NOT emit to the usage sink, so reading changes nothing observable about the router.
+//   - It does NOT silently skip a chain with no known providers; that chain is named in
+//     ChainsUnavailable so the caller can fail loudly instead of returning an empty list that reads
+//     like "scored, all fine".
+//
+// It also deliberately does not serve the cached reportsToSend: that cache is empty until the first
+// sampling tick and after a score reset, and "empty because we have not sampled yet" would be
+// indistinguishable from "no providers". Computing here removes that ambiguity and lets one test
+// reset scores and read them back in sequence.
+//
+// chainIDFilter (optional, case-insensitive) narrows to a single chain. Nil-receiver safe: an
+// unwired client returns the zero snapshot, which the caller reports as "unavailable".
+func (coqc *ConsumerOptimizerQoSClient) SnapshotReports(chainIDFilter string) OptimizerScoresSnapshot {
+	snapshot := OptimizerScoresSnapshot{
+		Reports:           []OptimizerQoSReportToSend{},
+		ChainsRegistered:  []string{},
+		ChainsUnavailable: []string{},
+	}
+	if coqc == nil {
+		return snapshot
+	}
+
+	coqc.lock.RLock() // read-only throughout, like getReportsFromOptimizers
+	defer coqc.lock.RUnlock()
+
+	ignoredProviders := map[string]struct{}{}
+	cu := uint64(10)
+	requestedBlock := spectypes.LATEST_BLOCK
+	currentEpoch := coqc.currentEpoch.Load()
+
+	for chainId, optimizer := range coqc.optimizers {
+		if chainIDFilter != "" && !strings.EqualFold(chainIDFilter, chainId) {
+			continue
+		}
+		snapshot.ChainsRegistered = append(snapshot.ChainsRegistered, chainId)
+
+		providersMap, ok := coqc.chainIdToProviderToEpochToStake[chainId]
+		if !ok || len(providersMap) == 0 {
+			// No providers known for this chain yet: there is nothing to score, and saying so is the
+			// whole point (the sampler just drops this case).
+			snapshot.ChainsUnavailable = append(snapshot.ChainsUnavailable, chainId)
+			continue
+		}
+
+		reports := optimizer.CalculateQoSScoresForMetrics(slices.Collect(maps.Keys(providersMap)), ignoredProviders, cu, requestedBlock)
+		if len(reports) == 0 {
+			snapshot.ChainsUnavailable = append(snapshot.ChainsUnavailable, chainId)
+			continue
+		}
+		for _, report := range reports {
+			snapshot.Reports = append(snapshot.Reports, coqc.buildOptimizerQoSReport(report, chainId, currentEpoch))
+		}
+	}
+	return snapshot
 }
 
 func (coqc *ConsumerOptimizerQoSClient) SetReportsToSend(reports []OptimizerQoSReportToSend) {

--- a/protocol/metrics/consumer_optimizer_qos_client.go
+++ b/protocol/metrics/consumer_optimizer_qos_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -382,6 +383,10 @@ func (coqc *ConsumerOptimizerQoSClient) SnapshotReports(chainIDFilter string) Op
 			snapshot.Reports = append(snapshot.Reports, coqc.buildOptimizerQoSReport(report, chainId, currentEpoch))
 		}
 	}
+	// Both chain lists are built by ranging a map, so sort them: they are reported to callers (and
+	// asserted on by tests), and Go's map order would otherwise vary between identical reads.
+	sort.Strings(snapshot.ChainsRegistered)
+	sort.Strings(snapshot.ChainsUnavailable)
 	return snapshot
 }
 

--- a/protocol/metrics/optimizer_scores_snapshot_test.go
+++ b/protocol/metrics/optimizer_scores_snapshot_test.go
@@ -1,0 +1,174 @@
+package metrics
+
+// Tests for the on-demand score snapshot behind GET /debug/provider-scores (MAG-2707).
+//
+// The load-bearing one is TestSnapshotReports_DoesNotEmitToUsageSink: the snapshot reuses the
+// periodic sampler's report assembly, and the whole point of splitting buildOptimizerQoSReport out
+// of appendOptimizerQoSReport is that a READ must not publish usage events. A regression there is
+// invisible in the response body and only shows up as double-counted dashboards.
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// countingSink records how many optimizer-QoS reports were published, so a test can assert that a
+// read published none.
+type countingSink struct {
+	NoopUsageSink
+	optimizerQoSEmits int
+}
+
+func (s *countingSink) EmitOptimizerQoS(report OptimizerQoSReportToSend) {
+	s.optimizerQoSEmits++
+}
+
+// staticOptimizer is an OptimizerInf returning fixed scores for the addresses it is asked about, so
+// the snapshot's enumeration and assembly can be tested without a live optimizer.
+type staticOptimizer struct {
+	calls   int
+	scores  map[string]float64
+	raw     map[string]float64
+	unknown bool // when true, return no reports at all regardless of the addresses asked for
+}
+
+func (o *staticOptimizer) CalculateQoSScoresForMetrics(allAddresses []string, ignoredProviders map[string]struct{}, cu uint64, requestedBlock int64) []*OptimizerQoSReport {
+	o.calls++
+	if o.unknown {
+		return nil
+	}
+	reports := make([]*OptimizerQoSReport, 0, len(allAddresses))
+	for i, addr := range allAddresses {
+		reports = append(reports, &OptimizerQoSReport{
+			ProviderAddress:    addr,
+			AvailabilityScore:  o.raw[addr],
+			SelectionComposite: o.scores[addr],
+			EntryIndex:         i,
+		})
+	}
+	return reports
+}
+
+func newSnapshotFixture(t *testing.T, sink UsageEventSink) (*ConsumerOptimizerQoSClient, *staticOptimizer) {
+	t.Helper()
+	coqc := NewConsumerOptimizerQoSClient("consumer", sink)
+	opt := &staticOptimizer{
+		scores: map[string]float64{"lava@provider1": 0.85},
+		raw:    map[string]float64{"lava@provider1": 0.99},
+	}
+	coqc.RegisterOptimizer(opt, "ETH1")
+	// A provider is only scored once it is known through the stake map — the same gate the periodic
+	// sampler applies.
+	coqc.UpdatePairingListStake(map[string]int64{"lava@provider1": 1000}, "ETH1", 7)
+	return coqc, opt
+}
+
+// TestSnapshotReports_ReturnsScoresForKnownProviders is the basic contract: a registered optimizer
+// with a known provider yields one fully-assembled row, carrying both the raw EWMA value and the
+// normalised composite, plus the enrichment (stake, chain, epoch) the sampler adds.
+func TestSnapshotReports_ReturnsScoresForKnownProviders(t *testing.T) {
+	coqc, opt := newSnapshotFixture(t, NoopUsageSink{})
+
+	snapshot := coqc.SnapshotReports("")
+	require.Equal(t, []string{"ETH1"}, snapshot.ChainsRegistered)
+	require.Empty(t, snapshot.ChainsUnavailable)
+	require.Len(t, snapshot.Reports, 1)
+
+	report := snapshot.Reports[0]
+	require.Equal(t, "ETH1", report.ChainId)
+	require.Equal(t, "lava@provider1", report.ProviderAddress)
+	require.Equal(t, 0.85, report.SelectionComposite)
+	require.Equal(t, 0.99, report.AvailabilityScore, "the raw EWMA value is reported alongside the normalised one")
+	require.Equal(t, int64(1000), report.ProviderStake)
+	require.Equal(t, uint64(7), report.Epoch)
+	require.False(t, report.Timestamp.IsZero())
+	require.Equal(t, 1, opt.calls, "the snapshot computes on demand, exactly once")
+}
+
+// TestSnapshotReports_DoesNotEmitToUsageSink is the MAG-2707 guard on "reading changes nothing":
+// the periodic sampler publishes every report it builds, and the snapshot must reuse that assembly
+// WITHOUT publishing — otherwise a debug read double-counts every dashboard fed by the sink.
+func TestSnapshotReports_DoesNotEmitToUsageSink(t *testing.T) {
+	sink := &countingSink{}
+	coqc, _ := newSnapshotFixture(t, sink)
+
+	snapshot := coqc.SnapshotReports("")
+	require.Len(t, snapshot.Reports, 1)
+	require.Zero(t, sink.optimizerQoSEmits, "a read must publish nothing")
+
+	// Positive control: the periodic path DOES emit, so the assertion above is a real difference
+	// between the two paths and not a sink that never fires.
+	reports := coqc.getReportsFromOptimizers()
+	require.Len(t, reports, 1)
+	require.Equal(t, 1, sink.optimizerQoSEmits, "the periodic sampler still publishes")
+}
+
+// TestSnapshotReports_SanitizesNonFiniteScores: scores can legitimately be NaN/Inf, and
+// encoding/json ERRORS on NaN — which, in a debug handler that has already written its status line,
+// would surface as a truncated body under a 200. Going through the shared builder neutralises them.
+func TestSnapshotReports_SanitizesNonFiniteScores(t *testing.T) {
+	coqc := NewConsumerOptimizerQoSClient("consumer", NoopUsageSink{})
+	coqc.RegisterOptimizer(&staticOptimizer{
+		scores: map[string]float64{"lava@provider1": math.NaN()},
+		raw:    map[string]float64{"lava@provider1": math.Inf(1)},
+	}, "ETH1")
+	coqc.UpdatePairingListStake(map[string]int64{"lava@provider1": 1}, "ETH1", 1)
+
+	snapshot := coqc.SnapshotReports("")
+	require.Len(t, snapshot.Reports, 1)
+	require.Equal(t, float64(0), snapshot.Reports[0].SelectionComposite, "NaN is neutralised")
+	require.Equal(t, float64(0), snapshot.Reports[0].AvailabilityScore, "Inf is neutralised")
+}
+
+// TestSnapshotReports_ReportsChainsWithNoProviders covers the case the periodic sampler drops
+// silently: a registered chain whose provider set is still empty. The snapshot must NAME it, so the
+// caller can answer "unavailable" rather than returning an empty list that reads like a clean run.
+func TestSnapshotReports_ReportsChainsWithNoProviders(t *testing.T) {
+	coqc := NewConsumerOptimizerQoSClient("consumer", NoopUsageSink{})
+	coqc.RegisterOptimizer(&staticOptimizer{}, "ETH1") // registered, but no stake/provider data yet
+
+	snapshot := coqc.SnapshotReports("")
+	require.Equal(t, []string{"ETH1"}, snapshot.ChainsRegistered)
+	require.Equal(t, []string{"ETH1"}, snapshot.ChainsUnavailable)
+	require.Empty(t, snapshot.Reports)
+
+	// Same when the optimizer knows the provider but produces no scores for it.
+	coqc2 := NewConsumerOptimizerQoSClient("consumer", NoopUsageSink{})
+	coqc2.RegisterOptimizer(&staticOptimizer{unknown: true}, "ETH1")
+	coqc2.UpdatePairingListStake(map[string]int64{"lava@provider1": 1}, "ETH1", 1)
+	snapshot = coqc2.SnapshotReports("")
+	require.Equal(t, []string{"ETH1"}, snapshot.ChainsUnavailable)
+	require.Empty(t, snapshot.Reports)
+}
+
+// TestSnapshotReports_ChainFilter: the filter narrows to one chain, case-insensitively, and a
+// filter matching no registered chain yields no registered chains — which the handler turns into a
+// 404 rather than an empty success.
+func TestSnapshotReports_ChainFilter(t *testing.T) {
+	coqc, _ := newSnapshotFixture(t, NoopUsageSink{})
+	coqc.RegisterOptimizer(&staticOptimizer{scores: map[string]float64{"lava@provider2": 0.5}}, "SOLANA")
+	coqc.UpdatePairingListStake(map[string]int64{"lava@provider2": 5}, "SOLANA", 7)
+
+	require.Len(t, coqc.SnapshotReports("").Reports, 2, "no filter returns every chain")
+
+	filtered := coqc.SnapshotReports("eth1")
+	require.Equal(t, []string{"ETH1"}, filtered.ChainsRegistered, "the filter matches case-insensitively")
+	require.Len(t, filtered.Reports, 1)
+	require.Equal(t, "lava@provider1", filtered.Reports[0].ProviderAddress)
+
+	missing := coqc.SnapshotReports("NOSUCHCHAIN")
+	require.Empty(t, missing.ChainsRegistered)
+	require.Empty(t, missing.Reports)
+}
+
+// TestSnapshotReports_NilClientIsSafe: a fixture with no QoS sampler wired must not panic; it
+// reports nothing registered, which the handler turns into "unavailable".
+func TestSnapshotReports_NilClientIsSafe(t *testing.T) {
+	var coqc *ConsumerOptimizerQoSClient
+	snapshot := coqc.SnapshotReports("")
+	require.Empty(t, snapshot.ChainsRegistered)
+	require.Empty(t, snapshot.Reports)
+	require.NotNil(t, snapshot.Reports, "empty, not nil, so callers can range without a guard")
+}

--- a/protocol/rpcsmartrouter/debug_provider_scores_test.go
+++ b/protocol/rpcsmartrouter/debug_provider_scores_test.go
@@ -55,6 +55,18 @@ func newScoresMux(t *testing.T) http.Handler {
 	})
 }
 
+// decodeScores unwraps the /debug/provider-scores envelope: the rows plus the names of any matched
+// chains that produced none.
+func decodeScores(t *testing.T, body []byte) ([]map[string]any, []string) {
+	t.Helper()
+	var response struct {
+		Rows              []map[string]any `json:"rows"`
+		ChainsUnavailable []string         `json:"chains_unavailable"`
+	}
+	require.NoError(t, json.Unmarshal(body, &response))
+	return response.Rows, response.ChainsUnavailable
+}
+
 func TestDebugProviderScores_MethodNotAllowed(t *testing.T) {
 	rr := postDebugRouter(newScoresMux(t), "/debug/provider-scores") // POST on a GET-only endpoint
 	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
@@ -68,8 +80,8 @@ func TestDebugProviderScores_ReturnsScores(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code, "body=%q", rr.Body.String())
 	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
 
-	var rows []map[string]any
-	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &rows))
+	rows, unavailable := decodeScores(t, rr.Body.Bytes())
+	require.Empty(t, unavailable, "every registered chain produced rows")
 	require.Len(t, rows, 1)
 	row := rows[0]
 	require.Equal(t, "ETH1", row["ChainID"])
@@ -107,6 +119,37 @@ func TestDebugProviderScores_UnavailableIsNot200(t *testing.T) {
 	rr = getDebugRouter(empty, "/debug/provider-scores")
 	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
 	require.Contains(t, rr.Body.String(), "ETH1", "the failure names the chain that produced nothing")
+}
+
+// TestDebugProviderScores_PartlyPopulatedRouterNamesTheEmptyChain is the PR #259 review case: a
+// router serving two chains where only one has providers. The old shape answered 200 with the
+// populated chain's rows and said NOTHING about the other, so a test reading the empty chain saw a
+// success with no rows for its provider and would conclude "no score" instead of "nothing was
+// measured" — the silent pass this endpoint exists to end, narrowed from the whole router to one
+// chain. The answer must name the chain that produced nothing.
+func TestDebugProviderScores_PartlyPopulatedRouterNamesTheEmptyChain(t *testing.T) {
+	qosClient := metrics.NewConsumerOptimizerQoSClient("consumer", metrics.NoopUsageSink{})
+	// ETH1 is populated; SOLANA is registered but has no providers known yet.
+	qosClient.RegisterOptimizer(&fixedScoreOptimizer{composite: 0.85, availability: 0.99}, "ETH1")
+	qosClient.UpdatePairingListStake(map[string]int64{"lava@provider1": 1000}, "ETH1", 7)
+	qosClient.RegisterOptimizer(&fixedScoreOptimizer{}, "SOLANA")
+
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano, qosClient: qosClient})
+
+	rr := getDebugRouter(mux, "/debug/provider-scores")
+	require.Equal(t, http.StatusOK, rr.Code, "the populated chain is still readable")
+
+	rows, unavailable := decodeScores(t, rr.Body.Bytes())
+	require.Len(t, rows, 1)
+	require.Equal(t, "ETH1", rows[0]["ChainID"])
+	require.Equal(t, []string{"SOLANA"}, unavailable,
+		"a chain that produced no rows is named, not silently omitted")
+
+	// Narrowing to the empty chain is still an outright failure: nothing to report at all.
+	rr = getDebugRouter(mux, "/debug/provider-scores?chain_id=SOLANA")
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	require.Contains(t, rr.Body.String(), "SOLANA")
 }
 
 // TestDebugProviderScores_CarriesEndpointURLsForJoin covers the field that makes the endpoint
@@ -161,8 +204,7 @@ func TestDebugProviderScores_CarriesEndpointURLsForJoin(t *testing.T) {
 	rr := getDebugRouter(mux, "/debug/provider-scores")
 	require.Equal(t, http.StatusOK, rr.Code, "body=%q", rr.Body.String())
 
-	var rows []map[string]any
-	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &rows))
+	rows, _ := decodeScores(t, rr.Body.Bytes())
 	require.Len(t, rows, 1)
 	require.Equal(t, providerAddr, rows[0]["ProviderAddress"])
 	require.Equal(t, []any{urlA, urlB}, rows[0]["NetworkAddresses"],
@@ -176,8 +218,7 @@ func TestDebugProviderScores_ChainFilter(t *testing.T) {
 
 	rr := getDebugRouter(mux, "/debug/provider-scores?chain_id=eth1")
 	require.Equal(t, http.StatusOK, rr.Code, "chain_id matches case-insensitively")
-	var rows []map[string]any
-	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &rows))
+	rows, _ := decodeScores(t, rr.Body.Bytes())
 	require.Len(t, rows, 1)
 
 	rr = getDebugRouter(mux, "/debug/provider-scores?chain_id=SOLANA")

--- a/protocol/rpcsmartrouter/debug_provider_scores_test.go
+++ b/protocol/rpcsmartrouter/debug_provider_scores_test.go
@@ -1,0 +1,185 @@
+package rpcsmartrouter
+
+// HTTP-contract tests for GET /debug/provider-scores (MAG-2707). The score computation itself is
+// proven in metrics (TestSnapshotReports_*); here we pin what the automation codes against — above
+// all that an unobtainable read is a NON-2xx. The endpoint exists because the previous way of
+// reading scores returned empty when it was not working, and the test passed anyway.
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/protocol/metrics"
+	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
+	"github.com/magma-Devs/smart-router/utils/rand"
+	"github.com/stretchr/testify/require"
+)
+
+// fixedScoreOptimizer is a metrics.OptimizerInf returning a known score per address, so the handler
+// can be exercised without a live optimizer.
+type fixedScoreOptimizer struct {
+	composite    float64
+	availability float64
+}
+
+func (o *fixedScoreOptimizer) CalculateQoSScoresForMetrics(allAddresses []string, ignoredProviders map[string]struct{}, cu uint64, requestedBlock int64) []*metrics.OptimizerQoSReport {
+	reports := make([]*metrics.OptimizerQoSReport, 0, len(allAddresses))
+	for i, addr := range allAddresses {
+		reports = append(reports, &metrics.OptimizerQoSReport{
+			ProviderAddress:    addr,
+			AvailabilityScore:  o.availability,
+			SelectionComposite: o.composite,
+			EntryIndex:         i,
+		})
+	}
+	return reports
+}
+
+// newScoresMux wires a debug mux over a QoS client holding one scored provider on ETH1.
+func newScoresMux(t *testing.T) http.Handler {
+	t.Helper()
+	qosClient := metrics.NewConsumerOptimizerQoSClient("consumer", metrics.NoopUsageSink{})
+	qosClient.RegisterOptimizer(&fixedScoreOptimizer{composite: 0.85, availability: 0.99}, "ETH1")
+	qosClient.UpdatePairingListStake(map[string]int64{"lava@provider1": 1000}, "ETH1", 7)
+
+	var offsetNano atomic.Int64
+	return buildDebugMux(debugMuxDeps{
+		optimizers: newEmptyOptimizersRouter(),
+		offsetNano: &offsetNano,
+		qosClient:  qosClient,
+	})
+}
+
+func TestDebugProviderScores_MethodNotAllowed(t *testing.T) {
+	rr := postDebugRouter(newScoresMux(t), "/debug/provider-scores") // POST on a GET-only endpoint
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}
+
+// TestDebugProviderScores_ReturnsScores is the contract the automation reads: one row per provider,
+// carrying the raw EWMA value (what a "was this provider marked down?" test asserts on) alongside
+// the normalised composite that selection ranks by.
+func TestDebugProviderScores_ReturnsScores(t *testing.T) {
+	rr := getDebugRouter(newScoresMux(t), "/debug/provider-scores")
+	require.Equal(t, http.StatusOK, rr.Code, "body=%q", rr.Body.String())
+	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	row := rows[0]
+	require.Equal(t, "ETH1", row["ChainID"])
+	require.Equal(t, "lava@provider1", row["ProviderAddress"])
+	require.Equal(t, 0.99, row["AvailabilityScore"], "the raw EWMA availability is exposed")
+	require.Equal(t, 0.85, row["SelectionComposite"], "the composite selection ranks on is exposed")
+	require.Equal(t, float64(1000), row["ProviderStake"])
+	require.Equal(t, float64(7), row["Epoch"])
+	require.NotEmpty(t, row["Timestamp"])
+	require.Equal(t, []any{}, row["NetworkAddresses"], "no session managers wired → empty list, never null")
+	for _, field := range []string{"LatencyScore", "SyncScore", "SelectionAvailability", "SelectionLatency",
+		"SelectionSync", "SelectionStake", "AvailabilityContribution", "LatencyContribution",
+		"SyncContribution", "StakeContribution", "NodeErrorRate", "SelectionCount", "SelectionRate"} {
+		require.Contains(t, row, field, "the row shape is part of the contract")
+	}
+}
+
+// TestDebugProviderScores_UnavailableIsNot200 is the heart of the ticket: when the scores cannot be
+// obtained the caller must see a failure, never an empty 200 that a test would sail past. Both
+// unobtainable cases are covered — nothing wired at all, and a chain registered but with no
+// providers known yet (which the periodic sampler drops silently).
+func TestDebugProviderScores_UnavailableIsNot200(t *testing.T) {
+	var offsetNano atomic.Int64
+
+	// No QoS sampler wired at all.
+	bare := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano})
+	rr := getDebugRouter(bare, "/debug/provider-scores")
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	require.NotEmpty(t, rr.Body.String(), "the failure says why")
+
+	// Registered chain, but no providers known yet.
+	qosClient := metrics.NewConsumerOptimizerQoSClient("consumer", metrics.NoopUsageSink{})
+	qosClient.RegisterOptimizer(&fixedScoreOptimizer{}, "ETH1")
+	empty := buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano, qosClient: qosClient})
+	rr = getDebugRouter(empty, "/debug/provider-scores")
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	require.Contains(t, rr.Body.String(), "ETH1", "the failure names the chain that produced nothing")
+}
+
+// TestDebugProviderScores_CarriesEndpointURLsForJoin covers the field that makes the endpoint
+// usable next to /debug/endpoint-state. Scores are keyed by PROVIDER ADDRESS while endpoint health
+// is keyed by NETWORK ADDRESS, and neither identity can be derived from the other — so without
+// NetworkAddresses on the row the automation cannot ask "this provider's score moved, was its
+// endpoint healthy?" without a third lookup.
+func TestDebugProviderScores_CarriesEndpointURLsForJoin(t *testing.T) {
+	if !rand.Initialized() {
+		rand.InitRandomSeed()
+	}
+	ctx := t.Context()
+
+	const chainID, apiInterface, providerAddr = "ETH1", "jsonrpc", "provider-0"
+	// TWO endpoints on ONE provider — the case the list-valued field exists for. They are declared
+	// in reverse order so a pass proves the URLs are collected AND sorted, not merely echoed back in
+	// declaration order (and that the second does not overwrite the first).
+	const urlA, urlB = "http://127.0.0.1:1/a", "http://127.0.0.2:2/b"
+
+	csm := lavasession.NewConsumerSessionManager(
+		&lavasession.RPCEndpoint{NetworkAddress: "127.0.0.1:0", ChainID: chainID, ApiInterface: apiInterface, HealthCheckPath: "/"},
+		provideroptimizer.NewProviderOptimizer(provideroptimizer.StrategyBalanced, time.Second, uint(1), nil, chainID),
+		nil, "lava@test", lavasession.NewActiveSubscriptionProvidersStorage(),
+	)
+	endpoints := make([]*lavasession.Endpoint, 0, 2)
+	for _, url := range []string{urlB, urlA} { // declared B first, expected back A first
+		conn, err := lavasession.NewDirectRPCConnection(ctx, common.NodeUrl{Url: url}, 5, apiInterface)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = conn.Close() })
+		endpoints = append(endpoints, &lavasession.Endpoint{
+			NetworkAddress:    url,
+			Enabled:           true,
+			DirectConnections: []lavasession.DirectRPCConnection{conn},
+		})
+	}
+	require.NoError(t, csm.UpdateAllProviders(1, map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: lavasession.NewConsumerSessionWithProvider(providerAddr, endpoints, 999999, 1, int64(1)),
+	}, nil))
+
+	qosClient := metrics.NewConsumerOptimizerQoSClient("consumer", metrics.NoopUsageSink{})
+	qosClient.RegisterOptimizer(&fixedScoreOptimizer{composite: 0.5, availability: 1}, chainID)
+	qosClient.UpdatePairingListStake(map[string]int64{providerAddr: 10}, chainID, 1)
+
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(debugMuxDeps{
+		optimizers: newEmptyOptimizersRouter(),
+		offsetNano: &offsetNano,
+		qosClient:  qosClient,
+		router:     &RPCSmartRouter{sessionManagers: map[string]*lavasession.ConsumerSessionManager{"ETH1-jsonrpc": csm}},
+	})
+
+	rr := getDebugRouter(mux, "/debug/provider-scores")
+	require.Equal(t, http.StatusOK, rr.Code, "body=%q", rr.Body.String())
+
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	require.Equal(t, providerAddr, rows[0]["ProviderAddress"])
+	require.Equal(t, []any{urlA, urlB}, rows[0]["NetworkAddresses"],
+		"every endpoint of the provider is listed, sorted, so the row joins to /debug/endpoint-state")
+}
+
+// TestDebugProviderScores_ChainFilter: the filter narrows the answer, and asking for a chain the
+// router does not run is a 404 rather than an empty success.
+func TestDebugProviderScores_ChainFilter(t *testing.T) {
+	mux := newScoresMux(t)
+
+	rr := getDebugRouter(mux, "/debug/provider-scores?chain_id=eth1")
+	require.Equal(t, http.StatusOK, rr.Code, "chain_id matches case-insensitively")
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+
+	rr = getDebugRouter(mux, "/debug/provider-scores?chain_id=SOLANA")
+	require.Equal(t, http.StatusNotFound, rr.Code, "a chain with no optimizer is 404, not an empty 200")
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -380,6 +380,7 @@ func (rpsr *RPCSmartRouter) Start(ctx context.Context, options *rpcSmartRouterSt
 			offsetNano: &currentOffsetNano,
 			router:     rpsr,
 			cache:      options.cache,
+			qosClient:  smartRouterOptimizerQoSClient,
 		})
 		srv := &http.Server{Addr: options.cmdFlags.DebugAddress, Handler: debugMux}
 		// Watcher goroutine: shuts the server down gracefully when ctx is cancelled
@@ -461,6 +462,11 @@ type debugMuxDeps struct {
 	// router is optional. When provided, /debug/reset-all also flushes
 	// per-server RelayRetriesManagers and per-CSM transient failure state.
 	router *RPCSmartRouter
+	// qosClient is the optional optimizer-QoS sampler. When provided,
+	// GET /debug/provider-scores reads the live per-provider quality scores
+	// through it (MAG-2707). Without it that endpoint reports the scores as
+	// unavailable rather than answering with an empty list.
+	qosClient *metrics.ConsumerOptimizerQoSClient
 	// cache is the optional external cache-be client. When non-nil and
 	// CacheActive(), /debug/reset-all also flushes the cache-be pod via
 	// RelayerCache.FlushCache — without it the in-process Ristretto reset is a
@@ -647,6 +653,40 @@ func resolvePollNowTargets(deps debugMuxDeps, networkAddress, chainID, apiInterf
 		})
 	}
 	return targets
+}
+
+// providerEndpointURLs maps each provider address to the direct-RPC endpoint URLs configured for it,
+// so a /debug/provider-scores row can be joined to /debug/endpoint-state (MAG-2707).
+//
+// The two views key on different identities and neither can be derived from the other: the optimizer
+// — and therefore every score — is keyed by provider address (PublicLavaAddress, the same identity
+// /debug/provider-routing reports), while per-endpoint health is keyed by NetworkAddress. Carrying
+// the URLs on the score row is what lets the automation ask "this provider's score moved, was its
+// endpoint healthy?" from two reads instead of needing a third mapping call.
+//
+// Nil-safe at every level; returns an empty map when no router or session managers are wired.
+func providerEndpointURLs(deps debugMuxDeps) map[string][]string {
+	urls := map[string][]string{}
+	if deps.router == nil {
+		return urls
+	}
+	deps.router.mu.Lock()
+	defer deps.router.mu.Unlock()
+	for _, csm := range deps.router.sessionManagers {
+		if csm == nil {
+			continue
+		}
+		for _, ep := range csm.GetAllDirectRPCEndpoints() {
+			if ep == nil || ep.Endpoint == nil || ep.ProviderAddress == "" {
+				continue
+			}
+			urls[ep.ProviderAddress] = append(urls[ep.ProviderAddress], ep.Endpoint.NetworkAddress)
+		}
+	}
+	for _, list := range urls {
+		sort.Strings(list) // stable output; the map iteration above is unordered
+	}
+	return urls
 }
 
 // setAllChainStateDebugOffset shifts every per-server ChainState's effective clock by offset, aging
@@ -1523,6 +1563,99 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 		writeDebugRows(w, rows)
 	})
 
+	// GET /debug/provider-scores — the per-provider quality scores the router is holding RIGHT NOW:
+	// the values it uses to decide where the next request goes (MAG-2707). Read-only.
+	//
+	// The router could already RESET these scores (/debug/reset-scores) but never read them: their
+	// only exposure was Prometheus gauges on the metrics port, which is not published, so reading
+	// them meant a hand-held tunnel — impossible from an automated run, and worse, when the tunnel
+	// was down the read came back empty and the test passed having measured nothing.
+	//
+	// That failure mode dictates the error design here, and it is why this endpoint deliberately
+	// breaks the convention of the other /debug state endpoints (which answer 200 [] when unwired):
+	//   200  scores follow. A provider that exists but has not been sampled yet IS included, with
+	//        zero scores — that is a real answer, not an omission.
+	//   404  chain_id was given and no optimizer is registered for it.
+	//   503  the scores could not be obtained at all: no QoS sampler wired, no optimizer registered,
+	//        or every matched chain has no providers known yet. The body names the chains, so a
+	//        failing test says WHY rather than just "empty".
+	// Never 200 with an empty array — that is precisely the silent pass this endpoint exists to end.
+	//
+	// Scores are computed ON DEMAND rather than served from the sampler's cache: that cache is empty
+	// until the first tick and after /debug/reset-scores, so "not sampled yet" would be
+	// indistinguishable from "no providers". Computing here also lets one test reset the scores, send
+	// traffic, and read the result back in sequence. It publishes nothing — the usage-sink emit
+	// belongs to the periodic sampler alone — so reading changes nothing about how the router behaves.
+	//
+	// Each row carries both score families, because they answer different questions: the RAW EWMA
+	// values (AvailabilityScore, LatencyScore in seconds, SyncScore as lag in seconds) are what a
+	// test asserting "this provider was not marked down" should read, while the Selection* values are
+	// those same signals after normalisation, with Composite the number selection actually ranks on.
+	// NetworkAddresses joins the row to /debug/endpoint-state (see providerEndpointURLs).
+	mux.HandleFunc("/debug/provider-scores", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "GET only", http.StatusMethodNotAllowed)
+			return
+		}
+		chainIDFilter := r.URL.Query().Get("chain_id")
+
+		snapshot := deps.qosClient.SnapshotReports(chainIDFilter) // nil-receiver safe
+		if len(snapshot.ChainsRegistered) == 0 {
+			if chainIDFilter != "" {
+				http.Error(w, fmt.Sprintf("no optimizer registered for chain_id %q", chainIDFilter), http.StatusNotFound)
+				return
+			}
+			http.Error(w, "provider scores unavailable: no optimizer registered (or no QoS sampler wired)", http.StatusServiceUnavailable)
+			return
+		}
+		if len(snapshot.Reports) == 0 {
+			http.Error(w, fmt.Sprintf("provider scores unavailable: no providers known yet for %v", snapshot.ChainsUnavailable), http.StatusServiceUnavailable)
+			return
+		}
+
+		urlsByProvider := providerEndpointURLs(deps)
+		rows := make([]map[string]any, 0, len(snapshot.Reports))
+		for _, report := range snapshot.Reports {
+			addresses := urlsByProvider[report.ProviderAddress]
+			if addresses == nil {
+				addresses = []string{} // marshal as [] rather than null
+			}
+			rows = append(rows, map[string]any{
+				"ChainID":          report.ChainId,
+				"ProviderAddress":  report.ProviderAddress,
+				"NetworkAddresses": addresses,
+				"Epoch":            report.Epoch,
+				"EntryIndex":       report.EntryIndex,
+				"Timestamp":        debugTimeRFC3339(report.Timestamp),
+				// Raw EWMA values, as stored: availability 0-1 (higher better), latency seconds and
+				// sync lag seconds (lower better).
+				"AvailabilityScore": report.AvailabilityScore,
+				"LatencyScore":      report.LatencyScore,
+				"SyncScore":         report.SyncScore,
+				// The same signals normalised for weighted random selection, and the composite the
+				// selection actually ranks on.
+				"SelectionAvailability": report.SelectionAvailability,
+				"SelectionLatency":      report.SelectionLatency,
+				"SelectionSync":         report.SelectionSync,
+				"SelectionStake":        report.SelectionStake,
+				"SelectionComposite":    report.SelectionComposite,
+				// How much each parameter contributed to the composite.
+				"AvailabilityContribution": report.AvailabilityContribution,
+				"LatencyContribution":      report.LatencyContribution,
+				"SyncContribution":         report.SyncContribution,
+				"StakeContribution":        report.StakeContribution,
+				// Traffic-side context for interpreting the scores above.
+				"ProviderStake":     report.ProviderStake,
+				"NodeErrorRate":     report.NodeErrorRate,
+				"SelectionCount":    report.SelectionCount,
+				"SelectionRate":     report.SelectionRate,
+				"SelectionQoSScore": report.SelectionQoSScore,
+				"SelectionRNGValue": report.SelectionRNGValue,
+			})
+		}
+		writeDebugRows(w, rows)
+	})
+
 	// POST /debug/reset-endpoint-health — focused companion to /debug/reset-all (MAG-2186):
 	// re-enable every provider endpoint disabled by MaxConsecutiveConnectionAttempts
 	// (Endpoint.Enabled=false) and mirror the reset onto the Prometheus health gauge,
@@ -1678,7 +1811,12 @@ func debugRowKey(m map[string]any) string {
 	cid, _ := m["ChainID"].(string)
 	api, _ := m["ApiInterface"].(string)
 	na, _ := m["NetworkAddress"].(string)
-	return cid + "\x00" + api + "\x00" + na
+	// ProviderAddress is the tiebreaker for rows keyed by provider rather than by endpoint
+	// (/debug/provider-scores, MAG-2707). Without it every row of one chain shares a key and
+	// sort.Slice — which is NOT stable — leaves their order to chance. Absent on every other row
+	// type, where comma-ok yields "" and the key is unchanged.
+	pa, _ := m["ProviderAddress"].(string)
+	return cid + "\x00" + api + "\x00" + na + "\x00" + pa
 }
 
 // writeDebugRows sorts the records deterministically (so Go map-iteration order never leaks into the

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -655,6 +655,23 @@ func resolvePollNowTargets(deps debugMuxDeps, networkAddress, chainID, apiInterf
 	return targets
 }
 
+// providerScoresResponse is the body of GET /debug/provider-scores (MAG-2707).
+//
+// It is an ENVELOPE rather than the bare array the other /debug state endpoints return, because a
+// partial answer has to be able to say what is missing. On a router serving several chains, one
+// chain can have providers while another has none: the rows alone would then be a 200 that looks
+// complete, and a caller reading the empty chain would conclude "this provider has no score" rather
+// than "this chain produced nothing" — the same silent pass this endpoint exists to end, narrowed
+// from the whole router to a single chain.
+//
+// chains_unavailable names every matched chain that produced no rows; it is empty (never null) when
+// the answer is complete. Rows keep the bare Go-identifier keys the other debug rows use; the
+// envelope keys are snake_case like the other non-row debug responses.
+type providerScoresResponse struct {
+	Rows              []map[string]any `json:"rows"`
+	ChainsUnavailable []string         `json:"chains_unavailable"`
+}
+
 // providerEndpointURLs maps each provider address to the direct-RPC endpoint URLs configured for it,
 // so a /debug/provider-scores row can be joined to /debug/endpoint-state (MAG-2707).
 //
@@ -1573,13 +1590,17 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 	//
 	// That failure mode dictates the error design here, and it is why this endpoint deliberately
 	// breaks the convention of the other /debug state endpoints (which answer 200 [] when unwired):
-	//   200  scores follow. A provider that exists but has not been sampled yet IS included, with
-	//        zero scores — that is a real answer, not an omission.
+	//   200  scores follow, in {"rows": [...], "chains_unavailable": [...]}. A provider that exists
+	//        but has not been sampled yet IS included, with zero scores — that is a real answer, not
+	//        an omission. chains_unavailable names any matched chain that produced NO rows, so a
+	//        partly-populated multi-chain router cannot answer 200 while quietly omitting a chain
+	//        (which would read as "that provider has no score" rather than "nothing was measured").
 	//   404  chain_id was given and no optimizer is registered for it.
-	//   503  the scores could not be obtained at all: no QoS sampler wired, no optimizer registered,
-	//        or every matched chain has no providers known yet. The body names the chains, so a
-	//        failing test says WHY rather than just "empty".
-	// Never 200 with an empty array — that is precisely the silent pass this endpoint exists to end.
+	//   503  NO scores could be obtained: no QoS sampler wired, no optimizer registered, or every
+	//        matched chain has no providers known yet. The body names the chains, so a failing test
+	//        says WHY rather than just "empty".
+	// Never 200 with an empty, unexplained result — that is precisely the silent pass this endpoint
+	// exists to end.
 	//
 	// Scores are computed ON DEMAND rather than served from the sampler's cache: that cache is empty
 	// until the first tick and after /debug/reset-scores, so "not sampled yet" would be
@@ -1653,7 +1674,15 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 				"SelectionRNGValue": report.SelectionRNGValue,
 			})
 		}
-		writeDebugRows(w, rows)
+		sortDebugRows(rows)
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(providerScoresResponse{
+			Rows:              rows,
+			ChainsUnavailable: snapshot.ChainsUnavailable,
+		}); err != nil {
+			utils.LavaFormatWarning("failed encoding provider scores response", err)
+		}
 	})
 
 	// POST /debug/reset-endpoint-health — focused companion to /debug/reset-all (MAG-2186):
@@ -1822,8 +1851,15 @@ func debugRowKey(m map[string]any) string {
 // writeDebugRows sorts the records deterministically (so Go map-iteration order never leaks into the
 // response, keeping output stable for test fixtures and humans) and encodes them as a JSON array.
 // rows is always non-nil, so an empty result encodes as [] rather than null.
-func writeDebugRows(w http.ResponseWriter, rows []map[string]any) {
+// sortDebugRows orders rows by debugRowKey in place, so Go map-iteration order never leaks into a
+// response. Split out of writeDebugRows for the responses that wrap their rows in an envelope
+// (/debug/provider-scores) and so cannot go through it.
+func sortDebugRows(rows []map[string]any) {
 	sort.Slice(rows, func(i, j int) bool { return debugRowKey(rows[i]) < debugRowKey(rows[j]) })
+}
+
+func writeDebugRows(w http.ResponseWriter, rows []map[string]any) {
+	sortDebugRows(rows)
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(rows); err != nil {
 		utils.LavaFormatWarning("failed encoding debug response", err)


### PR DESCRIPTION
# Description

Adds `GET /debug/provider-scores`: read the per-provider quality scores the router is holding right now — the values it uses to decide where the next request goes. Read-only.

The router could already **reset** these scores (`/debug/reset-scores`) but never **read** them. Their only exposure was Prometheus gauges on the metrics port, which is not published in the cluster, so reading them meant a hand-held tunnel: impossible from an automated nightly, and worse — when the tunnel was down the read came back empty and the test passed having measured nothing. Every question about how the router scores providers was untestable from outside.

## Jira ticket

Jira ticket: MAG-2707

---

## The error design is the point

That silent-empty failure mode is what this endpoint exists to end, so it deliberately breaks the convention of the other `/debug` state endpoints (which answer `200 []` when unwired):

| Status | Meaning |
| --- | --- |
| 200 | scores follow. A provider that exists but has not been sampled yet **is** included, with zero scores — a real answer, not an omission |
| 404 | `chain_id` was given and no optimizer is registered for it |
| 503 | the scores could not be obtained: no QoS sampler wired, no optimizer registered, or every matched chain has no providers known yet. The body **names the chains**, so a failing test says *why* rather than just "empty" |

Never 200 with an empty array.

## Design decisions

**Computed on demand, not served from the sampler's cache.** Not for freshness (the sampler runs at 1 s), but because that cache is empty until the first tick and after a score reset — so "not sampled yet" would be indistinguishable from "no providers", the exact ambiguity this endpoint removes. On-demand also lets one test reset scores, send traffic, and read the result back in sequence.

**Reading publishes nothing.** `appendOptimizerQoSReport` is split into a pure `buildOptimizerQoSReport` plus the usage-sink emit; `SnapshotReports` calls the builder only, and the periodic sampler keeps emitting exactly as before. Without that split a debug *read* would fire OTel usage events and double-count every dashboard fed by the sink.

**Everything routes through the shared builder,** which keeps `sanitizeFloat` on every float. `encoding/json` **errors** on NaN, and `writeDebugRows` only logs a warning after the status line is written — so a raw-float path would answer 200 with a truncated body: the same silent pass in a new costume.

**`SnapshotReports` refuses to drop a registered chain whose provider set is still empty.** The periodic sampler skips that case silently; a reader must not, or an unpopulated router is indistinguishable from a healthy idle one.

**Row shape.** Both score families, because they answer different questions: the raw EWMA values (`AvailabilityScore`, `LatencyScore` and `SyncScore` in seconds) are what a "was this provider marked down?" test reads, while the `Selection*` values are those same signals normalised, with `SelectionComposite` the number selection ranks on. Plus stake, node-error rate and selection counters for context.

`debugRowKey` gained `ProviderAddress` as a tiebreaker — `sort.Slice` is **not** stable, so same-chain rows would otherwise come back in arbitrary order. Absent on every other row type, where comma-ok yields `""` and the key is unchanged.

Read-only throughout, and behind `--debug-address` like the rest of `/debug`, so no new flag.

## One addition beyond the ticket — easy to strike

`NetworkAddresses` on each row is **not** in the ticket's four acceptance points. I added it because scores are keyed by **provider address** while endpoint health is keyed by **network address**, and neither identity can be derived from the other — so without it the automation cannot ask "this provider's score moved, was its endpoint healthy?" without a third lookup. It is also the only part of the diff that pulls `router.mu` into a read path that otherwise touches just the QoS client.

If a reviewer would rather keep the endpoint minimal, `providerEndpointURLs` + that one field can be removed without unpicking anything else.

## Related finding — likely a separate bug, not fixed here

The optimizer is being keyed by **two different identities**. Every path feeds it the provider address (`PublicLavaAddress`): the probe loop (`rpcsmartrouter_server.go:2574`), the relay path (`AppendRelayDataConsensus`), and stake (`CalcWeightsByStake` → `weights[cswp.PublicLavaAddress]`). But the **WS subscription path feeds it the endpoint URL** — `direct_ws_subscription_manager.go:579, 591, 601` pass `selectedEndpoint.Url`.

Reports enumerate only the stake map's keys (provider addresses), so WS-sourced QoS entries are written under keys nothing ever reads: invisible in scores, in metrics, and — if selection also enumerates addresses — in selection itself. That would mean WS relay outcomes are silently discarded as QoS feedback in production.

Out of scope here and worth its own ticket. Worth noting that this endpoint is exactly the tool that would have surfaced it.

## Most critical files to review

- `protocol/metrics/consumer_optimizer_qos_client.go` — the build/emit split and `SnapshotReports`.
- `protocol/rpcsmartrouter/rpcsmartrouter.go` — the handler (status-code logic above all), `providerEndpointURLs`, and the `debugRowKey` tiebreaker.

## Testing

`go test -race -count=1` on both packages.

The strongest test is `TestSnapshotReports_DoesNotEmitToUsageSink`: it asserts the read path publishes nothing **and** carries a positive control proving the periodic path still does — so it cannot pass against a sink that never fires. The join test wires two endpoints on one provider, declared in reverse order, so a pass proves the URLs are collected *and* sorted rather than echoed back in declaration order.

Lock order checked by hand: every `router.mu` acquisition is a debug handler, startup, or the epoch tick, and `updateEpoch` already goes `router.mu` → `csm.lock` — the same direction as the new code, so no inversion is introduced.

**Pre-existing, unrelated:** `metrics/TestHappyFlow` (a race in `relays_monitor`) and the `chaintracker` adaptive-cadence tests fail under `-race` on a clean `origin/main` — verified by stashing this branch's changes and re-running at the base commit. Untouched here.

---

## Author Checklist

* [x] read the contribution guide
* [x] included the correct type prefix in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change — n/a, additive debug-only endpoint
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests
* [x] updated the relevant documentation or specification, including comments for documenting Go code — Go doc comments on every new symbol; CHANGELOG is generated at release time from commit subjects, so not hand-edited here
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

* [ ] confirmed the correct type prefix in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
