### PR TITLE
ci: strip retired periodic-probe args in PR gate

### DIFF
--- a/.github/workflows/pr-gate-build-artifact.yml
+++ b/.github/workflows/pr-gate-build-artifact.yml
@@ -496,12 +496,16 @@ jobs:
               ($arg == "--show-provider-address-in-metrics") or
               ($arg == "--geolocation") or
               ($arg == "--concurrent-providers") or
+              ($arg == "--enable-periodic-probe-providers") or
+              ($arg == "--periodic-probe-providers-interval") or
               (($arg | startswith("--provider-optimizer-")) and (($arg | contains("=")) | not));
             def retired_flag_assignment($arg):
               ($arg | startswith("--optimizer-qos-listen=")) or
               ($arg | startswith("--show-provider-address-in-metrics=")) or
               ($arg | startswith("--geolocation=")) or
               ($arg | startswith("--concurrent-providers=")) or
+              ($arg | startswith("--enable-periodic-probe-providers=")) or
+              ($arg | startswith("--periodic-probe-providers-interval=")) or
               (($arg | startswith("--provider-optimizer-")) and ($arg | contains("=")));
             def sanitize_arg($arg):
               if retired_flag_name($arg) then


### PR DESCRIPTION
Jira ticket: MAG-2733

Unblocks the `dev-sim-prtests` **rollout step** for #260. See "Remaining work" — this is necessary but not sufficient.

## The failure

The rollout step swaps only the image on the pre-existing `eth-sim-router` Deployment (`kubectl set image`), so the live container args outlive the binary that understood them. #260 removes the legacy synthetic prober and with it two flags the deployed args still pass. Cobra rejects the first and exits 1 before the router starts:

```
Error: unknown flag: --periodic-probe-providers-interval
```

The pod CrashLoopBackOffs, the gate fails and rolls back. Seen on runs [31487560320](https://github.com/Magma-Devs/smart-router/actions/runs/31487560320) and [31488457933](https://github.com/Magma-Devs/smart-router/actions/runs/31488457933).

## The change

The gate already sanitizes previously-retired flags out of the live args before rollout — `--optimizer-qos-listen`, `--show-provider-address-in-metrics`, `--geolocation`, `--concurrent-providers`, `--provider-optimizer-*`. #260's two flags simply aren't on that list. This adds them to both predicates: `retired_flag_name` for the `--flag value` form and `retired_flag_assignment` for `--flag=value`, which is the form the chart uses.

| Flag | Removed by #260 | In deployed args | Listed here |
|---|---|---|---|
| `--periodic-probe-providers-interval` | yes | yes (chart line 153, literal) | yes |
| `--enable-periodic-probe-providers` | yes | yes (chart line 156, literal) | yes |
| `--probe-update-weight` | **no** | yes (chart line 207, values-driven) | **no** |

### Why `--probe-update-weight` is not listed

An earlier revision of this PR listed it. That was wrong on both counts, per review:

- **#260 keeps it.** It only looks deleted because gofmt re-aligned the constant block when its two neighbours went — name and value are identical on both sides. On #260's branch it is still registered (`rpcsmartrouter.go:3087`) and still applied (`:2906`, via `scoreutils.SetProbeUpdateWeight`).
- **It is in the deployed args**, rendered from a values key at `charts/smart-router/templates/routers_deployment.yaml:207`. Stripping it is a no-op only by coincidence — chart default and binary default are both `0.25`. Tune `probeUpdateWeight` and the gate would silently reset it, validating a router whose provider-scoring weight differs from production's.

Only flags the binary under test rejects belong on this list. A pre-emptive entry inverts what the gate is for: instead of failing when chart and binary disagree, it hides the disagreement.

## Verification

Extracted the jq program from the workflow and ran it against a realistic arg list drawn from the chart:

- strips both retired flags, in the `--flag=value` form the chart uses
- leaves every retained flag and its value intact, including `--min-relay-timeout=5s` immediately after a stripped flag, and `--probe-update-weight=0.9` (a deliberately non-default value, to prove a tuned setting survives)
- control run with `main`'s current sanitizer lets both through, confirming this is the delta that fixes it

## Remaining work — this alone does not get #260 green

The sanitizer applies only to the `kubectl set image` path. The next step in the same job, "Deploy and validate latest Helm chart with PR image", installs `smart-router-helm-chart@main` fresh with the PR image, and that chart **hardcodes both flags as literals** (not values-driven, so no values file suppresses them):

```
charts/smart-router/templates/routers_deployment.yaml:153  - --periodic-probe-providers-interval=120s
charts/smart-router/templates/routers_deployment.yaml:156  - --enable-periodic-probe-providers=true
```

The install runs `--wait --atomic`, so a pod that won't start rolls back and fails the step. That step has never executed for #260 (the run dies at the rollout step first), so this is read from chart source plus a successful run of the same step on #259 — not an observed #260 failure.

**A change in `smart-router-helm-chart` guarding or removing lines 153 and 156 — leaving 207 alone — must land on that repo's `main` before the gate is re-dispatched for #260.**

## Ordering

The gate is `workflow_dispatch` and the sanitizer is inline in the workflow YAML, so the version that executes comes from the dispatched ref — not from the PR under test. This has to be on `main` before re-dispatching for #260; putting it on #260's branch alone would not help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)