### PR TITLE
fix(smart-router): boot on any usable provider instead of exiting (MAG-2525)

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -258,6 +258,34 @@ assert `/debug/reset-all` emptied each store (see MAG-1762). All drop to `0` aft
 | `smartrouter_csm_sticky_sessions` | Gauge | `spec`, `apiInterface` | Live sticky-session affinities. |
 | `smartrouter_csm_reported_providers` | Gauge | `spec`, `apiInterface` | Size of the reported-providers register. |
 
+#### Serving tier (availability)
+
+| Metric | Type | Labels | Description |
+| --- | --- | --- | --- |
+| `smartrouter_endpoint_serving_tier` | Gauge | `spec`, `apiInterface` | Which provider tier the endpoint is serving from: `2` = primaries, `1` = degraded (backups only), `0` = dark (no healthy providers). |
+
+Before MAG-2525 an endpoint with no healthy provider exited the process, so a
+CrashLoopBackOff was the de-facto alert. It now boots and reports unhealthy instead,
+which is what makes a restart during a failover survivable — and it means **this gauge,
+not pod restarts, is the signal that a chain cannot serve**. It is republished from
+every path that mutates the live pairing (boot, background retry, epoch
+promote/demote, config reload), so it tracks the current state rather than the boot
+verdict.
+
+Suggested alerts:
+
+| Condition | Meaning |
+| --- | --- |
+| `smartrouter_endpoint_serving_tier == 0` | Endpoint is dark — all relays 5xx. Page. |
+| `smartrouter_endpoint_serving_tier < 2` | Serving on backups only. Redundancy is gone; the next failure is an outage. |
+
+Sizing the `for:` window: recovery from `0` is not one cadence. A chain that was **dark
+at boot** is retried on an adaptive schedule starting at ~2s and doubling to a 3m
+ceiling, so it typically self-heals in seconds. A chain that booted healthy and was
+later **demoted to dark** has no retry loop — demoted providers are not fed into the
+failed-provider lists — and is only re-checked by the 15m epoch re-verifier. Alert
+windows should assume the 15m case.
+
 ---
 
 ## Shared metrics

--- a/protocol/metrics/relays_monitor.go
+++ b/protocol/metrics/relays_monitor.go
@@ -31,6 +31,27 @@ func NewRelaysMonitor(interval time.Duration, chainID, apiInterface string) *Rel
 	}
 }
 
+// SeedInitialHealth overrides the optimistic default before Start runs.
+//
+// The default assumes healthy because, for a normally-booting chain, nothing is
+// known until the first health relay completes and reporting 503 in that window
+// would fail readiness for every rollout. But when startup validation already
+// found zero usable providers, that optimism is a lie: the endpoint would answer
+// 200 on its health path while every relay 503s, until the first health relay
+// resolves an interval later. Since MAG-2525 a chain in that state boots instead
+// of exiting, so this is the difference between being pulled from rotation and
+// silently accepting traffic it cannot serve.
+//
+// Must be called before Start; Start's immediate probe overwrites this with the
+// real verdict, which is the intent — the seed only covers the boot window.
+func (sem *RelaysMonitor) SeedInitialHealth(healthy bool) {
+	if sem == nil {
+		return
+	}
+
+	sem.storeHealthStatus(healthy)
+}
+
 func (sem *RelaysMonitor) SetRelaySender(relaySender func() (bool, error)) {
 	if sem == nil {
 		return

--- a/protocol/metrics/serving_tier_metrics_test.go
+++ b/protocol/metrics/serving_tier_metrics_test.go
@@ -1,0 +1,101 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func newSmartRouterForServingTierTest() *SmartRouterMetricsManager {
+	return &SmartRouterMetricsManager{
+		endpointServingTier: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{Name: "t_sr_endpoint_serving_tier"},
+			[]string{"spec", "apiInterface"},
+		),
+		urlToProviderNames: make(map[string][]string),
+	}
+}
+
+func TestServingTier_Mapping(t *testing.T) {
+	for _, tc := range []struct {
+		name                         string
+		healthyStatic, healthyBackup int
+		want                         int
+	}{
+		{"serving from primaries", 3, 2, ServingTierPrimary},
+		{"primaries healthy, no backups configured", 1, 0, ServingTierPrimary},
+		{"all primaries down, backups healthy", 0, 2, ServingTierDegraded},
+		{"backup-only configuration", 0, 1, ServingTierDegraded},
+		{"nothing healthy", 0, 0, ServingTierDark},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, ServingTier(tc.healthyStatic, tc.healthyBackup))
+		})
+	}
+}
+
+// Operators alert on `< 2` for degraded and `== 0` for dark, so the ordering is
+// part of the contract rather than an implementation detail.
+func TestServingTier_ConstantOrdering(t *testing.T) {
+	require.Equal(t, 0, ServingTierDark)
+	require.Equal(t, 1, ServingTierDegraded)
+	require.Equal(t, 2, ServingTierPrimary)
+	require.Less(t, ServingTierDark, ServingTierDegraded)
+	require.Less(t, ServingTierDegraded, ServingTierPrimary)
+}
+
+func TestSetEndpointServingTier_PublishesGauge(t *testing.T) {
+	m := newSmartRouterForServingTierTest()
+	gauge := m.endpointServingTier.WithLabelValues("BSC", "jsonrpc")
+
+	m.SetEndpointServingTier("BSC", "jsonrpc", 3, 2)
+	require.Equal(t, float64(ServingTierPrimary), testutil.ToFloat64(gauge))
+
+	m.SetEndpointServingTier("BSC", "jsonrpc", 0, 2)
+	require.Equal(t, float64(ServingTierDegraded), testutil.ToFloat64(gauge),
+		"all primaries down but backups serving is degraded, not dark")
+
+	m.SetEndpointServingTier("BSC", "jsonrpc", 0, 0)
+	require.Equal(t, float64(ServingTierDark), testutil.ToFloat64(gauge))
+}
+
+// The gauge is a gauge, not a high-water mark: it has to fall back down when a
+// provider recovers. It is set once at boot and then republished from every path
+// that mutates the session maps, so a stale reading would either page forever
+// after a recovery or stay silent after a demotion.
+func TestSetEndpointServingTier_RecoversAfterDark(t *testing.T) {
+	m := newSmartRouterForServingTierTest()
+	gauge := m.endpointServingTier.WithLabelValues("BSC", "jsonrpc")
+
+	m.SetEndpointServingTier("BSC", "jsonrpc", 0, 0) // booted dark
+	require.Equal(t, float64(ServingTierDark), testutil.ToFloat64(gauge))
+
+	m.SetEndpointServingTier("BSC", "jsonrpc", 0, 1) // a backup came back
+	require.Equal(t, float64(ServingTierDegraded), testutil.ToFloat64(gauge))
+
+	m.SetEndpointServingTier("BSC", "jsonrpc", 2, 1) // primaries followed
+	require.Equal(t, float64(ServingTierPrimary), testutil.ToFloat64(gauge))
+
+	m.SetEndpointServingTier("BSC", "jsonrpc", 0, 0) // and back down on demotion
+	require.Equal(t, float64(ServingTierDark), testutil.ToFloat64(gauge))
+}
+
+func TestSetEndpointServingTier_ChainsAreLabelledSeparately(t *testing.T) {
+	m := newSmartRouterForServingTierTest()
+
+	m.SetEndpointServingTier("BSC", "jsonrpc", 0, 0)
+	m.SetEndpointServingTier("ETH1", "jsonrpc", 3, 0)
+
+	require.Equal(t, float64(ServingTierDark),
+		testutil.ToFloat64(m.endpointServingTier.WithLabelValues("BSC", "jsonrpc")))
+	require.Equal(t, float64(ServingTierPrimary),
+		testutil.ToFloat64(m.endpointServingTier.WithLabelValues("ETH1", "jsonrpc")),
+		"one dark chain must not drag down another chain's reading")
+}
+
+func TestSetEndpointServingTier_NilManagerIsSafe(t *testing.T) {
+	var m *SmartRouterMetricsManager
+	require.NotPanics(t, func() { m.SetEndpointServingTier("BSC", "jsonrpc", 0, 0) })
+}

--- a/protocol/metrics/smartrouter_metrics_manager.go
+++ b/protocol/metrics/smartrouter_metrics_manager.go
@@ -113,6 +113,7 @@ type SmartRouterMetricsManager struct {
 	// emptied each store. See MAG-1762.
 	csmBlockedProvidersCount       *prometheus.GaugeVec // smartrouter_csm_blocked_providers
 	csmBlockedBackupProvidersCount *prometheus.GaugeVec // smartrouter_csm_blocked_backup_providers
+	endpointServingTier            *prometheus.GaugeVec // smartrouter_endpoint_serving_tier
 	csmStickySessionsCount         *prometheus.GaugeVec // smartrouter_csm_sticky_sessions
 	csmReportedProvidersCount      *prometheus.GaugeVec // smartrouter_csm_reported_providers
 
@@ -461,6 +462,10 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 		Name: "smartrouter_csm_reported_providers",
 		Help: "Number of providers currently in the ReportedProviders unresponsiveness register. Goes to 0 after /debug/reset-all.",
 	}, csmStateLabels)
+	endpointServingTier := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "smartrouter_endpoint_serving_tier",
+		Help: "Which provider tier an endpoint is serving from: 2=primaries, 1=DEGRADED (backups only), 0=DARK (no healthy providers). Since MAG-2525 a dark chain no longer crash-loops, so this gauge — not pod restarts — is the signal that a chain cannot serve.",
+	}, csmStateLabels)
 
 	// =========================================================================
 	// Request group metrics
@@ -582,6 +587,7 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	csmBlockedBackupProvidersCount = registerOrReuse(csmBlockedBackupProvidersCount)
 	csmStickySessionsCount = registerOrReuse(csmStickySessionsCount)
 	csmReportedProvidersCount = registerOrReuse(csmReportedProvidersCount)
+	endpointServingTier = registerOrReuse(endpointServingTier)
 
 	manager := &SmartRouterMetricsManager{
 		// Endpoint-scoped (with function)
@@ -669,6 +675,7 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 		csmBlockedBackupProvidersCount: csmBlockedBackupProvidersCount,
 		csmStickySessionsCount:         csmStickySessionsCount,
 		csmReportedProvidersCount:      csmReportedProvidersCount,
+		endpointServingTier:            endpointServingTier,
 
 		// Internal state
 		// Start fail-closed (0 = not-ready) so /readyz reports 503 until the
@@ -1376,6 +1383,37 @@ func (m *SmartRouterMetricsManager) SetCSMBlockedBackupProvidersCount(chainId, a
 		return
 	}
 	m.csmBlockedBackupProvidersCount.WithLabelValues(chainId, apiInterface).Set(float64(count))
+}
+
+// Serving-tier gauge values. A chain that cannot serve no longer exits the
+// process (MAG-2525), so this gauge carries the signal that pod restarts used to.
+const (
+	ServingTierDark     = 0 // no healthy provider in either tier — endpoint reports unhealthy
+	ServingTierDegraded = 1 // no healthy primaries; serving from backups only
+	ServingTierPrimary  = 2 // serving from primaries
+)
+
+// ServingTier maps healthy per-tier provider counts onto the serving posture.
+// Backups count as serving: the router falls back to them on primary exhaustion,
+// so "all primaries down" is degraded rather than dark.
+func ServingTier(healthyStatic, healthyBackup int) int {
+	switch {
+	case healthyStatic > 0:
+		return ServingTierPrimary
+	case healthyBackup > 0:
+		return ServingTierDegraded
+	default:
+		return ServingTierDark
+	}
+}
+
+// SetEndpointServingTier publishes which provider tier an endpoint is serving
+// from. Alert on < 2 for degraded and == 0 for a chain that is dark.
+func (m *SmartRouterMetricsManager) SetEndpointServingTier(chainId, apiInterface string, healthyStatic, healthyBackup int) {
+	if m == nil {
+		return
+	}
+	m.endpointServingTier.WithLabelValues(chainId, apiInterface).Set(float64(ServingTier(healthyStatic, healthyBackup)))
 }
 
 // SetCSMStickySessionsCount publishes the number of live sticky-session affinities.

--- a/protocol/metrics/smartrouter_metrics_manager.go
+++ b/protocol/metrics/smartrouter_metrics_manager.go
@@ -464,7 +464,7 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	}, csmStateLabels)
 	endpointServingTier := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "smartrouter_endpoint_serving_tier",
-		Help: "Which provider tier an endpoint is serving from: 2=primaries, 1=DEGRADED (backups only), 0=DARK (no healthy providers). Since MAG-2525 a dark chain no longer crash-loops, so this gauge — not pod restarts — is the signal that a chain cannot serve.",
+		Help: "Which provider tier an endpoint is serving from: 2=primaries, 1=DEGRADED (backups only), 0=DARK (no healthy providers). Since MAG-2525 a dark chain no longer crash-loops, so this gauge — not pod restarts — is the signal that a chain cannot serve. Expected time at 0 depends on how the chain went dark: dark at boot is retried from ~2s (doubling to a 3m ceiling), but a chain demoted to dark after booting healthy is only re-checked by the 15m epoch re-verifier. Size alert windows for the 15m case.",
 	}, csmStateLabels)
 
 	// =========================================================================

--- a/protocol/rpcsmartrouter/boot_resilience_test.go
+++ b/protocol/rpcsmartrouter/boot_resilience_test.go
@@ -1,0 +1,474 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/chainlib"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/protocol/metrics"
+	"github.com/magma-Devs/smart-router/utils/rand"
+	"github.com/stretchr/testify/require"
+)
+
+// Boot resilience (MAG-2525, subsuming MAG-2532).
+//
+// Before this change CreateSmartRouterEndpoint exited the process when every
+// static provider failed boot verification, even with healthy backups configured.
+// The rule is now: configuration errors are fatal, provider health never is. A
+// chain boots on backups alone, or boots dark and retries, and the health endpoint
+// — not a crash loop — is what reports that it cannot serve.
+//
+// The boot path itself needs live upstreams and a chain parser, so these tests
+// target the extracted units that carry the behavior: tier validation, the dark
+// verdict, the adaptive retry cadence, re-admission merging, and the health seed.
+
+func bootTestEndpoint() *lavasession.RPCEndpoint {
+	return &lavasession.RPCEndpoint{ChainID: "BSC", ApiInterface: "jsonrpc", NetworkAddress: "127.0.0.1:0"}
+}
+
+func bootTestProviders(names ...string) []*lavasession.RPCStaticProviderEndpoint {
+	providers := make([]*lavasession.RPCStaticProviderEndpoint, 0, len(names))
+	for _, n := range names {
+		providers = append(providers, &lavasession.RPCStaticProviderEndpoint{
+			Name: n, ChainID: "BSC", ApiInterface: "jsonrpc",
+			NodeUrls: []common.NodeUrl{{Url: "http://" + n + ":8545"}},
+		})
+	}
+	return providers
+}
+
+// failThese returns a validate func that fails exactly the named providers.
+func failThese(names ...string) func(context.Context, *lavasession.RPCStaticProviderEndpoint) error {
+	failing := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		failing[n] = struct{}{}
+	}
+	return func(_ context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
+		if _, bad := failing[p.Name]; bad {
+			return errors.New("unreachable")
+		}
+		return nil
+	}
+}
+
+func TestValidateProviderTier_PartitionsAndPreservesConfiguredOrder(t *testing.T) {
+	// Enough providers to exceed SpecReVerifyConcurrency, so completion order
+	// definitely differs from configured order.
+	providers := bootTestProviders("p0", "p1", "p2", "p3", "p4", "p5", "p6", "p7")
+
+	failedSet, failedOrdered := validateProviderTier(
+		context.Background(), providers, bootTestEndpoint(), nil, reverifyTierStatic,
+		failThese("p6", "p1", "p3"))
+
+	require.Len(t, failedSet, 3)
+	names := make([]string, 0, len(failedOrdered))
+	for _, p := range failedOrdered {
+		names = append(names, p.Name)
+	}
+	require.Equal(t, []string{"p1", "p3", "p6"}, names,
+		"failed slice must follow configured order, not goroutine completion order — it seeds the retry loop")
+
+	// Pointer-keyed, so the healthy providers are identifiable by identity.
+	for _, p := range providers {
+		_, failed := failedSet[p]
+		require.Equal(t, p.Name == "p1" || p.Name == "p3" || p.Name == "p6", failed, p.Name)
+	}
+}
+
+func TestValidateProviderTier_EmptyTierIsNotAnError(t *testing.T) {
+	failedSet, failedOrdered := validateProviderTier(
+		context.Background(), nil, bootTestEndpoint(), nil, reverifyTierBackup,
+		func(context.Context, *lavasession.RPCStaticProviderEndpoint) error {
+			t.Fatal("validate must not be called for an empty tier")
+			return nil
+		})
+
+	require.Empty(t, failedSet)
+	require.Empty(t, failedOrdered)
+}
+
+// A chain configured with backups only has an empty static tier. That case skipped
+// the fatal check even before this change, and must stay non-fatal.
+func TestValidateProviderTier_AllProvidersFailingIsReportedNotFatal(t *testing.T) {
+	providers := bootTestProviders("dead1", "dead2", "dead3")
+
+	failedSet, failedOrdered := validateProviderTier(
+		context.Background(), providers, bootTestEndpoint(), nil, reverifyTierStatic,
+		failThese("dead1", "dead2", "dead3"))
+
+	require.Len(t, failedSet, 3, "every provider failed")
+	require.Len(t, failedOrdered, 3, "and every one is queued for retry rather than aborting boot")
+}
+
+func TestValidateProviderTier_RunsConcurrently(t *testing.T) {
+	// Each validation blocks until released. If the tier ran serially none would
+	// overlap and this would deadlock on the barrier below.
+	providers := bootTestProviders("a", "b", "c", "d", "e")
+	release := make(chan struct{})
+	var inFlight, peak int64
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		validateProviderTier(
+			context.Background(), providers, bootTestEndpoint(), nil, reverifyTierStatic,
+			func(context.Context, *lavasession.RPCStaticProviderEndpoint) error {
+				cur := atomic.AddInt64(&inFlight, 1)
+				for {
+					old := atomic.LoadInt64(&peak)
+					if cur <= old || atomic.CompareAndSwapInt64(&peak, old, cur) {
+						break
+					}
+				}
+				<-release
+				atomic.AddInt64(&inFlight, -1)
+				return nil
+			})
+	}()
+
+	require.Eventually(t, func() bool { return atomic.LoadInt64(&inFlight) > 1 }, 5*time.Second, 5*time.Millisecond,
+		"validations must overlap; a serial tier delays the backup tier by N x timeout")
+	close(release)
+	<-done
+
+	require.LessOrEqual(t, atomic.LoadInt64(&peak), int64(SpecReVerifyConcurrency),
+		"concurrency must stay bounded by the semaphore")
+}
+
+func TestChainIsDark(t *testing.T) {
+	const chainKey = "BSC-jsonrpc"
+	session := map[uint64]*lavasession.ConsumerSessionsWithProvider{0: createTestProviderSession("p", 1)}
+
+	for _, tc := range []struct {
+		name           string
+		static, backup map[uint64]*lavasession.ConsumerSessionsWithProvider
+		wantDark       bool
+	}{
+		{"primaries healthy", session, nil, false},
+		{"backups only — degraded, not dark", nil, session, false},
+		{"both tiers present", session, session, false},
+		{"nothing usable", nil, nil, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rpsr := createTestRPCSmartRouter()
+			if tc.static != nil {
+				rpsr.providerSessions[chainKey] = tc.static
+			}
+			if tc.backup != nil {
+				rpsr.backupProviderSessions[chainKey] = tc.backup
+			}
+			require.Equal(t, tc.wantDark, rpsr.chainIsDark(chainKey))
+		})
+	}
+}
+
+func TestRetryIntervalFor(t *testing.T) {
+	require.Equal(t, retryDarkBaseInterval, retryIntervalFor(true),
+		"a chain that cannot serve retries promptly — every second is downtime")
+	require.Equal(t, retryMaxInterval, retryIntervalFor(false),
+		"a merely degraded chain waits the full interval; retries buy redundancy, not availability")
+	require.Less(t, retryDarkBaseInterval, retryMaxInterval)
+}
+
+func TestSeedInitialHealth_DarkChainReportsUnhealthyImmediately(t *testing.T) {
+	// The monitor is optimistic by default, which would answer 200 on the health
+	// path for a chain that came up with nothing to serve from.
+	monitor := metrics.NewRelaysMonitor(time.Minute, "BSC", "jsonrpc")
+	require.True(t, monitor.IsHealthy(), "default is optimistic")
+
+	monitor.SeedInitialHealth(false)
+	require.False(t, monitor.IsHealthy(),
+		"a chain that booted dark must fail its health check rather than accept traffic it cannot serve")
+
+	monitor.SeedInitialHealth(true)
+	require.True(t, monitor.IsHealthy(), "seeding is not one-way")
+}
+
+func TestSeedInitialHealth_NilReceiverIsSafe(t *testing.T) {
+	var monitor *metrics.RelaysMonitor
+	require.NotPanics(t, func() { monitor.SeedInitialHealth(false) })
+	require.False(t, monitor.IsHealthy(), "an absent monitor is not healthy")
+}
+
+func TestMergeRecoveredSessions(t *testing.T) {
+	convert := func(providers []*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+		out := make(map[uint64]*lavasession.ConsumerSessionsWithProvider, len(providers))
+		for i, p := range providers {
+			out[uint64(i)] = createTestProviderSession(p.Name, 0)
+		}
+		return out
+	}
+
+	t.Run("no recoveries returns the original map untouched", func(t *testing.T) {
+		existing := map[uint64]*lavasession.ConsumerSessionsWithProvider{0: createTestProviderSession("a", 1)}
+		require.Equal(t, existing, mergeRecoveredSessions(existing, nil, convert, 7))
+	})
+
+	t.Run("recovered sessions append past the highest existing index", func(t *testing.T) {
+		existing := map[uint64]*lavasession.ConsumerSessionsWithProvider{
+			0: createTestProviderSession("a", 1),
+			5: createTestProviderSession("b", 1),
+		}
+		merged := mergeRecoveredSessions(existing, bootTestProviders("c", "d"), convert, 9)
+
+		require.Len(t, merged, 4, "nothing is overwritten")
+		require.Len(t, existing, 2, "copy-on-write: the old map is still safe for concurrent readers")
+		for _, idx := range []uint64{0, 5, 6, 7} {
+			require.Contains(t, merged, idx)
+		}
+		require.Equal(t, uint64(9), merged[6].PairingEpoch, "recovered sessions adopt the current epoch")
+		require.Equal(t, uint64(9), merged[7].PairingEpoch)
+	})
+
+	t.Run("recovering into an empty pairing works", func(t *testing.T) {
+		merged := mergeRecoveredSessions(nil, bootTestProviders("first"), convert, 3)
+		require.Len(t, merged, 1, "a dark chain must be able to adopt its first provider")
+		require.Equal(t, uint64(3), merged[0].PairingEpoch)
+	})
+}
+
+func TestPruneRestoredFromFailed(t *testing.T) {
+	const chainKey = "BSC-jsonrpc"
+
+	t.Run("restored providers are dropped, others kept", func(t *testing.T) {
+		failed := map[string][]*lavasession.RPCStaticProviderEndpoint{
+			chainKey: bootTestProviders("x", "y", "z"),
+		}
+		pruneRestoredFromFailed(failed, chainKey, map[string]struct{}{"y": {}})
+
+		require.Len(t, failed[chainKey], 2)
+		require.Equal(t, "x", failed[chainKey][0].Name)
+		require.Equal(t, "z", failed[chainKey][1].Name)
+	})
+
+	t.Run("entry is deleted once nothing is pending so the retry loop can stop", func(t *testing.T) {
+		failed := map[string][]*lavasession.RPCStaticProviderEndpoint{
+			chainKey: bootTestProviders("x", "y"),
+		}
+		pruneRestoredFromFailed(failed, chainKey, map[string]struct{}{"x": {}, "y": {}})
+		require.NotContains(t, failed, chainKey)
+	})
+
+	t.Run("absent chain is a no-op", func(t *testing.T) {
+		failed := map[string][]*lavasession.RPCStaticProviderEndpoint{}
+		require.NotPanics(t, func() {
+			pruneRestoredFromFailed(failed, chainKey, map[string]struct{}{"x": {}})
+		})
+	})
+}
+
+func TestReadmitRecoveredProviders_RestoresBothTiers(t *testing.T) {
+	rand.InitRandomSeed()
+	const chainKey = "BSC-jsonrpc"
+	rpsr := createTestRPCSmartRouter()
+	sm, rpcEndpoint := createTestSessionManager("BSC", "jsonrpc")
+	rpsr.sessionManagers[chainKey] = sm
+
+	// A chain that booted dark: nothing registered, both tiers pending retry.
+	staticProviders := bootTestProviders("primary1")
+	backupProviders := bootTestProviders("backup1")
+	rpsr.failedStaticProviders[chainKey] = staticProviders
+	rpsr.failedBackupProviders[chainKey] = backupProviders
+	require.True(t, rpsr.chainIsDark(chainKey))
+
+	var convertCalls int32
+	convert := func(providers []*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+		atomic.AddInt32(&convertCalls, 1)
+		out := make(map[uint64]*lavasession.ConsumerSessionsWithProvider, len(providers))
+		for i, p := range providers {
+			out[uint64(i)] = createTestProviderSession(p.Name, 0)
+		}
+		return out
+	}
+
+	rpsr.readmitRecoveredProviders(chainKey, rpcEndpoint, convert,
+		staticProviders, nil, backupProviders, nil)
+
+	require.Len(t, rpsr.providerSessions[chainKey], 1, "primary re-admitted")
+	require.Len(t, rpsr.backupProviderSessions[chainKey], 1, "backup re-admitted — backups are retried too now")
+	require.Empty(t, rpsr.failedStaticProviders[chainKey])
+	require.Empty(t, rpsr.failedBackupProviders[chainKey])
+	require.False(t, rpsr.chainIsDark(chainKey), "chain is serving again without a restart")
+}
+
+func TestReadmitRecoveredProviders_NoRecoveriesStillRecordsStillFailed(t *testing.T) {
+	rand.InitRandomSeed()
+	const chainKey = "BSC-jsonrpc"
+	rpsr := createTestRPCSmartRouter()
+	sm, rpcEndpoint := createTestSessionManager("BSC", "jsonrpc")
+	rpsr.sessionManagers[chainKey] = sm
+
+	stillFailing := bootTestProviders("primary1")
+	rpsr.failedStaticProviders[chainKey] = stillFailing
+
+	rpsr.readmitRecoveredProviders(chainKey, rpcEndpoint,
+		func([]*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+			t.Fatal("nothing recovered — must not build sessions")
+			return nil
+		},
+		nil, stillFailing, nil, nil)
+
+	require.Len(t, rpsr.failedStaticProviders[chainKey], 1, "still queued for the next retry")
+	require.Empty(t, rpsr.providerSessions[chainKey])
+	require.True(t, rpsr.chainIsDark(chainKey))
+}
+
+// A dark chain must keep retrying and start serving as soon as an upstream returns,
+// without a process restart. This is MAG-2525's headline requirement.
+func TestRetryFailedProviders_DarkChainAdoptsProviderWhenItReturns(t *testing.T) {
+	rand.InitRandomSeed()
+	shortenRetryIntervals(t)
+	const chainKey = "BSC-jsonrpc"
+	rpsr := createTestRPCSmartRouter()
+	sm, rpcEndpoint := createTestSessionManager("BSC", "jsonrpc")
+	rpsr.sessionManagers[chainKey] = sm
+
+	providers := bootTestProviders("primary1")
+	rpsr.failedStaticProviders[chainKey] = providers
+	require.True(t, rpsr.chainIsDark(chainKey), "boots dark")
+
+	// The upstream stays down for the first few attempts, then recovers.
+	var attempts int32
+	restoreValidate := swapBootValidate(func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+		if atomic.AddInt32(&attempts, 1) < 3 {
+			return errors.New("still down")
+		}
+		return nil
+	})
+	defer restoreValidate()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		rpsr.retryFailedProviders(ctx, chainKey, nil, rpcEndpoint,
+			func(providers []*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+				out := make(map[uint64]*lavasession.ConsumerSessionsWithProvider, len(providers))
+				for i, p := range providers {
+					out[uint64(i)] = createTestProviderSession(p.Name, 0)
+				}
+				return out
+			})
+	}()
+
+	// The dark backoff doubles from its base, so three attempts land well inside this.
+	require.Eventually(t, func() bool { return !rpsr.chainIsDark(chainKey) }, 10*time.Second, 5*time.Millisecond,
+		"a dark chain must adopt a recovered provider on the fast backoff, not wait for the 15m epoch tick")
+
+	// With nothing left failing, the loop reports done and exits on its own.
+	select {
+	case <-done:
+	case <-time.After(retryMaxInterval + 5*time.Second):
+		cancel()
+		<-done
+		t.Fatal("retry loop should self-terminate once every provider has recovered")
+	}
+
+	require.GreaterOrEqual(t, atomic.LoadInt32(&attempts), int32(3))
+}
+
+func TestRetryFailedProviders_StopsWhenNothingIsPending(t *testing.T) {
+	rand.InitRandomSeed()
+	shortenRetryIntervals(t)
+	const chainKey = "BSC-jsonrpc"
+	rpsr := createTestRPCSmartRouter()
+	sm, rpcEndpoint := createTestSessionManager("BSC", "jsonrpc")
+	rpsr.sessionManagers[chainKey] = sm
+	// Dark, so the first wait is the short one.
+	require.True(t, rpsr.chainIsDark(chainKey))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		rpsr.retryFailedProviders(ctx, chainKey, nil, rpcEndpoint,
+			func([]*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+				t.Error("no failed providers — must not build sessions")
+				return nil
+			})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(retryDarkBaseInterval + 5*time.Second):
+		cancel()
+		<-done
+		t.Fatal("loop must exit when both failed lists are empty")
+	}
+}
+
+// One chain being dark must not disturb another chain's state.
+func TestRetryFailedProviders_ChainsAreIsolated(t *testing.T) {
+	rand.InitRandomSeed()
+	shortenRetryIntervals(t)
+	rpsr := createTestRPCSmartRouter()
+	const darkKey, healthyKey = "BSC-jsonrpc", "ETH1-jsonrpc"
+
+	smDark, darkEndpoint := createTestSessionManager("BSC", "jsonrpc")
+	rpsr.sessionManagers[darkKey] = smDark
+	rpsr.failedStaticProviders[darkKey] = bootTestProviders("bsc-primary")
+
+	smHealthy, _ := createTestSessionManager("ETH1", "jsonrpc")
+	rpsr.sessionManagers[healthyKey] = smHealthy
+	rpsr.providerSessions[healthyKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: createTestProviderSession("eth-primary", 1),
+	}
+
+	require.True(t, rpsr.chainIsDark(darkKey))
+	require.False(t, rpsr.chainIsDark(healthyKey))
+
+	restoreValidate := swapBootValidate(func(context.Context, *lavasession.RPCStaticProviderEndpoint) error {
+		return errors.New("still down")
+	})
+	defer restoreValidate()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		rpsr.retryFailedProviders(ctx, darkKey, nil, darkEndpoint,
+			func([]*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+				return nil
+			})
+	}()
+	<-done
+
+	require.True(t, rpsr.chainIsDark(darkKey), "BSC never recovered")
+	require.False(t, rpsr.chainIsDark(healthyKey), "ETH1 is untouched by BSC being dark")
+	require.Len(t, rpsr.providerSessions[healthyKey], 1)
+}
+
+// swapBootValidate substitutes the retry loop's provider probe and returns a
+// restore func. The chainParser argument is irrelevant to these tests, so the
+// fake takes the shorter signature.
+func swapBootValidate(fn func(context.Context, *lavasession.RPCStaticProviderEndpoint) error) func() {
+	prev := retryValidateFn
+	retryValidateFn = func(ctx context.Context, p *lavasession.RPCStaticProviderEndpoint, _ chainlib.ChainParser) error {
+		return fn(ctx, p)
+	}
+	return func() { retryValidateFn = prev }
+}
+
+// shortenRetryIntervals compresses the retry cadence so loop behavior can be
+// exercised in milliseconds. The ratio between the two is preserved, since the
+// point of the design is that a dark chain retries far sooner than a degraded one.
+func shortenRetryIntervals(t *testing.T) {
+	t.Helper()
+	prevDark, prevMax := retryDarkBaseInterval, retryMaxInterval
+	retryDarkBaseInterval = 10 * time.Millisecond
+	retryMaxInterval = 500 * time.Millisecond
+	t.Cleanup(func() {
+		retryDarkBaseInterval, retryMaxInterval = prevDark, prevMax
+	})
+}

--- a/protocol/rpcsmartrouter/boot_resilience_test.go
+++ b/protocol/rpcsmartrouter/boot_resilience_test.go
@@ -472,3 +472,95 @@ func shortenRetryIntervals(t *testing.T) {
 		retryDarkBaseInterval, retryMaxInterval = prevDark, prevMax
 	})
 }
+
+// The epoch re-verifier promotes a provider back into the pairing, but until this fix
+// it left that provider sitting in the failed list. retryFailedProviders would then
+// revalidate it, succeed, and merge a SECOND session for the same name —
+// mergeRecoveredSessions keys by index and does not dedupe by PublicLavaAddress. The
+// consumer session manager's pairing map collapses the duplicate but validAddresses
+// does not, so the provider ends up with double its selection weight.
+func TestUpdateEpoch_PromotedProviderLeavesTheFailedList(t *testing.T) {
+	rand.InitRandomSeed()
+	const chainKey = "BSC-jsonrpc"
+	rpsr := createTestRPCSmartRouter()
+	sm, rpcEndpoint := createTestSessionManager("BSC", "jsonrpc")
+	rpsr.sessionManagers[chainKey] = sm
+
+	// primary1 failed boot verification and is pending retry; backup1 likewise.
+	staticProviders := bootTestProviders("primary1")
+	backupProviders := bootTestProviders("backup1")
+	rpsr.failedStaticProviders[chainKey] = staticProviders
+	rpsr.failedBackupProviders[chainKey] = backupProviders
+
+	convert := func(providers []*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+		out := make(map[uint64]*lavasession.ConsumerSessionsWithProvider, len(providers))
+		for i, p := range providers {
+			out[uint64(i)] = createTestProviderSession(p.Name, 0)
+		}
+		return out
+	}
+	rpsr.reverifyInputs = map[string]*chainReverifyInputs{
+		chainKey: {
+			rpcEndpoint:                rpcEndpoint,
+			convertProvidersToSessions: convert,
+			configuredStatic:           staticProviders,
+			configuredBackup:           backupProviders,
+			validateFn:                 failThese(), // both upstreams are back
+		},
+	}
+
+	rpsr.updateEpoch(context.Background(), 2)
+
+	require.Len(t, rpsr.providerSessions[chainKey], 1, "primary promoted")
+	require.Len(t, rpsr.backupProviderSessions[chainKey], 1, "backup promoted")
+	require.Empty(t, rpsr.failedStaticProviders[chainKey],
+		"promoted provider must not stay pending, or the retry loop merges a duplicate session")
+	require.Empty(t, rpsr.failedBackupProviders[chainKey])
+}
+
+// Pruning is per tier: a name configured in both tiers must not have its still-failing
+// backup dropped from the retry loop just because its static twin recovered.
+func TestUpdateEpoch_PromotionPrunesOnlyItsOwnTier(t *testing.T) {
+	rand.InitRandomSeed()
+	const chainKey = "BSC-jsonrpc"
+	rpsr := createTestRPCSmartRouter()
+	sm, rpcEndpoint := createTestSessionManager("BSC", "jsonrpc")
+	rpsr.sessionManagers[chainKey] = sm
+
+	// Same provider name configured in both tiers; only the static one recovers.
+	shared := bootTestProviders("shared")
+	sharedBackup := bootTestProviders("shared")
+	rpsr.failedStaticProviders[chainKey] = shared
+	rpsr.failedBackupProviders[chainKey] = sharedBackup
+
+	convert := func(providers []*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+		out := make(map[uint64]*lavasession.ConsumerSessionsWithProvider, len(providers))
+		for i, p := range providers {
+			out[uint64(i)] = createTestProviderSession(p.Name, 0)
+		}
+		return out
+	}
+	var tierSeen int
+	rpsr.reverifyInputs = map[string]*chainReverifyInputs{
+		chainKey: {
+			rpcEndpoint:                rpcEndpoint,
+			convertProvidersToSessions: convert,
+			configuredStatic:           shared,
+			configuredBackup:           sharedBackup,
+			// applyReverification runs static first, then backup.
+			validateFn: func(context.Context, *lavasession.RPCStaticProviderEndpoint) error {
+				tierSeen++
+				if tierSeen == 1 {
+					return nil // static recovered
+				}
+				return errors.New("backup still unreachable")
+			},
+		},
+	}
+
+	rpsr.updateEpoch(context.Background(), 2)
+
+	require.Empty(t, rpsr.failedStaticProviders[chainKey], "static promoted, so it leaves its own list")
+	require.Len(t, rpsr.failedBackupProviders[chainKey], 1,
+		"the backup never recovered — it must stay queued for retry")
+}

--- a/protocol/rpcsmartrouter/chaintracker_reconcile_test.go
+++ b/protocol/rpcsmartrouter/chaintracker_reconcile_test.go
@@ -65,7 +65,7 @@ func newReconcileFixture(t *testing.T, ctx context.Context) *reconcileFixture {
 }
 
 // admit replaces the live pairing with sessions for exactly these URLs, mirroring what the
-// post-startup admission paths do (retryFailedStaticProviders / applyReverification promote /
+// post-startup admission paths do (retryFailedProviders / applyReverification promote /
 // rebuildPairingFromConfig all rebuild sessions with FRESH DirectRPCConnections).
 //
 // The URLs point at a closed port: NewDirectRPCConnection for HTTP builds a client without
@@ -100,7 +100,7 @@ func (f *reconcileFixture) hasTracker(url string) bool {
 // An endpoint that is unreachable when the router boots fails startup verification and is held out
 // of the pairing, so the startup pass legitimately does not see it (which is why the boot log read
 // "failed=0 success=1" rather than "failed=2" — skipped, not failed). It is admitted later, with a
-// fresh DirectRPCConnection, by retryFailedStaticProviders / the epoch re-verify. Before the fix
+// fresh DirectRPCConnection, by retryFailedProviders / the epoch re-verify. Before the fix
 // nothing registered a tracker at that point and the endpoint never polled for the lifetime of the
 // process — PollIntervalMs=0 with ConsecutivePollFailures=0.
 //

--- a/protocol/rpcsmartrouter/direct_grpc_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_grpc_subscription_manager.go
@@ -82,6 +82,9 @@ type DirectGRPCSubscriptionManager struct {
 	// Primary tier serves all selections; backup tier is only consulted when
 	// primary is exhausted (analogous to ConsumerSessionManager's
 	// pairing/backupProviders split).
+	//
+	// Mutable, same as the WS manager's tiers: SetEndpoints swaps them (copy-on-write)
+	// when the live pairing changes. Guarded by `lock` — read via endpointsSnapshot.
 	grpcEndpoints       []*common.NodeUrl          // Primary tier — selected first
 	grpcBackupEndpoints []*common.NodeUrl          // Backup tier — used only when primary exhausted
 	endpointsByURL      map[string]*common.NodeUrl // Lookup across both tiers (sticky-session uniformity)
@@ -166,11 +169,62 @@ func NewDirectGRPCSubscriptionManager(
 	return manager
 }
 
+// grpcEndpointsSnapshot is an immutable view of both tiers plus the URL index,
+// taken under the read lock. See wsEndpointsSnapshot — same contract.
+type grpcEndpointsSnapshot struct {
+	primary []*common.NodeUrl
+	backup  []*common.NodeUrl
+	byURL   map[string]*common.NodeUrl
+}
+
+func (dgm *DirectGRPCSubscriptionManager) endpointsSnapshot() grpcEndpointsSnapshot {
+	dgm.lock.RLock()
+	defer dgm.lock.RUnlock()
+	return grpcEndpointsSnapshot{
+		primary: dgm.grpcEndpoints,
+		backup:  dgm.grpcBackupEndpoints,
+		byURL:   dgm.endpointsByURL,
+	}
+}
+
+// SetEndpoints replaces both tiers with the currently-serving gRPC endpoints and
+// reports whether anything changed. Counterpart to
+// DirectWSSubscriptionManager.SetEndpoints — see there for why the tiers must track
+// the live pairing and why only live endpoints may be passed in (MAG-2525).
+//
+// This also un-sticks gRPC reflection: GetReflectionConnection selects through the
+// same cascade, so a chain that booted dark answered reflection with "no endpoints"
+// until the tiers were repopulated.
+func (dgm *DirectGRPCSubscriptionManager) SetEndpoints(grpcEndpoints, grpcBackupEndpoints []*common.NodeUrl) (changed bool) {
+	byURL := make(map[string]*common.NodeUrl, len(grpcEndpoints)+len(grpcBackupEndpoints))
+	for _, ep := range grpcEndpoints {
+		byURL[ep.Url] = ep
+	}
+	for _, ep := range grpcBackupEndpoints {
+		byURL[ep.Url] = ep
+	}
+
+	dgm.lock.Lock()
+	defer dgm.lock.Unlock()
+
+	if sameEndpointURLs(dgm.grpcEndpoints, grpcEndpoints) && sameEndpointURLs(dgm.grpcBackupEndpoints, grpcBackupEndpoints) {
+		return false
+	}
+
+	dgm.grpcEndpoints = grpcEndpoints
+	dgm.grpcBackupEndpoints = grpcBackupEndpoints
+	dgm.endpointsByURL = byURL
+
+	// Pools for departed URLs are left for the cleanup loop to reap once idle —
+	// live streams on a provider that only failed re-verification keep running.
+	return true
+}
+
 // Start initializes the manager and starts background tasks
 func (dgm *DirectGRPCSubscriptionManager) Start(ctx context.Context) {
 	utils.LavaFormatInfo("DirectGRPCSubscriptionManager starting",
 		utils.LogAttr("chainID", dgm.chainID),
-		utils.LogAttr("endpoints", len(dgm.grpcEndpoints)),
+		utils.LogAttr("endpoints", len(dgm.endpointsSnapshot().primary)),
 	)
 
 	// Start cleanup goroutine
@@ -903,10 +957,13 @@ func (dgm *DirectGRPCSubscriptionManager) getOrCreatePool(ctx context.Context, e
 // after the upstream connection is verified, not here, so a primary that fails to
 // connect doesn't pin the client and block the cascade.
 func (dgm *DirectGRPCSubscriptionManager) selectEndpoint(ctx context.Context, clientKey string, ignoredEndpoints map[string]struct{}) (*common.NodeUrl, error) {
+	// One snapshot for the whole cascade — see DirectWSSubscriptionManager.selectEndpoint.
+	snapshot := dgm.endpointsSnapshot()
+
 	// Tier 0: sticky session for this client (resolves across both tiers).
 	if clientKey != "" {
 		if stickySession, exists := dgm.stickyStore.Get(clientKey); exists {
-			if stickyEndpoint, found := dgm.endpointsByURL[stickySession.Provider]; found {
+			if stickyEndpoint, found := snapshot.byURL[stickySession.Provider]; found {
 				if ignoredEndpoints == nil {
 					return stickyEndpoint, nil
 				}
@@ -924,15 +981,15 @@ func (dgm *DirectGRPCSubscriptionManager) selectEndpoint(ctx context.Context, cl
 	}
 
 	// Tier 1: primary (optimizer-aware).
-	if endpoint, err := dgm.selectFromTier(ctx, dgm.grpcEndpoints, ignoredEndpoints); err == nil {
+	if endpoint, err := dgm.selectFromTier(ctx, snapshot.primary, snapshot.byURL, ignoredEndpoints); err == nil {
 		return endpoint, nil
 	}
 
 	// Tier 2: backup (only when primary is empty/unavailable).
 	utils.LavaFormatDebug("DirectGRPC: primary endpoints exhausted, falling back to backup",
-		utils.LogAttr("backupCount", len(dgm.grpcBackupEndpoints)),
+		utils.LogAttr("backupCount", len(snapshot.backup)),
 	)
-	if endpoint, err := dgm.selectFromTier(ctx, dgm.grpcBackupEndpoints, ignoredEndpoints); err == nil {
+	if endpoint, err := dgm.selectFromTier(ctx, snapshot.backup, snapshot.byURL, ignoredEndpoints); err == nil {
 		return endpoint, nil
 	}
 
@@ -942,7 +999,9 @@ func (dgm *DirectGRPCSubscriptionManager) selectEndpoint(ctx context.Context, cl
 // selectFromTier picks an endpoint from a single tier using the optimizer when
 // available, falling back to first-non-ignored. Tier-agnostic — the cascade
 // order is the caller's responsibility.
-func (dgm *DirectGRPCSubscriptionManager) selectFromTier(ctx context.Context, tier []*common.NodeUrl, ignoredEndpoints map[string]struct{}) (*common.NodeUrl, error) {
+//
+// tier and byURL come from one endpointsSnapshot; see the WS counterpart.
+func (dgm *DirectGRPCSubscriptionManager) selectFromTier(ctx context.Context, tier []*common.NodeUrl, byURL map[string]*common.NodeUrl, ignoredEndpoints map[string]struct{}) (*common.NodeUrl, error) {
 	if len(tier) == 0 {
 		return nil, fmt.Errorf("tier is empty")
 	}
@@ -982,7 +1041,7 @@ func (dgm *DirectGRPCSubscriptionManager) selectFromTier(ctx context.Context, ti
 	}
 
 	selectedURL := selectedURLs[0]
-	if endpoint, exists := dgm.endpointsByURL[selectedURL]; exists {
+	if endpoint, exists := byURL[selectedURL]; exists {
 		return endpoint, nil
 	}
 	return nil, fmt.Errorf("optimizer selected unknown endpoint: %s", selectedURL)

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
@@ -101,6 +101,11 @@ type DirectWSSubscriptionManager struct {
 	// Upstream endpoint configuration - two-tier separation matches HTTP backup model.
 	// Primary tier serves all selections; backup tier is only consulted when primary is
 	// exhausted (analogous to ConsumerSessionManager's pairing/backupProviders split).
+	//
+	// These three are mutable: SetEndpoints swaps them (copy-on-write) whenever the live
+	// pairing changes, so a provider that was down at boot joins the tier once it
+	// recovers. All three are guarded by `lock` — read them via endpointsSnapshot, never
+	// directly, or selection races the swap.
 	wsEndpoints       []*common.NodeUrl          // Primary tier — selected first
 	wsBackupEndpoints []*common.NodeUrl          // Backup tier — used only when primary exhausted
 	endpointsByURL    map[string]*common.NodeUrl // Quick lookup by URL across both tiers (sticky-session uniformity)
@@ -181,6 +186,84 @@ func NewDirectWSSubscriptionManager(
 		config:               config,
 		rateLimiter:          NewClientRateLimiter(config),
 	}
+}
+
+// wsEndpointsSnapshot is an immutable view of both tiers plus the URL index,
+// taken under the read lock. SetEndpoints replaces the manager's slices and map
+// wholesale rather than mutating them, so a snapshot stays coherent for the
+// duration of a selection — including across the optimizer call, which must not
+// run while the lock is held.
+type wsEndpointsSnapshot struct {
+	primary []*common.NodeUrl
+	backup  []*common.NodeUrl
+	byURL   map[string]*common.NodeUrl
+}
+
+func (dwsm *DirectWSSubscriptionManager) endpointsSnapshot() wsEndpointsSnapshot {
+	dwsm.lock.RLock()
+	defer dwsm.lock.RUnlock()
+	return wsEndpointsSnapshot{
+		primary: dwsm.wsEndpoints,
+		backup:  dwsm.wsBackupEndpoints,
+		byURL:   dwsm.endpointsByURL,
+	}
+}
+
+// SetEndpoints replaces both tiers with the currently-serving WebSocket endpoints
+// and reports whether anything actually changed.
+//
+// The tiers are built once at boot from the providers that passed verification, so
+// without this the set is frozen for the process lifetime: a chain that booted dark
+// would keep the empty tiers forever and every eth_subscribe would fail even after
+// every provider recovered, and a chain that booted on backups alone would never
+// promote a recovered primary back into tier 1 (MAG-2525).
+//
+// Callers pass only endpoints that are live in the pairing. Seeding a tier with
+// configured-but-dead endpoints would be worse than an empty tier: selectEndpoint is
+// called once per subscription with no ignore set and no retry loop, so a dead entry
+// is handed straight to the client, and a non-empty primary tier suppresses the
+// primary→backup cascade entirely.
+func (dwsm *DirectWSSubscriptionManager) SetEndpoints(wsEndpoints, wsBackupEndpoints []*common.NodeUrl) (changed bool) {
+	byURL := make(map[string]*common.NodeUrl, len(wsEndpoints)+len(wsBackupEndpoints))
+	for _, ep := range wsEndpoints {
+		byURL[ep.Url] = ep
+	}
+	for _, ep := range wsBackupEndpoints {
+		byURL[ep.Url] = ep
+	}
+
+	dwsm.lock.Lock()
+	defer dwsm.lock.Unlock()
+
+	if sameEndpointURLs(dwsm.wsEndpoints, wsEndpoints) && sameEndpointURLs(dwsm.wsBackupEndpoints, wsBackupEndpoints) {
+		return false
+	}
+
+	// Copy-on-write: in-flight selections hold a snapshot of the old slices.
+	dwsm.wsEndpoints = wsEndpoints
+	dwsm.wsBackupEndpoints = wsBackupEndpoints
+	dwsm.endpointsByURL = byURL
+
+	// Existing upstream pools are deliberately left alone. A pool keyed by a URL that
+	// just left the tier still serves its live subscriptions until they close, and
+	// performCleanup reaps it once it is idle; tearing it down here would kill working
+	// subscriptions on a provider that merely failed spec re-verification.
+	return true
+}
+
+// sameEndpointURLs reports whether two tiers hold the same URLs in the same order.
+// Order matters: it is the fallback selection order when the optimizer is absent
+// or returns nothing.
+func sameEndpointURLs(a, b []*common.NodeUrl) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Url != b[i].Url {
+			return false
+		}
+	}
+	return true
 }
 
 // Start starts the background cleanup goroutine for the DirectWSSubscriptionManager.
@@ -298,10 +381,15 @@ func (dwsm *DirectWSSubscriptionManager) performCleanup() {
 // Backup-tier consultation mirrors ConsumerSessionManager.getSessionWithProviderOrError
 // (see protocol/lavasession/consumer_session_manager.go:820-852).
 func (dwsm *DirectWSSubscriptionManager) selectEndpoint(ctx context.Context, clientKey string, ignoredEndpoints map[string]struct{}) (*common.NodeUrl, error) {
+	// One snapshot for the whole cascade: SetEndpoints can swap the tiers underneath
+	// us, and re-reading between tiers could see primary from before the swap and
+	// backup from after.
+	snapshot := dwsm.endpointsSnapshot()
+
 	// Tier 0: sticky session for this client (resolves across both tiers).
 	if clientKey != "" {
 		if stickySession, exists := dwsm.stickyStore.Get(clientKey); exists {
-			stickyEndpoint, found := dwsm.endpointsByURL[stickySession.Provider]
+			stickyEndpoint, found := snapshot.byURL[stickySession.Provider]
 			if found {
 				// Check if sticky endpoint is not ignored
 				if ignoredEndpoints == nil {
@@ -329,7 +417,7 @@ func (dwsm *DirectWSSubscriptionManager) selectEndpoint(ctx context.Context, cli
 	}
 
 	// Tier 1: primary endpoints.
-	ep, primaryErr := dwsm.selectFromTier(ctx, dwsm.wsEndpoints, ignoredEndpoints)
+	ep, primaryErr := dwsm.selectFromTier(ctx, snapshot.primary, snapshot.byURL, ignoredEndpoints)
 	if primaryErr == nil {
 		return ep, nil
 	}
@@ -337,9 +425,9 @@ func (dwsm *DirectWSSubscriptionManager) selectEndpoint(ctx context.Context, cli
 	// Tier 2: backup endpoints (only when primary is exhausted).
 	utils.LavaFormatDebug("DirectWS: primary endpoints exhausted, falling back to backup",
 		utils.LogAttr("primaryReason", primaryErr.Error()),
-		utils.LogAttr("backupCount", len(dwsm.wsBackupEndpoints)),
+		utils.LogAttr("backupCount", len(snapshot.backup)),
 	)
-	ep, backupErr := dwsm.selectFromTier(ctx, dwsm.wsBackupEndpoints, ignoredEndpoints)
+	ep, backupErr := dwsm.selectFromTier(ctx, snapshot.backup, snapshot.byURL, ignoredEndpoints)
 	if backupErr == nil {
 		return ep, nil
 	}
@@ -350,7 +438,10 @@ func (dwsm *DirectWSSubscriptionManager) selectEndpoint(ctx context.Context, cli
 // selectFromTier picks one endpoint from the given tier's endpoint slice using
 // the optimizer when available, falling back to first-non-ignored. The caller is
 // responsible for cascade ordering — this helper is tier-agnostic.
-func (dwsm *DirectWSSubscriptionManager) selectFromTier(ctx context.Context, tier []*common.NodeUrl, ignoredEndpoints map[string]struct{}) (*common.NodeUrl, error) {
+//
+// tier and byURL come from one endpointsSnapshot so the optimizer's chosen URL is
+// resolved against the same generation of the index it was offered from.
+func (dwsm *DirectWSSubscriptionManager) selectFromTier(ctx context.Context, tier []*common.NodeUrl, byURL map[string]*common.NodeUrl, ignoredEndpoints map[string]struct{}) (*common.NodeUrl, error) {
 	if len(tier) == 0 {
 		return nil, fmt.Errorf("tier is empty")
 	}
@@ -391,7 +482,7 @@ func (dwsm *DirectWSSubscriptionManager) selectFromTier(ctx context.Context, tie
 	}
 
 	selectedURL := selectedURLs[0]
-	selectedEndpoint, exists := dwsm.endpointsByURL[selectedURL]
+	selectedEndpoint, exists := byURL[selectedURL]
 	if !exists {
 		return nil, fmt.Errorf("optimizer selected unknown endpoint: %s", selectedURL)
 	}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -2478,10 +2478,11 @@ func CreateRPCSmartRouterCobraCommand() *cobra.Command {
 	cmdRPCSmartRouter := &cobra.Command{
 		Use:   "rpcsmartrouter [config-file] | { {listen-ip:listen-port spec-chain-id api-interface} ... }",
 		Short: `rpcsmartrouter sets up a centralized server with static providers to perform api requests`,
-		// On startup failure (e.g. all static providers failed verification)
-		// cobra otherwise dumps the full --help text after the error line,
-		// swamping kubectl logs in a CrashLoopBackOff. Operators need to see
-		// the error, not the flag catalogue.
+		// On startup failure (now only configuration errors — a chain with no
+		// provider configured, an unresolvable spec — since MAG-2525 made provider
+		// health non-fatal) cobra otherwise dumps the full --help text after the
+		// error line, swamping kubectl logs in a CrashLoopBackOff. Operators need
+		// to see the error, not the flag catalogue.
 		SilenceUsage: true,
 		Long: `rpcsmartrouter sets up a centralized server with static and backup providers to perform api requests through the lava protocol.
 		This is the smart router mode that uses pre-configured static providers instead of dynamically discovering providers on-chain.

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -2355,12 +2355,22 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 
 	// Collect WebSocket-capable endpoints for direct subscriptions.
 	// Primary tier serves all selections; backup tier is consulted on primary exhaustion.
+	// Tiers hold only healthy providers — republishSubscriptionEndpointsLocked keeps them
+	// in step with the live pairing from here on.
 	wsEndpoints := collectWSEndpoints(healthyStaticProviders, "primary")
 	wsBackupEndpoints := collectWSEndpoints(healthyBackupProviders, "backup")
 
-	// Create DirectWSSubscriptionManager if any WebSocket endpoints are available
-	// (primary or backup); otherwise install the NoOp manager.
-	if len(wsEndpoints) > 0 || len(wsBackupEndpoints) > 0 {
+	// Whether a real manager is installed is decided from the CONFIGURED providers, not
+	// the healthy ones. Since MAG-2525 a chain can boot with nothing healthy, and keying
+	// this off the healthy lists would install the NoOp manager permanently: every
+	// eth_subscribe would fail for the process lifetime even after every provider
+	// recovered and HTTP relays were serving, because nothing re-creates the manager.
+	// A Direct manager with empty tiers returns the same "no endpoint" error today and
+	// can be filled in on recovery.
+	wsConfigured := len(collectWSEndpoints(relevantStaticProviderList, "")) > 0 ||
+		len(collectWSEndpoints(relevantBackupProviderList, "")) > 0
+
+	if wsConfigured {
 		directWSManager := NewDirectWSSubscriptionManager(
 			smartRouterMetricsManager,
 			spectypes.APIInterfaceJsonRPC, // WebSocket subscriptions use JSON-RPC
@@ -2382,7 +2392,9 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 			utils.LogAttr("optimizerEnabled", optimizer != nil),
 		)
 	} else {
-		// No WebSocket endpoints configured — use NoOp manager that returns clear errors
+		// Nothing ws:// or wss:// in the config at all — no amount of recovery can
+		// produce a WebSocket endpoint here, so the NoOp manager is permanent by
+		// definition and its error is the honest answer.
 		wsSubscriptionManager = NewNoOpWSSubscriptionManager(rpcEndpoint.ChainID, rpcEndpoint.ApiInterface)
 		utils.LavaFormatInfo("No WebSocket endpoints configured for direct subscriptions",
 			utils.LogAttr("chainID", rpcEndpoint.ChainID),
@@ -2394,14 +2406,18 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	// This supports Cosmos Event Streaming, Solana Geyser, and other gRPC streaming protocols.
 	// Primary tier from healthy static providers; backup tier from healthy backup providers.
 	var grpcEndpoints, grpcBackupEndpoints []*common.NodeUrl
+	grpcConfigured := false
 	if rpcEndpoint.ApiInterface == spectypes.APIInterfaceGrpc {
 		grpcEndpoints = collectGRPCEndpoints(healthyStaticProviders, "primary")
 		grpcBackupEndpoints = collectGRPCEndpoints(healthyBackupProviders, "backup")
+		// Same reasoning as wsConfigured above: keyed off the configured providers so a
+		// dark boot still gets a manager. Leaving grpcSubscriptionManager nil would also
+		// disable gRPC reflection permanently (GetGRPCReflectionConnection nil-checks it).
+		grpcConfigured = len(collectGRPCEndpoints(relevantStaticProviderList, "")) > 0 ||
+			len(collectGRPCEndpoints(relevantBackupProviderList, "")) > 0
 	}
 
-	// Initialize DirectGRPCSubscriptionManager if any gRPC endpoints are available
-	// (primary or backup).
-	if len(grpcEndpoints) > 0 || len(grpcBackupEndpoints) > 0 {
+	if grpcConfigured {
 		grpcSubManager := NewDirectGRPCSubscriptionManager(
 			smartRouterMetricsManager, // Metrics manager for tracking
 			rpcEndpoint.ChainID,
@@ -3087,9 +3103,26 @@ func (rpsr *RPCSmartRouter) updateEpoch(ctx context.Context, epoch uint64) {
 		if inputs := rpsr.reverifyInputs[chainKey]; inputs != nil {
 			reverifyStart := time.Now()
 			var demotedStatic, demotedBackup []*lavasession.ConsumerSessionsWithProvider
-			freshProviderSessions, demotedStatic = applyReverification(ctx, inputs, freshProviderSessions, reverifyTierStatic, epoch)
-			freshBackupSessions, demotedBackup = applyReverification(ctx, inputs, freshBackupSessions, reverifyTierBackup, epoch)
+			var promotedStatic, promotedBackup []string
+			freshProviderSessions, demotedStatic, promotedStatic = applyReverification(ctx, inputs, freshProviderSessions, reverifyTierStatic, epoch)
+			freshBackupSessions, demotedBackup, promotedBackup = applyReverification(ctx, inputs, freshBackupSessions, reverifyTierBackup, epoch)
 			demotedSessions = append(demotedStatic, demotedBackup...)
+
+			// A promoted provider supersedes any pending failed-init retry, the same
+			// invariant rebuildPairingFromConfig enforces. Without this the provider stays
+			// in the failed list, retryFailedProviders revalidates it, succeeds, and
+			// mergeRecoveredSessions appends a SECOND session for it — that helper keys by
+			// index and does not dedupe by PublicLavaAddress. csm.pairing collapses the
+			// duplicate but pairingAddresses and validAddresses do not, so the provider
+			// lands twice in validAddresses with double its selection weight, and the
+			// superseded ConsumerSessionsWithProvider is dropped without its
+			// DirectRPCConnection being closed.
+			//
+			// Pruned per tier, not by the union: a name configured in both tiers must not
+			// have its still-failing backup dropped from the retry loop because its static
+			// twin recovered.
+			pruneRestoredFromFailed(rpsr.failedStaticProviders, chainKey, nameSet(promotedStatic))
+			pruneRestoredFromFailed(rpsr.failedBackupProviders, chainKey, nameSet(promotedBackup))
 			// Per-chain re-verify is internally bounded by SpecReVerifyConcurrency,
 			// but updateEpoch iterates chains serially. Surfacing per-chain duration
 			// gives operators a signal when total tick time approaches epoch length —
@@ -3115,6 +3148,7 @@ func (rpsr *RPCSmartRouter) updateEpoch(ctx context.Context, epoch uint64) {
 			delete(rpsr.backupProviderSessions, chainKey)
 		}
 		rpsr.publishServingTierLocked(chainKey)
+		rpsr.republishSubscriptionEndpointsLocked(chainKey)
 		server := rpsr.rpcServers[chainKey]
 
 		// UpdateAllProviders stays under rpsr.mu so the (rpsr.providerSessions write
@@ -3209,6 +3243,91 @@ func (rpsr *RPCSmartRouter) publishServingTierLocked(chainKey string) {
 		len(rpsr.providerSessions[chainKey]),
 		len(rpsr.backupProviderSessions[chainKey]),
 	)
+}
+
+// subscriptionEndpointSetter is the slice of the Direct WS/gRPC subscription managers
+// republishSubscriptionEndpointsLocked needs. The NoOp WS manager deliberately does not
+// implement it — a chain with no ws:// URL configured has nothing to republish.
+type subscriptionEndpointSetter interface {
+	SetEndpoints(primary, backup []*common.NodeUrl) bool
+}
+
+// republishSubscriptionEndpointsLocked pushes the currently-serving WS and gRPC
+// endpoints into the subscription managers. Callers must already hold rpsr.mu.
+//
+// Companion to publishServingTierLocked, and it belongs on every path that mutates the
+// live pairing for the same reason: the managers' tiers are built once at boot, and
+// nothing else updates them. Left alone they are frozen for the process lifetime, which
+// after MAG-2525 turns both of this fix's own scenarios into permanent subscription
+// outages — a chain that booted dark keeps two empty tiers and fails every eth_subscribe
+// forever, and a chain that booted on backups alone never promotes a recovered primary.
+// HTTP relays recover in both cases, so nothing else surfaces the fault.
+//
+// The tiers are rebuilt from the configured providers filtered by what is live in the
+// session maps, which is the same source of truth publishServingTierLocked reads. Only
+// live endpoints go in: a configured-but-dead endpoint in the primary tier would be
+// handed to a subscription with no fallback, and would suppress the primary→backup
+// cascade, which only fires when the primary tier is empty or fully ignored.
+func (rpsr *RPCSmartRouter) republishSubscriptionEndpointsLocked(chainKey string) {
+	server := rpsr.rpcServers[chainKey]
+	if server == nil {
+		return // not yet registered (boot seeds the tiers via the constructors)
+	}
+	inputs := rpsr.reverifyInputs[chainKey]
+	if inputs == nil {
+		return // no configured lists to filter — test-constructed router
+	}
+
+	liveStatic := activeProviders(inputs.configuredStatic, rpsr.providerSessions[chainKey])
+	liveBackup := activeProviders(inputs.configuredBackup, rpsr.backupProviderSessions[chainKey])
+
+	if setter, ok := server.wsSubscriptionManager.(subscriptionEndpointSetter); ok {
+		primary := collectWSEndpoints(liveStatic, "")
+		backup := collectWSEndpoints(liveBackup, "")
+		if setter.SetEndpoints(primary, backup) {
+			utils.LavaFormatInfo("subscriptions: WebSocket endpoint tiers updated to match live pairing",
+				utils.LogAttr("chainKey", chainKey),
+				utils.LogAttr("primaryCount", len(primary)),
+				utils.LogAttr("backupCount", len(backup)),
+			)
+		}
+	}
+
+	if server.grpcSubscriptionManager != nil {
+		primary := collectGRPCEndpoints(liveStatic, "")
+		backup := collectGRPCEndpoints(liveBackup, "")
+		if server.grpcSubscriptionManager.SetEndpoints(primary, backup) {
+			utils.LavaFormatInfo("subscriptions: gRPC endpoint tiers updated to match live pairing",
+				utils.LogAttr("chainKey", chainKey),
+				utils.LogAttr("primaryCount", len(primary)),
+				utils.LogAttr("backupCount", len(backup)),
+			)
+		}
+	}
+}
+
+// activeProviders returns the configured providers that are currently in the pairing,
+// in configured order. Sessions are keyed by index and carry the provider name as
+// PublicLavaAddress (see convertProvidersToSessions), so this is the bridge from "what
+// is live" back to the RPCStaticProviderEndpoint records that own the NodeUrls.
+func activeProviders(
+	configured []*lavasession.RPCStaticProviderEndpoint,
+	sessions map[uint64]*lavasession.ConsumerSessionsWithProvider,
+) []*lavasession.RPCStaticProviderEndpoint {
+	if len(configured) == 0 || len(sessions) == 0 {
+		return nil
+	}
+	active := make(map[string]struct{}, len(sessions))
+	for _, s := range sessions {
+		active[s.PublicLavaAddress] = struct{}{}
+	}
+	live := make([]*lavasession.RPCStaticProviderEndpoint, 0, len(active))
+	for _, p := range configured {
+		if _, ok := active[p.Name]; ok {
+			live = append(live, p)
+		}
+	}
+	return live
 }
 
 // retryFailedProviders periodically re-validates providers that failed
@@ -3349,6 +3468,7 @@ func (rpsr *RPCSmartRouter) readmitRecoveredProviders(
 		rpsr.backupProviderSessions[sessionManagerKey] = mergedBackup
 	}
 	rpsr.publishServingTierLocked(sessionManagerKey)
+	rpsr.republishSubscriptionEndpointsLocked(sessionManagerKey)
 
 	err := rpsr.sessionManagers[sessionManagerKey].UpdateAllProviders(currentEpoch, mergedStatic, mergedBackup)
 	rpsr.mu.Unlock()
@@ -3374,6 +3494,18 @@ func (rpsr *RPCSmartRouter) readmitRecoveredProviders(
 			)
 		}
 	}
+}
+
+// nameSet turns a provider-name slice into the set pruneRestoredFromFailed wants.
+func nameSet(names []string) map[string]struct{} {
+	if len(names) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		set[n] = struct{}{}
+	}
+	return set
 }
 
 // pruneRestoredFromFailed removes providers named in `restored` from one chain's
@@ -3476,6 +3608,7 @@ func (rpsr *RPCSmartRouter) rebuildPairingFromConfig() map[string][]string {
 			delete(rpsr.backupProviderSessions, chainKey)
 		}
 		rpsr.publishServingTierLocked(chainKey)
+		rpsr.republishSubscriptionEndpointsLocked(chainKey)
 
 		// A re-admitted provider supersedes any pending failed-init retry: drop it
 		// from the failed lists so retryFailedProviders won't later merge a duplicate
@@ -3626,7 +3759,9 @@ func testModeWarn(desc string) {
 
 // collectWSEndpoints returns every ws://|wss:// NodeUrl from the given providers.
 // tierLabel ("primary" / "backup") is logged so operators can see which tier each
-// endpoint came from.
+// endpoint came from; an empty tierLabel suppresses that per-endpoint line. Boot wants
+// the full inventory, but the republish path runs on every pairing change and would
+// otherwise re-log every endpoint of every chain each epoch — it logs deltas instead.
 func collectWSEndpoints(providers []*lavasession.RPCStaticProviderEndpoint, tierLabel string) []*common.NodeUrl {
 	var endpoints []*common.NodeUrl
 	for _, provider := range providers {
@@ -3634,6 +3769,9 @@ func collectWSEndpoints(providers []*lavasession.RPCStaticProviderEndpoint, tier
 			url := strings.ToLower(provider.NodeUrls[i].Url)
 			if strings.HasPrefix(url, "ws://") || strings.HasPrefix(url, "wss://") {
 				endpoints = append(endpoints, &provider.NodeUrls[i])
+				if tierLabel == "" {
+					continue
+				}
 				utils.LavaFormatInfo("Found WebSocket endpoint for direct subscriptions",
 					utils.LogAttr("tier", tierLabel),
 					utils.LogAttr("url", provider.NodeUrls[i].Url),
@@ -3647,7 +3785,8 @@ func collectWSEndpoints(providers []*lavasession.RPCStaticProviderEndpoint, tier
 }
 
 // collectGRPCEndpoints returns every NodeUrl from providers whose ApiInterface is gRPC.
-// tierLabel ("primary" / "backup") is logged for operator visibility.
+// tierLabel ("primary" / "backup") is logged for operator visibility; an empty label
+// suppresses that line — see collectWSEndpoints.
 func collectGRPCEndpoints(providers []*lavasession.RPCStaticProviderEndpoint, tierLabel string) []*common.NodeUrl {
 	var endpoints []*common.NodeUrl
 	for _, provider := range providers {
@@ -3656,6 +3795,9 @@ func collectGRPCEndpoints(providers []*lavasession.RPCStaticProviderEndpoint, ti
 		}
 		for i := range provider.NodeUrls {
 			endpoints = append(endpoints, &provider.NodeUrls[i])
+			if tierLabel == "" {
+				continue
+			}
 			utils.LavaFormatInfo("Found gRPC endpoint for streaming subscriptions",
 				utils.LogAttr("tier", tierLabel),
 				utils.LogAttr("url", provider.NodeUrls[i].Url),

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -192,8 +192,21 @@ type RPCSmartRouter struct {
 	// to periodically re-validate and re-register recovered providers.
 	failedStaticProviders map[string][]*lavasession.RPCStaticProviderEndpoint
 
+	// failedBackupProviders is the backup-tier counterpart. Backups used to recover
+	// only on the 15m epoch reverification, five times slower than the static tier's
+	// retry loop. That gap did not matter while a chain could never boot on backups
+	// alone; since MAG-2525 it can, so a failed backup may be the only thing standing
+	// between the chain and serving traffic.
+	failedBackupProviders map[string][]*lavasession.RPCStaticProviderEndpoint
+
 	// Server references for per-endpoint ChainTracker cleanup on epoch updates
 	rpcServers map[string]*RPCSmartRouterServer // key: chainID-apiInterface
+
+	// smartRouterMetricsManager is held here, not just passed down, because the
+	// serving-tier gauge has to be republished from every path that mutates the
+	// session maps — including the epoch tick and the retry loop, which run long
+	// after CreateSmartRouterEndpoint has returned. Nil when metrics are disabled.
+	smartRouterMetricsManager *metrics.SmartRouterMetricsManager
 
 	// reverifyInputs holds the per-chain inputs applyReverification needs
 	// (chain parser, configured static/backup lists, the convertProvidersToSessions
@@ -240,6 +253,7 @@ func (rpsr *RPCSmartRouter) Start(ctx context.Context, options *rpcSmartRouterSt
 	rpsr.providerSessions = make(map[string]map[uint64]*lavasession.ConsumerSessionsWithProvider)
 	rpsr.backupProviderSessions = make(map[string]map[uint64]*lavasession.ConsumerSessionsWithProvider)
 	rpsr.failedStaticProviders = make(map[string][]*lavasession.RPCStaticProviderEndpoint)
+	rpsr.failedBackupProviders = make(map[string][]*lavasession.RPCStaticProviderEndpoint)
 	rpsr.rpcServers = make(map[string]*RPCSmartRouterServer)
 	rpsr.reverifyInputs = make(map[string]*chainReverifyInputs)
 
@@ -289,6 +303,8 @@ func (rpsr *RPCSmartRouter) Start(ctx context.Context, options *rpcSmartRouterSt
 		NetworkAddress:     options.analyticsServerAddresses.MetricsListenAddress,
 		OptimizerQoSClient: smartRouterOptimizerQoSClient,
 	})
+
+	rpsr.smartRouterMetricsManager = smartRouterMetricsManager
 
 	rpcSmartRouterMetrics, err := metrics.NewRPCConsumerLogs(smartRouterMetricsManager, usageSink, smartRouterOptimizerQoSClient)
 	if err != nil {
@@ -2152,248 +2168,61 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	}
 
 	// ============================================================================
-	// PHASE 1: Static Provider Validation
+	// PHASE 1: Provider Validation — both tiers, neither fatal
 	// ============================================================================
-	// Validate static providers BEFORE converting to sessions or registering.
-	// Only validates providers matching this endpoint's api-interface.
-	// See: the provider's validation approach for reference.
-	var failedStaticSet map[*lavasession.RPCStaticProviderEndpoint]struct{}
-	var failedStaticEndpoints []*lavasession.RPCStaticProviderEndpoint
+	// Validate both tiers BEFORE converting to sessions or registering, so only
+	// healthy providers ever reach the session manager.
+	//
+	// Neither tier is fatal (MAG-2525, and MAG-2532 for the backup-rescue case).
+	// Provider health is a runtime condition, not a configuration error: the router
+	// already tolerates every provider dropping while it is running — it stays up,
+	// returns 5xx, and re-adopts providers as they recover. Boot now behaves the
+	// same way instead of exiting, which turned a restart during a failover into an
+	// outage precisely when a restart was most likely. The only fatal case is a
+	// chain with nothing CONFIGURED, checked far above.
+	//
+	// What replaces the old fail-fast signal: a chain with no healthy provider in
+	// either tier boots but reports unhealthy on its health endpoint (see the
+	// relaysMonitor seeding below), so it is pulled from rotation rather than
+	// silently accepting traffic it cannot serve.
+	failedStaticSet, failedStaticEndpoints := validateProviderTier(
+		ctx, relevantStaticProviderList, rpcEndpoint, chainParser, reverifyTierStatic, nil)
+	failedBackupSet, failedBackupEndpoints := validateProviderTier(
+		ctx, relevantBackupProviderList, rpcEndpoint, chainParser, reverifyTierBackup, nil)
 
-	if len(relevantStaticProviderList) > 0 {
-		utils.LavaFormatInfo("Validating static providers",
+	healthyStaticCount := len(relevantStaticProviderList) - len(failedStaticSet)
+	healthyBackupCount := len(relevantBackupProviderList) - len(failedBackupSet)
+
+	// chainServable drives the initial health verdict and the retry cadence.
+	servingTier := metrics.ServingTier(healthyStaticCount, healthyBackupCount)
+	chainServable := servingTier > metrics.ServingTierDark
+
+	switch {
+	case !chainServable:
+		utils.LavaFormatWarning("ATTENTION: no healthy providers for endpoint — serving unavailable until one recovers", nil,
 			utils.LogAttr("chain", rpcEndpoint.ChainID),
 			utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
-			utils.LogAttr("providerCount", len(relevantStaticProviderList)),
+			utils.LogAttr("staticConfigured", len(relevantStaticProviderList)),
+			utils.LogAttr("backupConfigured", len(relevantBackupProviderList)),
+			utils.LogAttr("hint", "endpoint reports unhealthy; providers are retried in the background and adopted when they recover"),
 		)
-
-		totalAttemptedCount := 0
-		failedStaticSet = make(map[*lavasession.RPCStaticProviderEndpoint]struct{})
-
-		for _, staticProvider := range relevantStaticProviderList {
-			// Skip providers with different api-interface (validated by their own endpoint)
-			if staticProvider.ApiInterface != rpcEndpoint.ApiInterface {
-				utils.LavaFormatDebug("Skipping provider - different api-interface",
-					utils.LogAttr("provider", staticProvider.Name),
-					utils.LogAttr("providerInterface", staticProvider.ApiInterface),
-					utils.LogAttr("endpointInterface", rpcEndpoint.ApiInterface),
-				)
-				continue
-			}
-			totalAttemptedCount++
-
-			// Prepare ALL URLs for validation together (matches provider behavior).
-			// ChainRouter requires both with-addon and without-addon routes for addon URLs
-			// (see chain_router.go:258 which appends "" to addons list).
-			verificationNodeUrls := []common.NodeUrl{}
-			for _, nodeUrl := range staticProvider.NodeUrls {
-				verificationNodeUrls = append(verificationNodeUrls, nodeUrl)
-				// For addon URLs, also add a non-addon copy for routing flexibility
-				if len(nodeUrl.Addons) > 0 {
-					noAddonUrl := nodeUrl
-					noAddonUrl.Addons = []string{}
-					verificationNodeUrls = append(verificationNodeUrls, noAddonUrl)
-				}
-			}
-
-			verificationEndpoint := &lavasession.RPCProviderEndpoint{
-				NetworkAddress: staticProvider.NetworkAddress,
-				ChainID:        staticProvider.ChainID,
-				ApiInterface:   staticProvider.ApiInterface,
-				NodeUrls:       verificationNodeUrls,
-			}
-
-			// Scoped context for this verification attempt. GetChainRouter creates
-			// connector goroutines tied to ctx that only exit on cancellation.
-			// Without this, temporary routers leak goroutines for the app lifetime.
-			// Timeout bounds a hung provider (e.g. blackholed TCP) so it can't stall
-			// validation of the remaining providers.
-			verifyCtx, verifyCancel := context.WithTimeout(ctx, 30*time.Second)
-
-			// Create chain router with all URLs for complete supportedMap (HTTP + WebSocket)
-			parallelConnections := uint(lavasession.MaximumStreamsOverASingleConnection)
-			verificationRouter, err := chainlib.GetChainRouter(verifyCtx, parallelConnections, verificationEndpoint, chainParser)
-			if err != nil {
-				verifyCancel()
-				failedStaticSet[staticProvider] = struct{}{}
-				failedStaticEndpoints = append(failedStaticEndpoints, staticProvider)
-				utils.LavaFormatWarning("static provider: failed creating chain router — excluding from provider list", err,
-					utils.LogAttr("chain", rpcEndpoint.ChainID),
-					utils.LogAttr("provider", staticProvider.Name),
-				)
-				continue
-			}
-
-			// Create full ChainFetcher for verification (respects severity, skip-verifications)
-			verificationFetcher := chainlib.NewChainFetcher(verifyCtx, &chainlib.ChainFetcherOptions{
-				ChainRouter: verificationRouter,
-				ChainParser: chainParser,
-				Endpoint:    verificationEndpoint,
-				Cache:       nil,
-			})
-
-			utils.LavaFormatInfo("Validating static provider",
-				utils.LogAttr("name", staticProvider.Name),
-				utils.LogAttr("chain", rpcEndpoint.ChainID),
-				utils.LogAttr("urlCount", len(staticProvider.NodeUrls)),
-			)
-
-			err = verificationFetcher.Validate(verifyCtx)
-			verifyCancel() // cleanup temporary router resources regardless of outcome
-			if err != nil {
-				failedStaticSet[staticProvider] = struct{}{}
-				failedStaticEndpoints = append(failedStaticEndpoints, staticProvider)
-				utils.LavaFormatWarning("static provider validation failed — excluding from provider list", err,
-					utils.LogAttr("chain", rpcEndpoint.ChainID),
-					utils.LogAttr("provider", staticProvider.Name),
-				)
-				continue
-			}
-
-			utils.LavaFormatInfo("Static provider validated successfully",
-				utils.LogAttr("chain", rpcEndpoint.ChainID),
-				utils.LogAttr("provider", staticProvider.Name),
-			)
-		}
-
-		healthyCount := totalAttemptedCount - len(failedStaticSet)
-
-		// If ALL static providers failed verification, this endpoint cannot serve traffic
-		if totalAttemptedCount > 0 && healthyCount == 0 {
-			err := utils.LavaFormatError("all static providers failed verification — cannot serve endpoint", nil,
-				utils.LogAttr("chain", rpcEndpoint.ChainID),
-				utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
-				utils.LogAttr("failedCount", len(failedStaticSet)),
-			)
-			errCh <- err
-			return err
-		}
-
-		if len(failedStaticSet) > 0 {
-			utils.LavaFormatWarning("ATTENTION: some static providers failed verification and were excluded — they will be retried in the background",
-				nil,
-				utils.LogAttr("chain", rpcEndpoint.ChainID),
-				utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
-				utils.LogAttr("failed", len(failedStaticSet)),
-				utils.LogAttr("healthy", healthyCount),
-			)
-		} else {
-			utils.LavaFormatInfo("All providers validated for api-interface",
-				utils.LogAttr("chain", rpcEndpoint.ChainID),
-				utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
-				utils.LogAttr("validated", healthyCount),
-				utils.LogAttr("total", len(relevantStaticProviderList)),
-			)
-		}
-	}
-
-	// ============================================================================
-	// PHASE 1B: Backup Provider Validation (non-fatal)
-	// ============================================================================
-	// Validate backup providers using the same logic as PHASE 1, but treat all
-	// failures as non-fatal warnings. A broken backup should never block startup —
-	// static providers must still serve. Operators are clearly notified at startup
-	// so they can fix backup endpoints before they are actually needed in an emergency.
-	// Providers that fail validation are excluded from the registered backup list.
-	var failedBackupSet map[*lavasession.RPCStaticProviderEndpoint]struct{}
-
-	if len(relevantBackupProviderList) > 0 {
-		utils.LavaFormatInfo("Validating backup providers (non-fatal)",
+	case servingTier == metrics.ServingTierDegraded:
+		utils.LavaFormatWarning("ATTENTION: no healthy static providers — serving from backup providers only", nil,
 			utils.LogAttr("chain", rpcEndpoint.ChainID),
 			utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
-			utils.LogAttr("backupCount", len(relevantBackupProviderList)),
+			utils.LogAttr("staticFailed", len(failedStaticSet)),
+			utils.LogAttr("healthyBackups", healthyBackupCount),
+			utils.LogAttr("hint", "degraded: static providers are retried in the background"),
 		)
-
-		failedBackupSet = make(map[*lavasession.RPCStaticProviderEndpoint]struct{})
-		validatedBackups := 0
-		for _, backupProvider := range relevantBackupProviderList {
-			if backupProvider.ApiInterface != rpcEndpoint.ApiInterface {
-				utils.LavaFormatDebug("Skipping backup provider - different api-interface",
-					utils.LogAttr("provider", backupProvider.Name),
-					utils.LogAttr("providerInterface", backupProvider.ApiInterface),
-					utils.LogAttr("endpointInterface", rpcEndpoint.ApiInterface),
-				)
-				continue
-			}
-			validatedBackups++
-
-			// Build verificationNodeUrls with addon expansion (identical to PHASE 1)
-			verificationNodeUrls := []common.NodeUrl{}
-			for _, nodeUrl := range backupProvider.NodeUrls {
-				verificationNodeUrls = append(verificationNodeUrls, nodeUrl)
-				if len(nodeUrl.Addons) > 0 {
-					noAddonUrl := nodeUrl
-					noAddonUrl.Addons = []string{}
-					verificationNodeUrls = append(verificationNodeUrls, noAddonUrl)
-				}
-			}
-
-			verificationEndpoint := &lavasession.RPCProviderEndpoint{
-				NetworkAddress: backupProvider.NetworkAddress,
-				ChainID:        backupProvider.ChainID,
-				ApiInterface:   backupProvider.ApiInterface,
-				NodeUrls:       verificationNodeUrls,
-			}
-
-			verifyCtx, verifyCancel := context.WithCancel(ctx)
-
-			parallelConnections := uint(lavasession.MaximumStreamsOverASingleConnection)
-			verificationRouter, err := chainlib.GetChainRouter(verifyCtx, parallelConnections, verificationEndpoint, chainParser)
-			if err != nil {
-				verifyCancel()
-				failedBackupSet[backupProvider] = struct{}{}
-				utils.LavaFormatWarning("backup provider: failed creating chain router — excluding from backup list", err,
-					utils.LogAttr("chain", rpcEndpoint.ChainID),
-					utils.LogAttr("provider", backupProvider.Name),
-				)
-				continue
-			}
-
-			verificationFetcher := chainlib.NewChainFetcher(verifyCtx, &chainlib.ChainFetcherOptions{
-				ChainRouter: verificationRouter,
-				ChainParser: chainParser,
-				Endpoint:    verificationEndpoint,
-				Cache:       nil,
-			})
-
-			utils.LavaFormatInfo("Validating backup provider",
-				utils.LogAttr("name", backupProvider.Name),
-				utils.LogAttr("chain", rpcEndpoint.ChainID),
-				utils.LogAttr("urlCount", len(backupProvider.NodeUrls)),
-			)
-
-			err = verificationFetcher.Validate(verifyCtx)
-			verifyCancel()
-			if err != nil {
-				failedBackupSet[backupProvider] = struct{}{}
-				utils.LavaFormatWarning("backup provider validation failed — excluding from backup list", err,
-					utils.LogAttr("chain", rpcEndpoint.ChainID),
-					utils.LogAttr("provider", backupProvider.Name),
-				)
-				continue
-			}
-
-			utils.LavaFormatInfo("Backup provider validated successfully",
-				utils.LogAttr("chain", rpcEndpoint.ChainID),
-				utils.LogAttr("provider", backupProvider.Name),
-			)
-		}
-
-		if len(failedBackupSet) > 0 {
-			utils.LavaFormatWarning("ATTENTION: some backup providers failed validation and were excluded — they will not be used during emergency failover",
-				nil,
-				utils.LogAttr("chain", rpcEndpoint.ChainID),
-				utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
-				utils.LogAttr("failed", len(failedBackupSet)),
-				utils.LogAttr("validated", validatedBackups),
-			)
-		} else {
-			utils.LavaFormatInfo("All backup providers validated",
-				utils.LogAttr("chain", rpcEndpoint.ChainID),
-				utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
-				utils.LogAttr("validated", validatedBackups),
-			)
-		}
+	default:
+		utils.LavaFormatInfo("Providers validated for api-interface",
+			utils.LogAttr("chain", rpcEndpoint.ChainID),
+			utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
+			utils.LogAttr("healthyStatic", healthyStaticCount),
+			utils.LogAttr("staticFailed", len(failedStaticSet)),
+			utils.LogAttr("healthyBackups", healthyBackupCount),
+			utils.LogAttr("backupFailed", len(failedBackupSet)),
+		)
 	}
 
 	// Register the inputs updateEpoch needs every epoch tick: chain parser, the
@@ -2480,27 +2309,40 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	if len(failedStaticEndpoints) > 0 {
 		rpsr.failedStaticProviders[sessionManagerKey] = failedStaticEndpoints
 	}
+	if len(failedBackupEndpoints) > 0 {
+		rpsr.failedBackupProviders[sessionManagerKey] = failedBackupEndpoints
+	}
+	rpsr.publishServingTierLocked(sessionManagerKey)
 	rpsr.mu.Unlock()
 
-	// Launch background retry for failed static providers (if any)
-	if len(failedStaticEndpoints) > 0 {
-		failedNames := make([]string, len(failedStaticEndpoints))
-		for i, p := range failedStaticEndpoints {
-			failedNames[i] = p.Name
+	// Launch background retry for whichever tiers had failures. Backups are included
+	// because a chain can now be serving on them alone — or waiting on them to be the
+	// thing that lets it serve at all.
+	if len(failedStaticEndpoints) > 0 || len(failedBackupEndpoints) > 0 {
+		failedNames := make([]string, 0, len(failedStaticEndpoints)+len(failedBackupEndpoints))
+		for _, p := range failedStaticEndpoints {
+			failedNames = append(failedNames, p.Name)
 		}
-		utils.LavaFormatInfo("Launching background retry goroutine for failed static providers",
+		for _, p := range failedBackupEndpoints {
+			failedNames = append(failedNames, p.Name)
+		}
+		utils.LavaFormatInfo("Launching background retry goroutine for failed providers",
 			utils.LogAttr("chain", rpcEndpoint.ChainID),
 			utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
-			utils.LogAttr("failedCount", len(failedStaticEndpoints)),
+			utils.LogAttr("failedStatic", len(failedStaticEndpoints)),
+			utils.LogAttr("failedBackup", len(failedBackupEndpoints)),
 			utils.LogAttr("failedProviders", failedNames),
-			utils.LogAttr("retryInterval", "3m"),
+			utils.LogAttr("initialRetryInterval", retryIntervalFor(!chainServable).String()),
 		)
-		go rpsr.retryFailedStaticProviders(ctx, sessionManagerKey, chainParser, rpcEndpoint, convertProvidersToSessions)
+		go rpsr.retryFailedProviders(ctx, sessionManagerKey, chainParser, rpcEndpoint, convertProvidersToSessions)
 	}
 
 	var relaysMonitor *metrics.RelaysMonitor
 	if options.cmdFlags.RelaysHealthEnableFlag {
 		relaysMonitor = metrics.NewRelaysMonitor(options.cmdFlags.RelaysHealthIntervalFlag, rpcEndpoint.ChainID, rpcEndpoint.ApiInterface)
+		// Boot validation already knows whether anything can serve, so don't let the
+		// monitor's optimistic default claim health for a chain that came up dark.
+		relaysMonitor.SeedInitialHealth(chainServable)
 		relaysMonitorAggregator.RegisterRelaysMonitor(rpcEndpoint.String(), relaysMonitor)
 	}
 
@@ -3128,7 +2970,7 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 
 func (rpsr *RPCSmartRouter) updateEpoch(ctx context.Context, epoch uint64) {
 	// Copy session manager keys under lock to avoid iterating the map
-	// concurrently with retryFailedStaticProviders which writes to rpsr maps under rpsr.mu.
+	// concurrently with retryFailedProviders which writes to rpsr maps under rpsr.mu.
 	rpsr.mu.Lock()
 	chainKeys := make([]string, 0, len(rpsr.sessionManagers))
 	for k := range rpsr.sessionManagers {
@@ -3163,7 +3005,7 @@ func (rpsr *RPCSmartRouter) updateEpoch(ctx context.Context, epoch uint64) {
 			epochApiInterface = server.listenEndpoint.ApiInterface
 		}
 		// Lock for the read → create-fresh → write-back section.
-		// This prevents races with retryFailedStaticProviders, which merges
+		// This prevents races with retryFailedProviders, which merges
 		// recovered providers into rpsr.providerSessions under the same lock.
 		// The locked section is pure CPU work (map lookups + object creation).
 		rpsr.mu.Lock()
@@ -3272,10 +3114,11 @@ func (rpsr *RPCSmartRouter) updateEpoch(ctx context.Context, epoch uint64) {
 		} else {
 			delete(rpsr.backupProviderSessions, chainKey)
 		}
+		rpsr.publishServingTierLocked(chainKey)
 		server := rpsr.rpcServers[chainKey]
 
 		// UpdateAllProviders stays under rpsr.mu so the (rpsr.providerSessions write
-		// → csm push) pair is atomic with retryFailedStaticProviders' matching pair.
+		// → csm push) pair is atomic with retryFailedProviders' matching pair.
 		// Otherwise the two callers can push snapshots to csm in the opposite order
 		// they wrote rpsr.providerSessions, silently dropping providers until the
 		// next epoch. The synchronous body of UpdateAllProviders is a bounded map
@@ -3308,174 +3151,283 @@ func (rpsr *RPCSmartRouter) updateEpoch(ctx context.Context, epoch uint64) {
 	}
 }
 
-// retryFailedStaticProviders periodically re-validates failed static providers
-// and re-registers them with the session manager when they recover.
-// It runs as a background goroutine, one per endpoint that had failures.
-func (rpsr *RPCSmartRouter) retryFailedStaticProviders(
+// Retry cadence for providers that failed verification. A chain that still has a
+// healthy provider is merely degraded, so it waits the full interval — retries
+// there buy redundancy, not availability, and there is no reason to hammer a dead
+// upstream every few seconds. A chain that is dark cannot serve at all, so every
+// second of delay is downtime: it starts at retryDarkBaseInterval and backs off to
+// the same ceiling, which keeps recovery near-immediate for the common case (a
+// brief all-down window at boot) without pinning a chain to a 2s poll forever.
+// Package-level vars, not consts, so tests can shorten them.
+var (
+	retryDarkBaseInterval = 2 * time.Second
+	retryMaxInterval      = 3 * time.Minute // same as SpecValidator's disabled-chain interval
+)
+
+func retryIntervalFor(dark bool) time.Duration {
+	if dark {
+		return retryDarkBaseInterval
+	}
+	return retryMaxInterval
+}
+
+// chainIsDark reports whether the chain has no provider registered in either
+// tier. Reads the live session maps rather than the boot-time verdict so the
+// answer tracks recoveries and demotions.
+//
+// This is registration, not reachability: a chain whose registered providers are
+// all failing relays is not "dark" here. Those providers never entered the failed
+// lists this loop walks — the CSM's blocking and the epoch reverification own that
+// case — so treating them as dark would only make this loop spin without work.
+func (rpsr *RPCSmartRouter) chainIsDark(sessionManagerKey string) bool {
+	rpsr.mu.Lock()
+	defer rpsr.mu.Unlock()
+	return len(rpsr.providerSessions[sessionManagerKey]) == 0 &&
+		len(rpsr.backupProviderSessions[sessionManagerKey]) == 0
+}
+
+// publishServingTierLocked republishes the serving-tier gauge from the live
+// session maps. Callers must already hold rpsr.mu.
+//
+// Every path that mutates those maps has to call this, not just boot. The gauge
+// is what operators alert on now that a dark chain no longer crash-loops, and a
+// stale reading is worse than none: left at 0 it pages forever after a recovery,
+// left at 2 it stays silent after a demotion takes the last provider away.
+func (rpsr *RPCSmartRouter) publishServingTierLocked(chainKey string) {
+	if rpsr.smartRouterMetricsManager == nil {
+		return
+	}
+	// Labels come from reverifyInputs, the only per-chain record of the endpoint.
+	// Absent in tests that build RPCSmartRouter directly; nothing to publish then.
+	inputs := rpsr.reverifyInputs[chainKey]
+	if inputs == nil || inputs.rpcEndpoint == nil {
+		return
+	}
+	rpsr.smartRouterMetricsManager.SetEndpointServingTier(
+		inputs.rpcEndpoint.ChainID,
+		inputs.rpcEndpoint.ApiInterface,
+		len(rpsr.providerSessions[chainKey]),
+		len(rpsr.backupProviderSessions[chainKey]),
+	)
+}
+
+// retryFailedProviders periodically re-validates providers that failed
+// verification and re-registers them when they recover. One goroutine per
+// endpoint that had failures in either tier.
+//
+// It covers both tiers. Before MAG-2525 only static providers were retried here
+// and backups waited for the 15m epoch reverification, which was tolerable when a
+// chain could not boot on backups alone. Now it can, so a failed backup may be the
+// only thing between the chain and serving traffic.
+func (rpsr *RPCSmartRouter) retryFailedProviders(
 	ctx context.Context,
 	sessionManagerKey string,
 	chainParser chainlib.ChainParser,
 	rpcEndpoint *lavasession.RPCEndpoint,
 	convertProvidersToSessions func([]*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider,
 ) {
-	retryInterval := 3 * time.Minute // same as SpecValidator's disabled-chain interval
-	ticker := time.NewTicker(retryInterval)
-	defer ticker.Stop()
+	darkBackoff := retryDarkBaseInterval
+	timer := time.NewTimer(retryIntervalFor(rpsr.chainIsDark(sessionManagerKey)))
+	defer timer.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
+		case <-timer.C:
 		}
 
 		rpsr.mu.Lock()
-		failedProviders := rpsr.failedStaticProviders[sessionManagerKey]
+		failedStatic := rpsr.failedStaticProviders[sessionManagerKey]
+		failedBackup := rpsr.failedBackupProviders[sessionManagerKey]
 		rpsr.mu.Unlock()
 
-		if len(failedProviders) == 0 {
-			utils.LavaFormatInfo("All failed static providers recovered — stopping retry loop",
+		if len(failedStatic) == 0 && len(failedBackup) == 0 {
+			utils.LavaFormatInfo("All failed providers recovered — stopping retry loop",
 				utils.LogAttr("chain", rpcEndpoint.ChainID),
 				utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
 			)
 			return
 		}
 
-		utils.LavaFormatInfo("Retrying failed static providers",
+		utils.LavaFormatInfo("Retrying failed providers",
 			utils.LogAttr("chain", rpcEndpoint.ChainID),
 			utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
-			utils.LogAttr("failedCount", len(failedProviders)),
+			utils.LogAttr("failedStatic", len(failedStatic)),
+			utils.LogAttr("failedBackup", len(failedBackup)),
 		)
 
-		var stillFailed []*lavasession.RPCStaticProviderEndpoint
-		var recovered []*lavasession.RPCStaticProviderEndpoint
+		recoveredStatic, stillFailedStatic := rpsr.revalidateTier(ctx, failedStatic, chainParser, rpcEndpoint, reverifyTierStatic)
+		recoveredBackup, stillFailedBackup := rpsr.revalidateTier(ctx, failedBackup, chainParser, rpcEndpoint, reverifyTierBackup)
 
-		for _, provider := range failedProviders {
-			// Build verification endpoint (same logic as Phase 1)
-			verificationNodeUrls := []common.NodeUrl{}
-			for _, nodeUrl := range provider.NodeUrls {
-				verificationNodeUrls = append(verificationNodeUrls, nodeUrl)
-				if len(nodeUrl.Addons) > 0 {
-					noAddonUrl := nodeUrl
-					noAddonUrl.Addons = []string{}
-					verificationNodeUrls = append(verificationNodeUrls, noAddonUrl)
-				}
+		rpsr.readmitRecoveredProviders(
+			sessionManagerKey, rpcEndpoint, convertProvidersToSessions,
+			recoveredStatic, stillFailedStatic, recoveredBackup, stillFailedBackup)
+
+		if rpsr.chainIsDark(sessionManagerKey) {
+			darkBackoff *= 2
+			if darkBackoff > retryMaxInterval {
+				darkBackoff = retryMaxInterval
 			}
-
-			verificationEndpoint := &lavasession.RPCProviderEndpoint{
-				NetworkAddress: provider.NetworkAddress,
-				ChainID:        provider.ChainID,
-				ApiInterface:   provider.ApiInterface,
-				NodeUrls:       verificationNodeUrls,
-			}
-
-			// Scoped context for this verification attempt. GetChainRouter creates
-			// connector goroutines tied to ctx that only exit on cancellation.
-			// Without this, each retry iteration leaks goroutines and connections
-			// for permanently failing providers.
-			// Timeout bounds a hung provider so it can't stall retries of the
-			// remaining providers in this cycle.
-			attemptCtx, attemptCancel := context.WithTimeout(ctx, 30*time.Second)
-
-			parallelConnections := uint(lavasession.MaximumStreamsOverASingleConnection)
-			verificationRouter, err := chainlib.GetChainRouter(attemptCtx, parallelConnections, verificationEndpoint, chainParser)
-			if err != nil {
-				attemptCancel()
-				stillFailed = append(stillFailed, provider)
-				utils.LavaFormatWarning("retry: static provider chain router creation still failing", err,
-					utils.LogAttr("chain", rpcEndpoint.ChainID),
-					utils.LogAttr("provider", provider.Name),
-				)
-				continue
-			}
-
-			verificationFetcher := chainlib.NewChainFetcher(attemptCtx, &chainlib.ChainFetcherOptions{
-				ChainRouter: verificationRouter,
-				ChainParser: chainParser,
-				Endpoint:    verificationEndpoint,
-				Cache:       nil,
-			})
-
-			err = verificationFetcher.Validate(attemptCtx)
-			attemptCancel() // cleanup temporary router resources regardless of outcome
-			if err != nil {
-				stillFailed = append(stillFailed, provider)
-				utils.LavaFormatWarning("retry: static provider verification still failing", err,
-					utils.LogAttr("chain", rpcEndpoint.ChainID),
-					utils.LogAttr("provider", provider.Name),
-				)
-				continue
-			}
-
-			recovered = append(recovered, provider)
-			utils.LavaFormatInfo("[+] static provider recovered and passed verification",
-				utils.LogAttr("chain", rpcEndpoint.ChainID),
-				utils.LogAttr("provider", provider.Name),
-			)
-		}
-
-		// Update state: move recovered providers into active sessions
-		if len(recovered) > 0 {
-			recoveredSessions := convertProvidersToSessions(recovered)
-
-			rpsr.mu.Lock()
-			currentEpoch := rpsr.epochTimer.GetCurrentEpoch()
-
-			// Copy-on-write: create a new map merging old + recovered sessions.
-			// The old map may still be referenced by goroutines (probeProviders,
-			// cleanupStaleTrackers) that iterate it without the lock.
-			oldSessions := rpsr.providerSessions[sessionManagerKey]
-			mergedSessions := make(map[uint64]*lavasession.ConsumerSessionsWithProvider, len(oldSessions)+len(recoveredSessions))
-			for k, v := range oldSessions {
-				mergedSessions[k] = v
-			}
-			maxIdx := uint64(0)
-			for idx := range mergedSessions {
-				if idx >= maxIdx {
-					maxIdx = idx + 1
-				}
-			}
-			for _, session := range recoveredSessions {
-				session.Lock.Lock()
-				session.PairingEpoch = currentEpoch
-				session.Lock.Unlock()
-				mergedSessions[maxIdx] = session
-				maxIdx++
-			}
-			rpsr.providerSessions[sessionManagerKey] = mergedSessions
-
-			// Update failed list
-			rpsr.failedStaticProviders[sessionManagerKey] = stillFailed
-
-			sessionManager := rpsr.sessionManagers[sessionManagerKey]
-			backupSessions := rpsr.backupProviderSessions[sessionManagerKey]
-
-			// UpdateAllProviders stays under rpsr.mu so this (rpsr.providerSessions
-			// write → csm push) pair is atomic with updateEpoch's matching pair.
-			// Otherwise a concurrent epoch tick can push to csm in the opposite
-			// order it wrote rpsr.providerSessions, silently dropping recovered
-			// providers until the next epoch.
-			err := sessionManager.UpdateAllProviders(currentEpoch, mergedSessions, backupSessions)
-			rpsr.mu.Unlock()
-
-			if err != nil {
-				utils.LavaFormatWarning("retry: failed to re-register recovered providers", err,
-					utils.LogAttr("chain", rpcEndpoint.ChainID),
-				)
-			} else {
-				for _, p := range recovered {
-					utils.LavaFormatInfo("[+] static provider re-registered successfully",
-						utils.LogAttr("chain", rpcEndpoint.ChainID),
-						utils.LogAttr("provider", p.Name),
-					)
-				}
-			}
+			timer.Reset(darkBackoff)
 		} else {
-			rpsr.mu.Lock()
-			rpsr.failedStaticProviders[sessionManagerKey] = stillFailed
-			rpsr.mu.Unlock()
+			timer.Reset(retryMaxInterval)
+			darkBackoff = retryDarkBaseInterval
 		}
 	}
+}
+
+// retryValidateFn is the probe retryFailedProviders runs against a failed
+// provider. A package-level var purely so tests can substitute a fake without
+// standing up upstreams — production never reassigns it. Mirrors the
+// chainReverifyInputs.validateFn seam applyReverification uses.
+var retryValidateFn = func(ctx context.Context, provider *lavasession.RPCStaticProviderEndpoint, chainParser chainlib.ChainParser) error {
+	return validateProvider(ctx, provider, chainParser, BootValidateTimeout)
+}
+
+// revalidateTier re-runs verification over one tier's failed providers, returning
+// the recovered and still-failing partitions in configured order.
+func (rpsr *RPCSmartRouter) revalidateTier(
+	ctx context.Context,
+	failed []*lavasession.RPCStaticProviderEndpoint,
+	chainParser chainlib.ChainParser,
+	rpcEndpoint *lavasession.RPCEndpoint,
+	tier reverifyTier,
+) (recovered, stillFailed []*lavasession.RPCStaticProviderEndpoint) {
+	for _, provider := range failed {
+		if err := retryValidateFn(ctx, provider, chainParser); err != nil {
+			stillFailed = append(stillFailed, provider)
+			utils.LavaFormatWarning("retry: provider verification still failing", err,
+				utils.LogAttr("chain", rpcEndpoint.ChainID),
+				utils.LogAttr("tier", tier.String()),
+				utils.LogAttr("provider", provider.Name),
+			)
+			continue
+		}
+		recovered = append(recovered, provider)
+		utils.LavaFormatInfo("[+] provider recovered and passed verification",
+			utils.LogAttr("chain", rpcEndpoint.ChainID),
+			utils.LogAttr("tier", tier.String()),
+			utils.LogAttr("provider", provider.Name),
+		)
+	}
+	return recovered, stillFailed
+}
+
+// readmitRecoveredProviders merges recovered providers of both tiers back into the
+// live pairing and pushes the result to the session manager in one call.
+//
+// The merge is copy-on-write: the old maps may still be referenced by goroutines
+// (probeProviders, cleanupStaleTrackers) that iterate them without the lock.
+// UpdateAllProviders stays under rpsr.mu so the (session-map write → csm push) pair
+// is atomic with updateEpoch's matching pair — otherwise a concurrent epoch tick can
+// push to the csm in the opposite order it wrote the session maps, silently dropping
+// recovered providers until the next epoch.
+func (rpsr *RPCSmartRouter) readmitRecoveredProviders(
+	sessionManagerKey string,
+	rpcEndpoint *lavasession.RPCEndpoint,
+	convertProvidersToSessions func([]*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider,
+	recoveredStatic, stillFailedStatic []*lavasession.RPCStaticProviderEndpoint,
+	recoveredBackup, stillFailedBackup []*lavasession.RPCStaticProviderEndpoint,
+) {
+	rpsr.mu.Lock()
+
+	rpsr.failedStaticProviders[sessionManagerKey] = stillFailedStatic
+	rpsr.failedBackupProviders[sessionManagerKey] = stillFailedBackup
+
+	if len(recoveredStatic) == 0 && len(recoveredBackup) == 0 {
+		rpsr.mu.Unlock()
+		return
+	}
+
+	currentEpoch := rpsr.epochTimer.GetCurrentEpoch()
+	mergedStatic := mergeRecoveredSessions(rpsr.providerSessions[sessionManagerKey], recoveredStatic, convertProvidersToSessions, currentEpoch)
+	mergedBackup := mergeRecoveredSessions(rpsr.backupProviderSessions[sessionManagerKey], recoveredBackup, convertProvidersToSessions, currentEpoch)
+
+	rpsr.providerSessions[sessionManagerKey] = mergedStatic
+	if len(mergedBackup) > 0 {
+		rpsr.backupProviderSessions[sessionManagerKey] = mergedBackup
+	}
+	rpsr.publishServingTierLocked(sessionManagerKey)
+
+	err := rpsr.sessionManagers[sessionManagerKey].UpdateAllProviders(currentEpoch, mergedStatic, mergedBackup)
+	rpsr.mu.Unlock()
+
+	if err != nil {
+		utils.LavaFormatWarning("retry: failed to re-register recovered providers", err,
+			utils.LogAttr("chain", rpcEndpoint.ChainID),
+		)
+		return
+	}
+	for _, tier := range []struct {
+		name      reverifyTier
+		recovered []*lavasession.RPCStaticProviderEndpoint
+	}{
+		{reverifyTierStatic, recoveredStatic},
+		{reverifyTierBackup, recoveredBackup},
+	} {
+		for _, p := range tier.recovered {
+			utils.LavaFormatInfo("[+] provider re-registered successfully",
+				utils.LogAttr("chain", rpcEndpoint.ChainID),
+				utils.LogAttr("tier", tier.name.String()),
+				utils.LogAttr("provider", p.Name),
+			)
+		}
+	}
+}
+
+// pruneRestoredFromFailed removes providers named in `restored` from one chain's
+// failed list, deleting the entry entirely once nothing is left pending.
+func pruneRestoredFromFailed(
+	failedByChain map[string][]*lavasession.RPCStaticProviderEndpoint,
+	chainKey string,
+	restored map[string]struct{},
+) {
+	failed := failedByChain[chainKey]
+	if len(failed) == 0 {
+		return
+	}
+	var kept []*lavasession.RPCStaticProviderEndpoint
+	for _, p := range failed {
+		if _, ok := restored[p.Name]; !ok {
+			kept = append(kept, p)
+		}
+	}
+	if len(kept) > 0 {
+		failedByChain[chainKey] = kept
+		return
+	}
+	delete(failedByChain, chainKey)
+}
+
+// mergeRecoveredSessions returns a new map holding `existing` plus freshly built
+// sessions for `recovered`, appended at indices past the current maximum.
+func mergeRecoveredSessions(
+	existing map[uint64]*lavasession.ConsumerSessionsWithProvider,
+	recovered []*lavasession.RPCStaticProviderEndpoint,
+	convertProvidersToSessions func([]*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider,
+	currentEpoch uint64,
+) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+	if len(recovered) == 0 {
+		return existing
+	}
+	recoveredSessions := convertProvidersToSessions(recovered)
+	merged := make(map[uint64]*lavasession.ConsumerSessionsWithProvider, len(existing)+len(recoveredSessions))
+	maxIdx := uint64(0)
+	for k, v := range existing {
+		merged[k] = v
+		if k >= maxIdx {
+			maxIdx = k + 1
+		}
+	}
+	for _, session := range recoveredSessions {
+		session.Lock.Lock()
+		session.PairingEpoch = currentEpoch
+		session.Lock.Unlock()
+		merged[maxIdx] = session
+		maxIdx++
+	}
+	return merged
 }
 
 // rebuildPairingFromConfig restores configured static/backup providers that are
@@ -3489,7 +3441,7 @@ func (rpsr *RPCSmartRouter) retryFailedStaticProviders(
 // behaviour in the tests this serves, so verification is unnecessary. Only absent
 // providers are converted (which opens fresh DirectRPCConnections); already-active
 // sessions are reused untouched, so healthy providers are not churned. Mirrors
-// retryFailedStaticProviders' copy-on-write merge. Returns the restored provider
+// retryFailedProviders' copy-on-write merge. Returns the restored provider
 // names per chainKey (chains needing no restore are omitted).
 func (rpsr *RPCSmartRouter) rebuildPairingFromConfig() map[string][]string {
 	restored := make(map[string][]string)
@@ -3523,33 +3475,24 @@ func (rpsr *RPCSmartRouter) rebuildPairingFromConfig() map[string][]string {
 		} else {
 			delete(rpsr.backupProviderSessions, chainKey)
 		}
+		rpsr.publishServingTierLocked(chainKey)
 
 		// A re-admitted provider supersedes any pending failed-init retry: drop it
-		// from failedStaticProviders so retryFailedStaticProviders won't later merge
-		// a duplicate session for the same name (and can self-terminate once empty).
-		if failed := rpsr.failedStaticProviders[chainKey]; len(failed) > 0 {
-			restoredSet := make(map[string]struct{}, len(restoredStatic)+len(restoredBackup))
-			for _, n := range restoredStatic {
-				restoredSet[n] = struct{}{}
-			}
-			for _, n := range restoredBackup {
-				restoredSet[n] = struct{}{}
-			}
-			var kept []*lavasession.RPCStaticProviderEndpoint
-			for _, p := range failed {
-				if _, ok := restoredSet[p.Name]; !ok {
-					kept = append(kept, p)
-				}
-			}
-			if len(kept) > 0 {
-				rpsr.failedStaticProviders[chainKey] = kept
-			} else {
-				delete(rpsr.failedStaticProviders, chainKey)
-			}
+		// from the failed lists so retryFailedProviders won't later merge a duplicate
+		// session for the same name (and can self-terminate once both are empty).
+		// Both tiers are pruned — retryFailedProviders now retries backups too.
+		restoredSet := make(map[string]struct{}, len(restoredStatic)+len(restoredBackup))
+		for _, n := range restoredStatic {
+			restoredSet[n] = struct{}{}
 		}
+		for _, n := range restoredBackup {
+			restoredSet[n] = struct{}{}
+		}
+		pruneRestoredFromFailed(rpsr.failedStaticProviders, chainKey, restoredSet)
+		pruneRestoredFromFailed(rpsr.failedBackupProviders, chainKey, restoredSet)
 
 		// UpdateAllProviders stays under rpsr.mu so the (providerSessions write →
-		// csm push) pair is atomic with updateEpoch / retryFailedStaticProviders —
+		// csm push) pair is atomic with updateEpoch / retryFailedProviders —
 		// otherwise a concurrent epoch tick can push to the csm in the opposite
 		// order it wrote providerSessions, silently dropping the restored providers.
 		if err := sessionManager.UpdateAllProviders(currentEpoch, mergedStatic, mergedBackup); err != nil {

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2812,7 +2812,7 @@ func (rpcss *RPCSmartRouterServer) ensureEndpointChainTracker(
 
 // chainTrackerReconcileInterval is how often initializeChainTrackers re-walks the live pairing
 // looking for direct-RPC endpoints that have no ChainTracker. It is deliberately short relative to
-// the paths that ADMIT an endpoint after startup (retryFailedStaticProviders' 3m ticker, the ~15m
+// the paths that ADMIT an endpoint after startup (retryFailedProviders' 2s–3m retry, the ~15m
 // epoch re-verify), because it is the only thing standing between a late-admitted endpoint and
 // permanent silence — a reconcile pass is a map lookup per endpoint when nothing is missing, so the
 // cost of running it often is nil. Package-level var, not a const, so tests can shorten it.
@@ -2825,7 +2825,7 @@ var chainTrackerReconcileInterval = 15 * time.Second
 // MAG-2622 — why this is a LOOP and not the one-shot it used to be. Endpoints enter the pairing at
 // three points AFTER this function's first pass, and none of them registered a tracker:
 //
-//	retryFailedStaticProviders   an upstream that failed boot verification recovers (3m ticker)
+//	retryFailedProviders   an upstream that failed boot verification recovers (2s–3m adaptive retry)
 //	applyReverification promote  a demoted provider passes re-verification (epoch tick)
 //	rebuildPairingFromConfig     /debug/reset-pairing re-admits cold
 //

--- a/protocol/rpcsmartrouter/rpcsmartrouter_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_test.go
@@ -51,6 +51,7 @@ func createTestRPCSmartRouter() *RPCSmartRouter {
 		providerSessions:       make(map[string]map[uint64]*lavasession.ConsumerSessionsWithProvider),
 		backupProviderSessions: make(map[string]map[uint64]*lavasession.ConsumerSessionsWithProvider),
 		failedStaticProviders:  make(map[string][]*lavasession.RPCStaticProviderEndpoint),
+		failedBackupProviders:  make(map[string][]*lavasession.RPCStaticProviderEndpoint),
 		rpcServers:             make(map[string]*RPCSmartRouterServer),
 	}
 }
@@ -674,7 +675,7 @@ func TestGracefulFailure_RetryGoroutineSelfTerminates(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		rpsr.retryFailedStaticProviders(ctx, chainKey, nil, rpcEndpoint, convertFn)
+		rpsr.retryFailedProviders(ctx, chainKey, nil, rpcEndpoint, convertFn)
 		close(done)
 	}()
 
@@ -759,7 +760,7 @@ func TestGracefulFailure_CopyOnWriteDoesNotMutateOldMap(t *testing.T) {
 	// Snapshot the original length
 	originalLen := len(oldSessions)
 
-	// Simulate the copy-on-write merge from retryFailedStaticProviders (lines 1719-1737)
+	// Simulate the copy-on-write merge from retryFailedProviders (lines 1719-1737)
 	recoveredSession := createTestProviderSession("providerB", 1)
 
 	mergedSessions := make(map[uint64]*lavasession.ConsumerSessionsWithProvider, len(oldSessions)+1)

--- a/protocol/rpcsmartrouter/spec_reverifier.go
+++ b/protocol/rpcsmartrouter/spec_reverifier.go
@@ -117,13 +117,17 @@ type chainReverifyInputs struct {
 // Configured lists are pre-filtered by chain+ApiInterface at startup (see
 // relevantStaticProviderList in rpcsmartrouter.go), so no further filter is
 // needed here.
+//
+// The third return is the names promoted this cycle. updateEpoch needs them to drop
+// those providers from the failed lists — promoting here while leaving them pending
+// for retryFailedProviders produces two sessions for one provider.
 func applyReverification(
 	ctx context.Context,
 	inputs *chainReverifyInputs,
 	fresh map[uint64]*lavasession.ConsumerSessionsWithProvider,
 	tier reverifyTier,
 	epoch uint64,
-) (map[uint64]*lavasession.ConsumerSessionsWithProvider, []*lavasession.ConsumerSessionsWithProvider) {
+) (map[uint64]*lavasession.ConsumerSessionsWithProvider, []*lavasession.ConsumerSessionsWithProvider, []string) {
 	var configured []*lavasession.RPCStaticProviderEndpoint
 	switch tier {
 	case reverifyTierStatic:
@@ -132,7 +136,7 @@ func applyReverification(
 		configured = inputs.configuredBackup
 	}
 	if len(configured) == 0 {
-		return fresh, nil
+		return fresh, nil, nil
 	}
 	validate := inputs.validateFn
 	if validate == nil {
@@ -234,6 +238,7 @@ func applyReverification(
 
 	// Promote: append fresh sessions for healthy providers absent from `fresh`.
 	// Pick keys that don't collide with surviving entries.
+	var promoted []string
 	if len(toAdmit) > 0 {
 		nextIdx := uint64(0)
 		for k := range next {
@@ -248,9 +253,13 @@ func applyReverification(
 			next[nextIdx] = s
 			nextIdx++
 		}
+		promoted = make([]string, 0, len(toAdmit))
+		for _, p := range toAdmit {
+			promoted = append(promoted, p.Name)
+		}
 	}
 
-	return next, demoted
+	return next, demoted, promoted
 }
 
 // byName builds a name → session lookup so callers can answer

--- a/protocol/rpcsmartrouter/spec_reverifier.go
+++ b/protocol/rpcsmartrouter/spec_reverifier.go
@@ -301,10 +301,6 @@ func closeDemotedDirectConnections(demoted []*lavasession.ConsumerSessionsWithPr
 	}
 }
 
-// validateProvider runs a single spec-verification pass against one provider.
-// It builds a fresh ChainRouter + ChainFetcher under a bounded attempt context
-// (so a hung upstream cannot stall a whole reconcile cycle), calls Validate,
-// and tears the temporary resources down regardless of outcome.
 // BootValidateTimeout bounds a single provider validation during startup.
 // Before MAG-2525 the two boot tiers disagreed: static providers got a 30s
 // timeout while backups got a bare context.WithCancel, so one blackholed backup
@@ -392,6 +388,10 @@ func validateProviderTier(
 	return failedSet, failedOrdered
 }
 
+// validateProvider runs a single spec-verification pass against one provider.
+// It builds a fresh ChainRouter + ChainFetcher under a bounded attempt context
+// (so a hung upstream cannot stall a whole reconcile cycle), calls Validate,
+// and tears the temporary resources down regardless of outcome.
 func validateProvider(
 	ctx context.Context,
 	provider *lavasession.RPCStaticProviderEndpoint,

--- a/protocol/rpcsmartrouter/spec_reverifier.go
+++ b/protocol/rpcsmartrouter/spec_reverifier.go
@@ -296,6 +296,93 @@ func closeDemotedDirectConnections(demoted []*lavasession.ConsumerSessionsWithPr
 // It builds a fresh ChainRouter + ChainFetcher under a bounded attempt context
 // (so a hung upstream cannot stall a whole reconcile cycle), calls Validate,
 // and tears the temporary resources down regardless of outcome.
+// BootValidateTimeout bounds a single provider validation during startup.
+// Before MAG-2525 the two boot tiers disagreed: static providers got a 30s
+// timeout while backups got a bare context.WithCancel, so one blackholed backup
+// URL could hang bring-up indefinitely. Both tiers share this now.
+var BootValidateTimeout = 30 * time.Second
+
+// validateProviderTier validates one configured tier at startup, in parallel and
+// bounded by SpecReVerifyConcurrency. It is the boot-time counterpart to
+// applyReverification: same validateProvider primitive, same semaphore, but no
+// promote/demote bookkeeping — at boot there is no prior pairing to reconcile
+// against, only a pass/fail partition.
+//
+// Parallelism here is an availability property, not just a speed one. The tiers
+// validate in sequence, so a serial static tier of N dead providers delayed the
+// backup tier — and therefore bring-up on backups — by up to N × the timeout.
+// Three dead primaries cost 90s before a healthy backup was even dialled.
+//
+// Returns failures twice: as a set for filtering, and as a slice in configured
+// order. The slice seeds the retry loop, which must not vary with the order
+// goroutines happen to finish in.
+//
+// `providers` is pre-filtered by chain + api-interface at the call site (see
+// relevantStaticProviderList in rpcsmartrouter.go), so nothing is filtered here.
+//
+// `validate` is nil in production and falls back to the real network probe; tests
+// inject a fake to exercise the partitioning and ordering without upstreams, the
+// same seam chainReverifyInputs.validateFn provides for applyReverification.
+func validateProviderTier(
+	ctx context.Context,
+	providers []*lavasession.RPCStaticProviderEndpoint,
+	rpcEndpoint *lavasession.RPCEndpoint,
+	chainParser chainlib.ChainParser,
+	tier reverifyTier,
+	validate func(context.Context, *lavasession.RPCStaticProviderEndpoint) error,
+) (map[*lavasession.RPCStaticProviderEndpoint]struct{}, []*lavasession.RPCStaticProviderEndpoint) {
+	failedSet := make(map[*lavasession.RPCStaticProviderEndpoint]struct{})
+	if len(providers) == 0 {
+		return failedSet, nil
+	}
+	if validate == nil {
+		validate = func(c context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
+			return validateProvider(c, p, chainParser, BootValidateTimeout)
+		}
+	}
+
+	utils.LavaFormatInfo("Validating providers",
+		utils.LogAttr("chain", rpcEndpoint.ChainID),
+		utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
+		utils.LogAttr("tier", tier.String()),
+		utils.LogAttr("providerCount", len(providers)),
+	)
+
+	results := make([]error, len(providers))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, SpecReVerifyConcurrency)
+	for i, p := range providers {
+		sem <- struct{}{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			results[i] = validate(ctx, p)
+		}()
+	}
+	wg.Wait()
+
+	var failedOrdered []*lavasession.RPCStaticProviderEndpoint
+	for i, p := range providers {
+		if err := results[i]; err != nil {
+			failedSet[p] = struct{}{}
+			failedOrdered = append(failedOrdered, p)
+			utils.LavaFormatWarning("provider validation failed — excluding from provider list", err,
+				utils.LogAttr("chain", rpcEndpoint.ChainID),
+				utils.LogAttr("tier", tier.String()),
+				utils.LogAttr("provider", p.Name),
+			)
+			continue
+		}
+		utils.LavaFormatInfo("Provider validated successfully",
+			utils.LogAttr("chain", rpcEndpoint.ChainID),
+			utils.LogAttr("tier", tier.String()),
+			utils.LogAttr("provider", p.Name),
+		)
+	}
+	return failedSet, failedOrdered
+}
+
 func validateProvider(
 	ctx context.Context,
 	provider *lavasession.RPCStaticProviderEndpoint,

--- a/protocol/rpcsmartrouter/spec_reverifier_test.go
+++ b/protocol/rpcsmartrouter/spec_reverifier_test.go
@@ -158,7 +158,7 @@ func TestApplyReverification(t *testing.T) {
 				validateFn:                 validate,
 			}
 
-			got, demoted := applyReverification(context.Background(), inputs, fresh, reverifyTierStatic, uint64(42))
+			got, demoted, _ := applyReverification(context.Background(), inputs, fresh, reverifyTierStatic, uint64(42))
 			gotNames := collectNames(got)
 
 			require.Len(t, gotNames, len(tt.want), "result size, tc #%d", i)
@@ -221,7 +221,7 @@ func TestApplyReverification_BackupTierReadsBackupList(t *testing.T) {
 		validateFn:                 validate,
 	}
 
-	_, _ = applyReverification(context.Background(), inputs, map[uint64]*lavasession.ConsumerSessionsWithProvider{}, reverifyTierBackup, 1)
+	_, _, _ = applyReverification(context.Background(), inputs, map[uint64]*lavasession.ConsumerSessionsWithProvider{}, reverifyTierBackup, 1)
 	require.Equal(t, []string{"B"}, calls, "backup tier must validate the backup list")
 }
 
@@ -312,7 +312,7 @@ func TestApplyReverification_DemoteHysteresis(t *testing.T) {
 		for i, n := range present {
 			fresh[uint64(i)] = makeSession(n)
 		}
-		got, demotedSessions := applyReverification(context.Background(), inputs, fresh, reverifyTierStatic, epoch)
+		got, demotedSessions, _ := applyReverification(context.Background(), inputs, fresh, reverifyTierStatic, epoch)
 		for _, s := range demotedSessions {
 			demoted = append(demoted, s.PublicLavaAddress)
 		}
@@ -369,7 +369,7 @@ func TestApplyReverification_SuccessResetsDemoteStreak(t *testing.T) {
 
 	run := func(epoch uint64) map[string]struct{} {
 		fresh := map[uint64]*lavasession.ConsumerSessionsWithProvider{0: makeSession("A")}
-		got, _ := applyReverification(context.Background(), inputs, fresh, reverifyTierStatic, epoch)
+		got, _, _ := applyReverification(context.Background(), inputs, fresh, reverifyTierStatic, epoch)
 		return collectNames(got)
 	}
 

--- a/protocol/rpcsmartrouter/subscription_endpoint_refresh_test.go
+++ b/protocol/rpcsmartrouter/subscription_endpoint_refresh_test.go
@@ -1,0 +1,316 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/chainlib"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/utils/rand"
+	"github.com/stretchr/testify/require"
+)
+
+// Subscription endpoint refresh (MAG-2525 follow-up).
+//
+// The WS and gRPC subscription managers build their tiers once, from the providers
+// that passed boot verification. Once a chain could boot with nothing healthy, that
+// froze both tiers empty for the process lifetime: HTTP relays recovered, every
+// eth_subscribe kept failing, and only a restart fixed it. These tests pin the two
+// halves of the fix — the managers accept a new endpoint set, and the router pushes
+// one on every path that mutates the live pairing.
+
+func wsProvider(name string, urls ...string) *lavasession.RPCStaticProviderEndpoint {
+	nodeUrls := make([]common.NodeUrl, 0, len(urls))
+	for _, u := range urls {
+		nodeUrls = append(nodeUrls, common.NodeUrl{Url: u})
+	}
+	return &lavasession.RPCStaticProviderEndpoint{
+		Name: name, ChainID: "BSC", ApiInterface: "jsonrpc", NodeUrls: nodeUrls,
+	}
+}
+
+func newTestWSManager(primary, backup []*common.NodeUrl) *DirectWSSubscriptionManager {
+	return NewDirectWSSubscriptionManager(
+		getTestMetricsManager(), "jsonrpc", "BSC", "jsonrpc", primary, backup, nil, nil)
+}
+
+// The MAG-2525 scenario end to end at the manager level: a chain that boots with
+// nothing healthy gets empty tiers, and must still be able to serve subscriptions
+// once a provider comes back — without a restart.
+func TestWSSetEndpoints_DarkBootRecoversWithoutRestart(t *testing.T) {
+	manager := newTestWSManager(nil, nil)
+
+	_, err := manager.selectEndpoint(context.Background(), "client-1", nil)
+	require.Error(t, err, "dark boot: nothing to select")
+
+	recovered := []*common.NodeUrl{{Url: "wss://primary-1.example.com"}}
+	require.True(t, manager.SetEndpoints(recovered, nil))
+
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", nil)
+	require.NoError(t, err, "recovered provider must be selectable — this is the whole fix")
+	require.Equal(t, "wss://primary-1.example.com", ep.Url)
+}
+
+// MAG-2532 shape: booted on backups alone, so tier 1 is empty and the cascade serves
+// tier 2. A recovered primary has to take over once it is republished.
+func TestWSSetEndpoints_RecoveredPrimaryTakesOverFromBackup(t *testing.T) {
+	backup := []*common.NodeUrl{{Url: "wss://backup-1.example.com"}}
+	manager := newTestWSManager(nil, backup)
+
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", nil)
+	require.NoError(t, err)
+	require.Equal(t, "wss://backup-1.example.com", ep.Url, "empty primary tier is what fires the cascade")
+
+	primary := []*common.NodeUrl{{Url: "wss://primary-1.example.com"}}
+	require.True(t, manager.SetEndpoints(primary, backup))
+
+	ep, err = manager.selectEndpoint(context.Background(), "client-2", nil)
+	require.NoError(t, err)
+	require.Equal(t, "wss://primary-1.example.com", ep.Url, "primary tier is served first again")
+}
+
+// A demotion must be able to empty a tier, or the manager keeps handing out an
+// endpoint the pairing has already dropped.
+func TestWSSetEndpoints_DemotionEmptiesTier(t *testing.T) {
+	primary := []*common.NodeUrl{{Url: "wss://primary-1.example.com"}}
+	manager := newTestWSManager(primary, nil)
+
+	require.True(t, manager.SetEndpoints(nil, nil))
+	_, err := manager.selectEndpoint(context.Background(), "client-1", nil)
+	require.Error(t, err)
+}
+
+// Republish runs on every pairing mutation, so the common case is "nothing changed".
+// It must not churn the URL index or log on those.
+func TestWSSetEndpoints_UnchangedSetIsANoOp(t *testing.T) {
+	primary := []*common.NodeUrl{{Url: "wss://primary-1.example.com"}}
+	backup := []*common.NodeUrl{{Url: "wss://backup-1.example.com"}}
+	manager := newTestWSManager(primary, backup)
+
+	require.False(t, manager.SetEndpoints(
+		[]*common.NodeUrl{{Url: "wss://primary-1.example.com"}},
+		[]*common.NodeUrl{{Url: "wss://backup-1.example.com"}},
+	), "same URLs in the same order")
+
+	require.True(t, manager.SetEndpoints(
+		[]*common.NodeUrl{{Url: "wss://primary-2.example.com"}},
+		[]*common.NodeUrl{{Url: "wss://backup-1.example.com"}},
+	), "different primary URL")
+
+	// Order is the no-optimizer selection order, so a reorder is a real change.
+	twoPrimaries := []*common.NodeUrl{{Url: "wss://a.example.com"}, {Url: "wss://b.example.com"}}
+	require.True(t, manager.SetEndpoints(twoPrimaries, nil))
+	require.True(t, manager.SetEndpoints(
+		[]*common.NodeUrl{{Url: "wss://b.example.com"}, {Url: "wss://a.example.com"}}, nil))
+}
+
+// The optimizer resolves its chosen URL through endpointsByURL; SetEndpoints has to
+// rebuild that index alongside the tiers or selection breaks on the new set.
+func TestWSSetEndpoints_RebuildsURLIndexForOptimizer(t *testing.T) {
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(), "jsonrpc", "BSC", "jsonrpc",
+		[]*common.NodeUrl{{Url: "wss://old-1.example.com"}, {Url: "wss://old-2.example.com"}},
+		nil,
+		&fakeSubscriptionOptimizer{},
+		nil,
+	)
+
+	fresh := []*common.NodeUrl{{Url: "wss://new-1.example.com"}, {Url: "wss://new-2.example.com"}}
+	require.True(t, manager.SetEndpoints(fresh, nil))
+
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", nil)
+	require.NoError(t, err, "optimizer-selected URL must resolve against the rebuilt index")
+	require.Contains(t, []string{"wss://new-1.example.com", "wss://new-2.example.com"}, ep.Url)
+
+	require.Len(t, manager.endpointsSnapshot().byURL, 2, "stale URLs must not linger in the index")
+}
+
+func TestGRPCSetEndpoints_DarkBootRecoversWithoutRestart(t *testing.T) {
+	manager := NewDirectGRPCSubscriptionManager(
+		getTestMetricsManager(), "BSC", "grpc", nil, nil, nil, nil)
+
+	_, err := manager.selectEndpoint(context.Background(), "client-1", nil)
+	require.Error(t, err)
+
+	require.True(t, manager.SetEndpoints([]*common.NodeUrl{{Url: "grpc-1.example.com:9090"}}, nil))
+
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", nil)
+	require.NoError(t, err, "also unblocks gRPC reflection, which selects through the same cascade")
+	require.Equal(t, "grpc-1.example.com:9090", ep.Url)
+
+	require.False(t, manager.SetEndpoints([]*common.NodeUrl{{Url: "grpc-1.example.com:9090"}}, nil))
+}
+
+// activeProviders is the bridge from "what is live in the pairing" back to the
+// configured records that own the NodeUrls.
+func TestActiveProviders_FiltersToPairingAndKeepsConfiguredOrder(t *testing.T) {
+	configured := []*lavasession.RPCStaticProviderEndpoint{
+		wsProvider("A", "wss://a"), wsProvider("B", "wss://b"), wsProvider("C", "wss://c"),
+	}
+	// Session map keys are arbitrary — configured order is what must survive.
+	sessions := map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		7: createTestProviderSession("C", 1),
+		1: createTestProviderSession("A", 1),
+	}
+
+	live := activeProviders(configured, sessions)
+	require.Len(t, live, 2)
+	require.Equal(t, "A", live[0].Name)
+	require.Equal(t, "C", live[1].Name)
+
+	require.Nil(t, activeProviders(configured, nil), "dark chain has no live providers")
+	require.Nil(t, activeProviders(nil, sessions))
+}
+
+// newRefreshTestRouter wires the minimum a republish needs: a registered server
+// holding a Direct WS manager, and the configured lists republish filters against.
+func newRefreshTestRouter(t *testing.T, chainKey string, configuredStatic, configuredBackup []*lavasession.RPCStaticProviderEndpoint) (*RPCSmartRouter, *DirectWSSubscriptionManager) {
+	t.Helper()
+	rpsr := createTestRPCSmartRouter()
+	rpsr.reverifyInputs = map[string]*chainReverifyInputs{
+		chainKey: {
+			rpcEndpoint:      bootTestEndpoint(),
+			configuredStatic: configuredStatic,
+			configuredBackup: configuredBackup,
+		},
+	}
+	// Boot-time state of a chain that came up dark: a real manager with empty tiers.
+	manager := newTestWSManager(nil, nil)
+	rpsr.rpcServers[chainKey] = &RPCSmartRouterServer{wsSubscriptionManager: manager}
+	return rpsr, manager
+}
+
+func TestRepublishSubscriptionEndpoints_FillsTiersFromLivePairing(t *testing.T) {
+	rand.InitRandomSeed()
+	const chainKey = "BSC-jsonrpc"
+	rpsr, manager := newRefreshTestRouter(t, chainKey,
+		[]*lavasession.RPCStaticProviderEndpoint{wsProvider("primary1", "wss://primary1")},
+		[]*lavasession.RPCStaticProviderEndpoint{wsProvider("backup1", "wss://backup1")},
+	)
+
+	require.Empty(t, manager.endpointsSnapshot().primary, "dark boot")
+
+	// The pairing recovers, as retryFailedProviders would leave it.
+	rpsr.providerSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: createTestProviderSession("primary1", 1),
+	}
+	rpsr.backupProviderSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: createTestProviderSession("backup1", 1),
+	}
+
+	rpsr.mu.Lock()
+	rpsr.republishSubscriptionEndpointsLocked(chainKey)
+	rpsr.mu.Unlock()
+
+	snapshot := manager.endpointsSnapshot()
+	require.Len(t, snapshot.primary, 1)
+	require.Equal(t, "wss://primary1", snapshot.primary[0].Url)
+	require.Len(t, snapshot.backup, 1)
+	require.Equal(t, "wss://backup1", snapshot.backup[0].Url)
+}
+
+// A configured provider that is NOT in the pairing must stay out of the tier: a dead
+// endpoint in tier 1 would be handed to a subscription with no fallback, and would
+// suppress the primary→backup cascade the empty tier is what triggers.
+func TestRepublishSubscriptionEndpoints_ExcludesProvidersOutsideThePairing(t *testing.T) {
+	rand.InitRandomSeed()
+	const chainKey = "BSC-jsonrpc"
+	rpsr, manager := newRefreshTestRouter(t, chainKey,
+		[]*lavasession.RPCStaticProviderEndpoint{
+			wsProvider("primary1", "wss://primary1"),
+			wsProvider("primary2", "wss://primary2"), // configured but still down
+		},
+		nil,
+	)
+
+	rpsr.providerSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: createTestProviderSession("primary1", 1),
+	}
+
+	rpsr.mu.Lock()
+	rpsr.republishSubscriptionEndpointsLocked(chainKey)
+	rpsr.mu.Unlock()
+
+	snapshot := manager.endpointsSnapshot()
+	require.Len(t, snapshot.primary, 1)
+	require.Equal(t, "wss://primary1", snapshot.primary[0].Url)
+}
+
+// The gauge falls back down on demotion; so must the tiers.
+func TestRepublishSubscriptionEndpoints_DemotionClearsTier(t *testing.T) {
+	rand.InitRandomSeed()
+	const chainKey = "BSC-jsonrpc"
+	rpsr, manager := newRefreshTestRouter(t, chainKey,
+		[]*lavasession.RPCStaticProviderEndpoint{wsProvider("primary1", "wss://primary1")}, nil)
+
+	rpsr.providerSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: createTestProviderSession("primary1", 1),
+	}
+	rpsr.mu.Lock()
+	rpsr.republishSubscriptionEndpointsLocked(chainKey)
+	rpsr.mu.Unlock()
+	require.Len(t, manager.endpointsSnapshot().primary, 1)
+
+	delete(rpsr.providerSessions, chainKey)
+	rpsr.mu.Lock()
+	rpsr.republishSubscriptionEndpointsLocked(chainKey)
+	rpsr.mu.Unlock()
+	require.Empty(t, manager.endpointsSnapshot().primary, "tier follows the pairing down as well as up")
+}
+
+// The NoOp manager is installed only when no ws:// URL is configured at all, so there
+// is genuinely nothing to republish — it must be skipped, not type-asserted into a panic.
+func TestRepublishSubscriptionEndpoints_ToleratesNoOpAndMissingWiring(t *testing.T) {
+	rand.InitRandomSeed()
+	const chainKey = "BSC-jsonrpc"
+	rpsr := createTestRPCSmartRouter()
+	rpsr.reverifyInputs = map[string]*chainReverifyInputs{
+		chainKey: {rpcEndpoint: bootTestEndpoint(), configuredStatic: bootTestProviders("primary1")},
+	}
+	rpsr.rpcServers[chainKey] = &RPCSmartRouterServer{
+		wsSubscriptionManager: NewNoOpWSSubscriptionManager("BSC", "jsonrpc"),
+	}
+	rpsr.providerSessions[chainKey] = map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: createTestProviderSession("primary1", 1),
+	}
+
+	require.NotPanics(t, func() {
+		rpsr.mu.Lock()
+		defer rpsr.mu.Unlock()
+		rpsr.republishSubscriptionEndpointsLocked(chainKey)
+		rpsr.republishSubscriptionEndpointsLocked("chain-with-no-server")
+	})
+}
+
+// updateEpoch is the path that promotes a recovered provider back into the pairing.
+// It must republish too, or a chain that recovers via the epoch re-verifier rather
+// than the retry loop keeps its stale tiers.
+func TestUpdateEpoch_RepublishesSubscriptionEndpoints(t *testing.T) {
+	rand.InitRandomSeed()
+	const chainKey = "BSC-jsonrpc"
+	rpsr, manager := newRefreshTestRouter(t, chainKey,
+		[]*lavasession.RPCStaticProviderEndpoint{wsProvider("primary1", "wss://primary1")}, nil)
+
+	sm, _ := createTestSessionManager("BSC", "jsonrpc")
+	rpsr.sessionManagers[chainKey] = sm
+	rpsr.reverifyInputs[chainKey].convertProvidersToSessions = func(providers []*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+		out := make(map[uint64]*lavasession.ConsumerSessionsWithProvider, len(providers))
+		for i, p := range providers {
+			out[uint64(i)] = createTestProviderSession(p.Name, 0)
+		}
+		return out
+	}
+	rpsr.reverifyInputs[chainKey].validateFn = func(context.Context, *lavasession.RPCStaticProviderEndpoint) error {
+		return nil // the provider is back
+	}
+
+	require.Empty(t, manager.endpointsSnapshot().primary, "booted dark")
+
+	rpsr.updateEpoch(context.Background(), 2)
+
+	require.Len(t, rpsr.providerSessions[chainKey], 1, "promoted by the epoch re-verifier")
+	require.Len(t, manager.endpointsSnapshot().primary, 1, "and its ws:// URL joined the tier")
+}
+
+var _ chainlib.WSSubscriptionManager = (*DirectWSSubscriptionManager)(nil)


### PR DESCRIPTION
# Description

The router exited at startup when every static provider failed verification, even with healthy backups configured. A restart during a failover — exactly when a restart is most likely — turned a handled failover into an outage. An all-down window at boot became a CrashLoopBackOff that never self-healed, because a crash-looping pod can't adopt a provider that comes back.

Reported twice: MAG-2532 (customer-facing, Kraken/BSC — primaries down, backups healthy, deploy restarted the pod, router refused to start) and MAG-2525 (total wipe-out at boot → crash loop). Both trace to the same check. MAG-2532 is a strict subset, so this closes both.

**Provider health is a runtime condition, not a configuration error.** The router already tolerates every provider dropping while it runs: it stays up, returns 5xx, and re-adopts providers as they recover. Boot now behaves the same way. Only a chain with nothing *configured* still exits.

Per chain + api-interface:

| healthy primaries | healthy backups | result |
| --- | --- | --- |
| ≥1 | any | serves primaries |
| 0 | ≥1 | serves backups (degraded) |
| 0 | 0 | boots, reports unhealthy, 500s on relays, retries |
| *none configured* | *none configured* | exits non-zero |

## Replacing the signal that fail-fast carried

Removing the fatal also removes what it told operators, so two things replace it:

- **The relays monitor is seeded from the boot verdict.** It defaults optimistic (`isHealthy: 1`), which would have answered `200` on `/lava/health` for a chain that came up dark, until the first health relay resolved an interval later. `/readyz` was already fail-closed and is unaffected.
- **New `smartrouter_endpoint_serving_tier` gauge** — 2=primaries, 1=degraded on backups only, 0=dark. Alert on `<2` and `==0`, now that pod restarts no longer signal a dark chain. Republished from every path that mutates the live pairing, not just boot: a stale reading would page forever after a recovery, or stay silent after a demotion.

## Recovery cadence

No longer a flat 3m. A **dark** chain retries from ~2s doubling to the same 3m ceiling, then decays back once serving — a boot-time blip costs seconds instead of minutes. A merely **degraded** chain keeps the flat interval; retries there buy redundancy, not availability. Backups joined that loop too; they previously recovered only on the 15m epoch reverification, which was tolerable only while a chain could never boot on backups alone.

## Three adjacent defects on the same path

All get worse once backups are load-bearing at boot:

- **Backup validation had no timeout** — `context.WithCancel` where the static tier used a 30s `WithTimeout`, so a blackholed backup hung bring-up indefinitely. Both tiers now share `BootValidateTimeout`.
- **Boot validation was sequential** at up to 30s per provider, so three dead primaries cost 90s before a healthy backup was even dialled. Both tiers now validate in parallel, bounded by `SpecReVerifyConcurrency`.
- **Boot validation didn't clone the chain parser**, which the epoch reverifier already does to stop gRPC verification mutating the live parser. Sharing `validateProvider` picks that up.

That sharing also collapses three near-identical copies of the verification logic (both boot tiers and the retry loop) into one — most of the 400 deleted lines.

## Review follow-up

Two defects Anna's review surfaced, fixed in `54832ad`:

- **Subscription tiers were frozen at the boot-time healthy lists.** Nothing updated them afterwards, which was survivable only while a chain could not boot without a healthy static provider. Once it can, both scenarios above became permanent subscription outages: a dark boot installed the NoOp WS manager and left `grpcSubscriptionManager` nil for the process lifetime, and a backups-only boot never promoted a recovered primary. HTTP relays recover in both cases, so nothing surfaced it until a client opened a subscription. Which manager is installed is now decided from the *configured* providers, and `SetEndpoints` repopulates the tiers from every path that mutates the live pairing. The tiers stay healthy-only — seeding them from the configured list would hand a subscription a dead endpoint with no fallback and suppress the primary→backup cascade.
- **The epoch promote path left providers in the failed lists**, so the retry loop later merged a second session for the same provider (`mergeRecoveredSessions` keys by index, not by `PublicLavaAddress`), doubling its weight in `validAddresses`. `applyReverification` now surfaces promoted names and `updateEpoch` prunes them per tier.

## Testing

- Full suite: 33/33 packages pass. `-race` clean on `rpcsmartrouter`. `go vet` (the repo's `make lint`) and `golangci-lint` clean on changed files.
- New unit tests in `boot_resilience_test.go` and `serving_tier_metrics_test.go` cover tier partitioning/ordering/concurrency, the dark verdict, adaptive cadence, re-admission merging, the health seed, and the gauge (including that it falls back down after recovery rather than acting as a high-water mark).
- **Verified end-to-end on k3d** against a live cluster. Two integration tests in `smart-router-automation` (`mag-2525-2532-boot-resilience`, PR to follow) pass against this branch and **fail** against a router built without it, so they're real regression guards:
  - MAG-2532 — primaries down, backups healthy → `rollout completed in 7.2s on backups alone`, then `HTTP 200 served by backup tier: ['simbackup1']`
  - MAG-2525 — everything down → boots, 500s cleanly, adopts primaries once healthy

Two pre-existing issues found and deliberately left alone: a data race in `relays_monitor_test.go` (`TestHappyFlow`, confirmed on main) and two `golangci-lint` findings in untouched code (`spec_reverifier.go:153`, `rpcsmartrouter.go:2723`, both confirmed on main).

## Not included

`errCh` handling at `rpcsmartrouter.go:330-333` still exits the process on the first endpoint error, so one chain's *config* error takes down every chain. The availability half of that is gone — only config errors reach `errCh` now — and whether a config error should still fail the whole process reads like an intentional choice, so I left it. Happy to change if not.

## Jira ticket

Jira ticket: MAG-2525

---

## Author Checklist

I have...

* [x] read the [contribution guide](https://github.com/magma-Devs/smart-router/blob/main/CONTRIBUTING.md)
* [x] included the correct type prefix in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change — n/a, no API or client break. `smartrouter_endpoint_serving_tier` is additive; the boot behavior change is the fix itself and is documented above.
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification — MAG-2525 carries the agreed behavior spec in a comment; MAG-2532 tracks the customer report.
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests
* [x] updated the relevant documentation or specification, including comments for documenting Go code
* [ ] confirmed all CI checks have passed — pending first run.

## Reviewers Checklist

I have...

* [ ] confirmed the correct type prefix in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage

