### PR TITLE
fix(smart-router): route two providers configured with one name (MAG-2724)

### DIFF
--- a/protocol/lavasession/provider_names_mag2724_test.go
+++ b/protocol/lavasession/provider_names_mag2724_test.go
@@ -1,0 +1,127 @@
+package lavasession
+
+import (
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// MAG-2724: two providers configured under one name collapsed into a single entry — one upstream
+// served every request while the other sat idle, and setting that name aside after a failure left
+// the router with nothing to retry against.
+//
+// A provider's name is its routing identity, so the fix is to refuse the configuration rather than
+// to invent a second identity for it: the router will not start, and the error tells the operator
+// which names to change. These tests cover the check that makes that decision.
+
+func mag2724Endpoint(name, chainID, apiInterface, url string) *RPCStaticProviderEndpoint {
+	return &RPCStaticProviderEndpoint{
+		Name:         name,
+		ChainID:      chainID,
+		ApiInterface: apiInterface,
+		NodeUrls:     []common.NodeUrl{{Url: url}},
+	}
+}
+
+func TestValidateUniqueProviderNames_RejectsCollisionWithinChainAndInterface(t *testing.T) {
+	err := ValidateUniqueProviderNames([]*RPCStaticProviderEndpoint{
+		mag2724Endpoint("SimTwin", "ETH1", "jsonrpc", "http://one:8545"),
+		mag2724Endpoint("SimTwin", "ETH1", "jsonrpc", "http://two:8545"),
+	})
+
+	require.Error(t, err)
+	// The operator has to be able to find the offending pair from the boot log alone — the router
+	// is down at this point, so the message is the only thing they have to work from.
+	require.Contains(t, err.Error(), "SimTwin")
+	require.Contains(t, err.Error(), "ETH1")
+	require.Contains(t, err.Error(), "jsonrpc")
+	require.Contains(t, err.Error(), "http://one:8545")
+	require.Contains(t, err.Error(), "http://two:8545")
+}
+
+func TestValidateUniqueProviderNames_ReportsEveryCollisionDeterministically(t *testing.T) {
+	// Refusing to boot is worth little if it names one collision at a time and the operator has to
+	// redeploy to find the next. It also must not vary run to run — the grouping is a Go map, and
+	// map order is exactly the nondeterminism that made the original bug hard to pin down.
+	endpoints := []*RPCStaticProviderEndpoint{
+		mag2724Endpoint("alpha", "ETH1", "jsonrpc", "http://a1:8545"),
+		mag2724Endpoint("alpha", "ETH1", "jsonrpc", "http://a2:8545"),
+		mag2724Endpoint("beta", "ETH1", "jsonrpc", "http://b1:8545"),
+		mag2724Endpoint("beta", "ETH1", "jsonrpc", "http://b2:8545"),
+		mag2724Endpoint("gamma", "POLYGON1", "rest", "http://g1:8545"),
+		mag2724Endpoint("gamma", "POLYGON1", "rest", "http://g2:8545"),
+	}
+
+	err := ValidateUniqueProviderNames(endpoints)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "alpha")
+	require.Contains(t, err.Error(), "beta")
+	require.Contains(t, err.Error(), "gamma")
+
+	for i := 0; i < 20; i++ {
+		require.Equal(t, err.Error(), ValidateUniqueProviderNames(endpoints).Error(),
+			"same config must produce the same message on every run")
+	}
+}
+
+func TestValidateUniqueProviderNames_AllowsRepeatedNameOutsideOneScope(t *testing.T) {
+	// One label per upstream operator, reused across chains and interfaces, is the normal way these
+	// configs are written. Each combination builds its own session manager with its own pairing map,
+	// so nothing collapses — rejecting these would refuse to start working deployments.
+	tests := []struct {
+		name      string
+		endpoints []*RPCStaticProviderEndpoint
+	}{
+		{
+			name: "same name on different chains",
+			endpoints: []*RPCStaticProviderEndpoint{
+				mag2724Endpoint("alchemy", "ETH1", "jsonrpc", "http://eth:8545"),
+				mag2724Endpoint("alchemy", "POLYGON1", "jsonrpc", "http://polygon:8545"),
+			},
+		},
+		{
+			name: "same name on different api-interfaces of one chain",
+			endpoints: []*RPCStaticProviderEndpoint{
+				mag2724Endpoint("alchemy", "ETH1", "jsonrpc", "http://eth:8545"),
+				mag2724Endpoint("alchemy", "ETH1", "rest", "http://eth:8546"),
+			},
+		},
+		{
+			name: "distinct names in one scope",
+			endpoints: []*RPCStaticProviderEndpoint{
+				mag2724Endpoint("primary", "ETH1", "jsonrpc", "http://one:8545"),
+				mag2724Endpoint("secondary", "ETH1", "jsonrpc", "http://two:8545"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, ValidateUniqueProviderNames(tt.endpoints))
+		})
+	}
+}
+
+func TestValidateUniqueProviderNames_RejectsCollisionAcrossStaticAndBackup(t *testing.T) {
+	// Static and backup providers live in separate maps but are looked up across both by address,
+	// so a name shared between the two lists is as ambiguous as one shared within either. This is
+	// why the boot path passes both lists in one call instead of checking each on its own.
+	static := []*RPCStaticProviderEndpoint{mag2724Endpoint("shared", "ETH1", "jsonrpc", "http://primary:8545")}
+	backup := []*RPCStaticProviderEndpoint{mag2724Endpoint("shared", "ETH1", "jsonrpc", "http://backup:8545")}
+
+	require.NoError(t, ValidateUniqueProviderNames(static), "each list is unique on its own")
+	require.NoError(t, ValidateUniqueProviderNames(backup))
+
+	err := ValidateUniqueProviderNames(static, backup)
+	require.Error(t, err, "the collision only exists when the two lists are checked together")
+	require.Contains(t, err.Error(), "shared")
+}
+
+func TestValidateUniqueProviderNames_ToleratesEmptyAndNilInput(t *testing.T) {
+	// Boot calls this with whichever lists the config happened to define; backup-direct-rpc is
+	// frequently absent, and an unset key unmarshals to nil.
+	require.NoError(t, ValidateUniqueProviderNames())
+	require.NoError(t, ValidateUniqueProviderNames(nil, nil))
+	require.NoError(t, ValidateUniqueProviderNames([]*RPCStaticProviderEndpoint{nil}))
+}

--- a/protocol/lavasession/provider_types.go
+++ b/protocol/lavasession/provider_types.go
@@ -2,6 +2,7 @@ package lavasession
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/magma-Devs/smart-router/protocol/common"
@@ -67,6 +68,76 @@ func (ext *RPCStaticProviderEndpoint) Validate() error {
 		return fmt.Errorf("provider api-interface cannot be empty")
 	}
 	return nil
+}
+
+// providerNameScope is the set within which a provider name has to be unique. A session manager is
+// built per chain+api-interface and owns its own pairing map, keyed by the provider's name, so that
+// is exactly the scope where two entries sharing a name collapse into one slot. The same name under
+// a different chain lands in a different session manager and is harmless — rejecting it would break
+// the common convention of labelling every upstream with its operator ("alchemy" on both ETH1 and
+// POLYGON1).
+type providerNameScope struct {
+	chainID      string
+	apiInterface string
+}
+
+// ValidateUniqueProviderNames rejects a configuration in which two providers on the same
+// chain+api-interface share a name. Pass every list that feeds one router — static and backup
+// together — because they are looked up against each other by address and a name shared across the
+// two is as ambiguous as one shared within either.
+//
+// A provider's name IS its routing identity: it is what the session manager keys csm.pairing by and
+// what the retry skip-list holds. Two providers sharing one collapse into a single entry, so one
+// upstream serves every request while the other sits idle, and setting that name aside after a
+// failure removes both and leaves nothing to retry against (MAG-2724).
+//
+// The router therefore refuses to start rather than serving at half capacity on a config it cannot
+// route unambiguously. The message names every collision so one edit fixes the config.
+func ValidateUniqueProviderNames(lists ...[]*RPCStaticProviderEndpoint) error {
+	grouped := map[providerNameScope]map[string][]*RPCStaticProviderEndpoint{}
+	for _, list := range lists {
+		for _, ext := range list {
+			if ext == nil {
+				continue
+			}
+			scope := providerNameScope{chainID: ext.ChainID, apiInterface: ext.ApiInterface}
+			if grouped[scope] == nil {
+				grouped[scope] = map[string][]*RPCStaticProviderEndpoint{}
+			}
+			grouped[scope][ext.Name] = append(grouped[scope][ext.Name], ext)
+		}
+	}
+
+	// Every collision is reported, sorted — an operator who duplicated three names should have to
+	// fix the config once, not boot three times to discover them one at a time. Sorted because the
+	// grouping is a map: reporting in range order would make the same bad config produce a
+	// different message on each run.
+	var collisions []string
+	for scope, byName := range grouped {
+		for name, entries := range byName {
+			if len(entries) < 2 {
+				continue
+			}
+			urls := make([]string, 0, len(entries))
+			for _, entry := range entries {
+				if len(entry.NodeUrls) > 0 {
+					urls = append(urls, entry.NodeUrls[0].Url)
+				}
+			}
+			collisions = append(collisions, fmt.Sprintf(
+				"%q on chain %s api-interface %s is shared by %d providers (urls: %s)",
+				name, scope.chainID, scope.apiInterface, len(entries), strings.Join(urls, ", "),
+			))
+		}
+	}
+	if len(collisions) == 0 {
+		return nil
+	}
+	sort.Strings(collisions)
+	return fmt.Errorf(
+		"duplicate provider names: %s — a provider name is the router's identity for a node, so two nodes sharing one on the same chain and api-interface cannot be told apart; give each a distinct name",
+		strings.Join(collisions, "; "),
+	)
 }
 
 func (endpoint *RPCProviderEndpoint) UrlsString() string {

--- a/protocol/rpcsmartrouter/health_cmd.go
+++ b/protocol/rpcsmartrouter/health_cmd.go
@@ -210,7 +210,7 @@ func collectHealthProviders(args []string, includeBackup bool) ([]healthProvider
 	if includeBackup {
 		keys = append(keys, commonlib.BackupDirectRPCConfigName)
 	}
-	var providers []healthProvider
+	lists := make([][]*lavasession.RPCStaticProviderEndpoint, 0, len(keys))
 	for _, key := range keys {
 		if !viper.IsSet(key) {
 			continue
@@ -219,6 +219,20 @@ func collectHealthProviders(args []string, includeBackup bool) ([]healthProvider
 		if err != nil {
 			return nil, err
 		}
+		lists = append(lists, static)
+	}
+
+	// A duplicate provider name stops the router from starting (MAG-2724), and this command is
+	// exactly what an operator reaches for to work out why a config will not boot — so it reports
+	// the collision and probes anyway, rather than refusing the config like the router does. The
+	// same check the router runs, run here for its message and not for its verdict; the rows are
+	// still told apart by their `url`, which is what identifies the broken node.
+	if err := lavasession.ValidateUniqueProviderNames(lists...); err != nil {
+		utils.LavaFormatWarning("the router will REFUSE TO START on this config — probing it anyway", err)
+	}
+
+	var providers []healthProvider
+	for _, static := range lists {
 		for _, ep := range static {
 			providers = append(providers, healthProvider{
 				name:         ep.Name,

--- a/protocol/rpcsmartrouter/provider_names_mag2724_test.go
+++ b/protocol/rpcsmartrouter/provider_names_mag2724_test.go
@@ -1,0 +1,91 @@
+package rpcsmartrouter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+// MAG-2724, router side. The duplicate-name check belongs to the boot path, not to the parser:
+// `smart-router health` is what an operator reaches for to work out why a config will not boot, so
+// it has to be able to load the config the router rejects.
+
+const mag2724DuplicateConfig = `direct-rpc:
+  - name: SimTwin
+    chain-id: ETH1
+    api-interface: jsonrpc
+    node-urls:
+      - url: https://one.example.com
+  - name: SimTwin
+    chain-id: ETH1
+    api-interface: jsonrpc
+    node-urls:
+      - url: https://two.example.com
+  - name: solo
+    chain-id: ETH1
+    api-interface: jsonrpc
+    node-urls:
+      - url: https://three.example.com
+backup-direct-rpc:
+  - name: SimTwin
+    chain-id: ETH1
+    api-interface: jsonrpc
+    node-urls:
+      - url: https://backup.example.com
+`
+
+// TestParseStaticProviderEndpoints_AcceptsDuplicateNames states the split of responsibility:
+// parsing is parsing. A name collision is a property of the whole set of lists a router loads —
+// static and backup are looked up against each other by address, so only a check over both together
+// is complete — and the boot path runs exactly that check. Rejecting inside the parser instead made
+// every non-boot consumer of a config, health included, inherit the boot path's strictness.
+func TestParseStaticProviderEndpoints_AcceptsDuplicateNames(t *testing.T) {
+	v := viper.New()
+	v.SetConfigType("yaml")
+	require.NoError(t, v.ReadConfig(strings.NewReader(mag2724DuplicateConfig)))
+
+	endpoints, err := ParseStaticProviderEndpoints(v, common.DirectRPCConfigName)
+	require.NoError(t, err, "the parser reports what the file says; the boot path decides whether to accept it")
+	require.Len(t, endpoints, 3)
+
+	// And the boot path is where it is rejected.
+	require.Error(t, lavasession.ValidateUniqueProviderNames(endpoints))
+}
+
+// TestCollectHealthProviders_LoadsConfigWithDuplicateNames pins that `smart-router health` still
+// works on a config the router refuses to start on. That config is precisely the one an operator
+// runs this command against — a diagnostic that declines to load the broken input is no diagnostic.
+// Every configured node is probed, including both halves of the collision, so the report says which
+// of the two is actually failing.
+func TestCollectHealthProviders_LoadsConfigWithDuplicateNames(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "dup.yml"), []byte(mag2724DuplicateConfig), 0o600))
+	t.Chdir(dir)
+	// collectHealthProviders drives the global viper; leave it as we found it.
+	t.Cleanup(viper.Reset)
+
+	providers, err := collectHealthProviders([]string{"dup"}, true)
+	require.NoError(t, err, "health must be able to load the config it is reached for, not refuse it")
+	require.Len(t, providers, 4, "both halves of the collision are probed, plus the unique provider and the backup")
+
+	// The colliding rows carry the same name — the router's identity for them really is ambiguous,
+	// and inventing a distinct label here would misrepresent what it would do with this config.
+	// They are told apart by url, which is what identifies the node.
+	urls := make([]string, 0, len(providers))
+	for _, p := range providers {
+		require.NotEmpty(t, p.nodeUrls)
+		urls = append(urls, p.nodeUrls[0].Url)
+	}
+	require.ElementsMatch(t, []string{
+		"https://one.example.com",
+		"https://two.example.com",
+		"https://three.example.com",
+		"https://backup.example.com",
+	}, urls)
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -2798,6 +2798,21 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 				}
 			}
 
+			// Refuse to start on a config that cannot be routed unambiguously (MAG-2724). A
+			// provider's name is its routing identity — the key of csm.pairing and of the retry
+			// skip-list — so two providers sharing one on a chain+api-interface collapse into a
+			// single entry: one upstream serves everything, the other sits idle, and setting that
+			// name aside after a failure leaves nothing to retry against.
+			//
+			// Both lists are checked together, which is the only complete check: static and backup
+			// land in separate maps but are looked up across both by address, so a name shared
+			// between the two is as ambiguous as one shared within either. Failing here means it
+			// fails before any listener binds, and the error names every collision so one edit to
+			// the config fixes it.
+			if err := lavasession.ValidateUniqueProviderNames(directRPCEndpoints, backupDirectRPCEndpoints); err != nil {
+				return utils.LavaFormatError("invalid direct-rpc endpoints definition", err)
+			}
+
 			if len(directRPCEndpoints) == 0 {
 				return utils.LavaFormatError(
 					"smart router requires direct-rpc endpoints configuration",

--- a/protocol/rpcsmartrouter/static_provider_endpoints.go
+++ b/protocol/rpcsmartrouter/static_provider_endpoints.go
@@ -20,5 +20,12 @@ func ParseStaticProviderEndpoints(viperEndpoints *viper.Viper, endpointsConfigNa
 				utils.Attribute{Key: "apiInterface", Value: endpoint.ApiInterface})
 		}
 	}
+	// Deliberately NOT checked here: duplicate provider names (MAG-2724). A name collision is a
+	// property of the whole set of lists a router loads, not of one list — static and backup are
+	// looked up against each other by address, so only a check over both together is complete, and
+	// the boot path runs exactly that (see ValidateUniqueProviderNames in CreateSmartRouterCobraCommand).
+	// Keeping this function purely a parser also keeps `smart-router health` usable: it is the tool
+	// an operator reaches for to diagnose a config that will not boot, so it must be able to load
+	// one.
 	return endpoints, err
 }


### PR DESCRIPTION
Jira ticket: MAG-2724

Fixes [MAG-2724](https://magmadevs.atlassian.net/browse/MAG-2724).

A provider's configured name is its routing identity — the key of `csm.pairing` and of the retry skip-list. Two providers sharing one collapse into a single entry: one upstream serves every request while the other sits idle, and once that name is set aside after a failure both go with it, so the customer gets an error while a healthy provider stands by.

`dffc0f2` established that duplicate names must be tracked separately, but only for the startup failed-provider set. Everything downstream was still keyed by name.

## Approach

**The router refuses to start on that configuration.** `ValidateUniqueProviderNames` runs on the boot path, over static and backup together, before any listener binds:

```
Error: invalid direct-rpc endpoints definition ErrMsg: duplicate provider names:
"SimTwin" on chain ETH1 api-interface jsonrpc is shared by 2 providers
(urls: https://one..., https://two...) — a provider name is the router's identity
for a node, so two nodes sharing one on the same chain and api-interface cannot be
told apart; give each a distinct name
```

Every collision is named at once and sorted, so one edit fixes the config and the same config always produces the same message (the grouping is a Go map — unsorted output would vary per run).

Scoped to chain + api-interface on purpose: a session manager is built per chain+interface and owns its own pairing map, so that is exactly where names collapse. Reusing one operator label across chains (`alchemy` on ETH1 and POLYGON1) is a normal way these configs are written and stays legal. Both lists go in one call because static and backup land in separate maps but are looked up across both by address — a per-list check would miss a name shared between the two.

## What this deliberately does not do

An earlier revision of this PR also gave colliding providers derived identities (`SimTwin#0`, `SimTwin#1`) so both stayed routable. That is removed. It kept a broken config running under names the operator never chose — including in the metrics `endpoint_id`, breaking any dashboard keyed on it — and it split "name" from "identity" across the whole codebase, so every map keyed by a provider had to key on the derived value instead. That invariant was violated four times in this PR alone (twice caught in review, twice more caught by a rebase). Refusing the config makes that entire class of bug unrepresentable: if names are unique, keying by name is simply correct.

## Where the check lives

On the boot path, not in `ParseStaticProviderEndpoints`. `smart-router health` is what an operator reaches for to work out why a config will not boot, so it has to be able to load the config the router rejects. It logs the collision as a warning and probes every node anyway:

```
$ smartrouter health dupcfg --use-static-spec specs/
rows: [('SimTwin', 'https://one...'), ('SimTwin', 'https://two...')]
stderr: warn  the router will REFUSE TO START on this config — probing it anyway
```

Both rows keep the configured name — the router's identity for them really is ambiguous, and inventing a label here would misrepresent what it does with this config. They are told apart by `url`, which is what identifies the node.

The chart-side check in smart-router-helm-chart catches the same mistake one step earlier, at template render, where it fails the release rather than the pods — and catches what this check cannot see: `SimTwin` vs `simtwin`, or `My Node` vs `my-node`, which look distinct in `values.yaml` and arrive at the router as one name after the configmap's `lower | replace " " "-"`.

## On boot behaviour

This makes a duplicate name fatal at boot, which cuts against the MAG-2525 direction of booting on any usable provider. Calling it out rather than leaving it implicit: the config is unroutable as written, the operator has to change it either way, and failing loudly at startup is a better outcome than silently serving at half capacity. **No live config trips it** — rendered `values_local.yml`, `values.yml`, `values_internal.yml` and `values_sim.yml` from smart-router-standalone plus the chart's own values, and scanned the repo's `direct-rpc` configs, so nothing deployed or in the dev gate crashloops.

## Testing

`go build ./protocol/...`, `go vet`, and the full `lavasession` + `rpcsmartrouter` suites pass.

Verified against the built binary rather than only in unit tests: boot exits with the message above, and `health` loads the same config, warns, and probes both nodes.

Heads-up: the lavasession suite has a **pre-existing flake** (`Failed locking selection after MaximumNumberOfSelectionLockAttempts`) — it failed 1 of 5 runs with these changes stashed, so it is not from this work, but it may show up in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MAG-2724]: https://magmadevs.atlassian.net/browse/MAG-2724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
