### PR TITLE
fix(lavasession): match lava-select-provider case-insensitively

### DIFF
--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -1278,37 +1278,40 @@ func convertSelectionStatsToMetrics(stats *provideroptimizer.SelectionStats) (al
 	return allScores, rngValue
 }
 
-// Provider names are free-form config strings and the pipeline does not preserve
-// their case — the helm chart folds node names into the router's config, the
-// values file spells them for humans. Both lookups below fold case.
-
-// resolveSelectedProviderAddress maps a header-supplied name onto the address the
-// router registered, so downstream lookups key on the router's spelling.
-func resolveSelectedProviderAddress(selectedProvider string, addresses []string) (string, bool) {
-	// Exact hit wins: two config names differing only in case resolve as spelled.
+// resolveSelectedProviderAddress maps a header-supplied provider name onto the address
+// the router registered. Provider names are free-form config strings and the pipeline
+// does not preserve their case — the helm chart folds node names into the router's
+// config, the values file spells them for humans — so the match folds case.
+//
+// It returns the canonical address rather than the header's spelling because everything
+// past this point keys on the router's own name: csm.pairing, the session store, the
+// in-request ignored set, the metrics labels. csm.pairing in particular is a
+// LavaFormatFatal on a miss, so handing the caller's spelling downstream would turn a
+// mis-cased header from a rejected relay into a dead router.
+//
+// An exact hit wins outright, so a config registering two names that differ only in case
+// still resolves the way the caller spelled it. Absent one, a fold matching more than one
+// address resolves to nothing and returns those candidates instead: validAddresses is
+// built by ranging a map and is reordered as providers are blocked and recovered, so
+// picking one would serve the same pinned name from a different upstream run to run —
+// the opposite of what pinning is for. The caller reports the collision so the operator
+// can rename a provider.
+func resolveSelectedProviderAddress(selectedProvider string, addresses []string) (address string, ambiguous []string) {
 	if slices.Contains(addresses, selectedProvider) {
-		return selectedProvider, true
+		return selectedProvider, nil
 	}
-	for _, address := range addresses {
-		if strings.EqualFold(address, selectedProvider) {
-			return address, true
+	var folded []string
+	for _, candidate := range addresses {
+		if strings.EqualFold(candidate, selectedProvider) {
+			folded = append(folded, candidate)
 		}
 	}
-	return "", false
-}
-
-// providerInSetFold reports whether a provider name is in a set keyed by
-// canonical addresses. Exact hit is the fast path; the scan handles a case diff.
-func providerInSetFold(set map[string]struct{}, provider string) bool {
-	if _, ok := set[provider]; ok {
-		return true
+	if len(folded) == 1 {
+		return folded[0], nil
 	}
-	for address := range set {
-		if strings.EqualFold(address, provider) {
-			return true
-		}
-	}
-	return false
+	// Sorted so the same collision reports the same way on every run.
+	sort.Strings(folded)
+	return "", folded
 }
 
 // Get a valid provider address.
@@ -1321,15 +1324,53 @@ func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context
 
 	// Handle provider selection via header (smartrouter only)
 	if selectedProvider != "" {
+		// Resolve to the router's own spelling first, so every check below — and everything
+		// downstream — keys on the canonical address rather than on what the header said.
+		providerAddress, ambiguous := resolveSelectedProviderAddress(selectedProvider, validAddresses)
+
+		if len(ambiguous) > 0 {
+			// Providers whose names differ only in case, and a header matching none of them
+			// exactly: which one the caller meant is unknowable. Pinning exists so a request
+			// is never served by a provider the caller did not ask for, so report the
+			// collision rather than picking one.
+			return nil, utils.LavaFormatError(
+				"Selected provider name matches more than one provider",
+				SelectedProviderUnavailableError,
+				utils.LogAttr("selectedProvider", selectedProvider),
+				utils.LogAttr("matchingProviders", ambiguous),
+				utils.LogAttr("addon", addon),
+				utils.LogAttr("extensions", extensions),
+				utils.LogAttr("GUID", ctx),
+			)
+		}
+
+		if providerAddress == "" {
+			// Return error instead of falling back to random selection
+			return nil, utils.LavaFormatError(
+				"Selected provider not available",
+				SelectedProviderUnavailableError,
+				utils.LogAttr("selectedProvider", selectedProvider),
+				utils.LogAttr("validProviders", validAddresses),
+				utils.LogAttr("addon", addon),
+				utils.LogAttr("extensions", extensions),
+				utils.LogAttr("GUID", ctx),
+			)
+		}
+
 		// If the pinned provider has already been added to ignoredProvidersList during this
 		// GetSessions call (e.g. a prior fetchEndpointConnectionFromConsumerSessionWithProvider
 		// returned connected=false), the outer loop would otherwise re-call us with the same
 		// selectedProvider and we'd return the same address again — an unbounded spin. Bound
 		// it here by returning an error the caller propagates as a single attempt.
-		if providerInSetFold(ignoredProvidersList, selectedProvider) {
+		//
+		// Looked up by the resolved address, exactly: the set is only ever written with
+		// addresses that came out of the pairing, so folding case here as well would let a
+		// case-twin's failure reject a provider that never failed.
+		if _, ignored := ignoredProvidersList[providerAddress]; ignored {
 			return nil, utils.LavaFormatWarning(
 				"Selected provider already failed in this request",
 				SelectedProviderUnavailableError,
+				utils.LogAttr("provider", providerAddress),
 				utils.LogAttr("selectedProvider", selectedProvider),
 				utils.LogAttr("addon", addon),
 				utils.LogAttr("extensions", extensions),
@@ -1337,29 +1378,14 @@ func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context
 			)
 		}
 
-		// Validate that the selected provider is in the valid addresses list, and
-		// carry the canonical address forward rather than what the header said.
-		if providerAddress, providerValid := resolveSelectedProviderAddress(selectedProvider, validAddresses); providerValid {
-			addresses = []string{providerAddress}
-			utils.LavaFormatInfo("Provider selected via header",
-				utils.LogAttr("provider", providerAddress),
-				utils.LogAttr("requestedProvider", selectedProvider),
-				utils.LogAttr("addon", addon),
-				utils.LogAttr("extensions", extensions),
-				utils.LogAttr("GUID", ctx))
-			return addresses, nil
-		}
-
-		// Return error instead of falling back to random selection
-		return nil, utils.LavaFormatError(
-			"Selected provider not available",
-			SelectedProviderUnavailableError,
-			utils.LogAttr("selectedProvider", selectedProvider),
-			utils.LogAttr("validProviders", validAddresses),
+		addresses = []string{providerAddress}
+		utils.LavaFormatInfo("Provider selected via header",
+			utils.LogAttr("provider", providerAddress),
+			utils.LogAttr("requestedProvider", selectedProvider),
 			utils.LogAttr("addon", addon),
 			utils.LogAttr("extensions", extensions),
-			utils.LogAttr("GUID", ctx),
-		)
+			utils.LogAttr("GUID", ctx))
+		return addresses, nil
 	}
 
 	if stickysession, ok := csm.stickySessions.Get(stickiness); ok {

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1277,6 +1278,39 @@ func convertSelectionStatsToMetrics(stats *provideroptimizer.SelectionStats) (al
 	return allScores, rngValue
 }
 
+// Provider names are free-form config strings and the pipeline does not preserve
+// their case — the helm chart folds node names into the router's config, the
+// values file spells them for humans. Both lookups below fold case.
+
+// resolveSelectedProviderAddress maps a header-supplied name onto the address the
+// router registered, so downstream lookups key on the router's spelling.
+func resolveSelectedProviderAddress(selectedProvider string, addresses []string) (string, bool) {
+	// Exact hit wins: two config names differing only in case resolve as spelled.
+	if slices.Contains(addresses, selectedProvider) {
+		return selectedProvider, true
+	}
+	for _, address := range addresses {
+		if strings.EqualFold(address, selectedProvider) {
+			return address, true
+		}
+	}
+	return "", false
+}
+
+// providerInSetFold reports whether a provider name is in a set keyed by
+// canonical addresses. Exact hit is the fast path; the scan handles a case diff.
+func providerInSetFold(set map[string]struct{}, provider string) bool {
+	if _, ok := set[provider]; ok {
+		return true
+	}
+	for address := range set {
+		if strings.EqualFold(address, provider) {
+			return true
+		}
+	}
+	return false
+}
+
 // Get a valid provider address.
 func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context, wantedProviders int, ignoredProvidersList map[string]struct{}, cu uint64, requestedBlock int64, addon string, extensions []string, stateful uint32, stickiness string, selectedProvider string) (addresses []string, err error) {
 	// cs.Lock must be Rlocked here.
@@ -1292,7 +1326,7 @@ func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context
 		// returned connected=false), the outer loop would otherwise re-call us with the same
 		// selectedProvider and we'd return the same address again — an unbounded spin. Bound
 		// it here by returning an error the caller propagates as a single attempt.
-		if _, ignored := ignoredProvidersList[selectedProvider]; ignored {
+		if providerInSetFold(ignoredProvidersList, selectedProvider) {
 			return nil, utils.LavaFormatWarning(
 				"Selected provider already failed in this request",
 				SelectedProviderUnavailableError,
@@ -1303,12 +1337,13 @@ func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context
 			)
 		}
 
-		// Validate that the selected provider is in the valid addresses list
-		providerValid := slices.Contains(validAddresses, selectedProvider)
-		if providerValid {
-			addresses = []string{selectedProvider}
+		// Validate that the selected provider is in the valid addresses list, and
+		// carry the canonical address forward rather than what the header said.
+		if providerAddress, providerValid := resolveSelectedProviderAddress(selectedProvider, validAddresses); providerValid {
+			addresses = []string{providerAddress}
 			utils.LavaFormatInfo("Provider selected via header",
-				utils.LogAttr("provider", selectedProvider),
+				utils.LogAttr("provider", providerAddress),
+				utils.LogAttr("requestedProvider", selectedProvider),
 				utils.LogAttr("addon", addon),
 				utils.LogAttr("extensions", extensions),
 				utils.LogAttr("GUID", ctx))

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -356,6 +356,22 @@ func createPairingList(providerPrefixAddress string, enabled bool) map[uint64]*C
 	return cswpList
 }
 
+// createNamedPairingList builds a pairing from exact provider names, for the cases where
+// the name itself is what is under test rather than the count of providers.
+func createNamedPairingList(names ...string) map[uint64]*ConsumerSessionsWithProvider {
+	cswpList := make(map[uint64]*ConsumerSessionsWithProvider, len(names))
+	for i, name := range names {
+		cswpList[uint64(i)] = &ConsumerSessionsWithProvider{
+			PublicLavaAddress: name,
+			Endpoints:         []*Endpoint{{Connections: []*EndpointConnection{}, NetworkAddress: grpcListener, Enabled: true, ConnectionRefusals: 0}},
+			Sessions:          map[int64]*SingleConsumerSession{},
+			MaxComputeUnits:   200,
+			PairingEpoch:      firstEpochHeight,
+		}
+	}
+	return cswpList
+}
+
 // TestNumberOfValidProviderGroups covers the Fix 3 group-capacity helper: distinct cross-validation
 // group labels across valid providers, with empty GroupLabel folded into the implicit "default" group.
 func TestNumberOfValidProviderGroups(t *testing.T) {
@@ -1628,54 +1644,103 @@ func TestSelectedProviderUnknownNameStillRejected(t *testing.T) {
 		"expected SelectedProviderUnavailableError, got: %v", err)
 }
 
+// With two providers whose names differ only in case, the in-request ignored set has to be
+// consulted by the resolved address rather than by a case-fold. `lava` having failed says
+// nothing about `Lava` — they are two different upstreams — so folding here would reject a
+// provider that is healthy and was never tried.
+func TestSelectedProviderIgnoredSetDoesNotFoldOntoACaseTwin(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+	err := csm.UpdateAllProviders(firstEpochHeight, createNamedPairingList("Lava", "lava"), nil)
+	require.NoError(t, err)
+	time.Sleep(5 * time.Millisecond) // let probes finish
+
+	require.ElementsMatch(t, []string{"Lava", "lava"}, csm.getValidAddresses("", nil, context.Background()))
+
+	// `lava` failed earlier in this request; the header pins `Lava`, which did not.
+	got, err := csm.getValidProviderAddresses(context.Background(), 1, map[string]struct{}{"lava": {}}, 10, 100, "", nil, common.NO_STATE, "", "Lava")
+	require.NoError(t, err, "Lava never failed — its case-twin's failure must not reject it")
+	require.Equal(t, []string{"Lava"}, got)
+
+	// ...and the reverse, so neither spelling is privileged.
+	got, err = csm.getValidProviderAddresses(context.Background(), 1, map[string]struct{}{"Lava": {}}, 10, 100, "", nil, common.NO_STATE, "", "lava")
+	require.NoError(t, err)
+	require.Equal(t, []string{"lava"}, got)
+
+	// The spin bound still holds when it is the pinned provider itself that failed.
+	_, err = csm.getValidProviderAddresses(context.Background(), 1, map[string]struct{}{"Lava": {}}, 10, 100, "", nil, common.NO_STATE, "", "Lava")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, SelectedProviderUnavailableError),
+		"expected SelectedProviderUnavailableError, got: %v", err)
+}
+
+// A header matching two case-colliding providers and neither of them exactly is refused,
+// not guessed: pinning exists so a request is never served by a provider the caller did
+// not ask for, and validAddresses has no stable order to break the tie with anyway.
+func TestSelectedProviderAmbiguousCaseIsRejected(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+	err := csm.UpdateAllProviders(firstEpochHeight, createNamedPairingList("Lava", "lava"), nil)
+	require.NoError(t, err)
+	time.Sleep(5 * time.Millisecond) // let probes finish
+
+	_, err = csm.getValidProviderAddresses(context.Background(), 1, map[string]struct{}{}, 10, 100, "", nil, common.NO_STATE, "", "LAVA")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, SelectedProviderUnavailableError),
+		"expected SelectedProviderUnavailableError, got: %v", err)
+	// The operator has to be able to see which names collided to know what to rename.
+	require.Contains(t, err.Error(), "matches more than one provider")
+	require.Contains(t, err.Error(), "Lava")
+	require.Contains(t, err.Error(), "lava")
+}
+
 func TestResolveSelectedProviderAddress(t *testing.T) {
 	addresses := []string{"lava", "blockdaemon", "my-node-co"}
 
 	for _, tt := range []struct {
 		requested string
 		want      string
-		wantOK    bool
 	}{
-		{"lava", "lava", true},
-		{"Lava", "lava", true},
-		{"LAVA", "lava", true},
-		{"BlockDaemon", "blockdaemon", true},
-		{"My-Node-Co", "my-node-co", true},
-		{"tatum", "", false},
-		{"", "", false},
+		{"lava", "lava"},
+		{"Lava", "lava"},
+		{"LAVA", "lava"},
+		{"BlockDaemon", "blockdaemon"},
+		{"My-Node-Co", "my-node-co"},
+		{"tatum", ""},
+		{"", ""},
 	} {
-		got, ok := resolveSelectedProviderAddress(tt.requested, addresses)
-		require.Equal(t, tt.wantOK, ok, "requested %q", tt.requested)
+		got, ambiguous := resolveSelectedProviderAddress(tt.requested, addresses)
 		require.Equal(t, tt.want, got, "requested %q", tt.requested)
+		require.Empty(t, ambiguous, "requested %q is not a collision", tt.requested)
 	}
 }
 
 func TestResolveSelectedProviderAddressPrefersTheExactSpelling(t *testing.T) {
-	// Two names differing only in case is legal in config; the exact spelling wins.
+	// Two names differing only in case is legal config — ValidateUniqueProviderNames
+	// groups by exact name — so an exact hit has to win outright.
 	addresses := []string{"Lava", "lava"}
 
-	got, ok := resolveSelectedProviderAddress("lava", addresses)
-	require.True(t, ok)
+	got, ambiguous := resolveSelectedProviderAddress("lava", addresses)
+	require.Empty(t, ambiguous)
 	require.Equal(t, "lava", got)
 
-	got, ok = resolveSelectedProviderAddress("Lava", addresses)
-	require.True(t, ok)
-	require.Equal(t, "Lava", got)
-
-	// No exact hit: the fold resolves to the first registered spelling.
-	got, ok = resolveSelectedProviderAddress("LAVA", addresses)
-	require.True(t, ok)
+	got, ambiguous = resolveSelectedProviderAddress("Lava", addresses)
+	require.Empty(t, ambiguous)
 	require.Equal(t, "Lava", got)
 }
 
-func TestProviderInSetFold(t *testing.T) {
-	set := map[string]struct{}{"lava": {}, "blockdaemon": {}}
+// Absent an exact hit, a fold matching two providers resolves to neither. Which one the
+// caller meant is unknowable, and there is no stable order to break the tie with:
+// validAddresses is built by ranging a map and is reordered as providers are blocked and
+// recovered, so picking by position would serve the same pinned name from a different
+// upstream run to run.
+func TestResolveSelectedProviderAddressRefusesAnAmbiguousFold(t *testing.T) {
+	got, ambiguous := resolveSelectedProviderAddress("LAVA", []string{"Lava", "lava"})
+	require.Empty(t, got)
+	require.Equal(t, []string{"Lava", "lava"}, ambiguous)
 
-	require.True(t, providerInSetFold(set, "lava"))
-	require.True(t, providerInSetFold(set, "Lava"))
-	require.True(t, providerInSetFold(set, "BLOCKDAEMON"))
-	require.False(t, providerInSetFold(set, "tatum"))
-	require.False(t, providerInSetFold(map[string]struct{}{}, "lava"))
+	// Reported sorted, so one bad config reads the same way on every run whatever order
+	// the reset happened to leave validAddresses in.
+	_, ambiguous = resolveSelectedProviderAddress("LAVA", []string{"lava", "Lava"})
+	require.Equal(t, []string{"Lava", "lava"}, ambiguous)
 }
 
 func TestPairingWithStateful(t *testing.T) {

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -1567,6 +1567,117 @@ func TestSelectedProviderAlreadyFailedReturnsError(t *testing.T) {
 		"expected SelectedProviderUnavailableError, got: %v", err)
 }
 
+// The header naming the right provider in the wrong case: `lava-select-provider:
+// Lava` and a registered `lava` are the same provider. A case-sensitive match
+// rejected the relay outright rather than falling back.
+func TestSelectedProviderMatchesCaseInsensitively(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+	pairingList := createPairingList("", true)
+	err := csm.UpdateAllProviders(firstEpochHeight, pairingList, nil)
+	require.NoError(t, err)
+	time.Sleep(5 * time.Millisecond) // let probes finish
+
+	validAddresses := csm.getValidAddresses("", nil, context.Background())
+	require.NotEmpty(t, validAddresses)
+	pinned := validAddresses[0]
+
+	for _, requested := range []string{
+		strings.ToUpper(pinned),
+		strings.ToLower(pinned),
+		strings.ToUpper(pinned[:1]) + pinned[1:], // "Provider0"
+	} {
+		got, err := csm.getValidProviderAddresses(context.Background(), 1, map[string]struct{}{}, 10, 100, "", nil, common.NO_STATE, "", requested)
+		require.NoError(t, err, "header %q should resolve to %q", requested, pinned)
+		// The canonical address comes back, not the caller's spelling.
+		require.Equal(t, []string{pinned}, got, "header %q must resolve to the registered address", requested)
+	}
+}
+
+// The ignored list is keyed by canonical address, so a differently-cased header
+// must still be recognised — otherwise the re-selection spin comes back.
+func TestSelectedProviderAlreadyFailedIsCaseInsensitive(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+	pairingList := createPairingList("", true)
+	err := csm.UpdateAllProviders(firstEpochHeight, pairingList, nil)
+	require.NoError(t, err)
+	time.Sleep(5 * time.Millisecond) // let probes finish
+
+	validAddresses := csm.getValidAddresses("", nil, context.Background())
+	require.NotEmpty(t, validAddresses)
+	pinned := validAddresses[0]
+
+	ignored := map[string]struct{}{pinned: {}}
+	_, err = csm.getValidProviderAddresses(context.Background(), 1, ignored, 10, 100, "", nil, common.NO_STATE, "", strings.ToUpper(pinned))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, SelectedProviderUnavailableError),
+		"expected SelectedProviderUnavailableError, got: %v", err)
+}
+
+// Folding case must not soften the contract: a name matching no provider in any
+// case is still an error, not a silent fallback.
+func TestSelectedProviderUnknownNameStillRejected(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+	pairingList := createPairingList("", true)
+	err := csm.UpdateAllProviders(firstEpochHeight, pairingList, nil)
+	require.NoError(t, err)
+	time.Sleep(5 * time.Millisecond) // let probes finish
+
+	_, err = csm.getValidProviderAddresses(context.Background(), 1, map[string]struct{}{}, 10, 100, "", nil, common.NO_STATE, "", "no-such-provider")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, SelectedProviderUnavailableError),
+		"expected SelectedProviderUnavailableError, got: %v", err)
+}
+
+func TestResolveSelectedProviderAddress(t *testing.T) {
+	addresses := []string{"lava", "blockdaemon", "my-node-co"}
+
+	for _, tt := range []struct {
+		requested string
+		want      string
+		wantOK    bool
+	}{
+		{"lava", "lava", true},
+		{"Lava", "lava", true},
+		{"LAVA", "lava", true},
+		{"BlockDaemon", "blockdaemon", true},
+		{"My-Node-Co", "my-node-co", true},
+		{"tatum", "", false},
+		{"", "", false},
+	} {
+		got, ok := resolveSelectedProviderAddress(tt.requested, addresses)
+		require.Equal(t, tt.wantOK, ok, "requested %q", tt.requested)
+		require.Equal(t, tt.want, got, "requested %q", tt.requested)
+	}
+}
+
+func TestResolveSelectedProviderAddressPrefersTheExactSpelling(t *testing.T) {
+	// Two names differing only in case is legal in config; the exact spelling wins.
+	addresses := []string{"Lava", "lava"}
+
+	got, ok := resolveSelectedProviderAddress("lava", addresses)
+	require.True(t, ok)
+	require.Equal(t, "lava", got)
+
+	got, ok = resolveSelectedProviderAddress("Lava", addresses)
+	require.True(t, ok)
+	require.Equal(t, "Lava", got)
+
+	// No exact hit: the fold resolves to the first registered spelling.
+	got, ok = resolveSelectedProviderAddress("LAVA", addresses)
+	require.True(t, ok)
+	require.Equal(t, "Lava", got)
+}
+
+func TestProviderInSetFold(t *testing.T) {
+	set := map[string]struct{}{"lava": {}, "blockdaemon": {}}
+
+	require.True(t, providerInSetFold(set, "lava"))
+	require.True(t, providerInSetFold(set, "Lava"))
+	require.True(t, providerInSetFold(set, "BLOCKDAEMON"))
+	require.False(t, providerInSetFold(set, "tatum"))
+	require.False(t, providerInSetFold(map[string]struct{}{}, "lava"))
+}
+
 func TestPairingWithStateful(t *testing.T) {
 	ctx := context.Background()
 	t.Run("stateful", func(t *testing.T) {


### PR DESCRIPTION
#Closes MAG-2816

Jira ticket: MAG-2816

## Summary

Provider names are free-form config strings, and the deployment pipeline does not preserve their case. The helm chart folds each node's name into the router's own config:

```yaml
# smart-router-helm-chart · charts/smart-router/templates/routers_configmap.yaml:52
name: {{ $node.name | lower | replace " " "-" }}
```

…while the values file (and the dashboard reading it) spells the name for people. So `lava-select-provider: Lava` against a registered `lava` names the right provider — and the exact match rejected it outright, since header selection deliberately does not fall back to another provider.

Observed on `gk8-prod`:

```
$ curl -X POST https://iota-mainnet-jsonrpc.gk8.magmadevs.com \
    -H 'lava-select-provider: Lava' -d '{…"method":"iota_getChainIdentifier"…}'
{"error":{"code":-32000,"message":"… {selectedProvider:Lava,validProviders:lava,…}"}}

# same request, lowercase header → {"jsonrpc":"2.0","id":1,"result":"6364aad5"}
```

The upstream was healthy throughout. Case-sensitivity bought nothing here and cost a rejected relay.

## The change

Both lookups in `getValidProviderAddresses` now fold case:

- **The valid-address match.** Resolution returns the **canonical** address rather than the header's spelling, so everything downstream — the pairing map, the session store, the metrics labels — keeps keying on the router's own name instead of whatever the caller typed. An exact hit still wins outright, so a config that registers two names differing only in case resolves the way the caller spelled it.
- **The in-request ignored set.** It is keyed by canonical address, so a differently-cased header would otherwise miss the very provider the check exists to bound — reinstating the unbounded re-selection spin that guard was added for.

Folding case does **not** soften the contract: a name matching no provider in any case is still an error, not a silent fallback to someone else.

## Test plan

- `go build ./...` clean
- `go test ./protocol/lavasession/...` — pass
- `go test ./protocol/rpcsmartrouter/...` — pass
- New: case-insensitive resolution returns the canonical address (upper / lower / mixed), the ignored-set check folds case, an unknown name is still rejected, exact-spelling-wins on a case-colliding config, plus unit tables for both helpers

**Pre-existing flake, unrelated:** `TestEndpointHealthRecovery` fails intermittently — reproduced on a clean `main` worktree at 1 failure in 8 runs with none of this branch's code applied. Not touched here.

## Relationship to #286

**Independent — either can merge first.** #286 splits the shared sentinel so "not available" and "already failed" stop reporting under one string; this one fixes the case-sensitive match that produced the example above. They touch adjacent lines in `getValidProviderAddresses`, so whichever lands second needs a trivial conflict resolution.

The dashboard currently works around this by pre-folding node names ([smart-router-dashboard#123](https://github.com/Magma-Devs/smart-router-dashboard/pull/123)); that shim can go once this ships.