### PR TITLE
fix(lavasession): split the two lava-select-provider failures apart

### DIFF
--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -1288,9 +1288,19 @@ func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context
 		}
 
 		if providerAddress == "" {
-			// Return error instead of falling back to random selection
+			// Return error instead of falling back to random selection.
+			//
+			// Deliberately broad. This branch fires both for a name that is not configured at
+			// all and for one that is configured but not usable for this request — blocked
+			// (removeAddressFromValidAddresses pops it into currentlyBlockedProviderAddresses)
+			// or not serving this addon/extension, since getValidAddresses returns the filtered
+			// list. Calling that "unknown" would tell an operator their provider does not exist
+			// in the middle of an outage, which is the same class of misdirection the split of
+			// this error from SelectedProviderAlreadyFailedError exists to remove. The sentinel
+			// carries the precision; this description has to stay true for every way the branch
+			// is reached.
 			return nil, utils.LavaFormatError(
-				"Selected provider is unknown",
+				"Selected provider not available",
 				SelectedProviderUnavailableError,
 				utils.LogAttr("selectedProvider", selectedProvider),
 				utils.LogAttr("validProviders", validAddresses),

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -1290,7 +1290,7 @@ func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context
 		if providerAddress == "" {
 			// Return error instead of falling back to random selection
 			return nil, utils.LavaFormatError(
-				"Selected provider not available",
+				"Selected provider is unknown",
 				SelectedProviderUnavailableError,
 				utils.LogAttr("selectedProvider", selectedProvider),
 				utils.LogAttr("validProviders", validAddresses),
@@ -1311,8 +1311,8 @@ func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context
 		// case-twin's failure reject a provider that never failed.
 		if _, ignored := ignoredProvidersList[providerAddress]; ignored {
 			return nil, utils.LavaFormatWarning(
-				"Selected provider already failed in this request",
-				SelectedProviderUnavailableError,
+				"Selected provider cannot be retried",
+				SelectedProviderAlreadyFailedError,
 				utils.LogAttr("provider", providerAddress),
 				utils.LogAttr("selectedProvider", selectedProvider),
 				utils.LogAttr("addon", addon),

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -1581,21 +1581,6 @@ func TestSelectedProviderAlreadyFailedIsCaseInsensitive(t *testing.T) {
 		"expected SelectedProviderAlreadyFailedError, got: %v", err)
 }
 
-// Folding case must not soften the contract: a name matching no provider in any
-// case is still an error, not a silent fallback.
-func TestSelectedProviderUnknownNameStillRejected(t *testing.T) {
-	csm := CreateConsumerSessionManager()
-	pairingList := createPairingList("", true)
-	err := csm.UpdateAllProviders(firstEpochHeight, pairingList, nil)
-	require.NoError(t, err)
-	time.Sleep(5 * time.Millisecond) // let probes finish
-
-	_, err = csm.getValidProviderAddresses(context.Background(), 1, map[string]struct{}{}, 10, 100, "", nil, common.NO_STATE, "", "no-such-provider")
-	require.Error(t, err)
-	require.True(t, errors.Is(err, SelectedProviderUnavailableError),
-		"expected SelectedProviderUnavailableError, got: %v", err)
-}
-
 // With two providers whose names differ only in case, the in-request ignored set has to be
 // consulted by the resolved address rather than by a case-fold. `lava` having failed says
 // nothing about `Lava` — they are two different upstreams — so folding here would reject a

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -1512,8 +1512,27 @@ func TestSelectedProviderAlreadyFailedReturnsError(t *testing.T) {
 	ignored := map[string]struct{}{pinned: {}}
 	_, err = csm.getValidProviderAddresses(context.Background(), 1, ignored, 10, 100, "", nil, common.NO_STATE, "", pinned)
 	require.Error(t, err)
+	require.True(t, errors.Is(err, SelectedProviderAlreadyFailedError),
+		"expected SelectedProviderAlreadyFailedError, got: %v", err)
+	// A provider that failed is not one that was never valid — must not alias.
+	require.False(t, errors.Is(err, SelectedProviderUnavailableError))
+}
+
+// An unknown pinned name reported itself as "already failed", sending whoever
+// read the message looking for an outage that had not happened.
+func TestSelectedProviderUnknownNameIsNotReportedAsAFailure(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+	pairingList := createPairingList("", true)
+	err := csm.UpdateAllProviders(firstEpochHeight, pairingList, nil)
+	require.NoError(t, err)
+	time.Sleep(5 * time.Millisecond) // let probes finish
+
+	_, err = csm.getValidProviderAddresses(context.Background(), 1, map[string]struct{}{}, 10, 100, "", nil, common.NO_STATE, "", "no-such-provider")
+	require.Error(t, err)
 	require.True(t, errors.Is(err, SelectedProviderUnavailableError),
 		"expected SelectedProviderUnavailableError, got: %v", err)
+	require.False(t, errors.Is(err, SelectedProviderAlreadyFailedError))
+	require.NotContains(t, err.Error(), "already failed")
 }
 
 // The header naming the right provider in the wrong case: `lava-select-provider:
@@ -1558,8 +1577,8 @@ func TestSelectedProviderAlreadyFailedIsCaseInsensitive(t *testing.T) {
 	ignored := map[string]struct{}{pinned: {}}
 	_, err = csm.getValidProviderAddresses(context.Background(), 1, ignored, 10, 100, "", nil, common.NO_STATE, "", strings.ToUpper(pinned))
 	require.Error(t, err)
-	require.True(t, errors.Is(err, SelectedProviderUnavailableError),
-		"expected SelectedProviderUnavailableError, got: %v", err)
+	require.True(t, errors.Is(err, SelectedProviderAlreadyFailedError),
+		"expected SelectedProviderAlreadyFailedError, got: %v", err)
 }
 
 // Folding case must not soften the contract: a name matching no provider in any
@@ -1602,8 +1621,8 @@ func TestSelectedProviderIgnoredSetDoesNotFoldOntoACaseTwin(t *testing.T) {
 	// The spin bound still holds when it is the pinned provider itself that failed.
 	_, err = csm.getValidProviderAddresses(context.Background(), 1, map[string]struct{}{"Lava": {}}, 10, 100, "", nil, common.NO_STATE, "", "Lava")
 	require.Error(t, err)
-	require.True(t, errors.Is(err, SelectedProviderUnavailableError),
-		"expected SelectedProviderUnavailableError, got: %v", err)
+	require.True(t, errors.Is(err, SelectedProviderAlreadyFailedError),
+		"expected SelectedProviderAlreadyFailedError, got: %v", err)
 }
 
 // A header matching two case-colliding providers and neither of them exactly is refused,

--- a/protocol/lavasession/errors.go
+++ b/protocol/lavasession/errors.go
@@ -21,9 +21,12 @@ var ( // Consumer Side Errors
 	ContextDoneNoNeedToLockSelectionError   = errors.New("Context deadline exceeded while trying to lock selection")
 	BlockEndpointError                      = errors.New("Block the endpoint")
 	ConsistencyPreValidationError           = errors.New("endpoint failed pre-request consistency validation")
-	SelectedProviderUnavailableError        = errors.New("Header-selected provider has already failed for this request")
+	// The two outcomes of `lava-select-provider`, kept apart because the message
+	// reaches the caller verbatim: "not a provider here" and "already failed"
+	// call for different reactions.
+	SelectedProviderUnavailableError   = errors.New("Header-selected provider is not a valid provider for this request")
+	SelectedProviderAlreadyFailedError = errors.New("Header-selected provider has already failed for this request")
 )
-
 
 // SessionOutOfSyncGRPCCode is the gRPC status code used when wrapping SessionOutOfSyncError
 // as a gRPC status error. This value was historically derived from the cosmos SDK error code (677).

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -3374,7 +3374,7 @@ func (rpcss *RPCSmartRouterServer) tryCacheWrite(
 // honored only on the first attempt. On a retry (firstAttempt == false) both are returned
 // empty so the relay falls through to a different provider instead of re-pinning the one
 // that just failed — otherwise a pinned provider that returned a retryable node error gets
-// re-selected, or the retry dead-ends on "Selected provider already failed in this request"
+// re-selected, or the retry dead-ends on "Selected provider cannot be retried"
 // (MAG-2228). firstAttempt is BatchNumber()==0, which stays 0 when attempt 1 never reached a
 // provider (e.g. PairingListEmpty), so the pin is correctly re-honored in that case. Mirrors
 // preserveRetrySafeDirectives, which omits both directives on a rebuilt archive retry.


### PR DESCRIPTION
#Closes MAG-2817

Jira ticket: MAG-2817

## Summary

`lava-select-provider` has two distinct failure outcomes, and one sentinel served both:

```go
SelectedProviderUnavailableError = errors.New("Header-selected provider has already failed for this request")
```

Its text describes only one of them. The other branch — the header naming a provider that does not exist — pairs that sentinel with its own description, and `LavaFormatError` concatenates the two. A typo therefore reported itself as an outage:

```json
{"error":{"code":-32000,"message":
  "Selected provider not available ErrMsg: Header-selected provider has already failed for this request {selectedProvider:Lava,validProviders:lava,…}"}}
```

Nothing had failed. `Lava` was simply not a provider name here — `validProviders:lava` is right there in the same payload. The message reaches the caller verbatim, so this sent whoever read it looking for a failure that never happened.

## The change

The sentinel splits in two, and each branch pairs with the one that describes it:

| Branch | Sentinel | Description |
|---|---|---|
| Pinned name resolves to no provider | `SelectedProviderUnavailableError` — *"…is not a valid provider for this request"* | "Selected provider not available" *(unchanged)* |
| Pinned name already failed in this request | `SelectedProviderAlreadyFailedError` — *"…has already failed for this request"* | "Selected provider cannot be retried" |

These call for different reactions — fix the request, versus retry without the pin — so a caller needs to be able to tell them apart. Tests assert the sentinels do not alias in either direction, and that the unknown-name path no longer says "already failed" at all.

`getValidProviderAddresses` has a third pinning branch since #285 — the header matching two providers whose names differ only in case. It stays on `SelectedProviderUnavailableError`: a name that does not uniquely identify a provider is not a valid provider for the request, and it certainly has not failed. This diff does not touch it.

### Why the unavailable description stays broad

Only the sentinel text is corrected. The description on that branch stays **"Selected provider not available"**, because the branch fires for three different reasons, not one:

- the name is not configured at all — a typo, the case in the example above
- the name **is** configured but is currently blocked, since `removeAddressFromValidAddresses` pops it out of `validAddresses` into `currentlyBlockedProviderAddresses`
- the name is configured and healthy but does not serve this addon/extension, since `getValidAddresses` returns the addon-filtered list

Narrowing it to something like "provider is unknown" would be true only of the first, and for the second it would tell an operator their provider does not exist in the middle of an actual outage — the same misdirection this PR exists to remove, aimed at the other failure mode. "Not available" is true of all three. The sentinel now carries the precision, so the description does not have to narrow; there is a comment at the branch saying so.

Making both messages precise rather than one merely true is possible — `csm.pairing` holds every configured provider and is never pruned on block, so a name present there but absent from `validAddresses` is exactly "configured but not usable right now" — but that is a change of behaviour beyond MAG-2817 and is not attempted here.

## Breaking change

`SelectedProviderUnavailableError`'s **sentinel text changed**, from *"has already failed for this request"* to *"is not a valid provider for this request"*. Anything matching that sentence to detect the not-a-valid-provider case needs updating.

`errors.Is(err, SelectedProviderUnavailableError)` now returns **false** for the already-failed path, which moved to `SelectedProviderAlreadyFailedError`. Nothing in-tree does `errors.Is` on either sentinel outside the tests updated here, so no in-tree caller changes behaviour — but an out-of-tree consumer using it to catch "already failed" would need the new sentinel.

Both **descriptions** that were already correct are preserved verbatim: `"Selected provider not available"` on the unavailable branch, and the *"has already failed for this request"* sentence, which now sits on `SelectedProviderAlreadyFailedError` and only fires when it is true. So string matchers on either keep working — including `chainlib/common_test.go`'s `TestConvertToJsonRpcError`, which asserts on `"Selected provider not available"` and needed no change.

## Test plan

- `go build ./...`, `go vet` and `gofmt` clean
- `protocol/lavasession`, `protocol/chainlib` and `protocol/rpcsmartrouter` all pass
- `TestSelectedProviderAlreadyFailedReturnsError` moved to the new sentinel and asserts non-aliasing in both directions; new `TestSelectedProviderUnknownNameIsNotReportedAsAFailure` asserts the unknown-name path does not claim a failure
- `TestSelectedProviderAlreadyFailedIsCaseInsensitive` and `TestSelectedProviderIgnoredSetDoesNotFoldOntoACaseTwin` — both from #285, both asserting the old sentinel on the ignored path — moved to `SelectedProviderAlreadyFailedError`

**Pre-existing flake, unrelated:** `TestCheckAndUnblock_BackupUnblockedWhenHealthy` fails intermittently — 3 failures in 20 runs on a clean `main` worktree with none of this branch's code applied. This diff renames a sentinel and a description and adds a comment; it cannot reach backup unblocking. It did not reproduce on the rebased branch.

## Relationship to #285

**#285 has merged.** This branch is rebased on top of it, and the conflict resolution was not entirely mechanical — two points are worth a reviewer's attention:

- #285 restructured this block, hoisting the validity check into an early `providerAddress == ""` return. This branch's original diff carried the **pre-#285** shape (`providerValid := slices.Contains(validAddresses, selectedProvider)`), so applying it verbatim would have reverted MAG-2816's case-insensitive lookup. Main's shape wins and the sentinel change moves onto the hoisted branch.
- The ambiguous-case-fold branch #285 added had no counterpart in this PR's taxonomy and needed a sentinel assigned to it — see above.

## Commits

`50dc4dd` (the original sentinel split) was rebased onto main as `b9cc3aa`, authorship preserved. Two later commits are **not** by the PR author and should be reviewed as such:

- `b9cc3aa` — rebase and conflict resolution, plus the two #285 test assertions that would otherwise have failed at test time
- `cf84238` — keeps the unavailable-branch description at "Selected provider not available" rather than narrowing it, per the reasoning above
