### PR TITLE
chore(lavasession)!: remove the legacy synthetic prober

### DIFF
--- a/protocol/common/cobra_common.go
+++ b/protocol/common/cobra_common.go
@@ -106,11 +106,9 @@ const (
 	LimitWebsocketIdleTimeFlag                   = "limit-websocket-connection-idle-time"
 	SkipWebsocketVerificationFlag                = "skip-websocket-verification"
 	// specification default flags
-	PeriodicProbeProvidersFlagName         = "enable-periodic-probe-providers"
-	PeriodicProbeProvidersIntervalFlagName = "periodic-probe-providers-interval"
-	ProbeUpdateWeightFlagName              = "probe-update-weight"
+	ProbeUpdateWeightFlagName = "probe-update-weight"
 	// ProbeLoopIntervalFlagName is the cadence of the MAG-2161 (Topic D) proactive health prober —
-	// the real telemetry-driven loop, distinct from the legacy synthetic periodic-probe loop above.
+	// the telemetry-driven loop that owns direct-RPC endpoint health and probe-fed QoS.
 	ProbeLoopIntervalFlagName = "probe-loop-interval"
 
 	// batch request size limit

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -56,7 +56,6 @@ type ConsumerSessionManager struct {
 	rpcEndpoint    *RPCEndpoint // used to filter out endpoints
 	lock           sync.RWMutex
 	pairing        map[string]*ConsumerSessionsWithProvider // key == provider address
-	rawPairing     map[uint64]*ConsumerSessionsWithProvider // key == provider index in pairing. Used for periodic probing of providers
 	stickySessions *StickySessionStore
 	currentEpoch   uint64
 	numberOfResets uint64
@@ -330,8 +329,6 @@ func (csm *ConsumerSessionManager) UpdateAllProviders(epoch uint64, pairingList 
 
 	csm.lock.Lock()         // start by locking the class lock.
 	defer csm.lock.Unlock() // we defer here so in case we return an error it will unlock automatically.
-
-	csm.rawPairing = pairingList
 
 	if epoch < previousEpoch { // sentry shouldn't update an old epoch
 		return utils.LavaFormatError("trying to update provider list for older epoch", nil, utils.Attribute{Key: "epoch", Value: epoch}, utils.Attribute{Key: "currentEpoch", Value: csm.atomicReadCurrentEpoch()})
@@ -2395,11 +2392,16 @@ func (csm *ConsumerSessionManager) checkAndUnblockHealthyReBlockedProviders(ctx 
 			continue // Provider not in current pairing or backup list
 		}
 
-		// reportedProviders is populated by relay-failure reporting (ReportProvider), which only
-		// ever fires for providers that actually served traffic. A backup provider that was never
-		// selected therefore never appears there, so using !IsReported for a backup would signal
-		// health it has not demonstrated and unblock it without any real check. Always run an
-		// explicit probe for backup providers.
+		// A backup ALWAYS takes the comprehensive-probe branch: !isBackup short-circuits, so a
+		// backup's report state is never consulted at all. That is deliberate — report state is
+		// only meaningful as a health signal for a provider we actually have evidence about, and
+		// a backup that was never selected has none. Falling through to !IsReported for it would
+		// read "absent from reportedProviders" as "healthy" and unblock it with no real check.
+		//
+		// Note a backup CAN legitimately appear in reportedProviders: blockProvider's
+		// AddressIndexWasNotFoundError branch marks blockedBackupProviders and then falls through
+		// to the reportProvider block below it. That is irrelevant here precisely because the
+		// short-circuit means we never look.
 		if !isBackup && !csm.reportedProviders.IsReported(blockedAddr) {
 			// Non-backup provider whose probe succeeded (it wasn't added to reportedProviders).
 			// Unblock immediately.
@@ -2412,7 +2414,7 @@ func (csm *ConsumerSessionManager) checkAndUnblockHealthyReBlockedProviders(ctx 
 			csm.validateAndReturnBlockedProviderToValidAddressesListLocked(blockedAddr)
 			csm.reportedProviders.RemoveReport(blockedAddr)
 		} else {
-			// Either a backup provider (needs an actual probe since it has no relay history),
+			// Either a backup provider (always routed here by the short-circuit above),
 			// or a non-backup that was reported for relay failures.
 			// In both cases, run a comprehensive probe with tryReconnect=true.
 			providersNeedingComprehensiveProbe[blockedAddr] = reBlockedProviderInfo{cswp: cswp, isBackup: isBackup}
@@ -2494,7 +2496,7 @@ func (csm *ConsumerSessionManager) SetLavaBlockHeightCallback(getLavaBlockHeight
 }
 
 // ResetTransientFailureState clears every cross-epoch failure-tracking store
-// without forcing an epoch transition. The "live pairing" (pairing, rawPairing,
+// without forcing an epoch transition. The "live pairing" (pairing,
 // pairingAddresses, validAddresses, currentlyBlockedProviderAddresses,
 // backupProviders) is left intact so the very next relay can route normally.
 //

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -30,7 +30,7 @@ const (
 	BlockedProviderSessionUnusedStatus = uint32(0)
 )
 
-// debugProbes is an atomic toggle: it is read by probe goroutines (probeProviders) while the CLI
+// debugProbes is an atomic toggle: it is read by probe goroutines (probeProvider) while the CLI
 // layer sets it from the parsed --debug-probes flag. A plain bool here raced the flag write against
 // those reads under -race (a leaked probe goroutine from one test vs another test building the cobra
 // command). Use SetDebugProbes/DebugProbesEnabled rather than touching it directly.
@@ -43,13 +43,11 @@ func SetDebugProbes(enabled bool) { debugProbes.Store(enabled) }
 func DebugProbesEnabled() bool { return debugProbes.Load() }
 
 var (
-	retrySecondChanceAfter         = time.Minute * 3
-	PeriodicProbeProviders         = false
-	PeriodicProbeProvidersInterval = 5 * time.Second
-	// ProbeLoopInterval is the configurable cadence (MAG-2161 D5) of the real proactive health prober
-	// (rpcsmartrouter.runProbeLoop). Default 5s; validated at startup (a non-positive value is rejected
-	// back to the default). Distinct from PeriodicProbeProvidersInterval, which clocks the legacy
-	// synthetic probe loop — the prober does NOT use that knob.
+	retrySecondChanceAfter = time.Minute * 3
+	// ProbeLoopInterval is the configurable cadence (MAG-2161 D5) of the proactive health prober
+	// (rpcsmartrouter.runProbeLoop) — the single source of truth for direct-RPC endpoint health and
+	// probe-fed QoS. Default 5s; validated at startup (a non-positive value is rejected back to the
+	// default).
 	ProbeLoopInterval = 5 * time.Second
 )
 
@@ -322,9 +320,6 @@ func (csm *ConsumerSessionManager) UpdateAllProviders(epoch uint64, pairingList 
 		time.Sleep(time.Duration(rand.Intn(500)) * time.Millisecond) // sleep up to 500ms in order to scatter different chains probe triggers
 		go func() {
 			ctx := context.Background()
-			// Probe all providers to eliminate offline ones from affecting relays
-			csm.probeProviders(ctx, pairingList, epoch) // pairingList is thread safe it's members are not (accessed through csm.pairing)
-
 			// Check re-blocked providers from previous epoch and unblock if healthy
 			csm.checkAndUnblockHealthyReBlockedProviders(ctx, epoch)
 		}()
@@ -614,71 +609,6 @@ func (csm *ConsumerSessionManager) closePurgedUnusedPairingsConnections(pairingP
 			continue
 		}
 		callbackPurge()
-	}
-}
-
-func (csm *ConsumerSessionManager) PeriodicProbeProviders(ctx context.Context, interval time.Duration) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			if csm.rawPairing != nil {
-				csm.probeProviders(ctx, csm.rawPairing, csm.atomicReadCurrentEpoch())
-			}
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-func (csm *ConsumerSessionManager) probeProviders(ctx context.Context, pairingList map[uint64]*ConsumerSessionsWithProvider, epoch uint64) error {
-	guid := utils.GenerateUniqueIdentifier()
-	ctx = utils.AppendUniqueIdentifier(ctx, guid)
-	if DebugProbesEnabled() {
-		utils.LavaFormatInfo("providers probe initiated", utils.Attribute{Key: "endpoint", Value: csm.rpcEndpoint}, utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: "epoch", Value: epoch})
-	}
-	// Create a wait group to synchronize the goroutines
-	wg := sync.WaitGroup{}
-	wg.Add(len(pairingList)) // increment by this and not by 1 for each go routine because we don;t want a race finishing the go routine before the next invocation
-	for _, consumerSessionWithProvider := range pairingList {
-		// Start a new goroutine for each provider
-		go func(consumerSessionsWithProvider *ConsumerSessionsWithProvider) {
-			// Call the probeProvider function and defer the WaitGroup Done call
-			defer wg.Done()
-			// MAG-2161 (Topic D / F3+F7): direct-RPC (static) providers are owned end-to-end by the
-			// real telemetry-driven prober (runProbeLoop): it scores their liveness/latency/sync from
-			// real observations (AppendProbeData) and proactively re-enables recovered endpoints. The
-			// legacy SYNTHETIC probe here only reads the Enabled bit and reports a nominal 1ms success —
-			// a fake liveness signal (SetProviderLiveness) and a fake QoS feed. Skip it entirely for
-			// static providers so the prober is the single source of truth for direct-RPC health.
-			if consumerSessionsWithProvider.StaticProvider {
-				return
-			}
-			latency, providerAddress, err := csm.probeProvider(ctx, consumerSessionsWithProvider, epoch, false)
-			success := err == nil // if failure then regard it in availability
-			csm.consumerMetricsManager.SetProviderLiveness(csm.rpcEndpoint.ChainID, providerAddress, consumerSessionsWithProvider.Endpoints[0].NetworkAddress, success)
-			csm.providerOptimizer.AppendProbeRelayData(providerAddress, latency, success)
-		}(consumerSessionWithProvider)
-	}
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		wg.Wait()
-	}()
-
-	select {
-	case <-done:
-		// all probes finished in time
-		if DebugProbesEnabled() {
-			utils.LavaFormatDebug("providers probe done", utils.Attribute{Key: "endpoint", Value: csm.rpcEndpoint}, utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: "epoch", Value: epoch})
-		}
-		return nil
-	case <-ctx.Done():
-		utils.LavaFormatWarning("providers probe ran out of time", nil, utils.Attribute{Key: "endpoint", Value: csm.rpcEndpoint}, utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: "epoch", Value: epoch})
-		// ran out of time
-		return ctx.Err()
 	}
 }
 
@@ -2465,11 +2395,11 @@ func (csm *ConsumerSessionManager) checkAndUnblockHealthyReBlockedProviders(ctx 
 			continue // Provider not in current pairing or backup list
 		}
 
-		// reportedProviders reflects probe outcomes only for pairingList providers —
-		// probeProviders only probes pairingList, so backup providers are never probed
-		// and will never appear in reportedProviders. Using !IsReported for a backup
-		// provider would incorrectly signal a successful probe and unblock it without
-		// any real health check. Always run an explicit probe for backup providers.
+		// reportedProviders is populated by relay-failure reporting (ReportProvider), which only
+		// ever fires for providers that actually served traffic. A backup provider that was never
+		// selected therefore never appears there, so using !IsReported for a backup would signal
+		// health it has not demonstrated and unblock it without any real check. Always run an
+		// explicit probe for backup providers.
 		if !isBackup && !csm.reportedProviders.IsReported(blockedAddr) {
 			// Non-backup provider whose probe succeeded (it wasn't added to reportedProviders).
 			// Unblock immediately.
@@ -2482,8 +2412,8 @@ func (csm *ConsumerSessionManager) checkAndUnblockHealthyReBlockedProviders(ctx 
 			csm.validateAndReturnBlockedProviderToValidAddressesListLocked(blockedAddr)
 			csm.reportedProviders.RemoveReport(blockedAddr)
 		} else {
-			// Either a backup provider (needs an actual probe since it was never probed
-			// by probeProviders), or a non-backup whose initial probe failed.
+			// Either a backup provider (needs an actual probe since it has no relay history),
+			// or a non-backup that was reported for relay failures.
 			// In both cases, run a comprehensive probe with tryReconnect=true.
 			providersNeedingComprehensiveProbe[blockedAddr] = reBlockedProviderInfo{cswp: cswp, isBackup: isBackup}
 			utils.LavaFormatDebug("Re-blocked provider needs explicit probe",

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -172,73 +172,6 @@ func TestEndpointHealthRecovery(t *testing.T) {
 	require.NoError(t, getSessions(), "ResetEndpointHealth alone must recover: the next GetSessions self-heals the blocked list")
 }
 
-func TestEndpointSortingFlow(t *testing.T) {
-	// Bind on port 0 so the kernel picks a free port: a fixed one collides with
-	// whatever else holds it on the host and cannot collide with grpcListener.
-	delayedAddress, err := createGRPCServer("127.0.0.1:0", 300*time.Millisecond)
-	// Checked here rather than after the connect loops below: those spin without a
-	// backoff, so a bind failure would busy-wait to the package timeout instead of
-	// reporting itself.
-	require.NoError(t, err)
-	utils.LavaFormatDebug("delayedAddress Chosen", utils.LogAttr("address", delayedAddress))
-	csp := &ConsumerSessionsWithProvider{}
-	for {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		_, _, err := csp.ConnectRawClientWithTimeout(ctx, delayedAddress)
-		if err != nil {
-			utils.LavaFormatDebug("delayedAddress - waiting for grpc server to launch")
-			continue
-		}
-		utils.LavaFormatDebug("delayedAddress - grpc server is live", utils.LogAttr("address", delayedAddress))
-		cancel()
-		break
-	}
-
-	for {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		_, _, err := csp.ConnectRawClientWithTimeout(ctx, grpcListener)
-		if err != nil {
-			utils.LavaFormatDebug("grpcListener - waiting for grpc server to launch")
-			continue
-		}
-		utils.LavaFormatDebug("grpcListener - grpc server is live", utils.LogAttr("address", grpcListener))
-		cancel()
-		break
-	}
-
-	csm := CreateConsumerSessionManager()
-	pairingList := createPairingList("", true)
-	pairingList[0].Endpoints = append(pairingList[0].Endpoints, &Endpoint{NetworkAddress: delayedAddress, Enabled: true, Connections: []*EndpointConnection{}, ConnectionRefusals: 0})
-	// swap locations so that the endpoint of the delayed will be first
-	pairingList[0].Endpoints[0], pairingList[0].Endpoints[1] = pairingList[0].Endpoints[1], pairingList[0].Endpoints[0]
-
-	// update the pairing and wait for the routine to send all requests
-	err = csm.UpdateAllProviders(firstEpochHeight, pairingList, nil) // update the providers.
-	require.NoError(t, err)
-
-	_, ok := csm.pairing[pairingList[0].PublicLavaAddress]
-	require.True(t, ok)
-
-	// because probing is in a routine we need to wait for the sorting and probing to end asynchronously.
-	// The probe goroutine reorders Endpoints under pairingList[0].Lock, so read the slice under that
-	// lock — an unsynchronized read here races the sort (data race under -race).
-	swapped := false
-	for i := 0; i < 20; i++ {
-		pairingList[0].Lock.RLock()
-		firstEndpoint := pairingList[0].Endpoints[0].NetworkAddress
-		pairingList[0].Lock.RUnlock()
-		if firstEndpoint == grpcListener {
-			fmt.Println("Endpoints Are Sorted!", i)
-			swapped = true
-			break
-		}
-		time.Sleep(1 * time.Second)
-		fmt.Println("Endpoints did not swap yet, attempt:", i)
-	}
-	require.True(t, swapped)
-	// after creating all the sessions
-}
-
 func CreateConsumerSessionManager() *ConsumerSessionManager {
 	rand.InitRandomSeed()
 	optimizer := provideroptimizer.NewProviderOptimizer(provideroptimizer.StrategyBalanced, 0, 1, nil, "dontcare")
@@ -2010,119 +1943,6 @@ func TestConnectRawClientWithTimeoutSuccessfulConnection(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 }
 
-// TestPeriodicProbeProvidersTickerCleanup tests that the ticker in PeriodicProbeProviders
-// is properly stopped when the context is cancelled. This was a bug where the ticker
-// was not stopped, causing a goroutine leak.
-func TestPeriodicProbeProvidersTickerCleanup(t *testing.T) {
-	t.Run("function exits promptly when context is cancelled", func(t *testing.T) {
-		csm := CreateConsumerSessionManager()
-
-		// Create a cancellable context
-		ctx, cancel := context.WithCancel(context.Background())
-
-		// Track when the function exits
-		done := make(chan struct{})
-
-		go func() {
-			defer close(done)
-			csm.PeriodicProbeProviders(ctx, 10*time.Millisecond)
-		}()
-
-		// Let it run for a few ticks to ensure ticker is active
-		time.Sleep(50 * time.Millisecond)
-
-		// Cancel the context
-		cancel()
-
-		// The function should exit promptly after context cancellation
-		select {
-		case <-done:
-			// Success - function exited after context cancellation
-		case <-time.After(500 * time.Millisecond):
-			t.Fatal("PeriodicProbeProviders did not exit after context cancellation - possible ticker leak")
-		}
-	})
-
-	t.Run("multiple probe sessions all exit on cancellation", func(t *testing.T) {
-		numSessions := 5
-		csms := make([]*ConsumerSessionManager, numSessions)
-		ctxs := make([]context.Context, numSessions)
-		cancels := make([]context.CancelFunc, numSessions)
-		dones := make([]chan struct{}, numSessions)
-
-		// Start multiple probe sessions
-		for i := 0; i < numSessions; i++ {
-			csms[i] = CreateConsumerSessionManager()
-			ctxs[i], cancels[i] = context.WithCancel(context.Background())
-			dones[i] = make(chan struct{})
-
-			go func(idx int) {
-				defer close(dones[idx])
-				csms[idx].PeriodicProbeProviders(ctxs[idx], 10*time.Millisecond)
-			}(i)
-		}
-
-		// Let them run briefly to ensure tickers are active
-		time.Sleep(30 * time.Millisecond)
-
-		// Cancel all contexts
-		for i := 0; i < numSessions; i++ {
-			cancels[i]()
-		}
-
-		// Wait for all to exit - they should all exit promptly
-		for i := 0; i < numSessions; i++ {
-			select {
-			case <-dones[i]:
-				// Success
-			case <-time.After(500 * time.Millisecond):
-				t.Fatalf("PeriodicProbeProviders %d did not exit after context cancellation - possible ticker leak", i)
-			}
-		}
-	})
-
-	t.Run("ticker fires expected number of times before cancellation", func(t *testing.T) {
-		// This test verifies the ticker is actually working and then properly cleaned up
-		tickerInterval := 20 * time.Millisecond
-		runDuration := 100 * time.Millisecond
-
-		ctx, cancel := context.WithCancel(context.Background())
-
-		started := make(chan struct{})
-		done := make(chan struct{})
-
-		go func() {
-			close(started)
-			// We can't easily count ticks in the real function, but we can verify
-			// the function runs for the expected duration and then exits cleanly
-			ticker := time.NewTicker(tickerInterval)
-			defer ticker.Stop() // This is what we added in the fix
-
-			for {
-				select {
-				case <-ticker.C:
-					// Tick occurred
-				case <-ctx.Done():
-					close(done)
-					return
-				}
-			}
-		}()
-
-		<-started
-		time.Sleep(runDuration)
-		cancel()
-
-		// Function should exit promptly
-		select {
-		case <-done:
-			// Success - function exited and ticker.Stop() was called
-		case <-time.After(200 * time.Millisecond):
-			t.Fatal("Function did not exit promptly after context cancellation")
-		}
-	})
-}
-
 // TestBackupProviderOptimizerSelection verifies that when all static providers are exhausted,
 // the optimizer selects backup providers one at a time (not as a batch), and that successive
 // retries each get a different backup until the pool is exhausted.
@@ -2614,8 +2434,9 @@ func TestUpdateAllProviders_NormalProviderBlockedAsBackupInNextEpoch(t *testing.
 }
 
 // TestCheckAndUnblock_BackupRoutedToComprehensiveProbe verifies the `!isBackup && !IsReported`
-// guard in checkAndUnblockHealthyReBlockedProviders. probeProviders only probes pairingList, so
-// backup providers are never added to reportedProviders — without the guard, every backup would
+// guard in checkAndUnblockHealthyReBlockedProviders. reportedProviders is populated only by
+// relay-failure reporting, so a backup that never served traffic is never added — without the
+// guard, every backup would
 // match `!IsReported` and take the immediate-unblock branch, skipping any real health check.
 // This test confirms a backup lands in the comprehensive-probe branch instead: we assert the
 // backup is absent from reportedProviders (guard precondition) and that the immediate-unblock
@@ -2644,7 +2465,7 @@ func TestCheckAndUnblock_BackupRoutedToComprehensiveProbe(t *testing.T) {
 	csm.blockedBackupProviders[backupAddr] = struct{}{}
 	csm.lock.Unlock()
 
-	// Guard precondition: backups are never reported (probeProviders skips them).
+	// Guard precondition: backups are never reported (no relay history).
 	require.False(t, csm.reportedProviders.IsReported(backupAddr),
 		"backup provider should never appear in reportedProviders")
 

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -2434,13 +2434,14 @@ func TestUpdateAllProviders_NormalProviderBlockedAsBackupInNextEpoch(t *testing.
 }
 
 // TestCheckAndUnblock_BackupRoutedToComprehensiveProbe verifies the `!isBackup && !IsReported`
-// guard in checkAndUnblockHealthyReBlockedProviders. reportedProviders is populated only by
-// relay-failure reporting, so a backup that never served traffic is never added — without the
-// guard, every backup would
-// match `!IsReported` and take the immediate-unblock branch, skipping any real health check.
-// This test confirms a backup lands in the comprehensive-probe branch instead: we assert the
-// backup is absent from reportedProviders (guard precondition) and that the immediate-unblock
-// path leaves blockedBackupProviders intact (since that path only touches validAddresses).
+// guard in checkAndUnblockHealthyReBlockedProviders. `!isBackup` short-circuits, so a backup
+// never has its report state consulted and always takes the comprehensive-probe branch. Without
+// the guard, a backup absent from reportedProviders — as this fixture's is, having never served
+// traffic — would match `!IsReported` and take the immediate-unblock branch, skipping any real
+// health check. This test confirms it lands in the comprehensive-probe branch instead: we assert
+// the backup is absent from reportedProviders (the fixture state the guard protects against) and
+// that the immediate-unblock path leaves blockedBackupProviders intact (since that path only
+// touches validAddresses).
 func TestCheckAndUnblock_BackupRoutedToComprehensiveProbe(t *testing.T) {
 	csm := CreateConsumerSessionManager()
 	// Point at an unreachable endpoint so the comprehensive probe's eventual outcome
@@ -2465,9 +2466,11 @@ func TestCheckAndUnblock_BackupRoutedToComprehensiveProbe(t *testing.T) {
 	csm.blockedBackupProviders[backupAddr] = struct{}{}
 	csm.lock.Unlock()
 
-	// Guard precondition: backups are never reported (no relay history).
+	// Fixture state the guard protects against: this backup never served traffic, so it was
+	// never reported. (A backup that DID fail a relay can be reported — blockProvider falls
+	// through to the reportProvider block — but then the guard is not what saves us.)
 	require.False(t, csm.reportedProviders.IsReported(backupAddr),
-		"backup provider should never appear in reportedProviders")
+		"this backup never served traffic, so it must not be in reportedProviders")
 
 	// The immediate-unblock branch calls validateAndReturnBlockedProviderToValidAddressesListLocked,
 	// which is a no-op for backups (they're not in validAddresses). So if the guard is missing and

--- a/protocol/lavasession/consumer_types.go
+++ b/protocol/lavasession/consumer_types.go
@@ -109,7 +109,6 @@ type SessionInfo struct {
 type ConsumerSessionsMap map[string]*SessionInfo
 
 type ProviderOptimizer interface {
-	AppendProbeRelayData(providerAddress string, latency time.Duration, success bool)
 	AppendRelayFailure(providerAddress string)
 	AppendRelayData(providerAddress string, latency time.Duration, cu, syncBlock uint64)
 	AppendRelayDataConsensus(providerAddress string, latency time.Duration, cu, syncBlock uint64, syncRef provideroptimizer.SyncReference)

--- a/protocol/metrics/consumer_metrics_manager_inf.go
+++ b/protocol/metrics/consumer_metrics_manager_inf.go
@@ -37,7 +37,6 @@ func (NoOpConsumerMetrics) SetCrossValidationMetric(string, string, string, bool
 func (NoOpConsumerMetrics) SetCrossValidationFailureMetric(string, string, string, string) {}
 func (NoOpConsumerMetrics) UpdateHealthCheckStatus(bool)                                   {}
 func (NoOpConsumerMetrics) UpdateHealthcheckStatusBreakdown(string, string, bool)          {}
-func (NoOpConsumerMetrics) SetProviderLiveness(string, string, string, bool)               {}
 func (NoOpConsumerMetrics) SetProviderSelected(string, string, string, []ProviderSelectionScores, float64) {
 }
 func (NoOpConsumerMetrics) SetBlockedProvider(string, string, string, string, bool) {}
@@ -97,7 +96,6 @@ type ConsumerMetricsManagerInf interface {
 	UpdateHealthcheckStatusBreakdown(chainId, apiInterface string, status bool)
 
 	// --- Provider state (ConsumerSessionManager) ---
-	SetProviderLiveness(chainId string, providerAddress string, providerEndpoint string, isAlive bool)
 	SetProviderSelected(chainId string, apiInterface string, providerAddress string, allProviderScores []ProviderSelectionScores, rngValue float64)
 	SetBlockedProvider(chainId, apiInterface, providerAddress, providerEndpoint string, isBlocked bool)
 	SetQOSMetrics(chainId string, apiInterface string, providerAddress string, providerEndpoint string, qos *pairingtypes.QualityOfServiceReport, reputation *pairingtypes.QualityOfServiceReport, latestBlock int64, relays uint64, relayLatency time.Duration, sessionSuccessful bool)

--- a/protocol/metrics/smartrouter_metrics_manager.go
+++ b/protocol/metrics/smartrouter_metrics_manager.go
@@ -1342,8 +1342,6 @@ func (m *SmartRouterMetricsManager) UpdateHealthcheckStatusBreakdown(chainId, ap
 	m.routerOverallHealthBreakdown.WithLabelValues(chainId, apiInterface).Set(value)
 }
 
-func (m *SmartRouterMetricsManager) SetProviderLiveness(string, string, string, bool) {}
-
 func (m *SmartRouterMetricsManager) SetProviderSelected(chainId string, apiInterface string, _ string, allProviderScores []ProviderSelectionScores, _ float64) {
 	if m == nil {
 		return

--- a/protocol/provideroptimizer/provider_optimizer.go
+++ b/protocol/provideroptimizer/provider_optimizer.go
@@ -124,8 +124,8 @@ const providerLockStripes = 256
 // providerSyncFloor is one stripe: it serializes the score read-modify-write for every provider
 // hashing to it AND holds the authoritative monotonic SyncBlock floor for those providers.
 //
-// Why a floor at all (Finding 5): the three writers (appendRelayData, AppendProbeData, the legacy
-// AppendProbeRelayData) each do getProviderData → mutate → providersStorage.Set. ristretto's Set is
+// Why a floor at all (Finding 5): the writers (appendRelayData, AppendProbeData) each do
+// getProviderData → mutate → providersStorage.Set. ristretto's Set is
 // ASYNC — a subsequent Get can miss a just-written value (the package's own tests sleep to let it
 // settle) — so the cache cannot be the source of truth for "SyncBlock never decreases": a serialized
 // writer could still read a stale cached block and write a lower one back (probe@150 clobbering
@@ -443,50 +443,9 @@ func (po *ProviderOptimizer) appendRelayData(provider string, latency time.Durat
 	)
 }
 
-// AppendProbeRelayData updates a provider's QoS metrics for a probe relay message
-func (po *ProviderOptimizer) AppendProbeRelayData(providerAddress string, latency time.Duration, success bool) {
-	// Legacy path (Finding 5): this writer only mutates availability/latency, but it Sets the WHOLE
-	// providerData back — including the SyncBlock it read. A stale cache read would therefore silently
-	// regress SyncBlock. Take the stripe lock and stamp the floor (observed=0 → pure preserve) so this
-	// writer can never undo a higher block recorded by a concurrent relay/probe.
-	stripe := po.providerStripe(providerAddress)
-	stripe.mu.Lock()
-	defer stripe.mu.Unlock()
-
-	providerData, _ := po.getProviderData(providerAddress)
-	stripe.applyLocked(providerAddress, 0, &providerData)
-	sampleTime := po.now()
-	halfTime := po.calculateHalfTime(providerAddress, sampleTime)
-	weight := score.ProbeUpdateWeight
-	var updateErr error
-	if success {
-		// update latency only on success
-		providerData, updateErr = po.updateDecayingWeightedAverage(providerData, score.AvailabilityScoreType, 1, weight, halfTime, 0, sampleTime)
-		if updateErr != nil {
-			return
-		}
-		providerData, updateErr = po.updateDecayingWeightedAverage(providerData, score.LatencyScoreType, latency.Seconds(), weight, halfTime, 0, sampleTime)
-		if updateErr != nil {
-			return
-		}
-	} else {
-		providerData, updateErr = po.updateDecayingWeightedAverage(providerData, score.AvailabilityScoreType, 0, weight, halfTime, 0, sampleTime)
-		if updateErr != nil {
-			return
-		}
-	}
-	po.providersStorage.Set(providerAddress, providerData, 1)
-
-	utils.LavaFormatTrace("[Optimizer] probe update",
-		utils.LogAttr("providerAddress", providerAddress),
-		utils.LogAttr("latency", latency),
-		utils.LogAttr("success", success),
-	)
-}
-
 // AppendProbeData feeds one provider-aggregated probe sample — the Topic E contract's probe path,
-// the proactive baseline that scores providers between (or without) real relays. Unlike the legacy
-// AppendProbeRelayData (availability + latency only), it feeds all three dimensions:
+// the proactive baseline that scores providers between (or without) real relays. It feeds all three
+// dimensions:
 //   - availability is a FRACTION in [0,1] (the share of the provider's endpoints healthy this cycle,
 //     per the fraction-healthy aggregation rule) and is ALWAYS fed, including 0 when the provider is
 //     fully down — so partial degradation decays the score;

--- a/protocol/provideroptimizer/provider_optimizer_test.go
+++ b/protocol/provideroptimizer/provider_optimizer_test.go
@@ -53,8 +53,8 @@ func (po *ProviderOptimizer) readSyncFloor(provider string) uint64 {
 }
 
 // TestProviderOptimizer_SyncBlockNeverDecreasesUnderConcurrency is the Finding 5 regression: a
-// relay carrying block 200 and a probe carrying block 150 (plus the legacy availability-only
-// AppendProbeRelayData) race on ONE provider. Without serialized RMW + an authoritative floor, the
+// relay carrying block 200 and a probe carrying block 150 (plus a sync-less probe that still writes
+// the whole record back) race on ONE provider. Without serialized RMW + an authoritative floor, the
 // probe's stale-cache read could write 150 back AFTER the relay wrote 200, silently regressing the
 // block. The floor must guarantee SyncBlock settles at 200 and is NEVER observed below it. Run with
 // -race -count to actually hit the interleaving.
@@ -87,11 +87,12 @@ func TestProviderOptimizer_SyncBlockNeverDecreasesUnderConcurrency(t *testing.T)
 			po.AppendProbeData(provider, 1, TEST_BASE_WORLD_LATENCY, true, 150, true, freshRef(150))
 		}
 	}()
-	// Legacy availability-only writer: reads + writes back the whole providerData, incl. SyncBlock.
+	// Sync-less writer: carries no block evidence, but still reads + writes back the whole
+	// providerData, incl. SyncBlock — the shape that could regress the floor.
 	go func() {
 		defer wg.Done()
 		for i := 0; i < rounds; i++ {
-			po.AppendProbeRelayData(provider, TEST_BASE_WORLD_LATENCY, true)
+			po.AppendProbeData(provider, 1, TEST_BASE_WORLD_LATENCY, true, 0, false, SyncReference{})
 		}
 	}()
 	wg.Wait()
@@ -140,20 +141,20 @@ func TestProviderOptimizerBasicProbeData(t *testing.T) {
 	cu := uint64(10)
 	requestBlock := spectypes.LATEST_BLOCK
 
-	// damage providers 5-7 scores with bad latency probes relays
+	// damage providers 5-7 scores with bad latency probes
 	// they should be selected less often due to lower weighted scores
 	badLatency := TEST_BASE_WORLD_LATENCY * 3
-	providerOptimizer.AppendProbeRelayData(providersGen.providersAddresses[5], badLatency, true)
-	providerOptimizer.AppendProbeRelayData(providersGen.providersAddresses[6], badLatency, true)
-	providerOptimizer.AppendProbeRelayData(providersGen.providersAddresses[7], badLatency, true)
+	providerOptimizer.AppendProbeData(providersGen.providersAddresses[5], 1, badLatency, true, 0, false, SyncReference{})
+	providerOptimizer.AppendProbeData(providersGen.providersAddresses[6], 1, badLatency, true, 0, false, SyncReference{})
+	providerOptimizer.AppendProbeData(providersGen.providersAddresses[7], 1, badLatency, true, 0, false, SyncReference{})
 	time.Sleep(4 * time.Millisecond)
 
-	// improve providers 0-2 scores with good latency probes relays
+	// improve providers 0-2 scores with good latency probes
 	// they should be selected by the optimizer more often
 	goodLatency := TEST_BASE_WORLD_LATENCY / 2
-	providerOptimizer.AppendProbeRelayData(providersGen.providersAddresses[0], goodLatency, true)
-	providerOptimizer.AppendProbeRelayData(providersGen.providersAddresses[1], goodLatency, true)
-	providerOptimizer.AppendProbeRelayData(providersGen.providersAddresses[2], goodLatency, true)
+	providerOptimizer.AppendProbeData(providersGen.providersAddresses[0], 1, goodLatency, true, 0, false, SyncReference{})
+	providerOptimizer.AppendProbeData(providersGen.providersAddresses[1], 1, goodLatency, true, 0, false, SyncReference{})
+	providerOptimizer.AppendProbeData(providersGen.providersAddresses[2], 1, goodLatency, true, 0, false, SyncReference{})
 	time.Sleep(4 * time.Millisecond)
 	results := runChooseManyTimesAndReturnResults(t, providerOptimizer, providersGen.providersAddresses, nil, 1000, cu, requestBlock)
 
@@ -371,11 +372,11 @@ func TestProviderOptimizerUpdatingLatency(t *testing.T) {
 	requestBlock := int64(1000)
 	syncBlock := uint64(requestBlock)
 
-	// add an average latency probe relay to determine average score
-	providerOptimizer.AppendProbeRelayData(providerAddress, TEST_BASE_WORLD_LATENCY, true)
+	// add an average latency probe to determine average score
+	providerOptimizer.AppendProbeData(providerAddress, 1, TEST_BASE_WORLD_LATENCY, true, 0, false, SyncReference{})
 	time.Sleep(4 * time.Millisecond)
 
-	// add good latency probe relays, score should improve
+	// add good latency probes, score should improve
 	for i := 0; i < 10; i++ {
 		// get current score
 		qos, _ := providerOptimizer.GetReputationReportForProvider(providerAddress)
@@ -384,7 +385,7 @@ func TestProviderOptimizerUpdatingLatency(t *testing.T) {
 		require.NoError(t, err)
 
 		// add good latency probe
-		providerOptimizer.AppendProbeRelayData(providerAddress, TEST_BASE_WORLD_LATENCY/10, true)
+		providerOptimizer.AppendProbeData(providerAddress, 1, TEST_BASE_WORLD_LATENCY/10, true, 0, false, SyncReference{})
 		time.Sleep(4 * time.Millisecond)
 
 		// check score again and compare to the last score
@@ -395,7 +396,7 @@ func TestProviderOptimizerUpdatingLatency(t *testing.T) {
 		require.True(t, newScore < score, fmt.Sprintf("newScore: %v, score: %v", newScore, score))
 	}
 
-	// add an average latency probe relay to determine average score
+	// add an average latency probe to determine average score
 	providerAddress = providersGen.providersAddresses[1]
 	providerOptimizer.AppendRelayData(providerAddress, TEST_BASE_WORLD_LATENCY, cu, syncBlock)
 	time.Sleep(4 * time.Millisecond)

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -2156,10 +2156,6 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	rpsr.sessionManagers[sessionManagerKey] = sessionManager
 	rpsr.mu.Unlock()
 
-	if lavasession.PeriodicProbeProviders {
-		go sessionManager.PeriodicProbeProviders(ctx, lavasession.PeriodicProbeProvidersInterval)
-	}
-
 	// Helper function to convert provider endpoints to sessions
 	convertProvidersToSessions := func(providerList []*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
 		sessions := make(map[uint64]*lavasession.ConsumerSessionsWithProvider)
@@ -3054,8 +3050,6 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 
 	cmdRPCSmartRouter.Flags().BoolVar(&chainlib.SkipWebsocketVerification, common.SkipWebsocketVerificationFlag, chainlib.SkipWebsocketVerification, "skip websocket verification for chains that require ws/wss endpoints")
 
-	cmdRPCSmartRouter.Flags().BoolVar(&lavasession.PeriodicProbeProviders, common.PeriodicProbeProvidersFlagName, lavasession.PeriodicProbeProviders, "enable periodic probing of providers")
-	cmdRPCSmartRouter.Flags().DurationVar(&lavasession.PeriodicProbeProvidersInterval, common.PeriodicProbeProvidersIntervalFlagName, lavasession.PeriodicProbeProvidersInterval, "interval for periodic probing of providers")
 	cmdRPCSmartRouter.Flags().DurationVar(&lavasession.ProbeLoopInterval, common.ProbeLoopIntervalFlagName, lavasession.ProbeLoopInterval, "cadence of the proactive health prober (MAG-2161 Topic D); must be > 0, default 5s")
 	cmdRPCSmartRouter.Flags().Float64(common.ProbeUpdateWeightFlagName, scoreutils.DefaultProbeUpdateWeight, "weight multiplier for provider-optimizer probe updates (liveness/latency); must be > 0")
 	if err := viper.BindPFlag(common.ProbeUpdateWeightFlagName, cmdRPCSmartRouter.Flags().Lookup(common.ProbeUpdateWeightFlagName)); err != nil {
@@ -3546,7 +3540,7 @@ func (rpsr *RPCSmartRouter) revalidateTier(
 // live pairing and pushes the result to the session manager in one call.
 //
 // The merge is copy-on-write: the old maps may still be referenced by goroutines
-// (probeProviders, cleanupStaleTrackers) that iterate them without the lock.
+// (cleanupStaleTrackers) that iterate them without the lock.
 // UpdateAllProviders stays under rpsr.mu so the (session-map write → csm push) pair
 // is atomic with updateEpoch's matching pair — otherwise a concurrent epoch tick can
 // push to the csm in the opposite order it wrote the session maps, silently dropping
@@ -3781,7 +3775,7 @@ func mergeAbsentProviders(
 		return current, nil
 	}
 
-	// Copy-on-write: probeProviders / cleanupStaleTrackers may iterate the old map
+	// Copy-on-write: cleanupStaleTrackers may iterate the old map
 	// without the lock, so never mutate it in place. Re-key appended sessions past
 	// the existing max — convert() keys by its own list index, which would collide.
 	merged := make(map[uint64]*lavasession.ConsumerSessionsWithProvider, len(current)+len(absent))

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -256,8 +256,8 @@ func (rpcss *RPCSmartRouterServer) ServeRPCRequests(
 
 	// Proactive health prober (MAG-2160 / Topic D): on its own cadence, score EVERY direct-RPC
 	// endpoint from stored telemetry + the consensus baseline (zero upstream calls), proactively
-	// re-enable recovered endpoints, and feed one QoS sample per provider. Replaces the synthetic
-	// direct-RPC probe (the legacy AppendProbeRelayData feed is gated off for static providers).
+	// re-enable recovered endpoints, and feed one QoS sample per provider. It is the single source of
+	// truth for direct-RPC endpoint health and probe-fed QoS.
 	// effectiveBlockTime, NOT the raw spec value (see probeVerdictConfigFor): the verdict's alive
 	// horizon must share the SAME staleness horizon as ChainState and the monitor's poll cadence,
 	// and the "keeping up" tolerance must match consistency pre-validation's per-chain threshold.
@@ -2334,9 +2334,8 @@ type probeQoSAppender interface {
 // no QoS feed) if AppendProbeData's signature ever drifts — a regression no test would catch.
 var _ probeQoSAppender = (*provideroptimizer.ProviderOptimizer)(nil)
 
-// defaultProbeCadence is the prober's own polling period — distinct from the legacy synthetic
-// probe's PeriodicProbeProvidersInterval. It floors runProbeLoop's cadence so time.NewTicker can
-// never be handed a non-positive duration (which panics).
+// defaultProbeCadence is the prober's polling period. It floors runProbeLoop's cadence so
+// time.NewTicker can never be handed a non-positive duration (which panics).
 const defaultProbeCadence = 5 * time.Second
 
 // validatedProbeCadence validates the operator-configured probe cadence (MAG-2161 D5): a non-positive


### PR DESCRIPTION
Jira ticket: MAG-2733

# ⚠️ Testing status — please read before approving

**Only unit tests have been run. Nothing else.** This change deletes code across the session manager, the provider optimizer, the metrics interface and the CLI surface, and it has not been exercised against a running router.

What *was* verified:

- `go build ./...` — clean
- `go vet ./protocol/...` — clean
- `go test ./protocol/... ./types/... ./utils/...` — all green
- `go test -race -count=2` on the migrated concurrency test — green
- `gofumpt` — no new findings on touched files

What was **not** done, and should be before this merges:

- **No integration or e2e run.** None of `scripts/pre_setups/*` (`test_uc1_smartrouter_lava.sh`, `test_uc2_smartrouter_lava.sh`, `test_uc4_smartrouter_sim.sh`, `test_smartrouter_sol.sh`, `test_chaintracker_chainstate_sim.sh`) or `scripts/test_mag2062_e2e.sh` was executed.
- **No manual run** against real upstream endpoints — no router was started with this build.
- **No deployment / sim validation.** The dev-sim PR gate has not been run.
- **Note: CI does not run `go test` at all.** No workflow in `.github/workflows/` invokes it — the green checks here are build, lint, govulncheck and security scanning only. The unit-test result above came from a local run and is not reproduced by CI.

Areas most worth a real-traffic sanity check, since deletions touched them:

1. **Startup** — two CLI flags were removed. Any deployment passing `--enable-periodic-probe-providers` or `--periodic-probe-providers-interval` will now **fail to start** with an unknown-flag error. This repo is clean (grepped across Go, shell, yaml, md and json, including `config/smartrouter_examples/` and `docker/`), but **deployment manifests and Helm values live outside this repo and still need checking — that check is not done and is the one real pre-merge gate.**
2. **Epoch / pairing update** — `UpdateAllProviders`' defer no longer calls `probeProviders`; confirm the re-blocked-provider unblock path still behaves.
3. **Provider selection** — the optimizer interface lost a method; confirm scores still populate and selection is sane under traffic.

---

# Description

Removes the legacy synthetic prober. It was unreachable in direct-RPC mode, and it was one of five writers into the provider optimizer's QoS scores — this is step 1 of consolidating those.

## Why it was dead

Two independent reasons:

1. **Every provider is static.** `convertProvidersToSessions` (`rpcsmartrouter.go:1686`) sets `providerEntry.StaticProvider = true`, and it builds all three provider sets — primary (`:2072`), backup (`:2076`) and recovered (`:3050`). `probeProviders` returned early for static providers, so the goroutine body never executed for any provider.
2. **The loop was off by default.** `PeriodicProbeProviders = false`; the ticker only started behind `--enable-periodic-probe-providers`. Enabling it would have changed nothing, because of (1).

The other caller — the `UpdateAllProviders` defer — did run, but hit the same early return for every provider.

## What was removed, bottom-up

| Layer | Symbol |
|---|---|
| Optimizer | `ProviderOptimizer.AppendProbeRelayData` |
| Interface | `ProviderOptimizer.AppendProbeRelayData` entry (`consumer_types.go`) |
| CSM | `csm.probeProviders`, `csm.PeriodicProbeProviders` |
| Vars | `PeriodicProbeProviders`, `PeriodicProbeProvidersInterval` |
| Flags | `--enable-periodic-probe-providers`, `--periodic-probe-providers-interval` (+ name constants) |
| Metrics | `ConsumerMetricsManagerInf.SetProviderLiveness` — only caller was the dead path, and **both** implementations were already no-ops, so no metric is lost |

`runProbeLoop` (`--probe-loop-interval`) is now the only probe loop and the only probe-fed QoS writer. `AppendProbeData` remains the single non-test entry point.

**`csm.probeProvider` (singular) is untouched** — it still backs `GenerateReconnectCallback` (`:2334`) and `checkAndUnblockHealthyReBlockedProviders` (`:2447`), as do `--debug-probes` / `DebugProbesEnabled`.

## One behaviour change, worth reading

`UpdateAllProviders` no longer probes the pairing list on epoch update, so **endpoints are no longer latency-sorted there**.

This never happened in this fork: `probeProviders` skipped static providers, and every provider is static. So nothing that ran in production stops running. But it does mean per-provider endpoint latency sorting on pairing update is absent — and was already absent. If we want it for static providers, that is a **new feature**, not a regression this PR introduces. Sorting still happens inside `probeProvider` (`:696`) on the reconnect and unblock paths.

`TestEndpointSortingFlow` covered exactly that path, using non-static providers (`createPairingList` leaves `StaticProvider` false) — a configuration the smart router cannot produce. It is removed with the behaviour it tested.

## Tests changed

- **`TestPeriodicProbeProvidersTickerCleanup`** — removed with the function it tested.
- **`TestEndpointSortingFlow`** — removed, see above.
- **`provider_optimizer_test.go`** — 8 call sites migrated to `AppendProbeData(addr, 1, latency, true, 0, false, SyncReference{})`: availability 1, latency fed, no sync evidence. Same dimensions and same `ProbeUpdateWeight` as the call they replace, so the scores under test are unchanged.
- **`TestProviderOptimizer_SyncBlockNeverDecreasesUnderConcurrency`** keeps its three racing writers — the third is now a sync-less `AppendProbeData`, which has the same read-modify-write-the-whole-record shape that made it a floor-regression risk.

Net: **-351 / +48** across 10 files.

## Review follow-ups (applied)

Two items from @avitenzer's review, both fixed in the second commit:

- **`rawPairing` was left write-only.** `probeProviders` was its only reader; with that deleted the field was declared (`:58`), assigned on every `UpdateAllProviders` (`:333`) and never read, with a comment naming the deleted function. Removed the field, the assignment, and the mention in `ResetTransientFailureState`'s doc comment — same reasoning as the write-only `EndpointMetrics` sweep in MAG-2691.
- **The replacement comment in `checkAndUnblockHealthyReBlockedProviders` was wrong.** It claimed a backup can never appear in `reportedProviders`. It can: `blockProvider`'s `AddressIndexWasNotFoundError` branch marks `blockedBackupProviders` (`:1832`) and then *falls through* to the `reportProvider` block (`:1842`), so a backup that was selected and failed a relay does get reported. The guard is correct for a simpler reason — `!isBackup` short-circuits, so a backup's report state is never consulted. Restated that way in the code, the test doc comment, and the test's assertion message.

One correction to the review, for the record: the second counterexample it offered — `probeProvider`'s `AllProviderEndpointsDisabledError` path calling `blockProvider(reportProvider=true)` at `:628` — is unreachable in this fork, since `probeProvider` returns at `:622` for static providers and every provider here is static. The load-bearing counterexample is the relay-failure one, which is what the new comment now cites.

## Follow-up

This leaves four QoS writers. The remaining consolidation is the relay paths — `AppendRelayDataConsensus` and `AppendRelayFailure` in the CSM, plus the websocket manager's pair — which is a design change rather than dead-code removal and is not attempted here.

**`probeProvider`'s entire gRPC branch may be dead by this PR's own argument.** Removing `TestEndpointSortingFlow` leaves `sortEndpointsByLatency` and `EndpointInfoList` with zero test coverage — but the sharper point is that if every provider is static, `probeProvider` returns at `:622` and lines `:625`–`:698` (the `fetchEndpointConnectionFromConsumerSessionWithProvider` call, the gRPC probe loop, and the latency sort) are unreachable for the same reason `probeProviders` was. That is ~75 lines, more than this PR deletes. Either it is reachable and now untested, or it is the next dead-code sweep. Deliberately **not** resolved here — it needs its own reachability audit rather than being bolted onto this one.

---

## Author Checklist

* [x] read the contribution guide
* [x] included the correct type prefix in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change — title is now `chore(lavasession)!:`. Two CLI flags are removed; they were no-ops, but a config passing them will fail to start, and release notes are generated from commit subjects so the `!` is the only signal operators get
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration tests — **unit only; see Testing status above**
* [x] updated the relevant documentation or specification, including comments for documenting Go code
* [ ] confirmed all CI checks have passed — pending; note CI does not run unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

