### PR TITLE
feat(smart-router/debug): add cross-validation-events (MAG-2772)

### DIFF
--- a/docs/CROSS-VALIDATION.md
+++ b/docs/CROSS-VALIDATION.md
@@ -91,6 +91,11 @@ failure — the structured signal lets the client decide whether to retry (quoru
 fall back (structural reasons). Header names, the closed failure-reason enum, and the gRPC-trailer
 caveat are tabulated in the [in-package reference](../protocol/rpcsmartrouter/README.md#response-headers).
 
+A router started with `--debug-address` additionally serves `GET /debug/cross-validation-events`, a
+read-only per-request record of the dissent it observed (which provider, which group, which
+recording path) for test suites that cannot scrape the metrics port — see
+[Reading recorded dissent](../protocol/rpcsmartrouter/README.md#reading-recorded-dissent).
+
 ## Caveats
 
 - **Writes.** An *operator policy* on a stateful (write) method is rejected at startup.

--- a/protocol/relaycore/relay_processor.go
+++ b/protocol/relaycore/relay_processor.go
@@ -659,6 +659,11 @@ type CrossValidationStragglerResult struct {
 	ProviderGroup   string        // "" folds to common.DefaultProviderGroup at the metric layer
 	Outcome         string        // one of common.CrossValidationStragglerOutcome*
 	Delay           time.Duration // how long after the reply the straggler resolved (watch duration for not-received)
+	// ResponseHash is the late response's own content hash, the value compared against the consensus
+	// to produce Outcome. Zero when there was no content to hash (node-error, protocol-error,
+	// not-received), which the debug event surface renders as "no hash" rather than as a differing
+	// one (MAG-2772).
+	ResponseHash [32]byte
 }
 
 // WatchCrossValidationStragglers consumes responses that arrive on the processor's channel AFTER the
@@ -698,11 +703,13 @@ func (rp *RelayProcessor) WatchCrossValidationStragglers(ctx context.Context, pe
 			return
 		}
 		delete(pending, addr)
+		outcome, responseHash := classifyStragglerResponse(response, consensusHash, protocolMessage)
 		record(CrossValidationStragglerResult{
 			ProviderAddress: addr,
 			ProviderGroup:   response.RelayResult.ProviderInfo.ProviderGroup,
-			Outcome:         classifyStragglerResponse(response, consensusHash, protocolMessage),
+			Outcome:         outcome,
 			Delay:           time.Since(start),
+			ResponseHash:    responseHash,
 		})
 	}
 	// resolveFromRecorded resolves pending providers whose response never reaches this watcher's
@@ -718,7 +725,8 @@ func (rp *RelayProcessor) WatchCrossValidationStragglers(ctx context.Context, pe
 		}
 		// resolveOne records a watched provider from its stored result and drops it from pending;
 		// a no-op for providers not in the pending set (already resolved, or never watched).
-		resolveOne := func(addr, group, outcome string) {
+		// responseHash is the stored content hash, zero for the outcomes with nothing to hash.
+		resolveOne := func(addr, group, outcome string, responseHash [32]byte) {
 			if _, watched := pending[addr]; !watched {
 				return
 			}
@@ -728,6 +736,7 @@ func (rp *RelayProcessor) WatchCrossValidationStragglers(ctx context.Context, pe
 				ProviderGroup:   group,
 				Outcome:         outcome,
 				Delay:           time.Since(start),
+				ResponseHash:    responseHash,
 			})
 		}
 		successResults, nodeErrorResults, protocolErrorResults := rp.GetResultsData()
@@ -738,13 +747,13 @@ func (rp *RelayProcessor) WatchCrossValidationStragglers(ctx context.Context, pe
 			if result.ResponseHash == consensusHash {
 				outcome = common.CrossValidationStragglerOutcomeAgreed
 			}
-			resolveOne(result.ProviderInfo.ProviderAddress, result.ProviderInfo.ProviderGroup, outcome)
+			resolveOne(result.ProviderInfo.ProviderAddress, result.ProviderInfo.ProviderGroup, outcome, result.ResponseHash)
 		}
 		for _, result := range nodeErrorResults {
-			resolveOne(result.ProviderInfo.ProviderAddress, result.ProviderInfo.ProviderGroup, common.CrossValidationStragglerOutcomeNodeError)
+			resolveOne(result.ProviderInfo.ProviderAddress, result.ProviderInfo.ProviderGroup, common.CrossValidationStragglerOutcomeNodeError, [32]byte{})
 		}
 		for _, relayError := range protocolErrorResults {
-			resolveOne(relayError.ProviderInfo.ProviderAddress, relayError.ProviderInfo.ProviderGroup, common.CrossValidationStragglerOutcomeProtocolError)
+			resolveOne(relayError.ProviderInfo.ProviderAddress, relayError.ProviderInfo.ProviderGroup, common.CrossValidationStragglerOutcomeProtocolError, [32]byte{})
 		}
 	}
 	// giveUp runs on deadline/cancel. It first drains responses already sitting in the buffered
@@ -786,26 +795,32 @@ func (rp *RelayProcessor) WatchCrossValidationStragglers(ctx context.Context, pe
 	}
 }
 
-// classifyStragglerResponse maps a late cross-validation response to its straggler outcome. Hashing
-// goes through responseContentHash — the same rule as handleResponse — so a late empty reply only
-// "agrees" with a nil-fallback consensus, exactly as it would have at quorum time.
-func classifyStragglerResponse(response *RelayResponse, consensusHash [32]byte, protocolMessage chainlib.ProtocolMessage) string {
+// classifyStragglerResponse maps a late cross-validation response to its straggler outcome, and
+// returns the content hash that decision was made on. Hashing goes through responseContentHash — the
+// same rule as handleResponse — so a late empty reply only "agrees" with a nil-fallback consensus,
+// exactly as it would have at quorum time.
+//
+// The returned hash is zero for the outcomes where no content was hashed (protocol error, node
+// error), so a caller can tell "this provider's answer differed" from "this provider had no answer"
+// rather than reading a zero hash as a differing one.
+func classifyStragglerResponse(response *RelayResponse, consensusHash [32]byte, protocolMessage chainlib.ProtocolMessage) (outcome string, responseHash [32]byte) {
 	if response.Err != nil {
-		return common.CrossValidationStragglerOutcomeProtocolError
+		return common.CrossValidationStragglerOutcomeProtocolError, [32]byte{}
 	}
 	reply := response.RelayResult.GetReply()
 	if reply == nil {
-		return common.CrossValidationStragglerOutcomeProtocolError
+		return common.CrossValidationStragglerOutcomeProtocolError, [32]byte{}
 	}
 	if protocolMessage != nil {
 		if foundError, _ := protocolMessage.CheckResponseError(reply.Data, response.RelayResult.StatusCode); foundError {
-			return common.CrossValidationStragglerOutcomeNodeError
+			return common.CrossValidationStragglerOutcomeNodeError, [32]byte{}
 		}
 	}
-	if responseContentHash(reply.Data) == consensusHash {
-		return common.CrossValidationStragglerOutcomeAgreed
+	responseHash = responseContentHash(reply.Data)
+	if responseHash == consensusHash {
+		return common.CrossValidationStragglerOutcomeAgreed, responseHash
 	}
-	return common.CrossValidationStragglerOutcomeDisagreed
+	return common.CrossValidationStragglerOutcomeDisagreed, responseHash
 }
 
 // this function waits for the processing results, they are written by multiple go routines and read by this go routine

--- a/protocol/rpcsmartrouter/README.md
+++ b/protocol/rpcsmartrouter/README.md
@@ -273,6 +273,45 @@ sync. The watcher's deadline is anchored at batch launch and sized generously (i
 of the individually-bounded relay phases), so a `not-received` outcome means the goroutine genuinely
 leaked; in the normal case the watcher exits as soon as the last straggler pushes its response.
 
+### Reading recorded dissent
+
+`GET /debug/cross-validation-events` returns the dissent the router actually recorded, as a flat JSON
+array of self-describing rows (MAG-2772). Read-only, and registered only in debug mode
+(`--debug-address`), like the rest of `/debug/*`.
+
+It exists because the two surfaces above cannot be asserted on from an automated run: logs are
+diagnostic evidence only, and `smartrouter_cross_validation_mismatch_total` lives on the unpublished
+metrics port, where a down tunnel reads as empty and a test passes having measured nothing. It is
+**event-shaped** rather than counter-shaped because the questions are per-request — *which* provider
+dissented on *this* request — and the counter's labels carry neither a provider nor a request id.
+Counts are derivable from these rows; the rows are not derivable from the counter.
+
+One row per recorded comparison outcome, oldest first:
+
+| Field | Meaning |
+| --- | --- |
+| `Seq`, `RecordedAt` | monotonic id and timestamp; `Seq` is the unambiguous ordering key |
+| `Source` | `reply-time` (seen before the reply → in `disagreeing-providers`) or `straggler` (resolved after it → was in `pending-providers`) |
+| `ChainID`, `ApiInterface` | the row's own chain identity, as on every other `/debug` row |
+| `RequestID` | the `Lava-Guid` response header value — **not** `/debug/logs`' `request_id`, which is the caller's `X-Request-Id` |
+| `Method`, `ProviderAddress`, `ProviderGroup`, `Finality` | who dissented, on what, in which group, at which finality |
+| `Outcome` | `disagreed` at reply time; any straggler outcome on the async path |
+| `ConsensusHash`, `OutlierHash` | full 32-byte hex; the log's short form is a prefix. `OutlierHash` is the provider's own hash — equal to `ConsensusHash` on an agreed straggler, and `""` when nothing was hashed (`node-error` / `protocol-error` / `not-received`) |
+| `MismatchCounted` | whether **this** row is the one that incremented `smartrouter_cross_validation_mismatch_total`, making the counter's once-per-distinct-group dedup visible rather than implicit |
+
+Every straggler resolution is recorded, not only dissent: an `agreed` row is the positive control a
+test asserting "no dissent happened" anchors on. A cross-validated request where **everyone agreed at
+reply time** records nothing — that request is proven to have run by its own
+`lava-cross-validation-status` / `-agreeing-providers` headers.
+
+Filters (optional, ANDed): `request_id`, `chain_id`, `outcome`, `limit` (keeps the most recent N).
+`POST /debug/cross-validation-events/clear` empties the ring for test isolation.
+
+Both answer **503**, never an empty 200, when the recorder is not installed — "nothing was being
+recorded" and "nothing dissented" are opposite answers. The ring is bounded (4096 events); the
+`X-Cross-Validation-Events-Dropped` response header reports evictions so truncation cannot pass for
+absence.
+
 ## Usage
 
 ```bash

--- a/protocol/rpcsmartrouter/cross_validation_events.go
+++ b/protocol/rpcsmartrouter/cross_validation_events.go
@@ -1,0 +1,255 @@
+package rpcsmartrouter
+
+// Bounded in-memory record of cross-validation dissent outcomes, read back by
+// GET /debug/cross-validation-events (MAG-2772).
+//
+// The router already recorded dissent twice, and neither surface can be asserted on from an
+// automated run:
+//
+//   - The info logs ("cross-validation outlier detected" / "cross-validation straggler resolved").
+//     The team's rule is that logs are diagnostic evidence only, never a gating assertion.
+//   - smartrouter_cross_validation_mismatch_total on the metrics port, which is not published in
+//     the cluster. Reading it needs a hand-held port-forward, and when the tunnel is down the read
+//     comes back empty and the test passes having measured nothing — the same silent pass
+//     /debug/provider-scores was added to end (MAG-2707).
+//
+// The counter also cannot answer what the parked tests ask. It carries {spec, apiInterface, method,
+// group, finality} and nothing else: no provider name, no request id. A test that needs "which
+// provider dissented on THIS request" gets no answer from a counter, which is why this surface is
+// event-shaped. Counts are derivable from events; the reverse is not.
+//
+// Recording is DEBUG-MODE ONLY. The ring is installed by enableCrossValidationEventRing, called
+// from Start alongside utils.EnableDebugLogBuffer when --debug-address is set, so a production
+// router pays one atomic nil load per dissent and stores nothing.
+
+import (
+	"context"
+	"encoding/hex"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/magma-Devs/smart-router/utils"
+)
+
+// crossValidationEventRingCapacity bounds the ring installed in debug mode. Events are recorded per
+// DISSENT and per STRAGGLER RESOLUTION, not per request, so this is a much slower-filling ring than
+// the 50k-line log buffer; 4096 covers a long nightly run and caps the store at roughly a megabyte.
+const crossValidationEventRingCapacity = 4096
+
+// Which recording path produced an event. The automation needs to tell the two apart: a dissent
+// compared BEFORE the reply was received in time to be in lava-cross-validation-disagreeing-providers,
+// while a straggler resolved AFTER the reply was not (it was in pending-providers instead).
+const (
+	crossValidationEventSourceReplyTime = "reply-time"
+	crossValidationEventSourceStraggler = "straggler"
+)
+
+// crossValidationEvent is one recorded cross-validation comparison outcome.
+//
+// Field names are the Go identifiers the other /debug row endpoints use, and every row carries its
+// own ChainID + ApiInterface so a multi-chain router's rows stay self-describing.
+type crossValidationEvent struct {
+	// Seq is a monotonic per-process counter, assigned under the ring lock. RecordedAt is RFC3339
+	// (the /debug convention) and therefore second-granular, so Seq — not the timestamp — is the
+	// unambiguous ordering and dedup key.
+	Seq        uint64
+	RecordedAt time.Time
+
+	Source       string // crossValidationEventSourceReplyTime | crossValidationEventSourceStraggler
+	ChainID      string
+	ApiInterface string
+
+	// RequestID is the lava-guid: the value the router returns in the Lava-Guid response header,
+	// formatted the same way (decimal). NOTE this is NOT /debug/logs' request_id, which is the
+	// caller's X-Request-Id header — a different identifier that this router does not require.
+	RequestID string
+	Method    string
+
+	ProviderAddress string
+	ProviderGroup   string // already folded to common.DefaultProviderGroup when the provider carries no label
+
+	// Outcome is "disagreed" for a reply-time content outlier, and the straggler outcome
+	// (agreed / disagreed / node-error / protocol-error / not-received) for the async path.
+	Outcome  string
+	Finality string // finalized | not_finalized | unknown
+
+	// ConsensusHash is the hash the quorum agreed on; OutlierHash is this provider's OWN response
+	// hash — the outlier hash on a dissent, and deliberately the same field on an agreed straggler,
+	// where it equals ConsensusHash and is exactly what the positive control asserts. Both are the
+	// full 32-byte SHA256 in hex, so the short form in the logs is a prefix of them and a log line
+	// and a row correlate. OutlierHash is the zero hash (rendered as "") for the outcomes with no
+	// content to hash: node-error, protocol-error and not-received.
+	ConsensusHash [32]byte
+	OutlierHash   [32]byte
+
+	// MismatchCounted reports whether THIS event is the one that incremented
+	// smartrouter_cross_validation_mismatch_total. The counter's contract is once per distinct
+	// outlier group per request, so a second dissent from an already-counted group records an event
+	// with MismatchCounted=false. Without this the dedup rule is invisible to a reader that only
+	// sees the events.
+	MismatchCounted bool
+
+	// DelayMs is how long after the reply a straggler resolved. 0 on the reply-time path, which by
+	// definition resolved before the reply.
+	DelayMs int64
+}
+
+// crossValidationEventRing is the bounded store: append at the tail, evict the oldest at capacity.
+// Written from the request goroutine (reply-time path) and from each request's straggler-watcher
+// goroutine, read from the debug HTTP handler — so every access takes the lock.
+type crossValidationEventRing struct {
+	mu       sync.Mutex
+	buf      []crossValidationEvent
+	capacity int
+	nextSeq  uint64
+	dropped  uint64 // evicted since the ring was installed, so truncation is never silent
+}
+
+// crossValidationEventRecorder holds the live ring, or nil when recording is off (the production
+// default). An atomic pointer because enableCrossValidationEventRing runs during Start while relay
+// goroutines may already be recording.
+var crossValidationEventRecorder atomic.Pointer[crossValidationEventRing]
+
+// enableCrossValidationEventRing installs a fresh ring. Debug-mode only — called from
+// rpcsmartrouter.Start when --debug-address is set, next to utils.EnableDebugLogBuffer, so the two
+// debug-only stores are switched on by the same condition in the same place.
+func enableCrossValidationEventRing(capacity int) {
+	if capacity <= 0 {
+		capacity = crossValidationEventRingCapacity
+	}
+	crossValidationEventRecorder.Store(&crossValidationEventRing{
+		buf:      make([]crossValidationEvent, 0, capacity),
+		capacity: capacity,
+	})
+}
+
+// crossValidationEventRecordingEnabled reports whether a ring is installed. The handler answers 503
+// rather than an empty 200 when it is not: "the recorder was never switched on" and "the recorder
+// was on and saw no dissent" are opposite answers, and only one of them means a test measured
+// something.
+func crossValidationEventRecordingEnabled() bool {
+	return crossValidationEventRecorder.Load() != nil
+}
+
+// recordCrossValidationEvent stores one event, or does nothing when recording is off. Seq and
+// RecordedAt are assigned here so callers cannot get them wrong.
+func recordCrossValidationEvent(event crossValidationEvent) {
+	ring := crossValidationEventRecorder.Load()
+	if ring == nil {
+		return
+	}
+	ring.mu.Lock()
+	defer ring.mu.Unlock()
+	ring.nextSeq++
+	event.Seq = ring.nextSeq
+	event.RecordedAt = time.Now()
+	if len(ring.buf) >= ring.capacity {
+		ring.buf = ring.buf[1:]
+		ring.dropped++
+	}
+	ring.buf = append(ring.buf, event)
+}
+
+// crossValidationEventFilter narrows a read. Every field is optional; the set ones are ANDed.
+type crossValidationEventFilter struct {
+	RequestID string // the lava-guid, exact match
+	ChainID   string // exact match, case-sensitive like the other debug chain filters
+	Outcome   string // exact match
+	Limit     int    // keep the most recent N after filtering; <= 0 means the whole ring
+}
+
+// readCrossValidationEvents returns the matching events oldest-first, along with the number evicted
+// since the ring was installed. enabled is false when no ring is installed, which the caller must
+// distinguish from an empty result.
+func readCrossValidationEvents(filter crossValidationEventFilter) (events []crossValidationEvent, dropped uint64, enabled bool) {
+	ring := crossValidationEventRecorder.Load()
+	if ring == nil {
+		return nil, 0, false
+	}
+	ring.mu.Lock()
+	defer ring.mu.Unlock()
+
+	matched := make([]crossValidationEvent, 0, len(ring.buf))
+	for _, event := range ring.buf {
+		if filter.RequestID != "" && event.RequestID != filter.RequestID {
+			continue
+		}
+		if filter.ChainID != "" && event.ChainID != filter.ChainID {
+			continue
+		}
+		if filter.Outcome != "" && event.Outcome != filter.Outcome {
+			continue
+		}
+		matched = append(matched, event)
+	}
+	// Tail, like /debug/logs: a limit keeps the most RECENT matches, since a test reading back its
+	// own request wants what just happened, not the oldest thing still in the ring.
+	if filter.Limit > 0 && len(matched) > filter.Limit {
+		matched = matched[len(matched)-filter.Limit:]
+	}
+	return matched, ring.dropped, true
+}
+
+// clearCrossValidationEvents drops every recorded event and resets the eviction count, so a test can
+// isolate itself from earlier traffic. Seq deliberately keeps counting: it identifies an event within
+// the process, and restarting it would let a cleared-then-refilled ring hand out ids a caller already
+// holds. Returns the number of events dropped and whether a ring was installed at all.
+func clearCrossValidationEvents() (cleared int, enabled bool) {
+	ring := crossValidationEventRecorder.Load()
+	if ring == nil {
+		return 0, false
+	}
+	ring.mu.Lock()
+	defer ring.mu.Unlock()
+	cleared = len(ring.buf)
+	ring.buf = ring.buf[:0]
+	ring.dropped = 0
+	return cleared, true
+}
+
+// crossValidationRequestID renders the request's lava-guid the same way the Lava-Guid response
+// header does (decimal), so the value a test reads off its own response is the value it filters
+// with. Empty when the context carries no guid — the recording paths always run under a relay
+// context that has one, so an empty value means an unwired test fixture, not a lost request.
+func crossValidationRequestID(ctx context.Context) string {
+	guid, found := utils.GetUniqueIdentifier(ctx)
+	if !found || guid == 0 {
+		return ""
+	}
+	return strconv.FormatUint(guid, 10)
+}
+
+// crossValidationHashHex renders a content hash for the wire: full 32-byte hex, and "" for the zero
+// hash. The zero value is a real sentinel here — it means "no content was hashed" (a node error, a
+// protocol error, or a straggler that never answered) — and rendering it as 64 zeros would read as a
+// hash that merely differs from the consensus.
+func crossValidationHashHex(hash [32]byte) string {
+	if hash == ([32]byte{}) {
+		return ""
+	}
+	return hex.EncodeToString(hash[:])
+}
+
+// crossValidationEventRow flattens an event into the self-describing row shape the other /debug
+// state endpoints return.
+func crossValidationEventRow(event crossValidationEvent) map[string]any {
+	return map[string]any{
+		"Seq":             event.Seq,
+		"RecordedAt":      debugTimeRFC3339(event.RecordedAt),
+		"Source":          event.Source,
+		"ChainID":         event.ChainID,
+		"ApiInterface":    event.ApiInterface,
+		"RequestID":       event.RequestID,
+		"Method":          event.Method,
+		"ProviderAddress": event.ProviderAddress,
+		"ProviderGroup":   event.ProviderGroup,
+		"Outcome":         event.Outcome,
+		"Finality":        event.Finality,
+		"ConsensusHash":   crossValidationHashHex(event.ConsensusHash),
+		"OutlierHash":     crossValidationHashHex(event.OutlierHash),
+		"MismatchCounted": event.MismatchCounted,
+		"DelayMs":         event.DelayMs,
+	}
+}

--- a/protocol/rpcsmartrouter/debug_cross_validation_events_test.go
+++ b/protocol/rpcsmartrouter/debug_cross_validation_events_test.go
@@ -1,0 +1,501 @@
+package rpcsmartrouter
+
+// Tests for the cross-validation dissent record and GET /debug/cross-validation-events (MAG-2772).
+//
+// Three layers, because the endpoint is only worth what the recording behind it is worth:
+//   - the ring itself (bounded, filterable, off by default),
+//   - the HTTP contract the automation codes against — above all that "recorder off" is a NON-2xx
+//     and never an empty 200, the same rule /debug/provider-scores established (MAG-2707),
+//   - the production glue: that the real reply-time and straggler paths actually record, with the
+//     provider, group, request id and mismatch-admission decision the counter cannot carry.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/chainlib"
+	"github.com/magma-Devs/smart-router/protocol/chainlib/extensionslib"
+	"github.com/magma-Devs/smart-router/protocol/chainstate"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/protocol/metrics"
+	"github.com/magma-Devs/smart-router/protocol/relaycore"
+	"github.com/magma-Devs/smart-router/protocol/relaycoretest"
+	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/magma-Devs/smart-router/utils"
+	"github.com/stretchr/testify/require"
+)
+
+// useCrossValidationEventRing installs a fresh ring for one test and removes it afterwards, so the
+// package-level recorder cannot leak state between tests (or record during the many other tests in
+// this package that exercise the cross-validation paths).
+func useCrossValidationEventRing(t *testing.T, capacity int) {
+	t.Helper()
+	enableCrossValidationEventRing(capacity)
+	t.Cleanup(func() { crossValidationEventRecorder.Store(nil) })
+}
+
+// newEventsMux builds a debug mux with nothing else wired: the events endpoint reads the
+// package-level recorder, not deps.
+func newEventsMux() http.Handler {
+	var offsetNano atomic.Int64
+	return buildDebugMux(debugMuxDeps{optimizers: newEmptyOptimizersRouter(), offsetNano: &offsetNano})
+}
+
+func decodeEventRows(t *testing.T, body []byte) []map[string]any {
+	t.Helper()
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(body, &rows))
+	return rows
+}
+
+func TestCrossValidationEventRing_OffByDefault(t *testing.T) {
+	// No enable call: this is the production configuration, and recording must be inert.
+	require.False(t, crossValidationEventRecordingEnabled())
+	recordCrossValidationEvent(crossValidationEvent{RequestID: "1", Outcome: "disagreed"})
+	events, _, enabled := readCrossValidationEvents(crossValidationEventFilter{})
+	require.False(t, enabled, "a read must report that nothing was being recorded")
+	require.Empty(t, events)
+}
+
+// TestCrossValidationEventRing_BoundedAndReportsDrops pins that the ring keeps the NEWEST events and
+// says how many it threw away — a silent truncation would read as "that dissent never happened".
+func TestCrossValidationEventRing_BoundedAndReportsDrops(t *testing.T) {
+	useCrossValidationEventRing(t, 3)
+	for i := 1; i <= 5; i++ {
+		recordCrossValidationEvent(crossValidationEvent{RequestID: strconv.Itoa(i), Outcome: "disagreed"})
+	}
+	events, dropped, enabled := readCrossValidationEvents(crossValidationEventFilter{})
+	require.True(t, enabled)
+	require.Len(t, events, 3)
+	require.Equal(t, []string{"3", "4", "5"}, []string{events[0].RequestID, events[1].RequestID, events[2].RequestID},
+		"the ring keeps the newest events, oldest-first")
+	require.Equal(t, uint64(2), dropped)
+	require.Equal(t, uint64(3), events[0].Seq, "Seq counts every event, including the evicted ones")
+}
+
+func TestCrossValidationEventRing_Filters(t *testing.T) {
+	useCrossValidationEventRing(t, 16)
+	recordCrossValidationEvent(crossValidationEvent{RequestID: "100", ChainID: "ETH1", Outcome: "disagreed"})
+	recordCrossValidationEvent(crossValidationEvent{RequestID: "100", ChainID: "ETH1", Outcome: "agreed"})
+	recordCrossValidationEvent(crossValidationEvent{RequestID: "200", ChainID: "ETH1", Outcome: "disagreed"})
+	recordCrossValidationEvent(crossValidationEvent{RequestID: "300", ChainID: "SOLANA", Outcome: "disagreed"})
+
+	byRequest, _, _ := readCrossValidationEvents(crossValidationEventFilter{RequestID: "100"})
+	require.Len(t, byRequest, 2, "the correlation key every test holds")
+
+	byChain, _, _ := readCrossValidationEvents(crossValidationEventFilter{ChainID: "SOLANA"})
+	require.Len(t, byChain, 1)
+
+	byOutcome, _, _ := readCrossValidationEvents(crossValidationEventFilter{Outcome: "disagreed"})
+	require.Len(t, byOutcome, 3)
+
+	anded, _, _ := readCrossValidationEvents(crossValidationEventFilter{RequestID: "100", Outcome: "agreed"})
+	require.Len(t, anded, 1)
+
+	// limit keeps the most recent matches, like /debug/logs.
+	tail, _, _ := readCrossValidationEvents(crossValidationEventFilter{Limit: 2})
+	require.Len(t, tail, 2)
+	require.Equal(t, "200", tail[0].RequestID)
+	require.Equal(t, "300", tail[1].RequestID)
+}
+
+func TestCrossValidationEventRing_Clear(t *testing.T) {
+	useCrossValidationEventRing(t, 2)
+	for i := 1; i <= 4; i++ {
+		recordCrossValidationEvent(crossValidationEvent{RequestID: strconv.Itoa(i)})
+	}
+	cleared, enabled := clearCrossValidationEvents()
+	require.True(t, enabled)
+	require.Equal(t, 2, cleared, "the ring held its capacity")
+
+	events, dropped, _ := readCrossValidationEvents(crossValidationEventFilter{})
+	require.Empty(t, events)
+	require.Zero(t, dropped, "the eviction count restarts with the cleared ring")
+
+	recordCrossValidationEvent(crossValidationEvent{RequestID: "5"})
+	events, _, _ = readCrossValidationEvents(crossValidationEventFilter{})
+	require.Len(t, events, 1)
+	require.Equal(t, uint64(5), events[0].Seq, "Seq keeps counting so a clear cannot reissue an id a caller already holds")
+}
+
+func TestDebugCrossValidationEvents_MethodNotAllowed(t *testing.T) {
+	useCrossValidationEventRing(t, 4)
+	mux := newEventsMux()
+	require.Equal(t, http.StatusMethodNotAllowed, postDebugRouter(mux, "/debug/cross-validation-events").Code)
+	require.Equal(t, http.StatusMethodNotAllowed, getDebugRouter(mux, "/debug/cross-validation-events/clear").Code)
+}
+
+// TestDebugCrossValidationEvents_RecorderOffIsNot200 is the MAG-2707 rule applied here: an empty 200
+// from a router that was never recording is a test passing having measured nothing.
+func TestDebugCrossValidationEvents_RecorderOffIsNot200(t *testing.T) {
+	crossValidationEventRecorder.Store(nil)
+	mux := newEventsMux()
+
+	rr := getDebugRouter(mux, "/debug/cross-validation-events")
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	require.NotEmpty(t, rr.Body.String(), "the failure says why")
+
+	rr = postDebugRouter(mux, "/debug/cross-validation-events/clear")
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code, "a clear that cleared nothing is not a success")
+}
+
+// TestDebugCrossValidationEvents_EnabledAndEmptyIs200 is the other half of that rule: with the
+// recorder live, no dissent is a real answer and must be a 200 with an empty array — never null.
+func TestDebugCrossValidationEvents_EnabledAndEmptyIs200(t *testing.T) {
+	useCrossValidationEventRing(t, 4)
+	rr := getDebugRouter(newEventsMux(), "/debug/cross-validation-events")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	require.Equal(t, "[]", strings.TrimSpace(rr.Body.String()), "an empty result marshals as [], never null")
+	require.Empty(t, decodeEventRows(t, rr.Body.Bytes()))
+	require.Equal(t, "0", rr.Header().Get("X-Cross-Validation-Events-Dropped"))
+}
+
+// TestDebugCrossValidationEvents_RowShape pins the row contract the automation reads.
+func TestDebugCrossValidationEvents_RowShape(t *testing.T) {
+	useCrossValidationEventRing(t, 8)
+	consensus := sha256.Sum256([]byte("consensus"))
+	outlier := sha256.Sum256([]byte("outlier"))
+	recordCrossValidationEvent(crossValidationEvent{
+		Source:          crossValidationEventSourceReplyTime,
+		ChainID:         "ETH1",
+		ApiInterface:    "jsonrpc",
+		RequestID:       "424242",
+		Method:          "eth_getBalance",
+		ProviderAddress: "lava@provider3",
+		ProviderGroup:   "tier-1",
+		Outcome:         common.CrossValidationStragglerOutcomeDisagreed,
+		Finality:        "finalized",
+		ConsensusHash:   consensus,
+		OutlierHash:     outlier,
+		MismatchCounted: true,
+	})
+	// A straggler that never answered: no content was hashed, and the row must not imply one.
+	recordCrossValidationEvent(crossValidationEvent{
+		Source:          crossValidationEventSourceStraggler,
+		ChainID:         "ETH1",
+		ApiInterface:    "jsonrpc",
+		RequestID:       "424242",
+		Method:          "eth_getBalance",
+		ProviderAddress: "lava@provider4",
+		ProviderGroup:   common.DefaultProviderGroup,
+		Outcome:         common.CrossValidationStragglerOutcomeNotReceived,
+		Finality:        "finalized",
+		ConsensusHash:   consensus,
+		DelayMs:         1500,
+	})
+
+	rr := getDebugRouter(newEventsMux(), "/debug/cross-validation-events")
+	require.Equal(t, http.StatusOK, rr.Code, "body=%q", rr.Body.String())
+	rows := decodeEventRows(t, rr.Body.Bytes())
+	require.Len(t, rows, 2)
+
+	first := rows[0]
+	require.Equal(t, "reply-time", first["Source"], "which recording path saw this dissent")
+	require.Equal(t, "ETH1", first["ChainID"], "rows are self-describing on a multi-chain router")
+	require.Equal(t, "jsonrpc", first["ApiInterface"])
+	require.Equal(t, "424242", first["RequestID"])
+	require.Equal(t, "eth_getBalance", first["Method"])
+	require.Equal(t, "lava@provider3", first["ProviderAddress"])
+	require.Equal(t, "tier-1", first["ProviderGroup"])
+	require.Equal(t, "disagreed", first["Outcome"])
+	require.Equal(t, "finalized", first["Finality"])
+	require.Equal(t, hex.EncodeToString(consensus[:]), first["ConsensusHash"])
+	require.Equal(t, hex.EncodeToString(outlier[:]), first["OutlierHash"])
+	require.Equal(t, true, first["MismatchCounted"])
+	require.Equal(t, float64(0), first["DelayMs"], "a reply-time dissent resolved before the reply")
+	require.NotEmpty(t, first["RecordedAt"])
+	require.Equal(t, float64(1), first["Seq"])
+
+	second := rows[1]
+	require.Equal(t, "straggler", second["Source"])
+	require.Equal(t, "not-received", second["Outcome"])
+	require.Equal(t, "", second["OutlierHash"], "nothing was hashed, so no hash is reported — not a zero one")
+	require.Equal(t, false, second["MismatchCounted"])
+	require.Equal(t, float64(1500), second["DelayMs"])
+	require.Equal(t, float64(2), second["Seq"], "rows are returned oldest-first, in recording order")
+}
+
+func TestDebugCrossValidationEvents_FiltersAndClearOverHTTP(t *testing.T) {
+	useCrossValidationEventRing(t, 8)
+	recordCrossValidationEvent(crossValidationEvent{RequestID: "100", ChainID: "ETH1", Outcome: "disagreed"})
+	recordCrossValidationEvent(crossValidationEvent{RequestID: "200", ChainID: "ETH1", Outcome: "agreed"})
+	recordCrossValidationEvent(crossValidationEvent{RequestID: "200", ChainID: "SOLANA", Outcome: "disagreed"})
+	mux := newEventsMux()
+
+	rows := decodeEventRows(t, getDebugRouter(mux, "/debug/cross-validation-events?request_id=200").Body.Bytes())
+	require.Len(t, rows, 2)
+
+	rows = decodeEventRows(t, getDebugRouter(mux, "/debug/cross-validation-events?request_id=200&outcome=agreed").Body.Bytes())
+	require.Len(t, rows, 1)
+	require.Equal(t, "ETH1", rows[0]["ChainID"])
+
+	rows = decodeEventRows(t, getDebugRouter(mux, "/debug/cross-validation-events?chain_id=SOLANA").Body.Bytes())
+	require.Len(t, rows, 1)
+
+	rows = decodeEventRows(t, getDebugRouter(mux, "/debug/cross-validation-events?limit=1").Body.Bytes())
+	require.Len(t, rows, 1)
+	require.Equal(t, "SOLANA", rows[0]["ChainID"], "limit keeps the most recent")
+
+	clear := postDebugRouter(mux, "/debug/cross-validation-events/clear")
+	require.Equal(t, http.StatusOK, clear.Code)
+	require.JSONEq(t, `{"cleared":true,"events_cleared":3}`, clear.Body.String())
+	require.Empty(t, decodeEventRows(t, getDebugRouter(mux, "/debug/cross-validation-events").Body.Bytes()))
+}
+
+func TestDebugCrossValidationEvents_DroppedHeader(t *testing.T) {
+	useCrossValidationEventRing(t, 2)
+	for i := 1; i <= 5; i++ {
+		recordCrossValidationEvent(crossValidationEvent{RequestID: strconv.Itoa(i)})
+	}
+	rr := getDebugRouter(newEventsMux(), "/debug/cross-validation-events")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "3", rr.Header().Get("X-Cross-Validation-Events-Dropped"),
+		"a truncated ring must say so rather than let the missing events read as absence")
+}
+
+// newCrossValidationEventTestServer builds a server wired the way the mismatch-metric tests wire one:
+// a real chain parser and a ChainState with a known head, so finality resolves to a real label rather
+// than "unknown".
+func newCrossValidationEventTestServer(t *testing.T) (*RPCSmartRouterServer, chainlib.ChainParser) {
+	t.Helper()
+	// Empty NetworkAddress => metrics registered on the default registry, no HTTP server started.
+	mm := metrics.NewSmartRouterMetricsManager(metrics.SmartRouterMetricsManagerOptions{})
+	require.NotNil(t, mm)
+	noop := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	chainParser, _, _, closeServer, _, err := chainlib.CreateChainLibMocks(context.Background(), "ETH1", spectypes.APIInterfaceJsonRPC, noop, nil, "../../", nil)
+	if closeServer != nil {
+		t.Cleanup(closeServer)
+	}
+	require.NoError(t, err)
+
+	cs := chainstate.New("ETH1", chainstate.DefaultConfig(12*time.Second))
+	cs.SetLatestBlock(1_000_000)
+	return &RPCSmartRouterServer{
+		smartRouterEndpointMetrics: mm,
+		listenEndpoint:             &lavasession.RPCEndpoint{ChainID: "ETH1", ApiInterface: "jsonrpc"},
+		chainParser:                chainParser,
+		chainState:                 cs,
+	}, chainParser
+}
+
+// TestCrossValidationEvents_ReplyTimePathRecords is the production glue for the first recording path:
+// the same deterministic successful outlier that increments the mismatch counter must also leave a
+// row naming the provider, its group and the request — the per-request facts the counter's labels
+// cannot carry, and the whole reason this surface is event-shaped.
+func TestCrossValidationEvents_ReplyTimePathRecords(t *testing.T) {
+	useCrossValidationEventRing(t, 32)
+	srv, _ := newCrossValidationEventTestServer(t)
+	ctx := utils.WithUniqueIdentifier(context.Background(), 987654321)
+
+	hashA := sha256.Sum256([]byte("A"))
+	hashB := sha256.Sum256([]byte("B"))
+	deterministicAPI := &spectypes.Api{Name: "test", Category: spectypes.SpecCategory{Deterministic: true}}
+	method := "cv_events_reply_time"
+
+	rp := &MockRelayProcessorForHeaders{
+		crossValidationParams:           &common.CrossValidationParams{AgreementThreshold: 2, MaxParticipants: 4},
+		selection:                       relaycore.CrossValidation,
+		crossValidationQueriedProviders: []string{"p1", "p2", "p3", "p4"},
+		successResults: []common.RelayResult{
+			{ProviderInfo: common.ProviderInfo{ProviderAddress: "p1", ProviderGroup: "tier-1"}, ResponseHash: hashA},
+			{ProviderInfo: common.ProviderInfo{ProviderAddress: "p2", ProviderGroup: "tier-1"}, ResponseHash: hashA},
+			{ProviderInfo: common.ProviderInfo{ProviderAddress: "p3", ProviderGroup: "external"}, ResponseHash: hashB}, // outlier
+			{ProviderInfo: common.ProviderInfo{ProviderAddress: "p4", ProviderGroup: "external"}, ResponseHash: hashB}, // same-group outlier
+		},
+	}
+	relayResult := &common.RelayResult{
+		ProviderInfo:    common.ProviderInfo{ProviderAddress: "p1"},
+		CrossValidation: 2,
+		ResponseHash:    hashA,
+		Reply:           &pairingtypes.RelayReply{Metadata: []pairingtypes.Metadata{}},
+	}
+	srv.appendHeadersToRelayResult(ctx, relayResult, 0, rp, &MockProtocolMessage{api: deterministicAPI, requestedBlock: 100}, method, nil, true)
+
+	events, _, enabled := readCrossValidationEvents(crossValidationEventFilter{RequestID: "987654321"})
+	require.True(t, enabled)
+	require.Len(t, events, 2, "one row per dissenting provider — the agreeing providers are not dissent")
+
+	require.Equal(t, crossValidationEventSourceReplyTime, events[0].Source)
+	require.Equal(t, "ETH1", events[0].ChainID)
+	require.Equal(t, "jsonrpc", events[0].ApiInterface)
+	require.Equal(t, method, events[0].Method)
+	require.Equal(t, "p3", events[0].ProviderAddress)
+	require.Equal(t, "external", events[0].ProviderGroup, "the chart's group label reaches the row")
+	require.Equal(t, common.CrossValidationStragglerOutcomeDisagreed, events[0].Outcome)
+	require.Equal(t, "finalized", events[0].Finality)
+	require.Equal(t, hashA, events[0].ConsensusHash)
+	require.Equal(t, hashB, events[0].OutlierHash)
+	require.True(t, events[0].MismatchCounted, "the first outlier of a group carries the group's single increment")
+
+	require.Equal(t, "p4", events[1].ProviderAddress)
+	require.False(t, events[1].MismatchCounted,
+		"the counter's once-per-distinct-group rule is visible on the row, not hidden behind it")
+}
+
+// TestCrossValidationEvents_ReplyTimeAgreementRecordsNothing guards the surface against becoming a
+// log of every cross-validated relay: with no outlier there is nothing to record. A test asserting
+// "no dissent happened" reads an empty result here and confirms the request ran from its own
+// response headers (lava-cross-validation-status / -agreeing-providers).
+func TestCrossValidationEvents_ReplyTimeAgreementRecordsNothing(t *testing.T) {
+	useCrossValidationEventRing(t, 32)
+	srv, _ := newCrossValidationEventTestServer(t)
+	ctx := utils.WithUniqueIdentifier(context.Background(), 111222333)
+
+	hashA := sha256.Sum256([]byte("A"))
+	rp := &MockRelayProcessorForHeaders{
+		crossValidationParams:           &common.CrossValidationParams{AgreementThreshold: 2, MaxParticipants: 2},
+		selection:                       relaycore.CrossValidation,
+		crossValidationQueriedProviders: []string{"p1", "p2"},
+		successResults: []common.RelayResult{
+			{ProviderInfo: common.ProviderInfo{ProviderAddress: "p1", ProviderGroup: "tier-1"}, ResponseHash: hashA},
+			{ProviderInfo: common.ProviderInfo{ProviderAddress: "p2", ProviderGroup: "external"}, ResponseHash: hashA},
+		},
+	}
+	relayResult := &common.RelayResult{
+		ProviderInfo:    common.ProviderInfo{ProviderAddress: "p1"},
+		CrossValidation: 2,
+		ResponseHash:    hashA,
+		Reply:           &pairingtypes.RelayReply{Metadata: []pairingtypes.Metadata{}},
+	}
+	srv.appendHeadersToRelayResult(ctx, relayResult, 0, rp, &MockProtocolMessage{api: &spectypes.Api{Name: "test", Category: spectypes.SpecCategory{Deterministic: true}}, requestedBlock: 100}, "cv_events_agreement", nil, true)
+
+	events, _, enabled := readCrossValidationEvents(crossValidationEventFilter{RequestID: "111222333"})
+	require.True(t, enabled, "the recorder was live — an empty result here means no dissent, not no measurement")
+	require.Empty(t, events)
+}
+
+// TestCrossValidationEvents_StragglerPathRecords is the production glue for the second recording
+// path. It covers both the late dissent (which reaches the mismatch surface the reply-time path
+// could never see for a provider that lost the race to quorum) and the late AGREEMENT — the positive
+// control, which records a row without touching the mismatch surface.
+func TestCrossValidationEvents_StragglerPathRecords(t *testing.T) {
+	useCrossValidationEventRing(t, 32)
+	srv, chainParser := newCrossValidationEventTestServer(t)
+	baseCtx := context.Background()
+
+	consensusBody := []byte(`{"jsonrpc":"2.0","id":1,"result":"0xAAAA"}`)
+	dissentBody := []byte(`{"jsonrpc":"2.0","id":1,"result":"0xBBBB"}`)
+	pushSuccess := func(rp *relaycore.RelayProcessor, provider, group string, body []byte) {
+		rp.SetResponse(&relaycore.RelayResponse{
+			RelayResult: common.RelayResult{
+				Reply:        &pairingtypes.RelayReply{Data: body},
+				ProviderInfo: common.ProviderInfo{ProviderAddress: provider, ProviderGroup: group},
+				StatusCode:   200,
+			},
+		})
+	}
+	// A real cross-validation processor holding the two agreeing responses, with p3 queried and still
+	// in flight — the reply-time state the straggler watcher is launched from.
+	newCVProcessorWithConsensus := func(t *testing.T) (*relaycore.RelayProcessor, [32]byte) {
+		t.Helper()
+		cm, perr := chainParser.ParseMsg("", []byte(`{"jsonrpc":"2.0","method":"eth_getBalance","params":["0xDEAD","latest"],"id":1}`), http.MethodPost, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+		require.NoError(t, perr)
+		pm := chainlib.NewProtocolMessage(cm, map[string]string{
+			common.CROSS_VALIDATION_HEADER_MAX_PARTICIPANTS:    "3",
+			common.CROSS_VALIDATION_HEADER_AGREEMENT_THRESHOLD: "2",
+		}, nil, "dapp", "1.2.3.4")
+		sm, smErr := NewSmartRouterRelayStateMachineWithPolicy(baseCtx, lavasession.NewUsedProviders(nil), &SmartRouterRelaySenderMock{retValue: nil}, pm, nil, false, nil, "ETH1", "jsonrpc")
+		require.NoError(t, smErr)
+		rp := relaycore.NewRelayProcessor(baseCtx, sm.GetCrossValidationParams(), relaycoretest.RelayProcessorMetrics, relaycoretest.RelayProcessorMetrics, relaycoretest.RelayRetriesManagerInstance, sm)
+		rp.SetCrossValidationQueriedProviders([]string{"p1", "p2", "p3"})
+		pushSuccess(rp, "p1", "tier-1", consensusBody)
+		pushSuccess(rp, "p2", "external", consensusBody)
+		require.Len(t, rp.NodeResults(), 2) // drains the received responses into the results manager
+		successResults, _, _ := rp.GetResultsData()
+		require.Len(t, successResults, 2)
+		return rp, successResults[0].ResponseHash
+	}
+	mkRelayResult := func(consensusHash [32]byte) *common.RelayResult {
+		return &common.RelayResult{
+			ProviderInfo:    common.ProviderInfo{ProviderAddress: "p1"},
+			CrossValidation: 2,
+			ResponseHash:    consensusHash,
+			Reply:           &pairingtypes.RelayReply{Metadata: []pairingtypes.Metadata{}},
+		}
+	}
+	deterministicAPI := func(method string) *spectypes.Api {
+		return &spectypes.Api{Name: method, Category: spectypes.SpecCategory{Deterministic: true}}
+	}
+	// The watcher runs on its own goroutine, so poll the ring rather than assuming it has recorded.
+	awaitEvents := func(t *testing.T, requestID string, want int) []crossValidationEvent {
+		t.Helper()
+		var events []crossValidationEvent
+		require.Eventually(t, func() bool {
+			events, _, _ = readCrossValidationEvents(crossValidationEventFilter{RequestID: requestID})
+			return len(events) == want
+		}, 5*time.Second, 10*time.Millisecond, "the straggler watcher must record %d event(s)", want)
+		return events
+	}
+
+	t.Run("late dissent", func(t *testing.T) {
+		ctx := utils.WithUniqueIdentifier(baseCtx, 555000111)
+		method := "cv_events_straggler_disagreed"
+		rp, consensusHash := newCVProcessorWithConsensus(t)
+		srv.watchCrossValidationStragglers(ctx, rp, mkRelayResult(consensusHash), &MockProtocolMessage{api: deterministicAPI(method), requestedBlock: 100}, method, []string{"p3"})
+		pushSuccess(rp, "p3", "external", dissentBody)
+
+		events := awaitEvents(t, "555000111", 1)
+		event := events[0]
+		require.Equal(t, crossValidationEventSourceStraggler, event.Source,
+			"the row says which path saw it: this provider was in pending-providers, not disagreeing-providers")
+		require.Equal(t, "ETH1", event.ChainID)
+		require.Equal(t, "jsonrpc", event.ApiInterface)
+		require.Equal(t, method, event.Method)
+		require.Equal(t, "p3", event.ProviderAddress)
+		require.Equal(t, "external", event.ProviderGroup)
+		require.Equal(t, common.CrossValidationStragglerOutcomeDisagreed, event.Outcome)
+		require.Equal(t, "finalized", event.Finality)
+		require.Equal(t, consensusHash, event.ConsensusHash)
+		// The late answer's OWN hash — the canonicalized content hash the comparison was made on
+		// (responseContentHash, not a raw sha256 of the body), so assert what it must be: a real
+		// hash, and a different one from the consensus.
+		require.NotEqual(t, [32]byte{}, event.OutlierHash, "the dissenting content was hashed, not left as the no-content sentinel")
+		require.NotEqual(t, event.ConsensusHash, event.OutlierHash)
+		require.True(t, event.MismatchCounted, "a late confirmed dissent reaches the mismatch alerting surface")
+	})
+
+	t.Run("late agreement is the positive control", func(t *testing.T) {
+		ctx := utils.WithUniqueIdentifier(baseCtx, 555000222)
+		method := "cv_events_straggler_agreed"
+		rp, consensusHash := newCVProcessorWithConsensus(t)
+		srv.watchCrossValidationStragglers(ctx, rp, mkRelayResult(consensusHash), &MockProtocolMessage{api: deterministicAPI(method), requestedBlock: 100}, method, []string{"p3"})
+		pushSuccess(rp, "p3", "external", consensusBody)
+
+		event := awaitEvents(t, "555000222", 1)[0]
+		require.Equal(t, common.CrossValidationStragglerOutcomeAgreed, event.Outcome,
+			"a straggler that agreed is recorded too, so 'no dissent' has something to anchor on")
+		require.Equal(t, consensusHash, event.OutlierHash, "an agreeing straggler's hash IS the consensus hash")
+		require.False(t, event.MismatchCounted, "agreement must not reach the mismatch alerting surface")
+	})
+
+	t.Run("two same-group late dissents are both recorded but counted once", func(t *testing.T) {
+		ctx := utils.WithUniqueIdentifier(baseCtx, 555000333)
+		method := "cv_events_straggler_dedup"
+		rp, consensusHash := newCVProcessorWithConsensus(t)
+		srv.watchCrossValidationStragglers(ctx, rp, mkRelayResult(consensusHash), &MockProtocolMessage{api: deterministicAPI(method), requestedBlock: 100}, method, []string{"p3", "p4"})
+		pushSuccess(rp, "p3", "external", dissentBody)
+		pushSuccess(rp, "p4", "external", dissentBody)
+
+		events := awaitEvents(t, "555000333", 2)
+		counted := 0
+		for _, event := range events {
+			require.Equal(t, common.CrossValidationStragglerOutcomeDisagreed, event.Outcome)
+			if event.MismatchCounted {
+				counted++
+			}
+		}
+		require.Equal(t, 2, len(events), "every dissenting provider is named, which a counter cannot do")
+		require.Equal(t, 1, counted, "while the counter still moves once for the group")
+	})
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -390,6 +390,10 @@ func (rpsr *RPCSmartRouter) Start(ctx context.Context, options *rpcSmartRouterSt
 		// Debug-mode-only: enable the in-memory ring-buffer log sink so the
 		// /debug/logs endpoint can serve recent logs to the test harness.
 		utils.EnableDebugLogBuffer(50000)
+		// Debug-mode-only, same reasoning: start recording cross-validation dissent so
+		// /debug/cross-validation-events can serve it (MAG-2772). Until this call the recorder is a
+		// nil check on the relay path, so a production router stores nothing.
+		enableCrossValidationEventRing(crossValidationEventRingCapacity)
 		var currentOffsetNano atomic.Int64
 		debugMux := buildDebugMux(debugMuxDeps{
 			optimizers: optimizers,
@@ -1699,6 +1703,95 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 		}); err != nil {
 			utils.LavaFormatWarning("failed encoding provider scores response", err)
 		}
+	})
+
+	// GET /debug/cross-validation-events — the cross-validation dissent the router actually recorded
+	// (MAG-2772). Read-only.
+	//
+	// Same reason /debug/provider-scores exists (MAG-2707): the two surfaces that already held this
+	// information could not be asserted on from an automated run. The info logs are diagnostic
+	// evidence only by team rule, and smartrouter_cross_validation_mismatch_total sits on the
+	// unpublished metrics port, where a down tunnel returns empty and the test passes having measured
+	// nothing.
+	//
+	// It is EVENT-shaped rather than counter-shaped because the questions are per-request: which
+	// provider dissented on THIS request, in which group. The counter's labels are
+	// {spec, apiInterface, method, group, finality} — no provider, no request id — so counts can be
+	// derived from these rows but these rows cannot be derived from the counter.
+	//
+	// One row per recorded comparison outcome, oldest first, from both recording paths (Source):
+	//   reply-time  a content outlier seen before the reply — it is in the request's
+	//               lava-cross-validation-disagreeing-providers header.
+	//   straggler   a provider that lost the race to quorum (it is in pending-providers) and whose
+	//               late answer the async watcher resolved. EVERY resolution is recorded, not only
+	//               dissent: an "agreed" row is the positive control a test asserting "no dissent
+	//               happened" anchors on, and node-error / protocol-error / not-received rows say a
+	//               late answer arrived broken or never arrived.
+	//
+	// Filters (all optional, ANDed): request_id (the Lava-Guid response header value — NOT
+	// /debug/logs' request_id, which is the caller's X-Request-Id), chain_id, outcome, limit (keeps
+	// the most recent N). Status codes:
+	//   200  the rows follow, as a flat JSON array; [] means the recorder was live and saw no dissent.
+	//   503  the recorder is not installed, so nothing was being recorded and an empty answer would
+	//        mean nothing. Structurally impossible on a router that serves this endpoint at all (the
+	//        ring is installed by the same --debug-address condition that registers this mux), and
+	//        answered anyway so the impossible case can never read as "no dissent".
+	//
+	// The ring is bounded; X-Cross-Validation-Events-Dropped reports how many events were evicted
+	// since it was installed (or since the last clear), so truncation cannot pass for absence.
+	mux.HandleFunc("/debug/cross-validation-events", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "GET only", http.StatusMethodNotAllowed)
+			return
+		}
+		q := r.URL.Query()
+		limit := 0 // 0 = the whole ring
+		if v := q.Get("limit"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				limit = n
+			}
+		}
+		events, dropped, enabled := readCrossValidationEvents(crossValidationEventFilter{
+			RequestID: q.Get("request_id"),
+			ChainID:   q.Get("chain_id"),
+			Outcome:   q.Get("outcome"),
+			Limit:     limit,
+		})
+		if !enabled {
+			http.Error(w, "cross-validation event recording is not enabled on this router", http.StatusServiceUnavailable)
+			return
+		}
+		rows := make([]map[string]any, 0, len(events))
+		for _, event := range events {
+			rows = append(rows, crossValidationEventRow(event))
+		}
+		// Deliberately NOT sortDebugRows: these are events, not state, and recording order is the
+		// meaningful one — it is what pairs a reply-time dissent with the straggler that followed it.
+		// Seq makes that order explicit for a caller that re-sorts.
+		w.Header().Set("X-Cross-Validation-Events-Dropped", strconv.FormatUint(dropped, 10))
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(rows); err != nil {
+			utils.LavaFormatWarning("failed encoding cross-validation events response", err)
+		}
+	})
+
+	// POST /debug/cross-validation-events/clear — drop every recorded event so a test can isolate
+	// itself from earlier traffic (MAG-2772). Optional for correctness — the rows are filterable by
+	// request_id, which every test already holds — and provided because it is the same one-liner
+	// /debug/logs/clear already offers. 503 when the recorder is not installed, so a clear that
+	// cleared nothing is never reported as success.
+	mux.HandleFunc("/debug/cross-validation-events/clear", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST only", http.StatusMethodNotAllowed)
+			return
+		}
+		cleared, enabled := clearCrossValidationEvents()
+		if !enabled {
+			http.Error(w, "cross-validation event recording is not enabled on this router", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"cleared":true,"events_cleared":%d}`, cleared)
 	})
 
 	// POST /debug/reset-endpoint-health — focused companion to /debug/reset-all (MAG-2186):

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -4000,22 +4000,49 @@ func (rpcss *RPCSmartRouterServer) watchCrossValidationStragglers(ctx context.Co
 			utils.LogAttr("method", apiName),
 			utils.LogAttr("consensusHashHex", fmt.Sprintf("%x", consensusHash[:8])),
 		)
+		group := straggler.ProviderGroup
+		if group == "" {
+			group = common.DefaultProviderGroup
+		}
+		// Decide admission to the mismatch alerting surface FIRST, so the decision is recorded on the
+		// debug event even on a fixture with no metrics manager wired. Shared admission rule with the
+		// reply-time outlier path — see crossValidationMismatchEligible — plus the once-per-distinct-
+		// group-per-request dedup this closure carries across stragglers.
+		mismatchCounted := false
+		if straggler.Outcome == common.CrossValidationStragglerOutcomeDisagreed && crossValidationMismatchEligible(deterministic, consensusHash) {
+			if _, counted := emittedMismatchGroups[group]; !counted {
+				emittedMismatchGroups[group] = struct{}{}
+				// The flag means the counter MOVED, so it stays false on a fixture with no metrics
+				// manager — matching the reply-time path rather than claiming an increment that
+				// never happened.
+				mismatchCounted = rpcss.smartRouterEndpointMetrics != nil
+			}
+		}
+		// Record the debug event BEFORE either metric, so the straggler counter remains the LAST side
+		// effect of record(): a caller (or test) that observes the straggler count reaching N is then
+		// guaranteed both the mismatch decision AND the event for those N have already landed
+		// (MAG-2772). Recording is a no-op unless the router runs with --debug-address.
+		recordCrossValidationEvent(crossValidationEvent{
+			Source:          crossValidationEventSourceStraggler,
+			ChainID:         chainId,
+			ApiInterface:    apiInterface,
+			RequestID:       crossValidationRequestID(ctx),
+			Method:          apiName,
+			ProviderAddress: straggler.ProviderAddress,
+			ProviderGroup:   group,
+			Outcome:         straggler.Outcome,
+			Finality:        finality,
+			ConsensusHash:   consensusHash,
+			OutlierHash:     straggler.ResponseHash,
+			MismatchCounted: mismatchCounted,
+			DelayMs:         straggler.Delay.Milliseconds(),
+		})
 		if rpcss.smartRouterEndpointMetrics == nil {
 			return
 		}
-		// Emit the mismatch metric BEFORE the straggler metric so the straggler counter is the LAST
-		// side effect of record(): a caller (or test) that observes the straggler count reaching N
-		// is then guaranteed record()'s mismatch decision for those N has already completed.
-		// Shared admission rule with the reply-time outlier path — see crossValidationMismatchEligible.
-		if straggler.Outcome == common.CrossValidationStragglerOutcomeDisagreed && crossValidationMismatchEligible(deterministic, consensusHash) {
-			group := straggler.ProviderGroup
-			if group == "" {
-				group = common.DefaultProviderGroup
-			}
-			if _, counted := emittedMismatchGroups[group]; !counted {
-				emittedMismatchGroups[group] = struct{}{}
-				rpcss.smartRouterEndpointMetrics.SetCrossValidationMismatchMetric(chainId, apiInterface, apiName, group, finality)
-			}
+		// Mismatch before straggler, for the same last-side-effect reason.
+		if mismatchCounted {
+			rpcss.smartRouterEndpointMetrics.SetCrossValidationMismatchMetric(chainId, apiInterface, apiName, group, finality)
 		}
 		rpcss.smartRouterEndpointMetrics.SetCrossValidationStragglerMetric(chainId, apiInterface, apiName, straggler.Outcome)
 	}
@@ -4129,16 +4156,24 @@ func (rpcss *RPCSmartRouterServer) appendHeadersToRelayResult(ctx context.Contex
 			consensusHash = relayResult.ResponseHash
 		}
 		successOutliers := crossValidationSuccessOutliers(successResults, consensusHash, cvSuccess, deterministic)
-		if len(successOutliers) > 0 && rpcss.smartRouterEndpointMetrics != nil && rpcss.listenEndpoint != nil {
+		// listenEndpoint is still required — it is where the chain identity comes from, and both the
+		// metric labels and the self-describing debug row are meaningless without it. The metrics
+		// manager is NOT required: a router that cannot count the dissent can still record it.
+		if len(successOutliers) > 0 && rpcss.listenEndpoint != nil {
 			chainId, apiInterface := rpcss.listenEndpoint.ChainID, rpcss.listenEndpoint.ApiInterface
 			finality := rpcss.crossValidationFinalityLabel(protocolMessage)
-			outlierGroups := map[string]struct{}{}
+			requestID := crossValidationRequestID(ctx)
+			// One pass, so the debug event can say WHICH outlier carried the group's single increment.
+			// The metric contract is unchanged — once per distinct outlier group — and emitting in
+			// outlier order rather than map order makes it deterministic as a side benefit.
+			countedGroups := map[string]struct{}{}
 			for _, outlier := range successOutliers {
 				group := outlier.ProviderInfo.ProviderGroup
 				if group == "" {
 					group = common.DefaultProviderGroup
 				}
-				outlierGroups[group] = struct{}{}
+				_, alreadyCounted := countedGroups[group]
+				countedGroups[group] = struct{}{}
 				utils.LavaFormatInfo("cross-validation outlier detected",
 					utils.LogAttr("GUID", ctx),
 					utils.LogAttr("provider", outlier.ProviderInfo.ProviderAddress),
@@ -4148,9 +4183,28 @@ func (rpcss *RPCSmartRouterServer) appendHeadersToRelayResult(ctx context.Contex
 					utils.LogAttr("consensusHashHex", fmt.Sprintf("%x", consensusHash[:8])),
 					utils.LogAttr("outlierHashHex", fmt.Sprintf("%x", outlier.ResponseHash[:8])),
 				)
-			}
-			for group := range outlierGroups {
-				rpcss.smartRouterEndpointMetrics.SetCrossValidationMismatchMetric(chainId, apiInterface, apiName, group, finality)
+				// The debug read surface for the same dissent the log and the counter describe, keyed
+				// by request so the automation can assert per-request facts a counter cannot carry
+				// (MAG-2772). No-op unless the router runs with --debug-address.
+				recordCrossValidationEvent(crossValidationEvent{
+					Source:          crossValidationEventSourceReplyTime,
+					ChainID:         chainId,
+					ApiInterface:    apiInterface,
+					RequestID:       requestID,
+					Method:          apiName,
+					ProviderAddress: outlier.ProviderInfo.ProviderAddress,
+					ProviderGroup:   group,
+					// A reply-time content outlier is by construction a dissent: crossValidationSuccessOutliers
+					// only returns successful responses whose hash differs from a reached consensus.
+					Outcome:         common.CrossValidationStragglerOutcomeDisagreed,
+					Finality:        finality,
+					ConsensusHash:   consensusHash,
+					OutlierHash:     outlier.ResponseHash,
+					MismatchCounted: !alreadyCounted && rpcss.smartRouterEndpointMetrics != nil,
+				})
+				if !alreadyCounted && rpcss.smartRouterEndpointMetrics != nil {
+					rpcss.smartRouterEndpointMetrics.SetCrossValidationMismatchMetric(chainId, apiInterface, apiName, group, finality)
+				}
 			}
 		}
 

--- a/scripts/pre_setups/init_smartrouter_eth_cv_events.sh
+++ b/scripts/pre_setups/init_smartrouter_eth_cv_events.sh
@@ -1,0 +1,485 @@
+#!/bin/bash
+# =============================================================================
+# Boot a smart router with --debug-address so GET /debug/cross-validation-events
+# (MAG-2772) can be exercised by hand, then prove it end to end.
+#
+# Shaped like init_smartrouter_eth.sh — same screens, same generated-config
+# style, same "leave it running and print the commands" ending — with two
+# deliberate differences:
+#
+#   1. --debug-address. That flag is what installs the cross-validation event
+#      recorder (see rpcsmartrouter.Start, next to utils.EnableDebugLogBuffer).
+#      Without it the endpoint is not registered at all, and a router that IS
+#      serving it but never recorded answers 503 rather than an empty 200.
+#
+#   2. The upstreams are the provider_simulator, not public Ethereum RPC. The
+#      feature under test only produces rows when providers DISAGREE, and real
+#      endpoints agree on finalized state — a shared-truth fleet can never
+#      manufacture a dissent. The simulator's per-method body override
+#      (POST /scenario) makes one provider return a valid-but-divergent
+#      eth_getBalance, which is exactly a "successful content outlier on a
+#      deterministic method after quorum": the one input the mismatch surface
+#      admits. If all you want is a debug-enabled router against real upstreams,
+#      add --debug-address to init_smartrouter_eth.sh instead — you just will
+#      not be able to make anything dissent.
+#
+# The three providers carry GROUP LABELS (tier-1 x2, external x1). That is not
+# decoration: whether a chart's group-label actually reaches
+# ProviderInfo.ProviderGroup on a live relay is the one thing the router-side Go
+# tests cannot prove — they inject the group directly — so the smoke below
+# asserts the label arrives on the row.
+#
+# Both recording paths are demonstrated, deterministically, using the
+# simulator's latency knob to decide who wins the race to quorum:
+#
+#   reply-time  the dissenter answers FIRST, so its response is in hand when the
+#               reply is built -> it lands in lava-cross-validation-disagreeing-providers.
+#   straggler   the dissenter is delayed past the quorum early-exit, so it is
+#               PENDING at reply time and the async watcher resolves it after.
+#
+# Usage:
+#   scripts/pre_setups/init_smartrouter_eth_cv_events.sh     # boot + smoke, leaves router up
+#   SKIP_SMOKE=1 scripts/pre_setups/init_smartrouter_eth_cv_events.sh
+#   SIM_DIR=/path/to/provider_simulator scripts/pre_setups/init_smartrouter_eth_cv_events.sh
+# =============================================================================
+__dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "$__dir"/../useful_commands.sh
+
+LOGS_DIR=${__dir}/../../debugging/logs
+mkdir -p "$LOGS_DIR"
+LOGS_DIR=$(cd "$LOGS_DIR" && pwd)
+
+PROJECT_ROOT=$(cd "${__dir}/../.." && pwd)
+LOG_FILE="$LOGS_DIR/SMARTROUTER_CV_EVENTS.log"
+SIM_LOG="$LOGS_DIR/CV_EVENTS_SIM.log"
+rm -f "$LOG_FILE" "$SIM_LOG" 2>/dev/null || true
+
+# --- Ports. Deliberately distinct from init_smartrouter_eth.sh (3360/7779) and
+# --- test_uc4_smartrouter_sim.sh (3392/7798) so this can run alongside them.
+ETH_PORT=3371          # router JSON-RPC listener
+METRICS_PORT=7797      # prometheus (NOT scraped by this script — that is the point)
+DEBUG_PORT=6767        # --debug-address: where /debug/cross-validation-events lives
+
+# --- provider_simulator: the eth-sim pool, pids 1/2/3 (see its topology.py).
+# Search upward for the sibling checkout rather than assuming one layout: a
+# working copy nested under a per-branch directory sits two levels down from the
+# workspace root, not one. SIM_DIR=... overrides the search entirely.
+if [[ -z "$SIM_DIR" ]]; then
+	for candidate in "$PROJECT_ROOT/.." "$PROJECT_ROOT/../.." "$PROJECT_ROOT/../../.."; do
+		if [ -f "$candidate/provider_simulator/run.py" ]; then
+			SIM_DIR=$(cd "$candidate/provider_simulator" && pwd)
+			break
+		fi
+	done
+	SIM_DIR="${SIM_DIR:-$(cd "$PROJECT_ROOT/.." && pwd)/provider_simulator}"
+fi
+SIM_CONTROL="127.0.0.1:19000"
+SIM_ETH_1=18545
+SIM_ETH_2=18546
+SIM_ETH_3=18547
+DISSENTER="eth-sim:3"          # the provider we make disagree
+DISSENTER_GROUP="external"     # its group-label -> expected ProviderGroup on the row
+
+# --- The policy under test: a plain 2-of-3 quorum on a deterministic method.
+CV_METHOD="eth_getBalance"
+CV_THRESHOLD=2
+MAX_PART=3
+# A concrete block well below the simulator's head (0x1312D00 = 20,000,000), so the
+# request is FINALIZED and the row's Finality reads "finalized" rather than "unknown".
+CV_BLOCK="0x1000000"
+DISSENT_BALANCE="0xdeadbeef"   # the divergent-but-valid result the outlier returns
+
+echo "============================================"
+echo "MAG-2772 — GET /debug/cross-validation-events"
+echo "============================================"
+echo "  router listener : 127.0.0.1:$ETH_PORT      (ETH1 jsonrpc)"
+echo "  debug endpoint  : 127.0.0.1:$DEBUG_PORT     (--debug-address)"
+echo "  metrics         : 127.0.0.1:$METRICS_PORT     (present, deliberately unused)"
+echo "  upstreams       : provider_simulator eth-sim 1/2/3 ($SIM_ETH_1/$SIM_ETH_2/$SIM_ETH_3)"
+echo "  policy          : $CV_METHOD, $CV_THRESHOLD of $MAX_PART, groups tier-1 x2 + $DISSENTER_GROUP x1"
+echo "============================================"
+echo ""
+
+for tool in jq curl python3; do
+	command_exists "$tool" || { echo "ERROR: '$tool' is required."; exit 1; }
+done
+SIM_PY="$(command -v python3.12 || command -v python3)"
+
+# -----------------------------------------------------------------------------
+# Simulator control helpers. Provider keys are "pool:pid" — the control API
+# rejects the older bare-pid + chain_family shape with a 400.
+# -----------------------------------------------------------------------------
+sim_up() { curl -s --max-time 2 "http://$SIM_CONTROL/health" >/dev/null 2>&1; }
+sim_reset() { curl -s -X POST "http://$SIM_CONTROL/reset/all" >/dev/null 2>&1; }
+
+# sim_scenario <json> : POST a scenario fragment, failing loudly on a rejected key.
+sim_scenario() {
+	local response
+	response=$(curl -s -w '\n%{http_code}' -X POST "http://$SIM_CONTROL/scenario" \
+		-H 'Content-Type: application/json' -d "$1")
+	if [[ "$(printf '%s' "$response" | tail -n1)" != "200" ]]; then
+		echo "  ! simulator rejected the scenario: $(printf '%s' "$response" | sed '$d')"
+		return 1
+	fi
+}
+
+# set_fleet <sim1_ms> <sim2_ms> <sim3_ms> <sim3_dissents:yes|no> : state the WHOLE
+# fleet every time rather than mutating one provider, so no scenario inherits the
+# previous one's latency or override.
+#
+# Latency is how this script picks the recording path deterministically. All three
+# upstreams are local and answer in microseconds, so who wins the race to quorum is
+# otherwise chance — and that choice is exactly what decides whether a dissent is
+# seen before the reply (reply-time) or after it (straggler).
+set_fleet() {
+	local l1=$1 l2=$2 l3=$3 dissents=$4 sim3_responses='{}'
+	if [[ "$dissents" == "yes" ]]; then
+		sim3_responses="{\"$CV_METHOD\":{\"result\":\"$DISSENT_BALANCE\"}}"
+	fi
+	sim_scenario "{\"providers\":{
+		\"eth-sim:1\":{\"latency_ms\":$l1,\"responses\":{}},
+		\"eth-sim:2\":{\"latency_ms\":$l2,\"responses\":{}},
+		\"$DISSENTER\":{\"latency_ms\":$l3,\"responses\":$sim3_responses}}}"
+}
+
+# -----------------------------------------------------------------------------
+# Debug-endpoint helpers — the surface under test.
+# -----------------------------------------------------------------------------
+events() { curl -s "http://127.0.0.1:$DEBUG_PORT/debug/cross-validation-events$1"; }
+events_clear() { curl -s -X POST "http://127.0.0.1:$DEBUG_PORT/debug/cross-validation-events/clear"; }
+
+# cv_call <nonce> : one cross-validated eth_getBalance, echoing the request's lava-guid.
+# The address varies per call so no response can be served from cache — a cache hit
+# would skip the fan-out entirely and there would be nothing to disagree about.
+cv_call() {
+	local nonce=$1 addr headers
+	addr=$(printf '0x%040x' "$nonce")
+	headers=$(curl -s -D - -o /dev/null -X POST "http://127.0.0.1:$ETH_PORT" \
+		-H 'Content-Type: application/json' \
+		-d "{\"jsonrpc\":\"2.0\",\"method\":\"$CV_METHOD\",\"params\":[\"$addr\",\"$CV_BLOCK\"],\"id\":$nonce}")
+	# grep -i, not awk's IGNORECASE: that is a gawk extension and macOS ships BWK awk,
+	# where it silently sets an unused variable and the match never fires.
+	printf '%s' "$headers" | grep -i '^lava-guid:' | tr -d '\r' | awk '{print $2}'
+}
+
+# cv_headers <nonce> : the cross-validation headers for one call, for the manual view.
+cv_headers() {
+	local nonce=$1 addr
+	addr=$(printf '0x%040x' "$nonce")
+	curl -s -D - -o /dev/null -X POST "http://127.0.0.1:$ETH_PORT" \
+		-H 'Content-Type: application/json' \
+		-d "{\"jsonrpc\":\"2.0\",\"method\":\"$CV_METHOD\",\"params\":[\"$addr\",\"$CV_BLOCK\"],\"id\":$nonce}" \
+		| grep -i '^lava-' | sed 's/\r//' | sed 's/^/    /'
+}
+
+# -----------------------------------------------------------------------------
+# Tear down only THIS script's router. The simulator is shared with other
+# harnesses and may be serving them, so it is reused rather than restarted.
+# -----------------------------------------------------------------------------
+screen -S smartrouter-cvevents -X quit >/dev/null 2>&1 || true
+killall smartrouter 2>/dev/null || true
+sleep 1
+screen -wipe >/dev/null 2>&1 || true
+
+echo "[Setup] installing binaries"
+make install || { echo "ERROR: make install failed"; exit 1; }
+
+echo ""
+if sim_up; then
+	echo "[Setup] provider_simulator already running on $SIM_CONTROL (reusing it)"
+else
+	echo "[Setup] starting provider_simulator from $SIM_DIR"
+	[ -f "$SIM_DIR/run.py" ] || { echo "ERROR: $SIM_DIR/run.py not found. Set SIM_DIR=... to the provider_simulator checkout."; exit 1; }
+	( cd "$SIM_DIR" && nohup "$SIM_PY" -u run.py > "$SIM_LOG" 2>&1 & )
+	for _ in $(seq 1 30); do sim_up && break; sleep 1; done
+	sim_up || { echo "ERROR: simulator did not become ready. See $SIM_LOG"; tail -n 20 "$SIM_LOG" 2>/dev/null | sed 's/^/    /'; exit 1; }
+	echo "  simulator up (control: $SIM_CONTROL, eth: $SIM_ETH_1/$SIM_ETH_2/$SIM_ETH_3)"
+fi
+# Clean slate so all three providers AGREE during router startup verification.
+sim_reset
+echo "  simulator scenarios reset (all providers clean)"
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+SPECS_DIR="$PROJECT_ROOT/specs/ethereum.json"
+[ -f "$SPECS_DIR" ] || { echo "ERROR: spec not found: $SPECS_DIR"; exit 1; }
+
+CONFIG_FILE="$PROJECT_ROOT/config/smartrouter_examples/smartrouter_eth_cv_events.yml"
+CONFIG_REL="config/smartrouter_examples/smartrouter_eth_cv_events.yml"
+echo ""
+echo "[Setup] generating config: $CONFIG_FILE"
+cat > "$CONFIG_FILE" <<EOF
+# Smart Router — MAG-2772 /debug/cross-validation-events manual test config.
+# Generated by: scripts/pre_setups/init_smartrouter_eth_cv_events.sh (do not hand-edit)
+#
+# Three ETH1 jsonrpc providers backed by the provider_simulator's eth-sim pool.
+# GROUP LABELS are the point: tier-1 x2 + $DISSENTER_GROUP x1, so a dissent row can be
+# checked for the label actually reaching ProviderInfo.ProviderGroup on a live relay.
+# The simulator is http-only here, so the router runs with --skip-websocket-verification.
+endpoints:
+  - listen-address: "0.0.0.0:$ETH_PORT"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    network-address: "0.0.0.0:$ETH_PORT"
+
+direct-rpc:
+  - name: "sim-1"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    group-label: "tier-1"
+    node-urls:
+      - url: "http://127.0.0.1:$SIM_ETH_1"
+        timeout: 10s
+        skip-verifications: [chain-id, pruning]
+  - name: "sim-2"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    group-label: "tier-1"
+    node-urls:
+      - url: "http://127.0.0.1:$SIM_ETH_2"
+        timeout: 10s
+        skip-verifications: [chain-id, pruning]
+  - name: "sim-3"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    group-label: "$DISSENTER_GROUP"
+    node-urls:
+      - url: "http://127.0.0.1:$SIM_ETH_3"
+        timeout: 10s
+        skip-verifications: [chain-id, pruning]
+
+# Plain cross-validation on a deterministic method — quorum of $CV_THRESHOLD, no min-groups.
+# A dissent here is a SUCCESSFUL content outlier after quorum, the only input the
+# mismatch surface (and therefore the event recorder) admits.
+cross-validation:
+  policies:
+    - chain-id: ETH1
+      api-interface: jsonrpc
+      method: $CV_METHOD
+      enabled: true
+      agreement-threshold: $CV_THRESHOLD
+      max-participants: $MAX_PART
+EOF
+echo "  config written ($(wc -c < "$CONFIG_FILE") bytes)"
+
+# -----------------------------------------------------------------------------
+# Start the router — WITH --debug-address, which is what installs the recorder.
+# No --cache-be: a cache hit would short-circuit the fan-out and there would be
+# no second opinion to disagree with.
+# -----------------------------------------------------------------------------
+echo ""
+echo "[Setup] starting Smart Router (log -> $LOG_FILE)"
+screen -d -m -S smartrouter-cvevents bash -c "cd \"$PROJECT_ROOT\" && source ~/.bashrc; smartrouter \
+$CONFIG_REL \
+--log-level debug \
+--use-static-spec \"$SPECS_DIR\" \
+--metrics-listen-address ':$METRICS_PORT' \
+--debug-address '127.0.0.1:$DEBUG_PORT' \
+--skip-websocket-verification 2>&1 | tee \"$LOG_FILE\"" && sleep 0.25
+
+echo "[Setup] waiting for the router and the debug listener ..."
+ready=0
+for _ in $(seq 1 40); do
+	# The debug listener answering 200 is the real readiness signal here: it proves
+	# both that --debug-address took effect and that the recorder is installed (an
+	# uninstalled recorder answers 503, never an empty 200).
+	if [[ "$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$DEBUG_PORT/debug/cross-validation-events" 2>/dev/null)" == "200" ]]; then
+		ready=1
+		break
+	fi
+	if ! screen -list | grep -q "smartrouter-cvevents"; then
+		echo "ERROR: the router screen exited during startup."
+		tail -n 30 "$LOG_FILE" 2>/dev/null | sed 's/^/    /'
+		exit 1
+	fi
+	sleep 1
+done
+if [ "$ready" -ne 1 ]; then
+	echo "ERROR: /debug/cross-validation-events did not answer 200 in time."
+	echo "  A 503 here means the router is up but the recorder was never installed."
+	echo "  Anything else means the debug listener never came up. See $LOG_FILE"
+	exit 1
+fi
+echo "  router ready; the recorder is live (endpoint answers 200)"
+
+# Give the chain tracker a moment to learn the head, so Finality resolves to
+# "finalized" instead of "unknown" (an unknown head is a valid answer, just a
+# less interesting demo).
+sleep 5
+
+# -----------------------------------------------------------------------------
+# Smoke: prove the feature end to end, then leave everything running.
+# -----------------------------------------------------------------------------
+FAILURES=0
+check() { # check <description> <actual> <expected>
+	if [[ "$2" == "$3" ]]; then
+		printf '  PASS  %s\n' "$1"
+	else
+		printf '  FAIL  %s (got %q, want %q)\n' "$1" "$2" "$3"
+		FAILURES=$((FAILURES + 1))
+	fi
+}
+
+if [[ "$SKIP_SMOKE" == "1" ]]; then
+	echo ""
+	echo "[Smoke] skipped (SKIP_SMOKE=1)"
+else
+	# await_row <guid> <jq-filter-args> : poll until exactly one row matches, then echo
+	# it. The straggler path resolves on a watcher goroutine after the reply has already
+	# been returned, so a read taken right after the curl is racing it.
+	await_row() {
+		local guid=$1 extra=$2 row='{}'
+		for _ in $(seq 1 25); do
+			if [[ "$(events "?request_id=$guid$extra" | jq 'length')" == "1" ]]; then
+				row=$(events "?request_id=$guid$extra" | jq '.[0]')
+				break
+			fi
+			sleep 1
+		done
+		printf '%s' "$row"
+	}
+
+	echo ""
+	echo "============================================"
+	echo "SMOKE 1/3 — nobody dissents: the agreeing-straggler positive control"
+	echo "============================================"
+	# sim-3 late but HONEST: quorum closes on sim-1 + sim-2, the reply ships, and sim-3
+	# is pending. The watcher resolves it as agreed — a row that exists precisely so a
+	# test asserting "no dissent happened" has something to anchor on instead of reading
+	# an empty array and hoping the request ran at all.
+	set_fleet 0 0 800 no
+	events_clear >/dev/null
+	GUID_OK=$(cv_call 1)
+	echo "  lava-guid: ${GUID_OK:-<none>}"
+	check "the guid is returned so a test can correlate" "$([[ -n "$GUID_OK" ]] && echo yes || echo no)" "yes"
+	ROW_OK=$(await_row "$GUID_OK" "")
+	echo "$ROW_OK" | jq . | sed 's/^/    /'
+	check "the agreeing straggler is recorded" "$(echo "$ROW_OK" | jq -r '.Outcome // ""')" "agreed"
+	check "it came from the async path"        "$(echo "$ROW_OK" | jq -r '.Source // ""')" "straggler"
+	check "an agreement never moves the counter" "$(echo "$ROW_OK" | jq -r '.MismatchCounted | tostring')" "false"
+	check "its hash IS the consensus hash" \
+		"$(echo "$ROW_OK" | jq -r 'if (.OutlierHash != "" and .OutlierHash == .ConsensusHash) then "yes" else "no" end')" "yes"
+	check "no dissent was recorded for this request" \
+		"$(events "?request_id=$GUID_OK&outcome=disagreed" | jq 'length')" "0"
+
+	echo ""
+	echo "============================================"
+	echo "SMOKE 2/3 — reply-time dissent (outlier answers before the quorum closes)"
+	echo "============================================"
+	# The dissenter answers FIRST and the two honest providers are held back, so its
+	# response is already in hand when quorum forms — the reply-time path, and the
+	# provider appears in lava-cross-validation-disagreeing-providers.
+	set_fleet 400 400 0 yes
+	events_clear >/dev/null
+	GUID_RT=$(cv_call 2)
+	echo "  lava-guid: ${GUID_RT:-<none>}"
+	ROW_RT=$(await_row "$GUID_RT" "")
+	echo "$ROW_RT" | jq . | sed 's/^/    /'
+	check "Source is reply-time"       "$(echo "$ROW_RT" | jq -r '.Source // ""')" "reply-time"
+	check "Outcome is disagreed"       "$(echo "$ROW_RT" | jq -r '.Outcome // ""')" "disagreed"
+	check "the dissenting provider is named" "$(echo "$ROW_RT" | jq -r '.ProviderAddress // ""')" "sim-3"
+	check "ProviderGroup is the chart's label" "$(echo "$ROW_RT" | jq -r '.ProviderGroup // ""')" "$DISSENTER_GROUP"
+	check "the counter moved for it"   "$(echo "$ROW_RT" | jq -r '.MismatchCounted | tostring')" "true"
+	check "the row is self-describing" "$(echo "$ROW_RT" | jq -r '.ChainID + "/" + .ApiInterface')" "ETH1/jsonrpc"
+	check "the outlier hash differs from consensus" \
+		"$(echo "$ROW_RT" | jq -r 'if (.ConsensusHash != "" and .OutlierHash != "" and .ConsensusHash != .OutlierHash) then "yes" else "no" end')" "yes"
+	check "the request is finalized, not unknown" "$(echo "$ROW_RT" | jq -r '.Finality // ""')" "finalized"
+
+	echo ""
+	echo "============================================"
+	echo "SMOKE 3/3 — straggler dissent (same outlier, delayed past the early-exit)"
+	echo "============================================"
+	# 1500 ms comfortably outlasts the two local honest responses, so quorum closes and
+	# the reply ships while the dissenter is still in flight. It is PENDING at reply
+	# time — the reply-time path could never see it — and only the async watcher can
+	# classify it.
+	set_fleet 0 0 1500 yes
+	events_clear >/dev/null
+	GUID_ST=$(cv_call 3)
+	echo "  lava-guid: ${GUID_ST:-<none>}"
+	echo "  waiting for the straggler watcher ..."
+	ROW_ST=$(await_row "$GUID_ST" "")
+	echo "$ROW_ST" | jq . | sed 's/^/    /'
+	check "Source is straggler"      "$(echo "$ROW_ST" | jq -r '.Source // ""')" "straggler"
+	check "Outcome is disagreed"     "$(echo "$ROW_ST" | jq -r '.Outcome // ""')" "disagreed"
+	check "ProviderGroup survives the async path" "$(echo "$ROW_ST" | jq -r '.ProviderGroup // ""')" "$DISSENTER_GROUP"
+	check "the late dissent reached the mismatch surface" "$(echo "$ROW_ST" | jq -r '.MismatchCounted | tostring')" "true"
+	check "the delay after the reply was measured" \
+		"$(echo "$ROW_ST" | jq -r 'if (.DelayMs // 0) > 0 then "yes" else "no" end')" "yes"
+
+	# Leave the fleet honest and prompt for manual poking; recorded rows are kept.
+	set_fleet 0 0 0 no
+	echo ""
+	echo "  fleet returned to agreement (recorded rows are kept)"
+
+	echo ""
+	echo "============================================"
+	if [ "$FAILURES" -eq 0 ]; then
+		echo "SMOKE PASSED — both recording paths verified against a live router"
+	else
+		echo "SMOKE FAILED — $FAILURES check(s) did not hold. Router left running for inspection."
+		echo "  logs: $LOG_FILE"
+	fi
+	echo "============================================"
+fi
+
+# -----------------------------------------------------------------------------
+# Manual cheat sheet
+# -----------------------------------------------------------------------------
+cat <<EOF
+
+============================================
+Router is running — manual commands
+============================================
+
+Read every recorded event:
+  curl -s http://127.0.0.1:$DEBUG_PORT/debug/cross-validation-events | jq
+
+Filter (all optional, ANDed) — request_id is the Lava-Guid response header value,
+NOT /debug/logs' request_id (that one is the caller's X-Request-Id):
+  curl -s "http://127.0.0.1:$DEBUG_PORT/debug/cross-validation-events?request_id=<lava-guid>" | jq
+  curl -s "http://127.0.0.1:$DEBUG_PORT/debug/cross-validation-events?chain_id=ETH1" | jq
+  curl -s "http://127.0.0.1:$DEBUG_PORT/debug/cross-validation-events?outcome=disagreed" | jq
+  curl -s "http://127.0.0.1:$DEBUG_PORT/debug/cross-validation-events?limit=5" | jq
+
+See the bounded-ring accounting (evictions are reported, never silent):
+  curl -si http://127.0.0.1:$DEBUG_PORT/debug/cross-validation-events | grep -i x-cross-validation
+
+Clear between scenarios:
+  curl -s -X POST http://127.0.0.1:$DEBUG_PORT/debug/cross-validation-events/clear | jq
+
+Send a cross-validated call and keep its guid (the address must vary — a cache hit
+would skip the fan-out):
+  curl -s -D - -o /dev/null -X POST http://127.0.0.1:$ETH_PORT \\
+    -H 'Content-Type: application/json' \\
+    -d '{"jsonrpc":"2.0","method":"$CV_METHOD","params":["0x000000000000000000000000000000000000beef","$CV_BLOCK"],"id":1}' \\
+    | grep -i '^lava-'
+
+Make sim-3 dissent (reply-time row), or delay it past the quorum (straggler row):
+  curl -s -X POST http://$SIM_CONTROL/scenario -H 'Content-Type: application/json' \\
+    -d '{"providers":{"$DISSENTER":{"latency_ms":0,"responses":{"$CV_METHOD":{"result":"$DISSENT_BALANCE"}}}}}'
+  curl -s -X POST http://$SIM_CONTROL/scenario -H 'Content-Type: application/json' \\
+    -d '{"providers":{"$DISSENTER":{"latency_ms":1500,"responses":{"$CV_METHOD":{"result":"$DISSENT_BALANCE"}}}}}'
+
+Stop dissenting:
+  curl -s -X POST http://$SIM_CONTROL/scenario -H 'Content-Type: application/json' \\
+    -d '{"providers":{"$DISSENTER":{"latency_ms":0,"responses":{}}}}'
+
+The positive control (an agreeing straggler still records a row) — delay a provider
+that is NOT dissenting, so it resolves late but in agreement:
+  curl -s -X POST http://$SIM_CONTROL/scenario -H 'Content-Type: application/json' \\
+    -d '{"providers":{"eth-sim:2":{"latency_ms":1500}}}'
+  ... then send a call and read: outcome=agreed, MismatchCounted=false.
+
+Cross-check the same dissent on the surfaces this endpoint replaces:
+  curl -s http://127.0.0.1:$METRICS_PORT/metrics | grep cross_validation
+  curl -s "http://127.0.0.1:$DEBUG_PORT/debug/logs?limit=200" | jq -r '.lines[].message' | grep cross-validation
+
+Logs / teardown:
+  tail -f $LOG_FILE | grep -i cross-validation
+  screen -S smartrouter-cvevents -X quit ; killall smartrouter ; screen -wipe
+============================================
+EOF
+
+exit $(( FAILURES > 0 ? 1 : 0 ))


### PR DESCRIPTION
Jira ticket: MAG-2772

## What

`GET /debug/cross-validation-events` — a read-only, per-request record of the cross-validation dissent the router observed. Built to Victoria's design from the ticket comments, after the 2026-08-16 decision to build the endpoint rather than repoint the parked tests at the Go tests.

## Why the existing surfaces don't work

The router already recorded this dissent twice, and neither can be asserted on from an automated run:

- **The info logs** (`cross-validation outlier detected` / `cross-validation straggler resolved`) — diagnostic evidence only by team rule, never a gating assertion.
- **`smartrouter_cross_validation_mismatch_total`** — on the unpublished metrics port. Reading it needs a hand-held port-forward, and when the tunnel is down the read comes back empty and the test passes having measured nothing. That is the silent pass `/debug/provider-scores` was added to end (MAG-2707, #259); this applies the same pattern.

The counter also can't answer what the parked tests ask. Its labels are `{spec, apiInterface, method, group, finality}` — no provider, no request id — so counts are derivable from events, but events are not derivable from the counter. Hence event-shaped.

## The endpoint

Flat JSON array of self-describing rows (each carries its own `ChainID` + `ApiInterface`), oldest first, from both recording paths:

| `Source` | Meaning |
| --- | --- |
| `reply-time` | a content outlier seen before the reply — it is in `lava-cross-validation-disagreeing-providers` |
| `straggler` | a provider that lost the race to quorum (it was in `pending-providers`) whose late answer the async watcher resolved |

Per row: `RequestID` (the **lava-guid**, i.e. the `Lava-Guid` response header value), `ProviderAddress`, `ProviderGroup`, `Method`, `Finality`, `ConsensusHash` + `OutlierHash` (full 32-byte hex; the log's short form is a prefix), `Outcome`, `DelayMs`, `Seq`/`RecordedAt`, and `MismatchCounted`.

`MismatchCounted` says whether **this** row is the one that moved `smartrouter_cross_validation_mismatch_total`. That makes the counter's once-per-distinct-group-per-request dedup visible instead of implicit — the exact rule two of the parked tests exist to pin.

**Every straggler resolution is recorded, not only dissent.** An `agreed` row is the positive control you asked for; `node-error` / `protocol-error` / `not-received` say a late answer arrived broken or never arrived.

Filters (optional, ANDed): `request_id`, `chain_id`, `outcome`, `limit`. Plus `POST /debug/cross-validation-events/clear` — the optional reset, included because it's the same one-liner `/debug/logs/clear` already offers.

```bash
curl -s "http://127.0.0.1:$DEBUG_PORT/debug/cross-validation-events?request_id=$LAVA_GUID" | jq
```

### Status codes

Following MAG-2707 rather than the flat-array endpoints' unconditional `200 []`:

- **200** — rows follow; `[]` means the recorder was **live** and saw no dissent.
- **503** — the recorder is not installed, so nothing was being recorded and an empty answer would mean nothing.

The ring is bounded (4096) and `X-Cross-Validation-Events-Dropped` reports evictions, so truncation cannot pass for absence.

## Cost when not in use

Recording is debug-mode only: the ring is installed next to `utils.EnableDebugLogBuffer` under the same `--debug-address` condition. A production router pays one atomic nil load per dissent and stores nothing.

## Two things worth a reviewer's eye

- **`CrossValidationStragglerResult` now carries `ResponseHash`.** Without it, straggler rows would have an empty outlier hash — one of the fields the ticket names. `classifyStragglerResponse` returns the hash it compared, zeroed for outcomes with no content, so "answered differently" and "had no answer" stay distinguishable.
- **The reply-time outlier loop is now one pass** (log + event + metric) so the event can name which outlier carried the group's single increment. The metric contract is unchanged — once per distinct outlier group — and emitting in outlier order rather than map-iteration order makes it deterministic. Its guard now requires only `listenEndpoint` and no longer requires a metrics manager: a router that cannot count the dissent can still record it.

## Known gap, deliberately left

A cross-validated request where **everyone agreed at reply time** and there were no stragglers records **no rows**. Reading `[]` for such a request therefore does not by itself prove the request ran — but the test already holds proof in its own response headers (`lava-cross-validation-status`, `-agreeing-providers`). Inventing a per-request anchor row was not asked for, so it is not here. Say the word if you'd rather have one.

Also out of scope, as the ticket says: reading the effective post-clamp cross-validation parameters, and provider-pin-header visibility. Neither fell out of this design.

## Testing

`go build ./...`, `go test ./protocol/rpcsmartrouter/ ./protocol/relaycore/` and `go test -race ./protocol/rpcsmartrouter/ -run CrossValidation` all pass locally.

New tests cover three layers:

- **the ring** — bounded and keeps the newest, filters, drop accounting, off by default, clear;
- **the HTTP contract** — 405, 503-when-off, 200-`[]`-when-live, the full row shape, filters, clear, the dropped header;
- **the production glue on both recording paths, against the real relay code** — reply-time outliers (including that two same-group outliers each get a row while the counter moves once, and that an all-agreeing request records nothing), and the straggler watcher (late dissent, late agreement as positive control, same-group dedup).

## For the automation side

The four parked tests in `tests/simulator/simulator_production_tests/cross_validation_enhancements/` can be repointed here and switched on. The correlation key is the `Lava-Guid` response header value, passed as `request_id`. Note that this is **not** `/debug/logs`' `request_id`, which is the caller's `X-Request-Id` — a different identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
