### PR TITLE
ci: exempt dependabot from the Jira gate and group otel bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,25 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      # The OpenTelemetry modules release in lockstep and share types across
+      # module boundaries: otel/log and otel/sdk/log are built against a
+      # specific otel core, so bumping any one of them alone does not compile
+      # (`undefined: log.KeyValue`). Ungrouped, dependabot opens one PR per
+      # module and every one of them is red on arrival. Grouped, the whole
+      # family moves in a single PR that builds.
+      opentelemetry:
+        patterns:
+          - "go.opentelemetry.io/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      # Action bumps are independent, but batching them keeps the queue short
+      # so the gomod PRs are not competing for the open-PR limit.
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/require-jira-ticket.yml
+++ b/.github/workflows/require-jira-ticket.yml
@@ -158,6 +158,34 @@ jobs:
             exit 1
           fi
 
+          # Automated dependency PRs carry no Jira ticket and cannot be made to
+          # carry one: the author is a GitHub App, so it can neither open a
+          # ticket nor be granted a ruleset bypass (bypass actors are users and
+          # teams, and an App cannot join a team). Left unhandled the gate is a
+          # permanent block, and the only workaround is a human hand-editing a
+          # ticket key into every bump's description.
+          #
+          # The status is published as success rather than the job being
+          # skipped on purpose. `jira-ticket/validated` is a REQUIRED check, and
+          # a skipped job never reports its context at all — the PR would stay
+          # blocked on a check that never arrives. It has to report green.
+          PR_AUTHOR=$(jq -r '.pull_request.user.login // empty' "$GITHUB_EVENT_PATH")
+          PR_AUTHOR_TYPE=$(jq -r '.pull_request.user.type // empty' "$GITHUB_EVENT_PATH")
+
+          # Both conditions are required. `type` is set by GitHub and is not
+          # spoofable, and the login allowlist keeps the exemption to bots we
+          # have actually vetted rather than any App that opens a PR.
+          EXEMPT_BOT_LOGINS='dependabot[bot]'
+
+          if [[ "$PR_AUTHOR_TYPE" == 'Bot' ]] && printf '%s\n' $EXEMPT_BOT_LOGINS | grep -qxF -- "$PR_AUTHOR"; then
+            write_summary 'Success' "Automated dependency PR by ${PR_AUTHOR}; Jira ticket not applicable."
+            if publish_status 'success' "Jira gate not applicable to ${PR_AUTHOR}"; then
+              FINAL_STATUS_PUBLISHED='true'
+              exit 0
+            fi
+            exit 1
+          fi
+
           JIRA_LINE_COUNT=$(jq '
             [
               ((.pull_request.body // "") | split("\n")[])

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/magma-Devs/smart-router
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/cometbft/cometbft v0.38.21


### PR DESCRIPTION
> **Jira ticket line intentionally omitted — needs a key.** I could not verify one, and attaching a wrong `MAG-` key would auto-transition an unrelated ticket to Testing on merge. Give me the key and I will add the line; the gate goes green on `edited`.

## Why

All five open dependabot PRs are blocked, for two unrelated reasons.

**The Jira gate can never pass for dependabot.** `require-jira-ticket.yml` requires a `Jira ticket: MAG-123` line in the PR body. Dependabot never writes one, and cannot be made to — the author is a GitHub App, so it can neither open a ticket nor be granted a ruleset bypass. Bypass actors on *Require valid Jira ticket* are users and teams, and an App cannot join a team; the existing actor there is `magmadevs-bot`, a machine **user**, which does not cover it. `jira-ticket/validated` is a required check, so every bump fails on arrival and re-running never helps. The workaround so far has been a human hand-editing a ticket key into the description — that is how #256 merged two days after the gate went live.

**#270 and #271 are red on the build, not on Jira.** `go.mod` pins 15+ OpenTelemetry modules in lockstep (core `1.44.0`, log family `0.20.0`). `otel/log` and `otel/sdk/log` are compiled against a specific core and share types across module boundaries, so bumping one alone does not build — `undefined: log.KeyValue`, `undefined: log.Value`. Ungrouped, dependabot opens one PR per module and they are red every week.

The two compound: `open-pull-requests-limit: 5` with exactly five stuck PRs means dependabot opens nothing new until the jam clears.

## What changed

**`.github/workflows/require-jira-ticket.yml`** — allowlisted bot authors get a green `jira-ticket/validated`.

The status is **published as success rather than the job being skipped**, deliberately. A skipped job never reports its context at all, so a required check that never arrives blocks the PR exactly as hard as a failing one. This is the trap in the obvious `if: github.actor != 'dependabot[bot]'` fix.

The predicate requires `user.type == "Bot"` **and** a login allowlist match:

| author | type | result |
| --- | --- | --- |
| `dependabot[bot]` | Bot | exempt |
| `dependabot[bot]` | User | enforced — impersonation by name alone fails |
| `dependabot` | Bot | enforced — near-miss login |
| `dependabot[bot]x` | Bot | enforced — no suffix match (`grep -x`) |
| `renovate[bot]` | Bot | enforced — unvetted bot stays gated |
| `*` | Bot | enforced — no glob match (`grep -F`) |
| empty | empty | enforced — fails closed |

`user.type` is set by GitHub and is not spoofable. The step reads the event payload and checks out no PR code, so `pull_request_target` exposure is unchanged.

**`.github/dependabot.yml`** — `go.opentelemetry.io/*` moves as one group, actions batch into one.

## How to verify

- `python3 -c "import yaml,sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]" .github/dependabot.yml .github/workflows/require-jira-ticket.yml`
- Extract the embedded predicate and run it against the table above — every row behaves as listed.
- After merge, reopen any of #270–#274: the gate re-runs from `main` under `pull_request_target` and reports green.

## Follow-up, not in this PR

Both fixes are forward-looking. To clear the five open today: close #270–#274 and let dependabot recreate them — one grouped otel PR that builds, instead of five. Reopening alone turns the gate green but leaves #270 and #271 red on the real build failure.

Dependabot PRs will still need one human approval, and `dev-sim-prtests / preflight` still only fires after that approval — same as any PR. Zero-touch auto-merge is possible with the existing `RELEASE_BOT_PAT` (`magmadevs-bot` bypasses both the Jira ruleset and, via the `bots` team, the approval rule), but auto-merging dependencies without human eyes is a policy call and is left out.
