### PR TITLE
feat(provideroptimizer): add --qos-selection-priority weight presets

### DIFF
--- a/protocol/common/cobra_common.go
+++ b/protocol/common/cobra_common.go
@@ -96,6 +96,7 @@ const (
 	ProviderOptimizerStakeWeight        = "qos-stake-weight"         // weight for stake (default: 0.1)
 	ProviderOptimizerMinSelectionChance = "qos-min-selection-chance" // minimum selection probability for any provider (default: 0.01)
 	ProviderOptimizerSelectionMode      = "qos-selection-mode"       // how the winner is picked from the scored providers: weighted-random (default) or best
+	ProviderOptimizerSelectionPriority  = "qos-selection-priority"   // preset over the four weights above: balanced (default), most-reliable, fastest, freshest
 
 	// optimizer qos sampling cadence — drives the in-memory /metrics
 	// selection-score cache and the OTel optimizer_qos emit.

--- a/protocol/provideroptimizer/selection_mode.go
+++ b/protocol/provideroptimizer/selection_mode.go
@@ -45,7 +45,16 @@ func SelectionModeNames() []string {
 // Unknown values are rejected rather than silently defaulted: the mode dispatch treats
 // anything that is not SelectionModeBest as weighted-random, so a typo'd flag would
 // otherwise leave an operator who asked for "best" quietly running the old policy.
+//
+// An empty string is the one exception — it means "not specified" and resolves to the
+// default. Rejecting it would tie startup to the flag being viper-bound: any call site
+// that has not bound the flag reads "" and would abort with a confusing "invalid
+// selection mode:" rather than simply using the default.
 func ParseSelectionMode(str string) (SelectionMode, error) {
+	if strings.TrimSpace(str) == "" {
+		return SelectionModeWeightedRandom, nil
+	}
+
 	normalized := strings.ReplaceAll(str, "-", "_")
 	for _, mode := range []SelectionMode{SelectionModeWeightedRandom, SelectionModeBest} {
 		if strings.EqualFold(normalized, mode.String()) {

--- a/protocol/provideroptimizer/selection_mode_test.go
+++ b/protocol/provideroptimizer/selection_mode_test.go
@@ -28,11 +28,19 @@ func TestParseSelectionMode(t *testing.T) {
 	// Unknown values must be rejected, not defaulted: the selection dispatch treats
 	// anything that is not SelectionModeBest as weighted-random, so a silent fallback
 	// would leave an operator who asked for "best" running the old policy unnoticed.
-	for _, in := range []string{"", "bset", "greedy", "highest"} {
+	for _, in := range []string{"bset", "greedy", "highest"} {
 		t.Run("invalid/"+in, func(t *testing.T) {
 			_, err := ParseSelectionMode(in)
 			require.Error(t, err)
 		})
+	}
+
+	// Empty means "not specified" and must resolve to the default rather than error —
+	// otherwise any caller that has not viper-bound the flag reads "" and aborts.
+	for _, in := range []string{"", "   "} {
+		got, err := ParseSelectionMode(in)
+		require.NoError(t, err)
+		require.Equal(t, SelectionModeWeightedRandom, got)
 	}
 }
 

--- a/protocol/provideroptimizer/selection_priority.go
+++ b/protocol/provideroptimizer/selection_priority.go
@@ -1,0 +1,149 @@
+package provideroptimizer
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SelectionPriority is a named preset over the four QoS weights that feed
+// CalculateScore. It answers "what should the router optimise for", while
+// SelectionMode answers "how is the winner picked from those scores" — the two are
+// orthogonal and compose:
+//
+//	--qos-selection-priority fastest --qos-selection-mode best
+//	  → sort providers by latency and always send to the head of the queue
+//
+//	--qos-selection-priority fastest --qos-selection-mode weighted_random
+//	  → a lottery biased heavily toward the fastest providers
+//
+// The preset only sets weights; it adds no scoring machinery. Operators who want
+// something other than the four presets can still set the individual
+// --qos-*-weight flags, which take precedence over whatever the preset chose.
+type SelectionPriority int
+
+const (
+	// SelectionPriorityBalanced is the zero value and keeps the historical default
+	// weights, so an unset flag changes nothing for existing deployments.
+	SelectionPriorityBalanced SelectionPriority = iota
+
+	// SelectionPriorityMostReliable favours the provider that answers successfully
+	// most often.
+	SelectionPriorityMostReliable
+
+	// SelectionPriorityFastest favours the provider that answers quickest.
+	SelectionPriorityFastest
+
+	// SelectionPriorityFreshest favours the provider closest to the head of the chain.
+	SelectionPriorityFreshest
+)
+
+// priorityWeights holds the four QoS weights a preset applies. Each set sums to 1.0,
+// which keeps NewProviderSelector's normaliser from rescaling them.
+type priorityWeights struct {
+	availability float64
+	latency      float64
+	sync         float64
+	stake        float64
+}
+
+// presetWeights maps each priority to its weights.
+//
+// The three axis presets are deliberately dominant rather than exclusive: the chosen
+// axis takes 0.70, but availability keeps real weight in every one of them so a
+// fast-but-flaky or fresh-but-flaky provider cannot outrank a fast-and-solid peer.
+// A pure 1.0 on one axis would make availability irrelevant everywhere above
+// score.MinAcceptableAvailability (below it the composite collapse in CalculateScore
+// still applies, so the floor is never at risk — but 0.80-to-1.00 would stop counting).
+//
+// The axis presets zero the stake weight. In a static-provider deployment
+// CalcWeightsByStake hands every provider an identical weight, so the stake term is the
+// same constant for all candidates: it cannot change the ordering, and under
+// SelectionModeWeightedRandom it actively flattens the lottery by putting every provider
+// on the same pedestal. Spending 20% of the score on a constant would just dilute the
+// axis the operator asked for. Balanced keeps its 0.20 stake weight because it is the
+// default: changing it would silently move every existing deployment.
+var presetWeights = map[SelectionPriority]priorityWeights{
+	SelectionPriorityBalanced:     {availability: 0.30, latency: 0.30, sync: 0.20, stake: 0.20},
+	SelectionPriorityMostReliable: {availability: 0.70, latency: 0.15, sync: 0.15, stake: 0.00},
+	SelectionPriorityFastest:      {availability: 0.20, latency: 0.70, sync: 0.10, stake: 0.00},
+	SelectionPriorityFreshest:     {availability: 0.20, latency: 0.10, sync: 0.70, stake: 0.00},
+}
+
+func (p SelectionPriority) String() string {
+	switch p {
+	case SelectionPriorityBalanced:
+		return "balanced"
+	case SelectionPriorityMostReliable:
+		return "most-reliable"
+	case SelectionPriorityFastest:
+		return "fastest"
+	case SelectionPriorityFreshest:
+		return "freshest"
+	}
+
+	return ""
+}
+
+// SelectionPriorityNames lists the accepted spellings, for flag help text.
+func SelectionPriorityNames() []string {
+	return []string{
+		SelectionPriorityBalanced.String(),
+		SelectionPriorityMostReliable.String(),
+		SelectionPriorityFastest.String(),
+		SelectionPriorityFreshest.String(),
+	}
+}
+
+// ParseSelectionPriority resolves the CLI/config spelling of a priority. Hyphens and
+// underscores are interchangeable, so both "most-reliable" and "most_reliable" work.
+//
+// Unknown values are rejected rather than defaulted, for the same reason as
+// ParseSelectionMode: silently falling back to balanced would leave an operator who
+// asked for "fastest" running the default weights without ever being told.
+//
+// An empty string is the one exception — it means "not specified" and resolves to the
+// default. Rejecting it would tie startup to the flag being viper-bound: any call site
+// that has not bound the flag reads "" and would abort with a confusing "invalid
+// selection priority:" rather than simply using the default.
+func ParseSelectionPriority(str string) (SelectionPriority, error) {
+	if strings.TrimSpace(str) == "" {
+		return SelectionPriorityBalanced, nil
+	}
+
+	normalized := strings.ReplaceAll(str, "_", "-")
+	for _, priority := range []SelectionPriority{
+		SelectionPriorityBalanced,
+		SelectionPriorityMostReliable,
+		SelectionPriorityFastest,
+		SelectionPriorityFreshest,
+	} {
+		if strings.EqualFold(normalized, priority.String()) {
+			return priority, nil
+		}
+	}
+
+	return SelectionPriorityBalanced, fmt.Errorf("invalid selection priority: %s (valid: %s)", str, strings.Join(SelectionPriorityNames(), "|"))
+}
+
+// ApplyTo returns cfg with the preset's four QoS weights applied. Every other field —
+// SelectionMode, MinSelectionChance, Strategy, the adaptive-max wiring — is left
+// untouched, so a priority never silently changes anything but the weighting.
+//
+// Callers that also honour explicit --qos-*-weight flags must apply those AFTER this,
+// so a hand-set weight overrides the preset.
+func (p SelectionPriority) ApplyTo(cfg ProviderSelectorConfig) ProviderSelectorConfig {
+	weights, ok := presetWeights[p]
+	if !ok {
+		// Unreachable via ParseSelectionPriority, which rejects unknown values. Guard
+		// anyway so a hand-constructed priority degrades to the default rather than
+		// zeroing every weight and tripping the normaliser's fallback.
+		weights = presetWeights[SelectionPriorityBalanced]
+	}
+
+	cfg.AvailabilityWeight = weights.availability
+	cfg.LatencyWeight = weights.latency
+	cfg.SyncWeight = weights.sync
+	cfg.StakeWeight = weights.stake
+
+	return cfg
+}

--- a/protocol/provideroptimizer/selection_priority_test.go
+++ b/protocol/provideroptimizer/selection_priority_test.go
@@ -1,0 +1,159 @@
+package provideroptimizer
+
+import (
+	"testing"
+
+	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseSelectionPriority covers the spellings accepted by --qos-selection-priority.
+func TestParseSelectionPriority(t *testing.T) {
+	valid := map[string]SelectionPriority{
+		"balanced":      SelectionPriorityBalanced,
+		"most-reliable": SelectionPriorityMostReliable,
+		"most_reliable": SelectionPriorityMostReliable,
+		"Most-Reliable": SelectionPriorityMostReliable,
+		"fastest":       SelectionPriorityFastest,
+		"FASTEST":       SelectionPriorityFastest,
+		"freshest":      SelectionPriorityFreshest,
+	}
+	for in, want := range valid {
+		t.Run(in, func(t *testing.T) {
+			got, err := ParseSelectionPriority(in)
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+		})
+	}
+
+	// "latency" and "sync-freshness" are the --strategy spellings; they are a plausible
+	// wrong guess here and must not silently resolve to a preset.
+	for _, in := range []string{"quickest", "reliable", "latency", "sync-freshness"} {
+		t.Run("invalid/"+in, func(t *testing.T) {
+			_, err := ParseSelectionPriority(in)
+			require.Error(t, err)
+		})
+	}
+
+	// Empty means "not specified" and must resolve to the default rather than error —
+	// otherwise any caller that has not viper-bound the flag reads "" and aborts.
+	for _, in := range []string{"", "   "} {
+		got, err := ParseSelectionPriority(in)
+		require.NoError(t, err)
+		require.Equal(t, SelectionPriorityBalanced, got)
+	}
+}
+
+// TestSelectionPriorityWeightsSumToOne matters because NewProviderSelector renormalises
+// any weight set that does not sum to 1.0 — a preset that drifted would be silently
+// rescaled, and the logged weights would stop matching the table in this file.
+func TestSelectionPriorityWeightsSumToOne(t *testing.T) {
+	for _, p := range []SelectionPriority{
+		SelectionPriorityBalanced,
+		SelectionPriorityMostReliable,
+		SelectionPriorityFastest,
+		SelectionPriorityFreshest,
+	} {
+		t.Run(p.String(), func(t *testing.T) {
+			cfg := p.ApplyTo(DefaultProviderSelectorConfig())
+			sum := cfg.AvailabilityWeight + cfg.LatencyWeight + cfg.SyncWeight + cfg.StakeWeight
+			require.InDelta(t, 1.0, sum, 1e-9)
+		})
+	}
+}
+
+// TestSelectionPriorityBalancedIsTheCurrentDefault pins the backward-compatibility
+// guarantee: balanced is the flag's default value, so it must not move any existing
+// deployment off the weights it runs today.
+func TestSelectionPriorityBalancedIsTheCurrentDefault(t *testing.T) {
+	def := DefaultProviderSelectorConfig()
+	applied := SelectionPriorityBalanced.ApplyTo(def)
+
+	require.Equal(t, def.AvailabilityWeight, applied.AvailabilityWeight)
+	require.Equal(t, def.LatencyWeight, applied.LatencyWeight)
+	require.Equal(t, def.SyncWeight, applied.SyncWeight)
+	require.Equal(t, def.StakeWeight, applied.StakeWeight)
+}
+
+// TestSelectionPriorityApplyToLeavesOtherFieldsAlone verifies a priority only ever moves
+// the four weights — it must not disturb the selection mode, the starvation floor, the
+// strategy or the adaptive-max wiring.
+func TestSelectionPriorityApplyToLeavesOtherFieldsAlone(t *testing.T) {
+	cfg := DefaultProviderSelectorConfig()
+	cfg.SelectionMode = SelectionModeBest
+	cfg.MinSelectionChance = 0.07
+	cfg.Strategy = StrategyLatency
+	cfg.UseAdaptiveLatencyMax = true
+
+	applied := SelectionPriorityFastest.ApplyTo(cfg)
+
+	require.Equal(t, SelectionModeBest, applied.SelectionMode)
+	require.Equal(t, 0.07, applied.MinSelectionChance)
+	require.Equal(t, StrategyLatency, applied.Strategy)
+	require.True(t, applied.UseAdaptiveLatencyMax)
+}
+
+// TestSelectionPriorityDominantNotExclusive pins the design decision: the chosen axis
+// carries most of the weight, but availability keeps a real share in every axis preset so
+// a fast-but-flaky provider cannot outrank a fast-and-solid one on latency alone.
+func TestSelectionPriorityDominantNotExclusive(t *testing.T) {
+	for _, tc := range []struct {
+		priority SelectionPriority
+		dominant func(ProviderSelectorConfig) float64
+	}{
+		{SelectionPriorityMostReliable, func(c ProviderSelectorConfig) float64 { return c.AvailabilityWeight }},
+		{SelectionPriorityFastest, func(c ProviderSelectorConfig) float64 { return c.LatencyWeight }},
+		{SelectionPriorityFreshest, func(c ProviderSelectorConfig) float64 { return c.SyncWeight }},
+	} {
+		t.Run(tc.priority.String(), func(t *testing.T) {
+			cfg := tc.priority.ApplyTo(DefaultProviderSelectorConfig())
+			require.Greater(t, tc.dominant(cfg), 0.5, "chosen axis must dominate")
+			require.Greater(t, cfg.AvailabilityWeight, 0.0, "availability must never be zeroed out")
+			// Stake is a constant per candidate in a static-provider deployment, so the
+			// axis presets spend nothing on it.
+			require.Equal(t, 0.0, cfg.StakeWeight)
+		})
+	}
+}
+
+// TestSelectionPriorityChangesTheWinner is the end-to-end check that the preset is not
+// just a table of numbers: given the same two providers, "fastest" and "most-reliable"
+// must pick different ones.
+//
+// The latency gap is deliberately large. With the fixed-max fallback (WorstLatencyScore,
+// 30s) the normalised latency range is compressed, so a sub-second difference moves the
+// composite far less than the availability rescale of [0.8,1.0] → [0,1] does. Extreme
+// values keep the assertion about the weighting rather than about normaliser sensitivity.
+func TestSelectionPriorityChangesTheWinner(t *testing.T) {
+	// reliable but slow
+	slowSolid := &pairingtypes.QualityOfServiceReport{Availability: 0.99, Latency: 20.0, Sync: 1.0}
+	// quick but noticeably less reliable (still above MinAcceptableAvailability, so the
+	// dead-provider collapse in CalculateScore does not fire)
+	fastFlaky := &pairingtypes.QualityOfServiceReport{Availability: 0.85, Latency: 0.05, Sync: 1.0}
+
+	scoreBoth := func(p SelectionPriority) (solid, flaky float64) {
+		ws := NewProviderSelector(p.ApplyTo(DefaultProviderSelectorConfig()))
+		return ws.CalculateScore(slowSolid, 0, 0, "slow_solid"),
+			ws.CalculateScore(fastFlaky, 0, 0, "fast_flaky")
+	}
+
+	solid, flaky := scoreBoth(SelectionPriorityFastest)
+	require.Greater(t, flaky, solid, "fastest must prefer the quick provider")
+
+	solid, flaky = scoreBoth(SelectionPriorityMostReliable)
+	require.Greater(t, solid, flaky, "most-reliable must prefer the dependable provider")
+}
+
+// TestSelectionPriorityFreshestPrefersTheFresherProvider covers the third axis, which the
+// winner-flip test above holds constant.
+func TestSelectionPriorityFreshestPrefersTheFresherProvider(t *testing.T) {
+	stale := &pairingtypes.QualityOfServiceReport{Availability: 0.99, Latency: 0.1, Sync: 600.0}
+	fresh := &pairingtypes.QualityOfServiceReport{Availability: 0.95, Latency: 0.1, Sync: 0.5}
+
+	ws := NewProviderSelector(SelectionPriorityFreshest.ApplyTo(DefaultProviderSelectorConfig()))
+	require.Greater(t,
+		ws.CalculateScore(fresh, 0, 0, "fresh"),
+		ws.CalculateScore(stale, 0, 0, "stale"),
+		"freshest must prefer the provider closer to the chain head",
+	)
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -49,6 +49,7 @@ import (
 	scoreutils "github.com/magma-Devs/smart-router/utils/score"
 	"github.com/magma-Devs/smart-router/version"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -689,6 +690,57 @@ func resetEndpointHealthAndGauge(deps debugMuxDeps) int {
 // active selection weights, used for each per-chain entry in the PerChainOptimizer map
 // returned by GET /debug/runtime-config. Fields carry no json tags, so each key marshals
 // as the bare Go identifier — tests grep the same string in test code and router source.
+// resolveSelectionWeights turns --qos-selection-priority plus the individual
+// --qos-*-weight flags into the four QoS weights the provider selector scores on.
+//
+// Precedence: the priority preset sets the weights, then any weight the operator set by
+// hand overrides it — so the preset is a starting point, never a cage.
+//
+// "Set by hand" deliberately checks the config file as well as the command line.
+// Changed() only reports flags typed on the CLI, so a weight set in config.yml would
+// otherwise lose silently to the preset; viper.InConfig covers that half.
+//
+// Only the four weights are decided here. Every other field is left at its default for
+// the caller to fill in, so a priority can never move something it does not own.
+func resolveSelectionWeights(flags *pflag.FlagSet) (provideroptimizer.ProviderSelectorConfig, error) {
+	config := provideroptimizer.DefaultProviderSelectorConfig()
+
+	priority, err := provideroptimizer.ParseSelectionPriority(viper.GetString(common.ProviderOptimizerSelectionPriority))
+	if err != nil {
+		return config, err
+	}
+	config = priority.ApplyTo(config)
+
+	overridden := []string{}
+	for _, w := range []struct {
+		flagName string
+		target   *float64
+	}{
+		{common.ProviderOptimizerAvailabilityWeight, &config.AvailabilityWeight},
+		{common.ProviderOptimizerLatencyWeight, &config.LatencyWeight},
+		{common.ProviderOptimizerSyncWeight, &config.SyncWeight},
+		{common.ProviderOptimizerStakeWeight, &config.StakeWeight},
+	} {
+		if (flags != nil && flags.Changed(w.flagName)) || viper.InConfig(w.flagName) {
+			*w.target = viper.GetFloat64(w.flagName)
+			overridden = append(overridden, w.flagName)
+		}
+	}
+
+	// Stay quiet on the default path so an untouched deployment logs nothing new.
+	if priority != provideroptimizer.SelectionPriorityBalanced || len(overridden) > 0 {
+		utils.LavaFormatInfo("Working with provider selection priority: "+priority.String(),
+			utils.LogAttr("availabilityWeight", config.AvailabilityWeight),
+			utils.LogAttr("latencyWeight", config.LatencyWeight),
+			utils.LogAttr("syncWeight", config.SyncWeight),
+			utils.LogAttr("stakeWeight", config.StakeWeight),
+			utils.LogAttr("manuallyOverridden", strings.Join(overridden, ",")),
+		)
+	}
+
+	return config, nil
+}
+
 type routerConfigOptimizerWeights struct {
 	AvailabilityWeight float64
 	LatencyWeight      float64
@@ -2543,11 +2595,10 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 			if err := scoreutils.SetProbeUpdateWeight(viper.GetFloat64(common.ProbeUpdateWeightFlagName)); err != nil {
 				return err
 			}
-			providerSelectorConfig := provideroptimizer.DefaultProviderSelectorConfig()
-			providerSelectorConfig.AvailabilityWeight = viper.GetFloat64(common.ProviderOptimizerAvailabilityWeight)
-			providerSelectorConfig.LatencyWeight = viper.GetFloat64(common.ProviderOptimizerLatencyWeight)
-			providerSelectorConfig.SyncWeight = viper.GetFloat64(common.ProviderOptimizerSyncWeight)
-			providerSelectorConfig.StakeWeight = viper.GetFloat64(common.ProviderOptimizerStakeWeight)
+			providerSelectorConfig, err := resolveSelectionWeights(cmd.Flags())
+			if err != nil {
+				return err
+			}
 			providerSelectorConfig.MinSelectionChance = viper.GetFloat64(common.ProviderOptimizerMinSelectionChance)
 			providerSelectorConfig.Strategy = strategyFlag.Strategy
 
@@ -2667,6 +2718,7 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	cmdRPCSmartRouter.Flags().Float64(common.ProviderOptimizerStakeWeight, defaultSelectorConfig.StakeWeight, "weight assigned to provider stake when computing selection scores")
 	cmdRPCSmartRouter.Flags().Float64(common.ProviderOptimizerMinSelectionChance, defaultSelectorConfig.MinSelectionChance, "minimum selection probability for any provider regardless of score")
 	cmdRPCSmartRouter.Flags().String(common.ProviderOptimizerSelectionMode, defaultSelectorConfig.SelectionMode.String(), fmt.Sprintf("how the winner is picked from the scored providers (%s): weighted_random draws proportionally to score, best always takes the highest scorer", strings.Join(provideroptimizer.SelectionModeNames(), "|")))
+	cmdRPCSmartRouter.Flags().String(common.ProviderOptimizerSelectionPriority, provideroptimizer.SelectionPriorityBalanced.String(), fmt.Sprintf("what to optimise for (%s) — a preset over the four qos-*-weight flags above; any weight set by hand overrides the preset", strings.Join(provideroptimizer.SelectionPriorityNames(), "|")))
 	if err := viper.BindPFlag(common.ProviderOptimizerAvailabilityWeight, cmdRPCSmartRouter.Flags().Lookup(common.ProviderOptimizerAvailabilityWeight)); err != nil {
 		utils.LavaFormatFatal("failed binding availability weight flag", err)
 	}
@@ -2684,6 +2736,9 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	}
 	if err := viper.BindPFlag(common.ProviderOptimizerSelectionMode, cmdRPCSmartRouter.Flags().Lookup(common.ProviderOptimizerSelectionMode)); err != nil {
 		utils.LavaFormatFatal("failed binding selection mode flag", err)
+	}
+	if err := viper.BindPFlag(common.ProviderOptimizerSelectionPriority, cmdRPCSmartRouter.Flags().Lookup(common.ProviderOptimizerSelectionPriority)); err != nil {
+		utils.LavaFormatFatal("failed binding selection priority flag", err)
 	}
 	cmdRPCSmartRouter.Flags().String(metrics.MetricsListenFlagName, metrics.DisabledFlagOption, "the address to expose prometheus metrics (such as localhost:7779)")
 	// Usage telemetry (OTel) — off by default. When enabled, per-relay and

--- a/protocol/rpcsmartrouter/selection_weights_test.go
+++ b/protocol/rpcsmartrouter/selection_weights_test.go
@@ -1,0 +1,125 @@
+package rpcsmartrouter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+// newWeightFlagSet mirrors the four weight flags as rpcsmartrouter registers them, so
+// Changed() behaves exactly as it does for the real command.
+func newWeightFlagSet(t *testing.T) *pflag.FlagSet {
+	t.Helper()
+	def := provideroptimizer.DefaultProviderSelectorConfig()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.Float64(common.ProviderOptimizerAvailabilityWeight, def.AvailabilityWeight, "")
+	fs.Float64(common.ProviderOptimizerLatencyWeight, def.LatencyWeight, "")
+	fs.Float64(common.ProviderOptimizerSyncWeight, def.SyncWeight, "")
+	fs.Float64(common.ProviderOptimizerStakeWeight, def.StakeWeight, "")
+	return fs
+}
+
+// withCleanViper isolates each case from viper's package-level state, which the router
+// shares process-wide.
+func withCleanViper(t *testing.T) {
+	t.Helper()
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+}
+
+// TestResolveSelectionWeights_PresetApplies verifies the preset reaches the weights when
+// nothing is overridden.
+func TestResolveSelectionWeights_PresetApplies(t *testing.T) {
+	withCleanViper(t)
+	viper.Set(common.ProviderOptimizerSelectionPriority, "fastest")
+
+	config, err := resolveSelectionWeights(newWeightFlagSet(t))
+	require.NoError(t, err)
+
+	want := provideroptimizer.SelectionPriorityFastest.ApplyTo(provideroptimizer.DefaultProviderSelectorConfig())
+	require.Equal(t, want.LatencyWeight, config.LatencyWeight)
+	require.Equal(t, want.AvailabilityWeight, config.AvailabilityWeight)
+	require.Equal(t, want.SyncWeight, config.SyncWeight)
+	require.Equal(t, want.StakeWeight, config.StakeWeight)
+}
+
+// TestResolveSelectionWeights_CLIFlagBeatsPreset is the headline precedence rule: a weight
+// typed on the command line wins over the preset, and the untouched axes keep the
+// preset's values.
+func TestResolveSelectionWeights_CLIFlagBeatsPreset(t *testing.T) {
+	withCleanViper(t)
+	viper.Set(common.ProviderOptimizerSelectionPriority, "fastest")
+
+	fs := newWeightFlagSet(t)
+	require.NoError(t, fs.Set(common.ProviderOptimizerLatencyWeight, "0.5"))
+	viper.Set(common.ProviderOptimizerLatencyWeight, 0.5)
+
+	config, err := resolveSelectionWeights(fs)
+	require.NoError(t, err)
+
+	require.Equal(t, 0.5, config.LatencyWeight, "hand-set weight must beat the preset")
+	// fastest's other axes survive untouched
+	require.Equal(t, 0.20, config.AvailabilityWeight)
+	require.Equal(t, 0.10, config.SyncWeight)
+	require.Equal(t, 0.00, config.StakeWeight)
+}
+
+// TestResolveSelectionWeights_ConfigFileBeatsPreset is the half that pflag.Changed()
+// cannot see. A weight set only in config.yml must still override the preset — using
+// Changed() alone would let the preset silently win here.
+func TestResolveSelectionWeights_ConfigFileBeatsPreset(t *testing.T) {
+	withCleanViper(t)
+	viper.SetConfigType("yaml")
+	require.NoError(t, viper.ReadConfig(strings.NewReader(
+		common.ProviderOptimizerSelectionPriority+": fastest\n"+
+			common.ProviderOptimizerLatencyWeight+": 0.42\n",
+	)))
+
+	// Flags exist but were never typed, so Changed() is false for every one of them.
+	fs := newWeightFlagSet(t)
+	for _, name := range []string{
+		common.ProviderOptimizerAvailabilityWeight,
+		common.ProviderOptimizerLatencyWeight,
+		common.ProviderOptimizerSyncWeight,
+		common.ProviderOptimizerStakeWeight,
+	} {
+		require.False(t, fs.Changed(name), "precondition: %s must not be marked as CLI-set", name)
+	}
+
+	config, err := resolveSelectionWeights(fs)
+	require.NoError(t, err)
+
+	require.Equal(t, 0.42, config.LatencyWeight, "config-file weight must beat the preset")
+	require.Equal(t, 0.20, config.AvailabilityWeight, "untouched axis keeps the preset value")
+}
+
+// TestResolveSelectionWeights_DefaultIsUnchanged pins that a deployment which sets nothing
+// keeps exactly today's weights.
+func TestResolveSelectionWeights_DefaultIsUnchanged(t *testing.T) {
+	withCleanViper(t)
+
+	config, err := resolveSelectionWeights(newWeightFlagSet(t))
+	require.NoError(t, err)
+
+	def := provideroptimizer.DefaultProviderSelectorConfig()
+	require.Equal(t, def.AvailabilityWeight, config.AvailabilityWeight)
+	require.Equal(t, def.LatencyWeight, config.LatencyWeight)
+	require.Equal(t, def.SyncWeight, config.SyncWeight)
+	require.Equal(t, def.StakeWeight, config.StakeWeight)
+}
+
+// TestResolveSelectionWeights_InvalidPriorityIsRejected verifies a typo aborts instead of
+// silently running the default weights.
+func TestResolveSelectionWeights_InvalidPriorityIsRejected(t *testing.T) {
+	withCleanViper(t)
+	viper.Set(common.ProviderOptimizerSelectionPriority, "quickest")
+
+	_, err := resolveSelectionWeights(newWeightFlagSet(t))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid selection priority")
+}


### PR DESCRIPTION
Third in the stack — #262 → #263 → **this**. Base is `refactor/rename-provider-selector`; retarget down the chain as each merges.

Implements [FAILOVER-TASKS](../blob/main/agent_docs/bug-reports/failover/FAILOVER-TASKS.md) section 1's `selection` setting.

## What

The scoring machinery already existed — four QoS weights, each individually settable. This adds a **named preset over them**, not a new scoring path.

```
--qos-selection-priority balanced|most-reliable|fastest|freshest   (default: balanced)
```

| priority | availability | latency | sync | stake |
|---|---|---|---|---|
| `balanced` | 0.30 | 0.30 | 0.20 | 0.20 | ← unchanged default |
| `most-reliable` | **0.70** | 0.15 | 0.15 | 0.00 |
| `fastest` | 0.20 | **0.70** | 0.10 | 0.00 |
| `freshest` | 0.20 | 0.10 | **0.70** | 0.00 |

**Dominant, not exclusive.** The chosen axis takes 0.70, but availability keeps real weight in every preset so a fast-but-flaky provider cannot outrank a fast-and-solid one on latency alone. `balanced` is byte-identical to today's defaults — it's the flag's default value, so anything else would silently move every existing deployment.

## Why the axis presets zero stake

`CalcWeightsByStake` hands every static provider an identical weight (`maxWeight * 10`, and `maxWeight` stays 1 in an all-static deployment). So the stake term is **the same constant for every candidate**:

- under `best` it cannot change the ordering
- under `weighted_random` it actively flattens the lottery — every provider sits on the same pedestal, compressing the probability ratio between a great provider and a mediocre one

Spending 20% of the score on a constant would just dilute the axis the operator asked for. `balanced` keeps its 0.20 for backward compatibility rather than silently changing today's behaviour.

## Composes with `--qos-selection-mode`, doesn't duplicate it

| flag | decides |
|---|---|
| `--qos-selection-priority` | **what** to optimise for (the weights) |
| `--qos-selection-mode` | **how** the winner is picked (queue vs lottery) |

Section 1's *"the order is fixed, not random"* needs **both**: `--qos-selection-priority fastest --qos-selection-mode best` is exactly the queue it describes — sort by latency, send to the head, on failure the next in line (the `wantedProviders` loop already yields top-1, top-2, top-3 under argmax).

## Precedence

The preset sets the weights, then **any weight set by hand overrides it** — the preset is a starting point, never a cage.

`resolveSelectionWeights` checks `viper.InConfig` **as well as** pflag `Changed()`. `Changed()` only reports flags typed on the command line, so a weight set in `config.yml` would otherwise lose silently to the preset. That rule is extracted out of the `RunE` body specifically so it can be tested — including the config-file half `Changed()` cannot observe.

## Drive-by fix the new tests surfaced

`ParseSelectionMode` (from #262) rejected the empty string, which tied startup correctness to the flag being viper-bound: any call site that hadn't bound it reads `""` and aborts with a confusing `invalid selection mode:` instead of using the default. **Empty now means "not specified"** and resolves to the default in both parsers. Genuinely wrong values (`bset`, `quickest`) still hard-fail — that's the property that actually matters.

This supersedes the "invalid values abort at startup" note in #262 on the empty-string case only.

## `--strategy` deliberately untouched

I measured what it does today: its only scoring effect is an exponent nudge worth **at most +0.015 on the composite** (typically +0.006), and it does not move the weights at all. `StrategyBalanced` — the default, and the only reachable value for YAML users since the flag has no `BindPFlag` — is a genuine no-op in the switch. So it cannot interfere with this flag.

Two things worth knowing but not fixed here: `--strategy` is CLI-only (not settable from `config.yml`), and `StrategyAccuracy`/`StrategyDistributed` apply `pow(x,1.2)` under a comment claiming it *"flattens the curve to encourage more provider diversity"* — measured, it does the opposite (contrast ratio 1.800 → 2.025).

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test ./...` — zero failures repo-wide
- `--help` output verified

Tests include the end-to-end proof that the preset is more than a table of numbers: given the same two providers, `fastest` and `most-reliable` pick **different** ones. Plus the sum-to-1.0 invariant (a drifted preset would be silently renormalised by `NewProviderSelector`), the `balanced == today's defaults` backward-compat pin, and both halves of the precedence rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)