### PR TITLE
fix(metrics): bound the method label for unmatched (Default-*) apis

### DIFF
--- a/protocol/metrics/batch_method_label.go
+++ b/protocol/metrics/batch_method_label.go
@@ -91,15 +91,21 @@ func buildBatchSignature(apiName string) (signature string, size int, tooWide bo
 	return BatchMethodPrefix + strings.Join(distinct, batchSignatureElementSeparator), size, false
 }
 
-// batchSignatureRegistry bounds the set of batch signatures allowed to become label
-// values, tracked per spec so a chatty chain can't consume another chain's budget.
+// batchSignatureRegistry bounds a set of label values, tracked per spec so a chatty
+// chain can't consume another chain's budget. Batch signatures were the first user;
+// unmatched-API names (default_method_label.go) reuse it with their own cap.
 type batchSignatureRegistry struct {
 	lock     sync.RWMutex
-	admitted map[string]map[string]struct{} // spec -> set of admitted signatures
+	cap      int
+	admitted map[string]map[string]struct{} // spec -> set of admitted values
 }
 
 func newBatchSignatureRegistry() *batchSignatureRegistry {
-	return &batchSignatureRegistry{admitted: make(map[string]map[string]struct{})}
+	return &batchSignatureRegistry{cap: maxBatchSignaturesPerSpec, admitted: make(map[string]map[string]struct{})}
+}
+
+func newDefaultMethodRegistry() *batchSignatureRegistry {
+	return &batchSignatureRegistry{cap: maxDefaultMethodsPerSpec, admitted: make(map[string]map[string]struct{})}
 }
 
 // admit reports whether signature may be used as a label value for spec.
@@ -127,13 +133,13 @@ func (r *batchSignatureRegistry) admit(spec, signature string) bool {
 
 	signatures, ok := r.admitted[spec]
 	if !ok {
-		signatures = make(map[string]struct{}, maxBatchSignaturesPerSpec)
+		signatures = make(map[string]struct{}, r.cap)
 		r.admitted[spec] = signatures
 	}
 	if _, alreadyAdmitted := signatures[signature]; alreadyAdmitted {
 		return true
 	}
-	if len(signatures) >= maxBatchSignaturesPerSpec {
+	if len(signatures) >= r.cap {
 		return false
 	}
 	signatures[signature] = struct{}{}
@@ -148,8 +154,13 @@ func (r *batchSignatureRegistry) admit(spec, signature string) bool {
 // RecordRelaySuccess → AddEndpointRelayServiced), and each normalizes at its own
 // boundary so that calling any of them directly is still safe.
 func (m *SmartRouterMetricsManager) normalizeMethodLabel(spec, method string) string {
-	if m == nil || !strings.Contains(method, batchMethodSeparator) {
+	if m == nil {
 		return method
+	}
+	if !strings.Contains(method, batchMethodSeparator) {
+		// Single-method names have their own unbounded case: the synthetic
+		// "Default-<raw request>" apis minted for spec misses (default_method_label.go).
+		return m.normalizeDefaultMethodLabel(spec, method)
 	}
 
 	signature, _, tooWide := buildBatchSignature(method)

--- a/protocol/metrics/default_method_label.go
+++ b/protocol/metrics/default_method_label.go
@@ -23,11 +23,122 @@ const (
 	// spec-gap signal this cap preserves — while a concrete-ID flood blows through
 	// the budget immediately and every later name collapses to DefaultMethodOther.
 	maxDefaultMethodsPerSpec = 32
+
+	// defaultMethodIDPlaceholder stands in for a path segment that carries a concrete
+	// value. It deliberately does not name the parameter: unlike a matched api, an
+	// unmatched path has no spec template to take a name from, and inventing one would
+	// make the label look like a template it is not.
+	defaultMethodIDPlaceholder = "{}"
+
+	// minOpaqueIDLen is the length at or above which an alphanumeric segment carrying a
+	// digit is read as an identifier rather than a path element. It clears the longest
+	// real segments seen in the specs (getBlockTransactionCountByNumber, 32 chars, has
+	// no digit) and sits below the shortest identifiers (base58 tx hashes ~43, bech32
+	// addresses ~39, Tezos block hashes 51).
+	minOpaqueIDLen = 26
 )
 
+// defaultMethodShape collapses concrete identifiers in an unmatched REST path to
+// defaultMethodIDPlaceholder, so /blocks/1/header and /blocks/12/header become the one
+// shape /blocks/{}/header. The per-spec budget is then spent on path SHAPES rather than
+// on one entry per block number, which is what keeps a flood from reaching the cap at
+// all — the cap stays the backstop for genuinely pathological specs.
+//
+// Only paths are reshaped. A JSON-RPC method name is already a stable identifier and
+// several carry digits that are part of the name (web3_clientVersion,
+// eth_getBlockByNumber), so anything not starting with "/" is returned untouched.
+//
+// The result is idempotent: defaultMethodIDPlaceholder is not itself a concrete
+// identifier, so reshaping an already-reshaped path is a no-op. That matters because
+// the public recorders delegate to one another and normalize at each boundary.
+func defaultMethodShape(method string) string {
+	raw := strings.TrimPrefix(method, defaultMethodPrefix)
+	if !strings.HasPrefix(raw, "/") {
+		return method
+	}
+
+	segments := strings.Split(raw, "/")
+	reshaped := false
+	for i, segment := range segments {
+		if isConcreteIDSegment(segment) {
+			segments[i] = defaultMethodIDPlaceholder
+			reshaped = true
+		}
+	}
+	if !reshaped {
+		return method
+	}
+	return defaultMethodPrefix + strings.Join(segments, "/")
+}
+
+// isConcreteIDSegment reports whether one path segment is a value rather than part of
+// the route: a block number, a hex address, or an opaque hash. A segment that mixes
+// letters without carrying an identifier's length is left alone, which is what keeps
+// route elements such as "v1", "head", "latest" and "ledger_info" intact.
+func isConcreteIDSegment(segment string) bool {
+	if segment == "" || segment == defaultMethodIDPlaceholder {
+		return false
+	}
+	if isAllDigits(segment) {
+		return true
+	}
+	if len(segment) > 2 && (strings.HasPrefix(segment, "0x") || strings.HasPrefix(segment, "0X")) && isHex(segment[2:]) {
+		return true
+	}
+	return len(segment) >= minOpaqueIDLen && hasDigit(segment) && isIDCharset(segment)
+}
+
+func isAllDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func isHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9', r >= 'a' && r <= 'f', r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func hasDigit(s string) bool {
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			return true
+		}
+	}
+	return false
+}
+
+// isIDCharset reports whether every rune could belong to an address or hash: letters,
+// digits, and the few separators real identifiers use (bech32 "lava@1...", prefixed
+// ids). A segment containing anything else is not treated as opaque.
+func isIDCharset(s string) bool {
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9', r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z':
+		case r == '@' || r == '-' || r == '_' || r == '.' || r == ':':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 // normalizeDefaultMethodLabel bounds the method label for unmatched ("Default-*")
-// APIs: the first maxDefaultMethodsPerSpec distinct names per spec pass through,
-// everything after collapses to DefaultMethodOther.
+// APIs in two steps: concrete identifiers in a path are collapsed to a shape
+// (defaultMethodShape), then the first maxDefaultMethodsPerSpec distinct shapes per
+// spec pass through and everything after collapses to DefaultMethodOther.
 //
 // Admission is monotone (see batchSignatureRegistry), so the same raw name maps to
 // the same label value for the lifetime of the process — paired call sites such as
@@ -37,6 +148,8 @@ func (m *SmartRouterMetricsManager) normalizeDefaultMethodLabel(spec, method str
 	if !strings.HasPrefix(method, defaultMethodPrefix) || method == DefaultMethodOther {
 		return method
 	}
+	// Reshape before admitting so the budget counts shapes, not instances.
+	method = defaultMethodShape(method)
 	if !m.defaultMethods.admit(spec, method) {
 		m.recordDefaultMethodOverflow(spec)
 		return DefaultMethodOther

--- a/protocol/metrics/default_method_label.go
+++ b/protocol/metrics/default_method_label.go
@@ -31,11 +31,16 @@ const (
 	defaultMethodIDPlaceholder = "{}"
 
 	// minOpaqueIDLen is the length at or above which an alphanumeric segment carrying a
-	// digit is read as an identifier rather than a path element. It clears the longest
-	// real segments seen in the specs (getBlockTransactionCountByNumber, 32 chars, has
-	// no digit) and sits below the shortest identifiers (base58 tx hashes ~43, bech32
-	// addresses ~39, Tezos block hashes 51).
-	minOpaqueIDLen = 26
+	// digit is read as an identifier rather than a path element. Measured over every
+	// REST api segment in the specs: the longest real route segment carrying a digit is
+	// 39 chars (TRX's gettriggerinputforshieldedtrc20contract) and the shortest real
+	// identifier class starts at 43 (base58 of a 32-byte hash is 43-44 chars; bech32
+	// addresses 44-45, Tezos block hashes 51). 43 is the top of that gap: it still
+	// catches every identifier class while maximizing route-segment headroom, which is
+	// the direction to err in — an under-collapsed value costs a budget entry the cap
+	// absorbs, an over-collapsed route segment merges two real endpoints into one
+	// series and cannot be undone.
+	minOpaqueIDLen = 43
 )
 
 // defaultMethodShape collapses concrete identifiers in an unmatched REST path to

--- a/protocol/metrics/default_method_label.go
+++ b/protocol/metrics/default_method_label.go
@@ -1,0 +1,52 @@
+package metrics
+
+import "strings"
+
+const (
+	// defaultMethodPrefix mirrors chainlib's DefaultApiName — the prefix the chain
+	// parser stamps on the synthetic Api it builds for a request that matched no
+	// spec API. It is redeclared here rather than imported because chainlib already
+	// imports this package; importing back would be a cycle (same situation as
+	// batchMethodSeparator in batch_method_label.go).
+	defaultMethodPrefix = "Default-"
+
+	// DefaultMethodOther is the overflow bucket for unmatched-API method names past
+	// the per-spec cap. Unmatched REST paths carry concrete values (block numbers,
+	// addresses) where a matched API would carry a {placeholder}, so left alone the
+	// label mints a new series per URL — 46k distinct method values observed on one
+	// deployment from a single client polling /blocks/<n>/header/ with a trailing
+	// slash the spec template did not match.
+	DefaultMethodOther = defaultMethodPrefix + "other"
+
+	// maxDefaultMethodsPerSpec caps how many distinct Default-* names one spec may
+	// register. A genuinely-missing spec API produces ONE stable name — the useful
+	// spec-gap signal this cap preserves — while a concrete-ID flood blows through
+	// the budget immediately and every later name collapses to DefaultMethodOther.
+	maxDefaultMethodsPerSpec = 32
+)
+
+// normalizeDefaultMethodLabel bounds the method label for unmatched ("Default-*")
+// APIs: the first maxDefaultMethodsPerSpec distinct names per spec pass through,
+// everything after collapses to DefaultMethodOther.
+//
+// Admission is monotone (see batchSignatureRegistry), so the same raw name maps to
+// the same label value for the lifetime of the process — paired call sites such as
+// the in-flight gauge's Add/Sub stay consistent. DefaultMethodOther itself passes
+// through unconditionally, which is what makes the collapse idempotent.
+func (m *SmartRouterMetricsManager) normalizeDefaultMethodLabel(spec, method string) string {
+	if !strings.HasPrefix(method, defaultMethodPrefix) || method == DefaultMethodOther {
+		return method
+	}
+	if !m.defaultMethods.admit(spec, method) {
+		m.recordDefaultMethodOverflow(spec)
+		return DefaultMethodOther
+	}
+	return method
+}
+
+func (m *SmartRouterMetricsManager) recordDefaultMethodOverflow(spec string) {
+	if m == nil || m.defaultMethodOverflow == nil {
+		return
+	}
+	m.defaultMethodOverflow.WithLabelValues(spec).Inc()
+}

--- a/protocol/metrics/default_method_label_test.go
+++ b/protocol/metrics/default_method_label_test.go
@@ -156,6 +156,9 @@ func TestDefaultMethodShapeKeepsRouteElements(t *testing.T) {
 		"/estimate_gas_price",
 		"/transactions/encode_submission",
 		"/wallet/getnowblock",
+		// The longest digit-carrying route segment in any spec (39 chars, TRX). It
+		// pins minOpaqueIDLen from below: a threshold at or under 39 reads it as an id.
+		"/wallet/gettriggerinputforshieldedtrc20contract",
 		"/robots.txt",
 		"/",
 	} {

--- a/protocol/metrics/default_method_label_test.go
+++ b/protocol/metrics/default_method_label_test.go
@@ -28,6 +28,15 @@ func defaultName(raw string) string {
 	return defaultMethodPrefix + raw
 }
 
+// exhaustDefaultBudget fills a spec's budget with distinct ROUTES. Concrete ids fold
+// into one shape before admission, so distinct routes are the only way to reach the
+// cap — which is the whole point of the reshaping step.
+func exhaustDefaultBudget(m *SmartRouterMetricsManager, spec string) {
+	for i := range maxDefaultMethodsPerSpec * 2 {
+		m.normalizeMethodLabel(spec, defaultName(fmt.Sprintf("/route_%d/state", i)))
+	}
+}
+
 func TestNormalizeMethodLabelLeavesMatchedMethodsAlone(t *testing.T) {
 	m := newSmartRouterForDefaultLabelTest()
 
@@ -51,11 +60,11 @@ func TestNormalizeMethodLabelAdmitsStableDefaultNames(t *testing.T) {
 func TestNormalizeMethodLabelCapsDefaultNamesPerSpec(t *testing.T) {
 	m := newSmartRouterForDefaultLabelTest()
 
-	// The production shape: a concrete ID in the path mints a genuinely new name
-	// per request (46k observed on one deployment from /blocks/<n>/header/ polling).
+	// Distinct routes, not a concrete-ID flood: reshaping folds ids into one shape,
+	// so only genuinely different paths can still exhaust a spec's budget.
 	distinct := make(map[string]struct{})
 	for i := range maxDefaultMethodsPerSpec * 4 {
-		raw := defaultName(fmt.Sprintf("/chains/main/blocks/%d/header/", i))
+		raw := defaultName(fmt.Sprintf("/route_%d/state", i))
 		distinct[m.normalizeMethodLabel("TEZOS", raw)] = struct{}{}
 	}
 
@@ -70,9 +79,7 @@ func TestNormalizeMethodLabelCapsDefaultNamesPerSpec(t *testing.T) {
 func TestNormalizeMethodLabelDefaultBudgetIsPerSpec(t *testing.T) {
 	m := newSmartRouterForDefaultLabelTest()
 
-	for i := range maxDefaultMethodsPerSpec * 2 {
-		m.normalizeMethodLabel("TEZOS", defaultName(fmt.Sprintf("/blocks/%d/", i)))
-	}
+	exhaustDefaultBudget(m, "TEZOS")
 
 	// A different spec starts with a full budget despite TEZOS having exhausted its own.
 	raw := defaultName("eth_newFilter")
@@ -90,9 +97,7 @@ func TestNormalizeMethodLabelDefaultIsStablePerName(t *testing.T) {
 
 	// Exhaust the budget between the two calls — the already-admitted name must
 	// survive, because admission never evicts.
-	for i := range maxDefaultMethodsPerSpec * 2 {
-		m.normalizeMethodLabel("OSMOSIS", defaultName(fmt.Sprintf("/junk/%d", i)))
-	}
+	exhaustDefaultBudget(m, "OSMOSIS")
 
 	require.Equal(t, first, m.normalizeMethodLabel("OSMOSIS", raw))
 }
@@ -110,4 +115,103 @@ func TestNormalizeMethodLabelDefaultOtherIsIdempotent(t *testing.T) {
 	require.Equal(t,
 		m.normalizeMethodLabel("TEZOS", raw),
 		m.normalizeMethodLabel("TEZOS", m.normalizeMethodLabel("TEZOS", raw)))
+}
+
+// TestDefaultMethodShapeCollapsesConcreteIDs covers the reshaping step: an unmatched
+// path carries concrete values where a matched api would carry a {placeholder}, so the
+// shape is what the per-spec budget should be spent on.
+func TestDefaultMethodShapeCollapsesConcreteIDs(t *testing.T) {
+	t.Parallel()
+
+	for raw, expected := range map[string]string{
+		// The production shape — every block number folded into one series.
+		"/chains/main/blocks/9427283/header/": "/chains/main/blocks/{}/header/",
+		"/chains/main/blocks/1/header/":       "/chains/main/blocks/{}/header/",
+		// Hex addresses, whatever their length.
+		"/accounts/0x1/resources":                                     "/accounts/{}/resources",
+		"/accounts/0xd85fd8b6d0f1b1a1c6c6e0d6b6f6a6d6e6f6a6b6/events": "/accounts/{}/events",
+		// Opaque hashes: Tezos block hash (51), cosmos bech32 with the lava@ prefix (45).
+		"/chains/main/blocks/BKiHLREqU3JkXfzEDYAkmmfX48gBDtYqbugTxCcv9YrK1H1EAy/header":    "/chains/main/blocks/{}/header",
+		"/cosmos/staking/v1beta1/delegations/lava@17ym998u666u8w2qgjd5m7w7ydjqmu3mlgl7ua2": "/cosmos/staking/v1beta1/delegations/{}",
+		// Several values in one path all collapse.
+		"/blocks/123/operations/0/4": "/blocks/{}/operations/{}/{}",
+	} {
+		require.Equal(t, defaultMethodPrefix+expected, defaultMethodShape(defaultName(raw)), "raw: %s", raw)
+	}
+}
+
+// TestDefaultMethodShapeKeepsRouteElements is the safety half: reshaping must not eat
+// path elements that identify the ROUTE. Everything here appears in a live spec or in
+// live traffic, and collapsing any of it would merge distinct endpoints into one label.
+func TestDefaultMethodShapeKeepsRouteElements(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{
+		"/v1",                              // an api version is not an id, despite the digit
+		"/v1/-/healthy",                    // ...nor is a health path
+		"/v1beta1/blocks",                  // cosmos version segments
+		"/chains/main/blocks/head/header/", // a named block id
+		"/blocks/latest",
+		"/v1/ledger_info",
+		"/estimate_gas_price",
+		"/transactions/encode_submission",
+		"/wallet/getnowblock",
+		"/robots.txt",
+		"/",
+	} {
+		require.Equal(t, defaultName(raw), defaultMethodShape(defaultName(raw)), "raw: %s", raw)
+	}
+}
+
+// TestDefaultMethodShapeLeavesNonPathsAlone guards the JSON-RPC side: several real
+// method names carry digits that are part of the name, and reshaping them would
+// destroy the very signal the Default- name exists to give.
+func TestDefaultMethodShapeLeavesNonPathsAlone(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{
+		"eth_getBlockByNumber",
+		"web3_clientVersion",
+		"web3_sha3",
+		"starknet_getBlockWithReceipts",
+		"sui.rpc.v2.LedgerService/GetServiceInfo",
+		"getBlockTransactionCountByNumber",
+	} {
+		require.Equal(t, defaultName(raw), defaultMethodShape(defaultName(raw)), "raw: %s", raw)
+	}
+}
+
+func TestDefaultMethodShapeIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{
+		"/chains/main/blocks/9427283/header/",
+		"/accounts/0x1/resources",
+		"/v1/ledger_info",
+		"eth_getBlockByNumber",
+	} {
+		once := defaultMethodShape(defaultName(raw))
+		require.Equal(t, once, defaultMethodShape(once), "raw: %s", raw)
+	}
+}
+
+// TestNormalizeMethodLabelShapesBeforeAdmitting is the point of the whole layer: the
+// flood that used to exhaust the budget in 32 requests now costs ONE entry, so the cap
+// never binds and the breakdown stays lossless.
+func TestNormalizeMethodLabelShapesBeforeAdmitting(t *testing.T) {
+	t.Parallel()
+	m := newSmartRouterForDefaultLabelTest()
+
+	distinct := make(map[string]struct{})
+	for i := range maxDefaultMethodsPerSpec * 100 {
+		raw := defaultName(fmt.Sprintf("/chains/main/blocks/%d/header/", i))
+		distinct[m.normalizeMethodLabel("TEZOS", raw)] = struct{}{}
+	}
+
+	require.Len(t, distinct, 1, "every concrete block number must fold into one shape")
+	require.Contains(t, distinct, defaultName("/chains/main/blocks/{}/header/"))
+	require.NotContains(t, distinct, DefaultMethodOther, "the cap must not bind for a single shape")
+	require.Zero(t,
+		testutil.ToFloat64(m.defaultMethodOverflow.WithLabelValues("TEZOS")),
+		"no overflow should be reported when the flood collapses to one shape")
 }

--- a/protocol/metrics/default_method_label_test.go
+++ b/protocol/metrics/default_method_label_test.go
@@ -1,0 +1,113 @@
+package metrics
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// newSmartRouterForDefaultLabelTest extends the batch-label test manager with the
+// unmatched-API collaborators, so Default-* normalization admits real names instead
+// of degrading to DefaultMethodOther on a nil registry.
+func newSmartRouterForDefaultLabelTest() *SmartRouterMetricsManager {
+	m := newSmartRouterForBatchLabelTest()
+	m.defaultMethodOverflow = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "t_sr_default_overflow"},
+		[]string{"spec"},
+	)
+	m.defaultMethods = newDefaultMethodRegistry()
+	return m
+}
+
+// defaultName builds a raw unmatched-API method the way chainlib's spec-miss
+// fallthrough does: the Default- prefix glued onto the raw request name.
+func defaultName(raw string) string {
+	return defaultMethodPrefix + raw
+}
+
+func TestNormalizeMethodLabelLeavesMatchedMethodsAlone(t *testing.T) {
+	m := newSmartRouterForDefaultLabelTest()
+
+	// Matched apis — jsonrpc names and templated REST paths — carry no Default-
+	// prefix and must pass through byte-identical.
+	for _, method := range []string{"eth_call", "/blocks/{blockId}/header", "getAccountInfo"} {
+		require.Equal(t, method, m.normalizeMethodLabel("ETH1", method))
+	}
+}
+
+func TestNormalizeMethodLabelAdmitsStableDefaultNames(t *testing.T) {
+	m := newSmartRouterForDefaultLabelTest()
+
+	// A genuinely-missing spec API produces one stable name. That is the spec-gap
+	// signal the cap exists to preserve, so it must survive normalization.
+	raw := defaultName("eth_newFilter")
+	require.Equal(t, raw, m.normalizeMethodLabel("ETH1", raw))
+	require.Equal(t, raw, m.normalizeMethodLabel("ETH1", raw), "repeat calls must stay stable")
+}
+
+func TestNormalizeMethodLabelCapsDefaultNamesPerSpec(t *testing.T) {
+	m := newSmartRouterForDefaultLabelTest()
+
+	// The production shape: a concrete ID in the path mints a genuinely new name
+	// per request (46k observed on one deployment from /blocks/<n>/header/ polling).
+	distinct := make(map[string]struct{})
+	for i := range maxDefaultMethodsPerSpec * 4 {
+		raw := defaultName(fmt.Sprintf("/chains/main/blocks/%d/header/", i))
+		distinct[m.normalizeMethodLabel("TEZOS", raw)] = struct{}{}
+	}
+
+	require.LessOrEqual(t, len(distinct), maxDefaultMethodsPerSpec+1,
+		"admitted names plus the overflow bucket must not exceed the cap")
+	require.Contains(t, distinct, DefaultMethodOther, "past the cap everything must land in the overflow bucket")
+	require.Positive(t,
+		testutil.ToFloat64(m.defaultMethodOverflow.WithLabelValues("TEZOS")),
+		"hitting the cap must be reported so the spec gap is detectable")
+}
+
+func TestNormalizeMethodLabelDefaultBudgetIsPerSpec(t *testing.T) {
+	m := newSmartRouterForDefaultLabelTest()
+
+	for i := range maxDefaultMethodsPerSpec * 2 {
+		m.normalizeMethodLabel("TEZOS", defaultName(fmt.Sprintf("/blocks/%d/", i)))
+	}
+
+	// A different spec starts with a full budget despite TEZOS having exhausted its own.
+	raw := defaultName("eth_newFilter")
+	require.Equal(t, raw, m.normalizeMethodLabel("ETH1", raw))
+}
+
+// TestNormalizeMethodLabelDefaultIsStablePerName covers the in-flight gauge pairing
+// hazard: relay start and relay end normalize independently, so an unstable mapping
+// would Add one series and Sub another, leaving a gauge stuck above zero forever.
+func TestNormalizeMethodLabelDefaultIsStablePerName(t *testing.T) {
+	m := newSmartRouterForDefaultLabelTest()
+	raw := defaultName("cosmos_missing_query")
+
+	first := m.normalizeMethodLabel("OSMOSIS", raw)
+
+	// Exhaust the budget between the two calls — the already-admitted name must
+	// survive, because admission never evicts.
+	for i := range maxDefaultMethodsPerSpec * 2 {
+		m.normalizeMethodLabel("OSMOSIS", defaultName(fmt.Sprintf("/junk/%d", i)))
+	}
+
+	require.Equal(t, first, m.normalizeMethodLabel("OSMOSIS", raw))
+}
+
+func TestNormalizeMethodLabelDefaultOtherIsIdempotent(t *testing.T) {
+	m := newSmartRouterForDefaultLabelTest()
+
+	// The collapsed value must pass through without consuming budget or counting
+	// overflow — the public recorders delegate to one another and each normalizes
+	// at its own boundary, so a collapsed value gets normalized again.
+	require.Equal(t, DefaultMethodOther, m.normalizeMethodLabel("TEZOS", DefaultMethodOther))
+	require.Zero(t, testutil.ToFloat64(m.defaultMethodOverflow.WithLabelValues("TEZOS")))
+
+	raw := defaultName("/blocks/head")
+	require.Equal(t,
+		m.normalizeMethodLabel("TEZOS", raw),
+		m.normalizeMethodLabel("TEZOS", m.normalizeMethodLabel("TEZOS", raw)))
+}

--- a/protocol/metrics/smartrouter_metrics_manager.go
+++ b/protocol/metrics/smartrouter_metrics_manager.go
@@ -1398,6 +1398,7 @@ func (m *SmartRouterMetricsManager) SetCrossValidationStragglerMetric(chainId, a
 	if m == nil || outcome == "" {
 		return
 	}
+	method = m.normalizeMethodLabel(chainId, method)
 	m.crossValidationStragglerTotalMetric.WithLabelValues(chainId, apiInterface, method, outcome).Inc()
 }
 

--- a/protocol/metrics/smartrouter_metrics_manager.go
+++ b/protocol/metrics/smartrouter_metrics_manager.go
@@ -136,6 +136,12 @@ type SmartRouterMetricsManager struct {
 	// batchSignatures bounds how many distinct batch signatures may become label values.
 	batchSignatures *batchSignatureRegistry
 
+	// Unmatched-API ("Default-*") method names are bounded the same way (see
+	// default_method_label.go) — defaultMethodOverflow reports when the cap binds.
+	defaultMethodOverflow *prometheus.CounterVec
+	// defaultMethods bounds how many distinct Default-* names may become label values.
+	defaultMethods *batchSignatureRegistry
+
 	// Internal state
 	lock                    sync.RWMutex
 	endpointsHealthChecksOk uint64
@@ -532,6 +538,10 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 		Name: "smartrouter_batch_signature_overflow_total",
 		Help: `Label normalizations that fell into method="batch:other". reason="cap": the spec exhausted its distinct-signature budget. reason="wide": one batch spanned more distinct methods than a signature may name. Non-zero means per-batch-type breakdowns are lossy — raise the cap or accept the aggregation.`,
 	}, []string{"spec", "reason"})
+	defaultMethodOverflow := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "smartrouter_default_method_overflow_total",
+		Help: `Label normalizations that fell into method="Default-other": the spec exhausted its distinct unmatched-API name budget. Sustained growth means clients are hitting URLs the spec does not match — concrete IDs in the path mint a new name per request — which usually indicates a spec gap (e.g. a path variant the templates miss).`,
+	}, []string{"spec"})
 
 	cacheLabels := []string{"spec", "apiInterface", "method"}
 	cacheRequestsTotalMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -595,6 +605,7 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	routerRequestsBatch = registerOrReuse(routerRequestsBatch)
 	batchSize = registerOrReuse(batchSize)
 	batchSignatureOverflow = registerOrReuse(batchSignatureOverflow)
+	defaultMethodOverflow = registerOrReuse(defaultMethodOverflow)
 	cacheRequestsTotalMetric = registerOrReuse(cacheRequestsTotalMetric)
 	cacheSuccessTotalMetric = registerOrReuse(cacheSuccessTotalMetric)
 	cacheFailedTotalMetric = registerOrReuse(cacheFailedTotalMetric)
@@ -680,6 +691,10 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 		batchSize:              batchSize,
 		batchSignatureOverflow: batchSignatureOverflow,
 		batchSignatures:        newBatchSignatureRegistry(),
+
+		// Unmatched-API method bounding
+		defaultMethodOverflow: defaultMethodOverflow,
+		defaultMethods:        newDefaultMethodRegistry(),
 
 		// Cache group
 		cacheRequestsTotalMetric: cacheRequestsTotalMetric,


### PR DESCRIPTION
#Closes MAG-2950

Jira ticket: MAG-2950

## Why

The `method` label on every `smartrouter_*` metric family is unbounded for requests that miss the spec: the parser mints a synthetic api named `Default-<raw request name>` (protocol/chainlib/base_chain_parser.go:375) and that raw name becomes the label value. For REST chains the raw name is the URL with **concrete values** where a matched template would carry `{placeholders}` — so every distinct block number or address mints a brand-new series.

Live evidence from production (2026-08-12): the `method` label held **46,067 distinct values, 45,942 of them** of the form `Default-/chains/main/blocks/<n>/header/` — one client polling Tezos block headers with a trailing slash the spec template doesn't match. That put ~79k series on each `smartrouter_requests_*` family and was the root cause behind the war-room dashboard timing out (dashboard side fixed separately in smart-router-standalone — PR #168 "check in the Customer Experience War Room dashboard").

Batches had the identical disease and were already cured by the signature admission registry (`batch_method_label.go`). This PR extends the same treatment to unmatched single-method names, at the same normalization funnel.

## What changed

- `protocol/metrics/default_method_label.go` (new) — `normalizeDefaultMethodLabel`: the first 32 distinct `Default-*` names per spec pass through; everything past the cap collapses to `Default-other`. The pass-through budget is deliberate: a genuinely-missing spec API produces **one stable name**, which is a valuable spec-gap signal — only concrete-ID floods blow the budget.
- `smartrouter_default_method_overflow_total{spec}` (new counter) — reports when the cap binds, so a lossy breakdown is detectable and alertable.
- `protocol/metrics/batch_method_label.go` — `normalizeMethodLabel` routes single-method names through the new bounding; `batchSignatureRegistry` cap becomes a field (`newBatchSignatureRegistry()` keeps 64, `newDefaultMethodRegistry()` uses 32) instead of a hardcoded constant.
- `protocol/metrics/smartrouter_metrics_manager.go` — registry + counter wiring.
- `protocol/metrics/default_method_label.go` — **shape normalization, applied before admission.** A path segment that is a *value* rather than part of the route folds to `{}`, so `/blocks/1/header` and `/blocks/12/header` become the one shape `/blocks/{}/header` and cost a single budget entry. A segment is read as a value when it is all digits, `0x`-hex, or ≥26 chars carrying a digit over an identifier charset (base58 hashes ~43, bech32 ~39, Tezos block hashes 51). The flood that motivated the cap now never reaches it; the cap stays the backstop for a spec that genuinely produces >32 distinct routes.
  - **Only paths are reshaped.** JSON-RPC names are already stable identifiers and several carry digits that belong to the name (`web3_clientVersion`, `eth_getBlockByNumber`), so anything not starting with `/` is returned untouched.
  - **Route elements survive by construction** — `v1`, `v1beta1`, `head`, `latest`, `ledger_info` are neither all-digit nor long enough to read as opaque. There is a test enumerating them.
  - The placeholder is bare `{}`, not a named one: an unmatched path has no spec template to take a parameter name from, and inventing one would make the label look like a template it is not. `{}` is not itself a concrete id, so reshaping is idempotent — which the delegating recorders rely on.
- `protocol/metrics/default_method_label_test.go` (new) — matched methods untouched, stable names admitted and stable across budget exhaustion (the in-flight gauge Add/Sub pairing hazard), per-spec budgets, cap collapse + overflow reporting, idempotence of `Default-other`.

Admission is monotone (never evicts), same as batches — a raw name maps to the same label value for the process lifetime.

The two layers compose: reshaping keeps the budget spent on **shapes** rather than instances, and the cap still bounds a spec that produces too many distinct shapes. The cap tests previously reached the cap via a block-number flood, which reshaping now prevents by design; they use distinct routes instead.

## How to verify

```bash
go test ./protocol/metrics/ -count=1
```

After deploy, on any affected box the method-label cardinality stops growing:

```bash
curl -s http://<prometheus>/api/v1/label/method/values | jq '.data | length'   # stabilizes at ~(real methods + 32×specs + 1)
```

`sum by (spec) (rate(smartrouter_default_method_overflow_total[5m]))` shows which specs have clients hitting unmatched URLs.

Note on the TEZOS case above: the follow-up investigation found it is a **matcher** bug rather than a spec gap — the spec already carries `/chains/main/blocks/{block_id}/header`, and only the client's trailing slash misses the anchored pattern. That is fixed in #312, which removes the flood at its source. This PR stays the backstop for names that genuinely miss the spec.



