### PR TITLE
fix(smart-router): clone chain parser in background provider recovery

### DIFF
--- a/protocol/chainlib/grpc_parser_validation_isolation_test.go
+++ b/protocol/chainlib/grpc_parser_validation_isolation_test.go
@@ -1,0 +1,64 @@
+package chainlib
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+)
+
+// startReflectionGRPCServer brings up a bare gRPC server that serves server
+// reflection on a random loopback port. Reflection is the only thing this test
+// needs: setupForProvider builds its registry from the reflection connection.
+func startReflectionGRPCServer(t *testing.T) string {
+	t.Helper()
+	srv := grpc.NewServer()
+	reflection.Register(srv)
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+	return lis.Addr().String()
+}
+
+func TestGetChainRouter_CloneProtectsLiveGrpcParser(t *testing.T) {
+	addr := startReflectionGRPCServer(t)
+	endpoint := &lavasession.RPCProviderEndpoint{
+		ChainID:      "TEST",
+		ApiInterface: "grpc",
+		NodeUrls:     []common.NodeUrl{{Url: addr}},
+	}
+
+	// Part 1 — the hazard is real. Passing the LIVE parser mutates its registry.
+	direct, err := NewGrpcChainParser()
+	require.NoError(t, err)
+	direct.SetSpec(spectypes.Spec{})
+	require.Nil(t, direct.registry, "fresh parser starts with no registry")
+
+	ctx1, cancel1 := context.WithTimeout(context.Background(), 15*time.Second)
+	_, err = GetChainRouter(ctx1, 1, endpoint, direct)
+	require.NoError(t, err)
+	require.NotNil(t, direct.registry,
+		"precondition: handing the live parser to GetChainRouter rebinds its registry")
+	cancel1()
+
+	// Part 2 — the clone absorbs the mutation, live parser untouched.
+	live, err := NewGrpcChainParser()
+	require.NoError(t, err)
+	live.SetSpec(spectypes.Spec{})
+	require.Nil(t, live.registry)
+
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel2()
+	_, err = GetChainRouter(ctx2, 1, endpoint, CloneChainParserForValidation(live))
+	require.NoError(t, err)
+	require.Nil(t, live.registry,
+		"MAG-2538: verification must not rebind the live parser's registry")
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -3308,6 +3308,11 @@ func (rpsr *RPCSmartRouter) updateEpoch(ctx context.Context, epoch uint64) {
 	}
 }
 
+// providerRetryVerificationTimeout bounds a single provider's verification attempt
+// so one hung upstream cannot stall the retries of the remaining providers in the
+// same cycle.
+const providerRetryVerificationTimeout = 30 * time.Second
+
 // retryFailedStaticProviders periodically re-validates failed static providers
 // and re-registers them with the session manager when they recover.
 // It runs as a background goroutine, one per endpoint that had failures.
@@ -3351,54 +3356,13 @@ func (rpsr *RPCSmartRouter) retryFailedStaticProviders(
 		var recovered []*lavasession.RPCStaticProviderEndpoint
 
 		for _, provider := range failedProviders {
-			// Build verification endpoint (same logic as Phase 1)
-			verificationNodeUrls := []common.NodeUrl{}
-			for _, nodeUrl := range provider.NodeUrls {
-				verificationNodeUrls = append(verificationNodeUrls, nodeUrl)
-				if len(nodeUrl.Addons) > 0 {
-					noAddonUrl := nodeUrl
-					noAddonUrl.Addons = []string{}
-					verificationNodeUrls = append(verificationNodeUrls, noAddonUrl)
-				}
-			}
-
-			verificationEndpoint := &lavasession.RPCProviderEndpoint{
-				NetworkAddress: provider.NetworkAddress,
-				ChainID:        provider.ChainID,
-				ApiInterface:   provider.ApiInterface,
-				NodeUrls:       verificationNodeUrls,
-			}
-
-			// Scoped context for this verification attempt. GetChainRouter creates
-			// connector goroutines tied to ctx that only exit on cancellation.
-			// Without this, each retry iteration leaks goroutines and connections
-			// for permanently failing providers.
-			// Timeout bounds a hung provider so it can't stall retries of the
-			// remaining providers in this cycle.
-			attemptCtx, attemptCancel := context.WithTimeout(ctx, 30*time.Second)
-
-			parallelConnections := uint(lavasession.MaximumStreamsOverASingleConnection)
-			verificationRouter, err := chainlib.GetChainRouter(attemptCtx, parallelConnections, verificationEndpoint, chainParser)
-			if err != nil {
-				attemptCancel()
-				stillFailed = append(stillFailed, provider)
-				utils.LavaFormatWarning("retry: static provider chain router creation still failing", err,
-					utils.LogAttr("chain", rpcEndpoint.ChainID),
-					utils.LogAttr("provider", provider.Name),
-				)
-				continue
-			}
-
-			verificationFetcher := chainlib.NewChainFetcher(attemptCtx, &chainlib.ChainFetcherOptions{
-				ChainRouter: verificationRouter,
-				ChainParser: chainParser,
-				Endpoint:    verificationEndpoint,
-				Cache:       nil,
-			})
-
-			err = verificationFetcher.Validate(attemptCtx)
-			attemptCancel() // cleanup temporary router resources regardless of outcome
-			if err != nil {
+			// Shares the spec re-verifier's verification sequence rather than
+			// duplicating it. validateProvider builds the addon-expanded endpoint,
+			// scopes a timeout so a hung upstream can't stall the rest of the cycle,
+			// and — load-bearing — clones the live chainParser before handing it to
+			// the chain router. A hand-copied version of this block did not clone,
+			// which broke live gRPC relays until pod restart (MAG-2538).
+			if err := validateProvider(ctx, provider, chainParser, providerRetryVerificationTimeout); err != nil {
 				stillFailed = append(stillFailed, provider)
 				utils.LavaFormatWarning("retry: static provider verification still failing", err,
 					utils.LogAttr("chain", rpcEndpoint.ChainID),


### PR DESCRIPTION
# Description

Closes: N/A — tracked in Jira, not a GitHub issue.

Background provider recovery breaks live gRPC relays until the pod restarts.

The 3-minute retry loop passed the **live** `chainParser` into `GetChainRouter` and then cancelled the scoped verification context. For gRPC, `NewGrpcChainProxy` → `setupForProvider` rebinds the parser's `registry`/`codec` to the verification connection, so cancelling it left the live parser pointing at a dead connection — every subsequent gRPC relay on that provider failed with a nil connector until the pod was restarted. Because a timer drives it, the outage recurred every 3 minutes.

**The fix already existed.** `CloneChainParserForValidation` (`protocol/chainlib/chainlib.go:103`) is written, documented and unit-tested, and was already applied in the spec re-verification path (`spec_reverifier.go:333`). `retryFailedStaticProviders` held a hand-copied duplicate of the same verification sequence and never got it.

So rather than clone in both copies, this deletes the duplicate: the retry loop now calls `validateProvider`, the helper the re-verifier already uses. One code path, so this can only ever be wrong in one place. The two blocks were already functionally identical — the apparent difference between `MaximumStreamsOverASingleConnection` and `DefaultMaximumStreamsOverASingleConnection` is a `uint64` cast of the same value (`consumer_types.go:83-90`).

## Most critical files to review

- `protocol/rpcsmartrouter/rpcsmartrouter.go` (+12 / −48) — the dedupe
- `protocol/chainlib/grpc_parser_validation_isolation_test.go` (new) — the regression pin

## Testing

The new test stands up a gRPC server with reflection on a loopback port and pins both halves of the invariant:

1. handing over the **live** parser rebinds its registry — the hazard is real
2. handing over the **clone** leaves the live parser untouched

**Confirmed to fail without the fix.** Reverting the clone produces:

```
Expected nil, but got: &dyncodec.Registry{remote:(*dyncodec.GRPCReflectionProtoFileRegistry)...}
MAG-2538: verification must not rebind the live parser's registry
```

Worth recording for whoever extends this: a first attempt at the test pointed at an unreachable address and passed on both fixed and broken code. `NewGRPCConnector` blocks on the first connection and errors out before `newGrpcChainProxy` runs, so `setupForProvider` is never reached and there is nothing to mutate. A live reflection server is required for the test to mean anything.

| Check | Result |
| --- | --- |
| `go build ./...` | pass |
| `go vet ./protocol/rpcsmartrouter/` | pass |
| `go test ./protocol/chainlib/` | pass |
| `go test ./protocol/rpcsmartrouter/` | pass |
| `go test -race` (retry goroutine tests) | pass |

## Behaviour change to note in review

The retry loop previously logged two distinct warnings — `retry: static provider chain router creation still failing` and `retry: static provider verification still failing`. It now logs only the second, since `validateProvider` returns a single error. The two cases stay distinguishable from the `error` field, but anyone grepping on the first string will need to adjust.

## Jira ticket

Jira ticket: MAG-2538

---

## Author Checklist

I have...

* [ ] read the [contribution guide](https://github.com/magma-Devs/smart-router/blob/main/CONTRIBUTING.md)
* [x] included the correct type prefix in the PR title (`fix`)
* [x] confirmed `!` in the type prefix if API or client breaking change — not breaking, no `!`
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification — MAG-2538 above
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests
* [x] updated the relevant documentation or specification, including comments for documenting Go code — the new call site carries a comment explaining why the clone is load-bearing
* [ ] confirmed all CI checks have passed — pending first CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
