### PR TITLE
fix(smart-router): classify gRPC status errors and cancellations correctly

### DIFF
--- a/docs/ERROR-REGISTRY-DESIGN.md
+++ b/docs/ERROR-REGISTRY-DESIGN.md
@@ -70,6 +70,8 @@ Errors returned by the blockchain node itself (not execution/state errors).
 | 2013 | `NODE_RESOURCE_UNAVAILABLE` | Resource exists but unavailable | Yes | JSON-RPC -32002 |
 | 2014 | `NODE_GATEWAY_TIMEOUT` | Gateway timeout (HTTP 504 from provider) | Yes | HTTP 504 |
 | 2015 | `NODE_BAD_GATEWAY` | Bad gateway (HTTP 502 from provider) | Yes | HTTP 502 |
+| 2016 | `NODE_UNAUTHORIZED` | Upstream rejected router credentials (HTTP 401) | No | HTTP 401 |
+| 2017 | `NODE_DATA_NOT_HELD` | Endpoint does not hold the requested data — pruned or never existed (SubCategoryDataScope) | Yes | gRPC 5, gRPC 11 |
 | **Bitcoin/UTXO Node Errors (2100-2149)** |||||
 | 2101 | `NODE_BITCOIN_WARMUP` | Node still warming up (Bitcoin -28 / RPC_IN_WARMUP) | Yes | — |
 | 2102 | `NODE_BITCOIN_INITIAL_DOWNLOAD` | Node in initial block download (Bitcoin -10 / RPC_CLIENT_IN_INITIAL_DOWNLOAD) | Yes | — |
@@ -411,10 +413,12 @@ const (
     SubCategoryNone              ErrorSubCategory = iota
     SubCategoryUnsupportedMethod                         // zero retries, zero CU, cached response, no provider scoring
     SubCategoryRateLimit                                 // endpoint is healthy but busy; apply backoff, do not mark unhealthy
+    SubCategoryDataScope                                 // endpoint does not hold the data; keep retrying elsewhere, but do not score it
 )
 
 func (sc ErrorSubCategory) IsUnsupportedMethod() bool { return sc == SubCategoryUnsupportedMethod }
 func (sc ErrorSubCategory) IsRateLimit() bool         { return sc == SubCategoryRateLimit }
+func (sc ErrorSubCategory) IsDataScope() bool         { return sc == SubCategoryDataScope }
 
 
 // LavaError is the central error definition
@@ -594,7 +598,7 @@ _Blocked on protocol upgrade: sdkerrors carry ABCI codes used in the gRPC wire f
 
 9. **Transparent hop: original errors pass through unchanged.** The router/consumer is a transparent hop — the user always receives the original error from the node, unmodified. `LavaError` classification is metadata for internal use only (logging, metrics, endpoint health). Unknown/unmatched errors default to `CategoryExternal` because they are node pass-throughs. _(Clarification added in Phase 7: `handleAndClassify` wraps classified errors in `LavaWrappedError` on the **Go error return path** — this is internal plumbing for retry/health decisions and never reaches the user. The actual node response body travels separately and is always returned unmodified to the user. The "transparent hop" principle applies to the response body, not the internal Go error return.)_
 
-10. **Retryable is the primary retry signal, not SubCategory.** The consumer and smart-router retry state machines short-circuit on `LavaError.Retryable=false` via `RelayResult.IsNonRetryable`, populated at classification time on both paths (consumer: `rpcconsumer_server.go`; smart-router: `direct_rpc_relay.go` / `rpcsmartrouter_server.go`). This covers every terminal classification — `CHAIN_EXECUTION_REVERTED`, `CHAIN_OUT_OF_GAS`, `CHAIN_DOUBLE_SPEND`, `CHAIN_INVALID_SIGNATURE`, all of 3000-range — not only unsupported methods. SubCategory continues to govern adjacent policy: `SubCategoryUnsupportedMethod` triggers the zero-CU carve-out and caching, and `SubCategoryRateLimit` drives backoff without marking the endpoint unhealthy. Layer D user-input errors are non-retryable but charge normal CU — the provider does real work because responses are not cached. `relay_processor.HasNonRetryableUserFacingErrors` keys off the `IsNonRetryable` flag rather than re-classifying, so adding a new non-retryable error type requires no state-machine changes.
+10. **Retryable is the primary retry signal, not SubCategory.** The consumer and smart-router retry state machines short-circuit on `LavaError.Retryable=false` via `RelayResult.IsNonRetryable`, populated at classification time on both paths (consumer: `rpcconsumer_server.go`; smart-router: `direct_rpc_relay.go` / `rpcsmartrouter_server.go`). This covers every terminal classification — `CHAIN_EXECUTION_REVERTED`, `CHAIN_OUT_OF_GAS`, `CHAIN_DOUBLE_SPEND`, `CHAIN_INVALID_SIGNATURE`, all of 3000-range — not only unsupported methods. SubCategory continues to govern adjacent policy: `SubCategoryUnsupportedMethod` triggers the zero-CU carve-out and caching, and `SubCategoryRateLimit` drives backoff without marking the endpoint unhealthy. `SubCategoryDataScope` is the third such axis and the one Retryable cannot express: the errors are retryable (a pruned endpoint's miss is an archive endpoint's hit) yet must stay out of the availability signal, because the endpoint answered truthfully about its own data scope. `rpcsmartrouter.shouldFailSessionForResult` reads all three. Layer D user-input errors are non-retryable but charge normal CU — the provider does real work because responses are not cached. `relay_processor.HasNonRetryableUserFacingErrors` keys off the `IsNonRetryable` flag rather than re-classifying, so adding a new non-retryable error type requires no state-machine changes.
 
 ## 8. Chains Analyzed
 

--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -448,6 +448,12 @@ type RelayResult struct {
 	// Orthogonal to IsNonRetryable — NODE_RATE_LIMITED (2005) is retryable,
 	// NODE_LIMIT_EXCEEDED (2011) is not, and both set this flag.
 	IsRateLimited bool
+	// IsDataScope is true when the node error carries SubCategoryDataScope: the
+	// endpoint answered truthfully that it does not hold the requested data
+	// (pruned height, object that never existed). Retryable — an archive node may
+	// hold it — but the endpoint is healthy, so the direct-RPC availability gate
+	// excludes it. Orthogonal to both flags above.
+	IsDataScope bool
 }
 
 // ApplyNodeErrorClassification stamps every registry-derived policy flag onto a node-error
@@ -465,6 +471,7 @@ func (rr *RelayResult) ApplyNodeErrorClassification(family ChainFamily, transpor
 	rr.IsNonRetryable = classification.IsNonRetryable
 	rr.IsUnsupportedMethod = classification.IsUnsupportedMethod
 	rr.IsRateLimited = classification.IsRateLimited
+	rr.IsDataScope = classification.IsDataScope
 }
 
 func (rr *RelayResult) GetReplyServer() pairingtypes.Relayer_RelaySubscribeClient {

--- a/protocol/common/error_classifier.go
+++ b/protocol/common/error_classifier.go
@@ -271,8 +271,39 @@ var genericErrorMappings = map[TransportType][]errorMapping{
 
 	TransportGRPC: {
 		// gRPC status code matchers (codes from google.golang.org/grpc/codes)
+		//
+		// A code earns a row here only when its verdict is the SAME at every
+		// endpoint. Rows are what let the direct-RPC availability gate
+		// (rpcsmartrouter.shouldFailSessionForResult) exempt a status from
+		// demoting the endpoint, and an unregistered code scores — which is the
+		// right default for "we have not catalogued this failure".
+		//
+		// codes.InvalidArgument is the one caller-fault code in the set: gRPC
+		// defines it as arguments "problematic regardless of the state of the
+		// system", so every endpoint rejects the same malformed request
+		// identically. Left unregistered it classified UNKNOWN_ERROR, and a burst
+		// of malformed client requests demoted the whole healthy pairing toward
+		// the selection floor — blocklisting on the 16th consecutive one
+		// (MAG-2549). USER_INVALID_PARAMS is Retryable=false, which both stops the
+		// pointless retry and keeps the gate off the endpoint.
+		{GRPCCodeEquals(3), LavaErrorUserInvalidParams},       // codes.InvalidArgument
 		{GRPCCodeEquals(12), LavaErrorNodeUnimplemented},      // codes.Unimplemented
 		{GRPCCodeEquals(14), LavaErrorNodeServiceUnavailable}, // codes.Unavailable
+		// Deliberately NOT registered, each for its own reason — do not add them
+		// as a block, which is how `Code >= 13` went wrong in the first place:
+		//   4  DeadlineExceeded  - this endpoint was too slow; another may not be.
+		//                          Demoting it is the correct signal.
+		//   5  NotFound          - pruned vs archive nodes genuinely disagree, so a
+		//   11 OutOfRange          retry elsewhere can legitimately succeed.
+		//   7  PermissionDenied  - credentials are configured per endpoint, so one
+		//   16 Unauthenticated     rejecting ours is unusable to us and should demote.
+		//   8  ResourceExhausted - ambiguous in the gRPC spec (per-user quota vs.
+		//                          out of disk). The "rate limit" message row below
+		//                          catches the quota case without asserting the code
+		//                          alone means "healthy but busy".
+		//   1  Canceled          - a LOCAL cancellation never reaches this table;
+		//                          handleGRPCError resolves it structurally. One that
+		//                          does reach here is remote and unproven.
 		// Message-based matchers for gRPC errors conveyed without status codes
 		{MessageContains("rate limit"), LavaErrorNodeRateLimited},
 		{MessageContains("enhance_your_calm"), LavaErrorNodeRateLimited}, // HTTP/2 GOAWAY ENHANCE_YOUR_CALM
@@ -636,22 +667,35 @@ func (r stringConnectionFallback) matches(msg string) bool {
 //
 // INVARIANT: written at package-init time (declaration), read-only thereafter.
 var stringConnectionFallbacks = []stringConnectionFallback{
-	// Remote gRPC status errors render as "rpc error: code = ..."; those carry a
-	// *remote* deadline/cancel and must not be classified as a local context error.
+	// Remote gRPC status errors start with "rpc error"; those carry a *remote*
+	// deadline/cancel and must not be classified as a local context error.
+	// The guard is encoded as a mustNotContain on the rpc-error prefix marker.
 	//
-	// The guard matches that full prefix and NOT the bare substring "rpc error".
-	// Our own local wrapper renders as "gRPC error 1: context canceled", which
-	// lowercased contains "rpc error" inside the word "gRPC" — so the bare guard
-	// disqualified local cancellations from the very rows they needed to match,
-	// classifying them as UNKNOWN_ERROR instead (MAG-2687).
+	// The guard is deliberately the BARE substring "rpc error", not the fuller
+	// "rpc error: code =" prefix. Widening it to the full prefix was tried and
+	// reverted (MAG-2687): lavasession.GRPCStatusError renders as
+	// "gRPC error 1: context canceled", which lowercased contains "rpc error"
+	// inside the word "gRPC" but NOT "rpc error: code =". That wrapper is built
+	// for REMOTE statuses — a cancel the *endpoint* reported — so admitting it
+	// here labels an upstream fault as local orchestration and, because
+	// PROTOCOL_CONTEXT_CANCELED is Retryable=false, silently suppresses the
+	// retry that would have reached a healthy endpoint.
+	//
+	// Nothing is lost by keeping the guard broad. A cancellation the router
+	// itself caused never depends on this table: GRPCDirectRPCConnection
+	// .handleGRPCError returns a nil response and an error wrapping the real
+	// context.Canceled sentinel, which DetectConnectionError resolves in its
+	// layer-1 errors.Is check well before the string fallback runs. This table
+	// only ever sees errors whose sentinel chain was already lost, and for those
+	// "contains an rpc-error marker" is the conservative read.
 	{
 		mustContain:    []string{"context deadline exceeded"},
-		mustNotContain: []string{"rpc error: code ="},
+		mustNotContain: []string{"rpc error"},
 		result:         LavaErrorContextDeadline,
 	},
 	{
 		mustContain:    []string{"context canceled"},
-		mustNotContain: []string{"rpc error: code ="},
+		mustNotContain: []string{"rpc error"},
 		result:         LavaErrorContextCanceled,
 	},
 	// HTTP/2 GOAWAY closes the whole connection. Exclude ENHANCE_YOUR_CALM —

--- a/protocol/common/error_classifier.go
+++ b/protocol/common/error_classifier.go
@@ -286,15 +286,33 @@ var genericErrorMappings = map[TransportType][]errorMapping{
 		// the selection floor — blocklisting on the 16th consecutive one
 		// (MAG-2549). USER_INVALID_PARAMS is Retryable=false, which both stops the
 		// pointless retry and keeps the gate off the endpoint.
-		{GRPCCodeEquals(3), LavaErrorUserInvalidParams},       // codes.InvalidArgument
+		//
+		// Reach: this table is keyed by TRANSPORT, not by relay path, so the row also
+		// applies on the provider-based gRPC path via chainlib.GrpcErrorHandler
+		// .HandleNodeError — an INVALID_ARGUMENT becomes non-retryable there too. That
+		// is intended and follows from gRPC's own definition of the code, but it is
+		// wider than "direct RPC only" and should be read as such.
+		{GRPCCodeEquals(3), LavaErrorUserInvalidParams}, // codes.InvalidArgument
+		// codes.NotFound and codes.OutOfRange are the ordinary "I do not have this"
+		// outcomes of a Cosmos or Sui gRPC query — a missing object, an account that
+		// was never funded, a height below the node's pruning window. They are the
+		// most COMMON non-OK codes on those chains, not a failure mode.
+		//
+		// They need a row for a reason the other two do not: sendGRPCRelay marks every
+		// non-OK status IsNodeError, so without one they fall through to UNKNOWN_ERROR
+		// and the availability gate scores them — one demotion per retry, on every
+		// endpoint asked, for a query whose answer is simply "no". NODE_DATA_NOT_HELD
+		// is Retryable=true so the pruned-node-to-archive-node retry survives, and
+		// SubCategoryDataScope is what keeps the gate off an endpoint that answered
+		// truthfully about its own data scope.
+		{GRPCCodeEquals(5), LavaErrorNodeDataNotHeld},         // codes.NotFound
+		{GRPCCodeEquals(11), LavaErrorNodeDataNotHeld},        // codes.OutOfRange
 		{GRPCCodeEquals(12), LavaErrorNodeUnimplemented},      // codes.Unimplemented
 		{GRPCCodeEquals(14), LavaErrorNodeServiceUnavailable}, // codes.Unavailable
 		// Deliberately NOT registered, each for its own reason — do not add them
 		// as a block, which is how `Code >= 13` went wrong in the first place:
 		//   4  DeadlineExceeded  - this endpoint was too slow; another may not be.
 		//                          Demoting it is the correct signal.
-		//   5  NotFound          - pruned vs archive nodes genuinely disagree, so a
-		//   11 OutOfRange          retry elsewhere can legitimately succeed.
 		//   7  PermissionDenied  - credentials are configured per endpoint, so one
 		//   16 Unauthenticated     rejecting ours is unusable to us and should demote.
 		//   8  ResourceExhausted - ambiguous in the gRPC spec (per-user quota vs.
@@ -482,6 +500,11 @@ type NodeErrorClassification struct {
 	IsNonRetryable      bool
 	IsUnsupportedMethod bool
 	IsRateLimited       bool
+	// IsDataScope is the third fault axis: the endpoint does not hold the
+	// requested data. Independent of IsNonRetryable — these errors ARE retryable
+	// (an archive node may answer) but must not demote the endpoint that told us
+	// the truth. See ErrorSubCategory.IsDataScope.
+	IsDataScope bool
 }
 
 // ClassifyNodeErrorForRetry runs ClassifyError exactly once and derives the
@@ -502,6 +525,7 @@ func ClassifyNodeErrorForRetry(family ChainFamily, transport TransportType, erro
 		IsNonRetryable:      !c.Retryable,
 		IsUnsupportedMethod: c.SubCategory.IsUnsupportedMethod(),
 		IsRateLimited:       c.SubCategory.IsRateLimit(),
+		IsDataScope:         c.SubCategory.IsDataScope(),
 	}
 }
 

--- a/protocol/common/error_classifier.go
+++ b/protocol/common/error_classifier.go
@@ -636,17 +636,22 @@ func (r stringConnectionFallback) matches(msg string) bool {
 //
 // INVARIANT: written at package-init time (declaration), read-only thereafter.
 var stringConnectionFallbacks = []stringConnectionFallback{
-	// Remote gRPC status errors start with "rpc error"; those carry a *remote*
-	// deadline/cancel and must not be classified as a local context error.
-	// The guard is encoded as a mustNotContain on the rpc-error prefix marker.
+	// Remote gRPC status errors render as "rpc error: code = ..."; those carry a
+	// *remote* deadline/cancel and must not be classified as a local context error.
+	//
+	// The guard matches that full prefix and NOT the bare substring "rpc error".
+	// Our own local wrapper renders as "gRPC error 1: context canceled", which
+	// lowercased contains "rpc error" inside the word "gRPC" — so the bare guard
+	// disqualified local cancellations from the very rows they needed to match,
+	// classifying them as UNKNOWN_ERROR instead (MAG-2687).
 	{
 		mustContain:    []string{"context deadline exceeded"},
-		mustNotContain: []string{"rpc error"},
+		mustNotContain: []string{"rpc error: code ="},
 		result:         LavaErrorContextDeadline,
 	},
 	{
 		mustContain:    []string{"context canceled"},
-		mustNotContain: []string{"rpc error"},
+		mustNotContain: []string{"rpc error: code ="},
 		result:         LavaErrorContextCanceled,
 	},
 	// HTTP/2 GOAWAY closes the whole connection. Exclude ENHANCE_YOUR_CALM —

--- a/protocol/common/error_codes.go
+++ b/protocol/common/error_codes.go
@@ -258,6 +258,21 @@ var (
 		Code: 2016, Name: "NODE_UNAUTHORIZED", Category: CategoryExternal,
 		Description: "Upstream rejected router credentials (HTTP 401)", Retryable: false,
 	})
+	// NODE_DATA_NOT_HELD: the endpoint answered correctly and the answer is "I do
+	// not have this" — a pruned height, an object that never existed, a request
+	// outside the range this node retains. Distinct from NODE_RESOURCE_NOT_FOUND
+	// (2012) in the fault axis, not the symptom: 2012 stays scoreable because a
+	// JSON-RPC -32001 is an error the node RAISED, whereas this is the node
+	// truthfully describing its own data scope.
+	//
+	// Retryable stays true so a pruned node still falls through to an archive one.
+	// SubCategoryDataScope is what keeps it out of the availability signal, which
+	// Retryable alone cannot express (see ErrorSubCategory.IsDataScope).
+	LavaErrorNodeDataNotHeld = registerError(&LavaError{
+		Code: 2017, Name: "NODE_DATA_NOT_HELD", Category: CategoryExternal,
+		SubCategory: SubCategoryDataScope,
+		Description: "Endpoint does not hold the requested data (pruned or never existed)", Retryable: true,
+	})
 
 	// Bitcoin/UTXO node errors (2100-2149)
 	// Source: Bitcoin Core src/rpc/protocol.h

--- a/protocol/common/error_registry.go
+++ b/protocol/common/error_registry.go
@@ -39,6 +39,7 @@ const (
 	SubCategoryNone              ErrorSubCategory = iota
 	SubCategoryUnsupportedMethod                  // zero retries, zero CU, cached response, no provider scoring
 	SubCategoryRateLimit                          // rate-limit signal: endpoint is healthy but busy, apply backoff, do not mark unhealthy
+	SubCategoryDataScope                          // endpoint does not hold the data: retry elsewhere may help, but it is not unhealthy
 )
 
 func (sc ErrorSubCategory) String() string {
@@ -47,6 +48,8 @@ func (sc ErrorSubCategory) String() string {
 		return "unsupported_method"
 	case SubCategoryRateLimit:
 		return "rate_limit"
+	case SubCategoryDataScope:
+		return "data_scope"
 	default:
 		return "none"
 	}
@@ -61,6 +64,27 @@ func (sc ErrorSubCategory) IsUnsupportedMethod() bool {
 // but NOT mark the endpoint unhealthy — it's working, just busy.
 func (sc ErrorSubCategory) IsRateLimit() bool {
 	return sc == SubCategoryRateLimit
+}
+
+// IsDataScope reports whether this subcategory represents "the endpoint answered
+// authoritatively that it does not hold the requested data" — pruned history, an
+// object that was never created, a height outside its retained range.
+//
+// It is a third fault axis, independent of the other two, and it exists because
+// neither of them can express this case:
+//
+//   - Retryable stays TRUE. A pruned node and an archive node genuinely disagree,
+//     so another endpoint can still answer. Marking these non-retryable to keep
+//     them out of the availability signal would buy the exemption by killing the
+//     archive fallback.
+//   - The endpoint is nonetheless HEALTHY. It did its job and reported the truth
+//     about its own data scope, so charging it an availability failure demotes it
+//     for the shape of the request rather than for anything it did wrong.
+//
+// Health-tracking callers should therefore keep retrying elsewhere but leave the
+// endpoint's availability score untouched.
+func (sc ErrorSubCategory) IsDataScope() bool {
+	return sc == SubCategoryDataScope
 }
 
 // LavaError is the central error definition — a classification struct, not a Go error.

--- a/protocol/common/unsupported_method_scoring_invariant_test.go
+++ b/protocol/common/unsupported_method_scoring_invariant_test.go
@@ -51,3 +51,28 @@ func TestRateLimitSubCategorySpansBothRetryabilities_MAG2156(t *testing.T) {
 	require.False(t, LavaErrorNodeLimitExceeded.Retryable,
 		"NODE_LIMIT_EXCEEDED (2011) is not retryable — same subcategory, opposite axis")
 }
+
+// TestDataScopeCodesAreAllRetryable_MAG2549 is the same invariant one axis over, and it exists
+// because SubCategoryDataScope only earns its keep while this holds.
+//
+// The axis was added for errors that are retryable AND must not be scored — a pruned endpoint's
+// NOT_FOUND is an archive endpoint's hit, so the retry is worth making, but the endpoint that
+// answered did nothing wrong. Register a data-scope code Retryable=false and the carve-out becomes
+// redundant with IsNonRetryable, which would mean the axis had quietly stopped buying anything and
+// the archive fallback had quietly been killed. Either is worth failing a build over.
+func TestDataScopeCodesAreAllRetryable_MAG2549(t *testing.T) {
+	var checked int
+	for code, le := range errorRegistry {
+		if !le.SubCategory.IsDataScope() {
+			continue
+		}
+		checked++
+		require.True(t, le.Retryable,
+			"%s (%d) carries SubCategoryDataScope but is Retryable=false. The axis exists precisely "+
+				"for errors IsNonRetryable cannot express: retry elsewhere IS worthwhile (a pruned "+
+				"endpoint's miss is an archive endpoint's hit) while the endpoint stays out of the "+
+				"availability signal. Non-retryable makes the carve-out redundant and stops the "+
+				"request from ever reaching the endpoint that holds the data.", le.Name, code)
+	}
+	require.NotZero(t, checked, "expected at least one SubCategoryDataScope code in the registry")
+}

--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -26,6 +26,7 @@ import (
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
 	"github.com/magma-Devs/smart-router/utils"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
@@ -905,6 +906,21 @@ func (g *GRPCDirectRPCConnection) parseInputMessage(
 
 // handleGRPCError handles gRPC errors and returns an appropriate response
 func (g *GRPCDirectRPCConnection) handleGRPCError(ctx context.Context, err error, respHeaders metadata.MD) (*DirectRPCResponse, error) {
+	// A relay the router itself cancelled — a loser of a stateful fan-out race,
+	// or a client that disconnected — is not a node failure and must not be
+	// scored as one. grpc-go reports this as status.Error(codes.Canceled, ...),
+	// which does NOT wrap context.Canceled, so re-attach the sentinel that
+	// common.IsClientCancellation looks for.
+	//
+	// Returning a NIL response is the load-bearing half: sendGRPCRelay only takes
+	// its error-with-response arm when response != nil, so a nil response is what
+	// routes cancellation through classifyAndWrap like every other transport
+	// instead of recording it as a successful relay with fabricated latency
+	// (MAG-2687).
+	if ctx.Err() != nil && status.Code(err) == codes.Canceled {
+		return nil, fmt.Errorf("gRPC relay cancelled: %w", context.Canceled)
+	}
+
 	var errorCode uint32 = GRPCStatusCodeOnFailedMessages
 	var errorMessage string
 
@@ -935,18 +951,32 @@ func (g *GRPCDirectRPCConnection) handleGRPCError(ctx context.Context, err error
 		}, &GRPCStatusError{
 			Code:    errorCode,
 			Message: errorMessage,
+			cause:   err,
 		}
 }
 
-// GRPCStatusError represents a gRPC status error
+// GRPCStatusError represents a gRPC status error.
+//
+// cause preserves the originating error. Without it this type was a dead end for
+// errors.Is / errors.As: every sentinel carried by the underlying grpc-go error
+// was lost the moment we rebuilt the error from just a code and a message, which
+// is what made gRPC cancellations invisible to the relay-race carve-out
+// (MAG-2687).
 type GRPCStatusError struct {
 	Code    uint32
 	Message string
+	cause   error
 }
 
 func (e *GRPCStatusError) Error() string {
 	return fmt.Sprintf("gRPC error %d: %s", e.Code, e.Message)
 }
+
+// Unwrap exposes the originating error so errors.Is / errors.As see through this
+// wrapper. Note this makes status.Code(err) resolve to the underlying gRPC code
+// rather than Unknown; SessionOutOfSyncGRPCCode is 677 and so cannot collide with
+// any real code, which grpc_status_error_test.go pins.
+func (e *GRPCStatusError) Unwrap() error { return e.cause }
 
 func (g *GRPCDirectRPCConnection) GetProtocol() DirectRPCProtocol {
 	return DirectRPCProtocolGRPC

--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -917,7 +918,10 @@ func (g *GRPCDirectRPCConnection) handleGRPCError(ctx context.Context, err error
 	// routes cancellation through classifyAndWrap like every other transport
 	// instead of recording it as a successful relay with fabricated latency
 	// (MAG-2687).
-	if ctx.Err() != nil && status.Code(err) == codes.Canceled {
+	// Match on context.Canceled specifically rather than `ctx.Err() != nil`: a ctx
+	// whose DEADLINE expired is also non-nil, and relabelling a timeout as a client
+	// cancellation would let a genuinely slow endpoint escape being blamed.
+	if errors.Is(ctx.Err(), context.Canceled) && status.Code(err) == codes.Canceled {
 		return nil, fmt.Errorf("gRPC relay cancelled: %w", context.Canceled)
 	}
 

--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -27,7 +27,6 @@ import (
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
 	"github.com/magma-Devs/smart-router/utils"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
@@ -921,8 +920,23 @@ func (g *GRPCDirectRPCConnection) handleGRPCError(ctx context.Context, err error
 	// Match on context.Canceled specifically rather than `ctx.Err() != nil`: a ctx
 	// whose DEADLINE expired is also non-nil, and relabelling a timeout as a client
 	// cancellation would let a genuinely slow endpoint escape being blamed.
-	if errors.Is(ctx.Err(), context.Canceled) && status.Code(err) == codes.Canceled {
-		return nil, fmt.Errorf("gRPC relay cancelled: %w", context.Canceled)
+	//
+	// The LOCAL context is the whole test. Pairing it with `status.Code(err) ==
+	// codes.Canceled` was a hole of the same class this branch exists to close: when
+	// the router cancels and grpc-go surfaces something other than Canceled — most
+	// often Unavailable from a connection torn down in the same instant — the
+	// conjunct fails, sendGRPCRelay takes its node-error arm and returns (result,
+	// nil), and the `err != nil` guard at the relay-race carve-out never fires. A
+	// relay we abandoned is then scored against a healthy endpoint. The risk is
+	// asymmetric: missing a local cancel penalises an endpoint that did nothing
+	// wrong, while over-detecting one only skips scoring for a relay whose result we
+	// were going to discard anyway.
+	//
+	// Both errors are wrapped. context.Canceled is the sentinel
+	// common.IsClientCancellation resolves; err keeps the originating gRPC status so
+	// logs can still say what the endpoint was doing when we pulled the plug.
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return nil, fmt.Errorf("gRPC relay cancelled: %w: %w", context.Canceled, err)
 	}
 
 	var errorCode uint32 = GRPCStatusCodeOnFailedMessages

--- a/protocol/lavasession/grpc_status_error_test.go
+++ b/protocol/lavasession/grpc_status_error_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
 )
 
 // TestHandleGRPCError_CancelledContextReturnsNilResponse is the MAG-2687 pin.
@@ -28,6 +30,57 @@ func TestHandleGRPCError_CancelledContextReturnsNilResponse(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, errors.Is(err, context.Canceled),
 		"the context.Canceled sentinel must be re-attached so the relay-race carve-out can see it")
+}
+
+// TestHandleGRPCError_RemoteCancellationIsNotLocal is the collateral guard for
+// the test above, and the one that actually constrains the classifier.
+//
+// Same gRPC status codes, but a LIVE context: nothing local was cancelled, so the
+// status came from the endpoint. Three things must hold, and each corresponds to a
+// distinct way this has gone wrong:
+//
+//  1. the response is non-nil, so sendGRPCRelay takes its node-error arm and the
+//     endpoint is actually held responsible;
+//  2. no context sentinel is attached, so common.IsClientCancellation's relay-race
+//     carve-out cannot fire and excuse the endpoint;
+//  3. the error does not classify as a LOCAL context error. This is the assertion
+//     that fails if the "rpc error" guard in stringConnectionFallbacks is narrowed
+//     to "rpc error: code =" — the wrapper renders as "gRPC error 1: context
+//     canceled", which slips past the narrower prefix and lands on
+//     PROTOCOL_CONTEXT_CANCELED (Retryable=false), suppressing the retry.
+func TestHandleGRPCError_RemoteCancellationIsNotLocal(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		code codes.Code
+		msg  string
+	}{
+		{"remote canceled", codes.Canceled, "context canceled"},
+		{"remote deadline", codes.DeadlineExceeded, "context deadline exceeded"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &GRPCDirectRPCConnection{}
+			// context.Background() is never cancelled — the production shape of a
+			// status the endpoint reported on a healthy local request.
+			resp, err := g.handleGRPCError(context.Background(), status.Error(tc.code, tc.msg), nil)
+
+			require.NotNil(t, resp,
+				"a remote status must keep its response so the node-error arm runs")
+			require.Equal(t, int(tc.code), resp.StatusCode)
+			require.Error(t, err)
+
+			require.False(t, errors.Is(err, context.Canceled),
+				"the local-cancellation sentinel must NOT be attached to a remote status")
+			require.False(t, errors.Is(err, context.DeadlineExceeded),
+				"the local-deadline sentinel must NOT be attached to a remote status")
+
+			if le := common.DetectConnectionError(err); le != nil {
+				require.NotEqual(t, common.LavaErrorContextCanceled.Code, le.Code,
+					"remote cancel classified as local — the rpc-error guard was narrowed")
+				require.NotEqual(t, common.LavaErrorContextDeadline.Code, le.Code,
+					"remote deadline classified as local — the rpc-error guard was narrowed")
+			}
+		})
+	}
 }
 
 // TestGrpcGoDoesNotWrapCancelSentinel documents WHY the sentinel has to be

--- a/protocol/lavasession/grpc_status_error_test.go
+++ b/protocol/lavasession/grpc_status_error_test.go
@@ -1,0 +1,110 @@
+package lavasession
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestHandleGRPCError_CancelledContextReturnsNilResponse is the MAG-2687 pin.
+//
+// The phantom-success arm in sendGRPCRelay is only reachable when handleGRPCError
+// returns a NON-nil response. On a router-initiated cancellation it must return
+// nil, so the error flows through normal classification instead of being recorded
+// as a completed relay with a latency sample that was never measured.
+func TestHandleGRPCError_CancelledContextReturnsNilResponse(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // a sibling relay won the stateful fan-out race
+
+	g := &GRPCDirectRPCConnection{}
+	resp, err := g.handleGRPCError(ctx, status.Error(codes.Canceled, "context canceled"), nil)
+
+	require.Nil(t, resp,
+		"a cancelled relay must not carry a response — that is the arm that records a success")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.Canceled),
+		"the context.Canceled sentinel must be re-attached so the relay-race carve-out can see it")
+}
+
+// TestGrpcGoDoesNotWrapCancelSentinel documents WHY the sentinel has to be
+// re-attached explicitly rather than merely preserved via Unwrap: grpc-go's own
+// status error does not carry it. If this ever starts failing, the explicit
+// re-attach in handleGRPCError can be simplified.
+func TestGrpcGoDoesNotWrapCancelSentinel(t *testing.T) {
+	require.False(t,
+		errors.Is(status.Error(codes.Canceled, "context canceled"), context.Canceled),
+		"grpc-go began wrapping context.Canceled — revisit handleGRPCError")
+}
+
+// TestHandleGRPCError_PreservesCause covers the non-cancellation path: a real
+// node error still takes the response arm, and its cause now survives so
+// errors.Is / errors.As can see through GRPCStatusError.
+func TestHandleGRPCError_PreservesCause(t *testing.T) {
+	cause := status.Error(codes.InvalidArgument, "malformed transaction")
+
+	g := &GRPCDirectRPCConnection{}
+	resp, err := g.handleGRPCError(context.Background(), cause, nil)
+
+	require.NotNil(t, resp, "a genuine node error still carries its response body")
+	require.Equal(t, int(codes.InvalidArgument), resp.StatusCode)
+
+	var statusErr *GRPCStatusError
+	require.True(t, errors.As(err, &statusErr))
+	require.Equal(t, uint32(codes.InvalidArgument), statusErr.Code)
+	require.ErrorIs(t, err, cause,
+		"cause must survive; without Unwrap this type was a dead end for sentinel checks")
+}
+
+// TestIsSessionSyncLoss_UnaffectedByUnwrap is MAG-2687 step 0 — and it records a
+// correction to that ticket's premise.
+//
+// The ticket warns that adding Unwrap makes status.Code(err) resolve via
+// errors.As where it previously returned Unknown, that IsSessionSyncLoss reads
+// that, and so the behaviour must be pinned before it becomes reachable.
+//
+// Verified empirically: it never becomes reachable. IsSessionSyncLoss lives in
+// common.go, which imports github.com/gogo/status — NOT
+// google.golang.org/grpc/status — and gogo's Code() does not unwrap. So
+// GRPCStatusError is opaque to it both before and after this change, and step 0's
+// hazard does not exist on this path.
+//
+// Still worth pinning: it is the test that will catch someone swapping gogo/status
+// for grpc/status in common.go, which WOULD make the wrapper transparent here.
+func TestIsSessionSyncLoss_UnaffectedByUnwrap(t *testing.T) {
+	for _, code := range []codes.Code{
+		codes.Canceled,         // 1
+		codes.DeadlineExceeded, // 4
+		codes.InvalidArgument,  // 3
+		codes.Internal,         // 13
+		codes.Unavailable,      // 14
+	} {
+		err := &GRPCStatusError{
+			Code:    uint32(code),
+			Message: "x",
+			cause:   status.Error(code, "x"),
+		}
+		require.False(t, IsSessionSyncLoss(err),
+			"real gRPC code %v must not be read as session sync loss", code)
+	}
+
+	// Even the genuine sync-loss code stays invisible THROUGH the wrapper, because
+	// gogo/status does not unwrap. This is not a regression introduced here: before
+	// this change GRPCStatusError carried no cause at all, so the result was the
+	// same. Adding Unwrap is neutral for this function.
+	wrapped := &GRPCStatusError{
+		Code:    SessionOutOfSyncGRPCCode,
+		Message: "session out of sync",
+		cause:   status.Error(codes.Code(SessionOutOfSyncGRPCCode), "session out of sync"),
+	}
+	require.False(t, IsSessionSyncLoss(wrapped),
+		"gogo/status does not unwrap — if this flips, common.go changed status packages")
+
+	// The undecorated forms are the ones that actually occur in production, and
+	// both must keep working.
+	require.True(t, IsSessionSyncLoss(SessionOutOfSyncError),
+		"the sentinel path must still fire")
+}

--- a/protocol/lavasession/grpc_status_error_test.go
+++ b/protocol/lavasession/grpc_status_error_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -30,6 +31,82 @@ func TestHandleGRPCError_CancelledContextReturnsNilResponse(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, errors.Is(err, context.Canceled),
 		"the context.Canceled sentinel must be re-attached so the relay-race carve-out can see it")
+}
+
+// TestHandleGRPCError_CancelledContextWinsOverTheReportedStatus closes the hole
+// the branch above was originally written with.
+//
+// That branch required BOTH a cancelled local context AND status.Code(err) ==
+// codes.Canceled. grpc-go does not promise the second: cancelling a call while its
+// connection is being torn down surfaces Unavailable, and a cancel racing a
+// response can surface Unknown or the status the endpoint had already sent. With
+// the conjunct in place those cases fell through to the node-error arm, which
+// returns (result, nil) — and `err != nil` at the relay-race carve-out
+// (rpcsmartrouter_server.go) then sees nil and scores a relay WE abandoned against
+// a healthy endpoint. Same bug class as MAG-2687, narrower window.
+//
+// The local context is the authoritative signal and is sufficient on its own. The
+// risk is asymmetric: missing a local cancel penalises an endpoint that did nothing
+// wrong, over-detecting one merely skips scoring for a result we were discarding.
+func TestHandleGRPCError_CancelledContextWinsOverTheReportedStatus(t *testing.T) {
+	for _, code := range []codes.Code{
+		codes.Unavailable, // connection torn down by the cancel itself
+		codes.Unknown,     // grpc-go's fallback when the cancel races the response
+		codes.Internal,    // a status the endpoint had already sent
+		codes.Canceled,    // the shape the old conjunct required
+	} {
+		t.Run(code.String(), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel() // a sibling relay won the race, or the client hung up
+
+			g := &GRPCDirectRPCConnection{}
+			resp, err := g.handleGRPCError(ctx, status.Error(code, "boom"), nil)
+
+			require.Nil(t, resp,
+				"a non-nil response routes this into the node-error arm, which returns err == nil "+
+					"and makes the cancellation invisible to the carve-out")
+			require.True(t, errors.Is(err, context.Canceled),
+				"the local context is the authoritative signal; the status the endpoint reported "+
+					"must not be able to veto it")
+		})
+	}
+}
+
+// TestHandleGRPCError_CancelledRelayKeepsItsCause covers the other half: the
+// branch resolves the cancellation but must not throw away what the endpoint was
+// doing when we pulled the plug — in a change whose other half is about preserving
+// causes, wrapping only the sentinel would be the same omission one level up.
+func TestHandleGRPCError_CancelledRelayKeepsItsCause(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cause := status.Error(codes.Unavailable, "connection reset by peer")
+	g := &GRPCDirectRPCConnection{}
+	_, err := g.handleGRPCError(ctx, cause, nil)
+
+	require.True(t, errors.Is(err, context.Canceled),
+		"the sentinel the carve-out resolves must still be reachable")
+	require.ErrorIs(t, err, cause,
+		"the originating gRPC status must survive alongside it, for logs and for any later inspector")
+}
+
+// TestHandleGRPCError_ExpiredDeadlineIsNotACancellation is the collateral guard
+// for the two tests above: dropping the status-code conjunct widens the branch, so
+// the remaining condition has to stay exact. A ctx whose DEADLINE expired is also
+// non-nil, and relabelling a timeout as a client cancellation would let a genuinely
+// slow endpoint escape being blamed for it.
+func TestHandleGRPCError_ExpiredDeadlineIsNotACancellation(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded, "precondition: expired, not cancelled")
+
+	g := &GRPCDirectRPCConnection{}
+	resp, err := g.handleGRPCError(ctx, status.Error(codes.DeadlineExceeded, "context deadline exceeded"), nil)
+
+	require.NotNil(t, resp,
+		"a timeout is the endpoint's problem and must keep its response so the node-error arm runs")
+	require.False(t, errors.Is(err, context.Canceled),
+		"a slow endpoint must not be excused as a relay we cancelled")
 }
 
 // TestHandleGRPCError_RemoteCancellationIsNotLocal is the collateral guard for

--- a/protocol/lavasession/grpc_status_error_test.go
+++ b/protocol/lavasession/grpc_status_error_test.go
@@ -59,6 +59,43 @@ func TestHandleGRPCError_PreservesCause(t *testing.T) {
 		"cause must survive; without Unwrap this type was a dead end for sentinel checks")
 }
 
+// TestGRPCStatusError_ResolvesThroughStatusFromError pins the behaviour change that
+// Unwrap causes for every grpc-go-based inspector of this error.
+//
+// Before Unwrap, status.FromError on a *GRPCStatusError returned ok=false, so
+// chainlib.ExtractNodeErrorDetails fell past its gRPC branch and reported code 0.
+// It now returns ok=true with the real code, which is what Tier-1 CodeEquals
+// matchers key on.
+//
+// The CODE is the whole of the change. The message is deliberately asserted to be
+// UNCHANGED: when grpc-go's FromError resolves via errors.As it overwrites the
+// status message with the OUTER error's Error() string, so st.Message() is our
+// "gRPC error N: ..." rendering, not the node's bare message. ExtractNodeErrorDetails
+// had already defaulted errorMessage to nodeError.Error(), so it sees the same
+// string either way — code 0 -> 3 is the only observable difference.
+//
+// Pinned here rather than in chainlib because `cause` is unexported: only this
+// package can build a wrapper that actually carries one, and package lavasession
+// cannot import chainlib (chainlib imports lavasession).
+func TestGRPCStatusError_ResolvesThroughStatusFromError(t *testing.T) {
+	cause := status.Error(codes.InvalidArgument, "malformed transaction")
+	wrapped := &GRPCStatusError{Code: uint32(codes.InvalidArgument), Message: "malformed transaction", cause: cause}
+
+	st, ok := status.FromError(wrapped)
+	require.True(t, ok,
+		"Unwrap must let grpc-go resolve this wrapper; ExtractNodeErrorDetails depends on it")
+	require.Equal(t, codes.InvalidArgument, st.Code(),
+		"the real gRPC code must surface, not Unknown — this is the behaviour change")
+	require.Equal(t, "gRPC error 3: malformed transaction", st.Message(),
+		"FromError rewrites Message to the outer Error(); the node's bare message does NOT surface")
+
+	// Without a cause the wrapper stays opaque — which is exactly the pre-fix
+	// behaviour, and confirms the cause is what does the work here.
+	_, okNoCause := status.FromError(&GRPCStatusError{Code: 3, Message: "x"})
+	require.False(t, okNoCause,
+		"a cause-less wrapper must remain unresolvable; if this flips, the fix is masked")
+}
+
 // TestIsSessionSyncLoss_UnaffectedByUnwrap is MAG-2687 step 0 — and it records a
 // correction to that ticket's premise.
 //

--- a/protocol/relaycore/grpc_status_node_error_test.go
+++ b/protocol/relaycore/grpc_status_node_error_test.go
@@ -1,0 +1,156 @@
+package relaycore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	"github.com/magma-Devs/smart-router/protocol/chainlib"
+	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcInterfaceMessages"
+	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcclient"
+	"github.com/magma-Devs/smart-router/protocol/chainlib/extensionslib"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+)
+
+// ---------------------------------------------------------------------------
+// MAG-2549 — the downstream half.
+//
+// direct_rpc_relay.sendGRPCRelay now stamps the gRPC status onto
+// RelayResult.StatusCode. This file pins WHY that mattered: results_manager
+// .setValidResponse re-runs CheckResponseError against that field, and
+// GrpcMessage.CheckResponseError decides purely from it. Left at its 0 default
+// the router filed a node error as a SUCCESS — returned to the client as a good
+// answer, counted toward the required-successes quorum, and eligible for caching.
+// ---------------------------------------------------------------------------
+
+// grpcChainMessage is a minimal ChainMessage on the gRPC interface. Only the
+// three methods setValidResponse actually consults carry behaviour:
+// CheckResponseError (delegated to the production GrpcMessage), GetApiCollection
+// (selects TransportGRPC) and GetApi (the subscribe-tag check). The rest are
+// inert stubs.
+type grpcChainMessage struct{}
+
+func (grpcChainMessage) CheckResponseError(data []byte, httpStatusCode int) (bool, string) {
+	// The production implementation, deliberately not re-implemented: it is the
+	// component whose contract ("non-OK status means node error") the fix relies on.
+	return rpcInterfaceMessages.GrpcMessage{}.CheckResponseError(data, httpStatusCode)
+}
+
+func (grpcChainMessage) GetApiCollection() *spectypes.ApiCollection {
+	return &spectypes.ApiCollection{
+		CollectionData: spectypes.CollectionData{ApiInterface: "grpc"},
+	}
+}
+
+func (grpcChainMessage) GetApi() *spectypes.Api {
+	return &spectypes.Api{Name: "cosmos.bank.v1beta1.Query/Balance"}
+}
+
+func (grpcChainMessage) GetRPCMessage() rpcInterfaceMessages.GenericMessage {
+	return &rpcInterfaceMessages.GrpcMessage{Path: "cosmos.bank.v1beta1.Query/Balance"}
+}
+
+func (grpcChainMessage) SubscriptionIdExtractor(*rpcclient.JsonrpcMessage) string { return "" }
+func (grpcChainMessage) RequestedBlock() (int64, int64)                           { return 0, 0 }
+func (grpcChainMessage) UpdateLatestBlockInMessage(int64, bool) bool              { return false }
+func (grpcChainMessage) AppendHeader([]pairingtypes.Metadata)                     {}
+func (grpcChainMessage) GetExtensions() []*spectypes.Extension                    { return nil }
+func (grpcChainMessage) OverrideExtensions([]string, *extensionslib.ExtensionParser) {
+}
+func (grpcChainMessage) DisableErrorHandling()                          {}
+func (grpcChainMessage) TimeoutOverride(...time.Duration) time.Duration { return 0 }
+func (grpcChainMessage) GetForceCacheRefresh() bool                     { return false }
+func (grpcChainMessage) SetForceCacheRefresh(bool) bool                 { return false }
+func (grpcChainMessage) GetRawRequestHash() ([]byte, error)             { return nil, nil }
+func (grpcChainMessage) GetRequestedBlocksHashes() []string             { return nil }
+func (grpcChainMessage) UpdateEarliestInMessage(int64) bool             { return false }
+func (grpcChainMessage) SetExtension(*spectypes.Extension)              {}
+func (grpcChainMessage) GetUsedDefaultValue() bool                      { return false }
+func (grpcChainMessage) GetParseDirective() *spectypes.ParseDirective   { return nil }
+func (grpcChainMessage) IsBatch() bool                                  { return false }
+
+func grpcProtocolMessage() chainlib.ProtocolMessage {
+	return chainlib.NewProtocolMessage(
+		grpcChainMessage{},
+		nil,
+		&pairingtypes.RelayPrivateData{ApiUrl: "cosmos.bank.v1beta1.Query/Balance"},
+		"dapp",
+		"127.0.0.1",
+	)
+}
+
+// TestResultsManager_GRPCStatusResponseIsANodeError drives the real
+// ResultsManager.SetResponse with the RelayResult shape sendGRPCRelay now
+// produces, and asserts it is filed as a node error rather than a success.
+//
+// The StatusCode=0 subtest is the regression itself: it reproduces the pre-fix
+// RelayResult and shows the identical error body landing in successResults.
+func TestResultsManager_GRPCStatusResponseIsANodeError(t *testing.T) {
+	errorBody := []byte(`{"error_message":"invalid address: decoding bech32 failed","error_code":3}`)
+
+	t.Run("status code carried through is filed as a node error", func(t *testing.T) {
+		rm := NewResultsManager(1, "LAVA")
+
+		nodeErr := rm.SetResponse(&RelayResponse{
+			RelayResult: common.RelayResult{
+				Reply:       &pairingtypes.RelayReply{Data: errorBody},
+				StatusCode:  int(codes.InvalidArgument),
+				IsNodeError: true,
+				Finalized:   true,
+			},
+		}, grpcProtocolMessage())
+
+		require.Error(t, nodeErr,
+			"setValidResponse returns non-nil exactly when it parsed a node error")
+
+		success, nodeErrors, _, protocolErrors := rm.GetResults()
+		require.Equal(t, 0, success,
+			"a gRPC INVALID_ARGUMENT must never count as a successful relay")
+		require.Equal(t, 1, nodeErrors)
+		require.Equal(t, 0, protocolErrors,
+			"this is a node error, not a protocol error — the relay itself completed")
+	})
+
+	// The pre-fix shape. Kept as an executable statement of the bug rather than a
+	// comment: if someone drops StatusCode from the RelayResult again, the test
+	// above goes red and this one explains what changed.
+	t.Run("REGRESSION: a zero status code is filed as a success", func(t *testing.T) {
+		rm := NewResultsManager(1, "LAVA")
+
+		nodeErr := rm.SetResponse(&RelayResponse{
+			RelayResult: common.RelayResult{
+				Reply:      &pairingtypes.RelayReply{Data: errorBody},
+				StatusCode: 0, // what this arm left behind before MAG-2549
+				Finalized:  true,
+			},
+		}, grpcProtocolMessage())
+
+		require.NoError(t, nodeErr)
+		success, nodeErrors, _, _ := rm.GetResults()
+		require.Equal(t, 1, success,
+			"documents the defect: GrpcMessage.CheckResponseError reads the status code alone, "+
+				"so a zero made an error body indistinguishable from a good answer")
+		require.Equal(t, 0, nodeErrors)
+	})
+}
+
+// TestGrpcCheckResponseError_DependsOnlyOnStatusCode isolates the contract the
+// test above depends on, so a change to GrpcMessage is attributed to GrpcMessage
+// rather than surfacing as a confusing failure in the results manager.
+func TestGrpcCheckResponseError_DependsOnlyOnStatusCode(t *testing.T) {
+	body := []byte(`{"error_message":"invalid address","error_code":3}`)
+
+	hasError, message := rpcInterfaceMessages.GrpcMessage{}.CheckResponseError(body, int(codes.InvalidArgument))
+	require.True(t, hasError, "any non-OK gRPC status is a node error")
+	require.Empty(t, message,
+		"and it yields NO message — which is why sendGRPCRelay must fall back to the node's "+
+			"own status message before classifying")
+
+	hasError, _ = rpcInterfaceMessages.GrpcMessage{}.CheckResponseError(body, 0)
+	require.False(t, hasError,
+		"the same error body with a zero status reads as success — the MAG-2549 defect")
+}

--- a/protocol/relaycore/grpc_status_node_error_test.go
+++ b/protocol/relaycore/grpc_status_node_error_test.go
@@ -138,6 +138,46 @@ func TestResultsManager_GRPCStatusResponseIsANodeError(t *testing.T) {
 	})
 }
 
+// TestResultsManager_ClassifiesOnTheNodesBodyWhenTheMessageIsEmpty pins the
+// empty-message fallback in setValidResponse.
+//
+// sendGRPCRelay already worked around GrpcMessage.CheckResponseError returning
+// ("", true) by falling back to the node's own status message. setValidResponse hit
+// the identical trap one layer up and did not: it built `err := fmt.Errorf("%s",
+// "")` and then classified on err.Error(). Code matchers still fired — StatusCode
+// is passed as errorCode — but every MESSAGE-based row was dead, so a
+// RESOURCE_EXHAUSTED whose body says "rate limit" was filed as UNKNOWN_ERROR and
+// the node error was logged with an empty error string.
+//
+// RESOURCE_EXHAUSTED is the witness because code 8 deliberately has NO registry row
+// of its own: NODE_RATE_LIMITED here can only come from the body surviving.
+func TestResultsManager_ClassifiesOnTheNodesBodyWhenTheMessageIsEmpty(t *testing.T) {
+	rm := NewResultsManager(1, "LAVA")
+
+	body := []byte(`{"error_message":"rate limit exceeded, retry after 1s","error_code":8}`)
+	nodeErr := rm.SetResponse(&RelayResponse{
+		RelayResult: common.RelayResult{
+			Reply:       &pairingtypes.RelayReply{Data: body},
+			StatusCode:  int(codes.ResourceExhausted),
+			IsNodeError: true,
+			Finalized:   true,
+		},
+	}, grpcProtocolMessage())
+
+	require.Error(t, nodeErr)
+	require.NotEmpty(t, nodeErr.Error(),
+		"an empty error string is what reached both the classifier and the node-error log line")
+
+	inst, ok := rm.(*ResultsManagerInst)
+	require.True(t, ok)
+	require.Len(t, inst.nodeResponseErrors.RelayErrors, 1)
+
+	classified := inst.nodeResponseErrors.RelayErrors[0].LavaError
+	require.NotNil(t, classified)
+	require.Equal(t, common.LavaErrorNodeRateLimited.Code, classified.Code,
+		"the message-based row must be reachable here; on the empty string this was UNKNOWN_ERROR")
+}
+
 // TestGrpcCheckResponseError_DependsOnlyOnStatusCode isolates the contract the
 // test above depends on, so a change to GrpcMessage is attributed to GrpcMessage
 // rather than surfacing as a confusing failure in the results manager.

--- a/protocol/relaycore/results_manager.go
+++ b/protocol/relaycore/results_manager.go
@@ -132,6 +132,21 @@ func (rp *ResultsManagerInst) setValidResponse(response *RelayResponse, protocol
 		// this is a node error, meaning we still didn't get a good response.
 		// we may choose to wait until there will be a response or timeout happens
 		// if we decide to wait and timeout happens we will take the majority of response messages
+		//
+		// A CheckResponseError implementation may report hasError WITHOUT a message:
+		// GrpcMessage decides purely from the status code and always returns "". Classifying on
+		// the empty string reduces the transport's registry to its code matchers and leaves every
+		// message-based row unreachable — a RESOURCE_EXHAUSTED whose body says "rate limit" would
+		// be scored as an availability failure instead of exempted as healthy-but-busy — and it
+		// also logs the node error below with an empty error string. Fall back to the node's own
+		// reply body, which is where the evidence actually is, and only then to a synthetic
+		// description so `err` is never blank.
+		if errorMessage == "" {
+			errorMessage = string(response.RelayResult.Reply.Data)
+		}
+		if errorMessage == "" {
+			errorMessage = fmt.Sprintf("node error with no message (status %d)", response.RelayResult.StatusCode)
+		}
 		err := fmt.Errorf("%s", errorMessage)
 		// Log node error payload and headers for troubleshooting
 		// also log the original request payload and request headers if available

--- a/protocol/rpcsmartrouter/direct_rpc_relay.go
+++ b/protocol/rpcsmartrouter/direct_rpc_relay.go
@@ -760,41 +760,64 @@ func (d *DirectRPCRelaySender) sendGRPCRelay(
 		)
 
 		// Check if it's a gRPC status error (use comma-ok idiom to avoid panic)
-		grpcErr, isGRPCErr := err.(*lavasession.GRPCStatusError)
+		_, isGRPCErr := err.(*lavasession.GRPCStatusError)
 
 		if isGRPCErr && response != nil {
-			// gRPC error with status code - might contain valid error response
-			// The response.Data contains the error details in JSON format
-			isNodeError := grpcErr.Code >= 13 // INTERNAL and above are node errors
-			grpcResult := &common.RelayResult{
+			// A gRPC status error that still carried a response body: the node
+			// answered, and its answer is an error. Classify it exactly the way the
+			// success path below does rather than applying a separate rule here —
+			// same CheckResponseError, same StatusCode, same classification call.
+			//
+			// This arm previously left StatusCode at its 0 default and derived
+			// IsNodeError from `Code >= 13`. Both were wrong, independently:
+			//
+			//   - StatusCode 0 makes GrpcMessage.CheckResponseError report "no error"
+			//     downstream in results_manager.setValidResponse, so any upstream
+			//     error (INVALID_ARGUMENT on a malformed tx, NOT_FOUND on an object)
+			//     was served to the client as a success and was cacheable (MAG-2549).
+			//   - `Code >= 13` additionally left DeadlineExceeded (4) and every other
+			//     sub-13 code marked as not-a-node-error, which is what gates the
+			//     cache write and the lava-identified-node-error header.
+			//
+			// response.StatusCode is the same value the error carried (handleGRPCError
+			// builds both from one errorCode), so this loses nothing.
+			hasError, errorMessage := chainMessage.CheckResponseError(response.Data, response.StatusCode)
+			// GrpcMessage.CheckResponseError reports hasError from the status code alone
+			// and always returns an EMPTY message. Classifying on "" would reduce the
+			// gRPC registry to its two code matchers and silently disable every
+			// message-based row it has — "rate limit", "unimplemented", ENHANCE_YOUR_CALM.
+			if errorMessage == "" {
+				errorMessage = err.Error()
+			}
+			result := &common.RelayResult{
 				Reply: &pairingtypes.RelayReply{
 					Data:     response.Data,                                   // Error response in JSON format
 					Metadata: convertHTTPHeadersToMetadata(response.Metadata), // Include metadata even for errors
 				},
-				Finalized: true,
+				Finalized:  true,
+				StatusCode: response.StatusCode,
 				ProviderInfo: common.ProviderInfo{
 					ProviderAddress: endpointIdentifier,
 					ProviderGroup:   d.groupLabel,
 				},
-				IsNodeError: isNodeError,
+				IsNodeError: hasError,
 			}
 			// This branch returns err == nil, so downstream sees a completed relay
 			// carrying a node error — same shape as the four body-error paths. It
 			// must therefore classify like them: without this, the availability gate
 			// in rpcsmartrouter_server.shouldFailSessionForResult had no carve-out to
-			// consult on the gRPC status-error path and scored every code >= 13 as an
-			// availability failure, with no way to exempt a deterministic one.
+			// consult on the gRPC status-error path and scored every non-OK status as
+			// an availability failure, with no way to exempt a deterministic one.
 			//
-			// Of the codes that reach here, only 14 (UNAVAILABLE) is registered; 13,
-			// 15 and 16 classify Unknown and so are scored. That is intended for all
-			// three, 16 (UNAUTHENTICATED) included: credentials are configured per
-			// endpoint, so an endpoint rejecting ours is unusable to us and should be
-			// demoted. If every endpoint rejects them, all demote together and
-			// selection degrades to uniform rather than starving.
-			if isNodeError {
-				grpcResult.ApplyNodeErrorClassification(d.chainFamily, common.TransportGRPC, int(grpcErr.Code), err.Error())
+			// ApplyNodeErrorClassification rather than assigning IsNonRetryable alone:
+			// the flags are a set. IsRateLimited is what keeps a busy-but-healthy
+			// endpoint (RESOURCE_EXHAUSTED) out of the availability signal, and
+			// IsUnsupportedMethod is what gates the zero-CU carve-out — setting only
+			// IsNonRetryable is how both ended up classified but never assigned before.
+			if hasError {
+				result.ApplyNodeErrorClassification(d.chainFamily, common.TransportGRPC, response.StatusCode, errorMessage)
 			}
-			return grpcResult, nil
+			return result, nil
 		}
 
 		return nil, classifyAndWrap(err, d.chainFamily, common.TransportGRPC)

--- a/protocol/rpcsmartrouter/direct_rpc_relay.go
+++ b/protocol/rpcsmartrouter/direct_rpc_relay.go
@@ -769,9 +769,16 @@ func (d *DirectRPCRelaySender) sendGRPCRelay(
 
 		if isGRPCErr && response != nil {
 			// A gRPC status error that still carried a response body: the node
-			// answered, and its answer is an error. Classify it exactly the way the
-			// success path below does rather than applying a separate rule here —
-			// same CheckResponseError, same StatusCode, same classification call.
+			// answered, and its answer is an error. Classify it through the same three
+			// steps every other node-error path uses — CheckResponseError, StatusCode,
+			// ApplyNodeErrorClassification — rather than applying a separate rule here.
+			//
+			// Note this arm is the ONLY one that classifies a gRPC node error. The
+			// success path 40 lines below runs the same three steps, but its
+			// CheckResponseError can never report an error: it is reached only with
+			// StatusCode = http.StatusOK, which GrpcMessage.CheckResponseError treats
+			// as "no error" by definition. Its shape is the model to copy; its
+			// hasError branch is unreachable on this transport.
 			//
 			// This arm previously left StatusCode at its 0 default and derived
 			// IsNodeError from `Code >= 13`. Both were wrong, independently:

--- a/protocol/rpcsmartrouter/direct_rpc_relay.go
+++ b/protocol/rpcsmartrouter/direct_rpc_relay.go
@@ -787,10 +787,21 @@ func (d *DirectRPCRelaySender) sendGRPCRelay(
 			// response.StatusCode is the same value the error carried (handleGRPCError
 			// builds both from one errorCode), so this loses nothing.
 			hasError, errorMessage := chainMessage.CheckResponseError(response.Data, response.StatusCode)
-			// GrpcMessage.CheckResponseError reports hasError from the status code alone
+			// GrpcMessage.CheckResponseError decides hasError from the status code alone
 			// and always returns an EMPTY message. Classifying on "" would reduce the
-			// gRPC registry to its two code matchers and silently disable every
-			// message-based row it has — "rate limit", "unimplemented", ENHANCE_YOUR_CALM.
+			// gRPC registry to its three code matchers and silently disable every
+			// message-based row it has — "rate limit", "unimplemented", ENHANCE_YOUR_CALM
+			// — so a RESOURCE_EXHAUSTED saying "rate limit exceeded" would be scored as
+			// an availability failure instead of exempted as healthy-but-busy.
+			//
+			// grpcErr.Message before err.Error(): the former is the node's own status
+			// message, the latter is that message wrapped in our "gRPC error N: "
+			// rendering. Feed the classifier the undecorated text — the wrapper adds a
+			// literal "rpc error" substring (inside "gRPC error") that several guards
+			// key on, and it is our string, not the node's evidence.
+			if errorMessage == "" {
+				errorMessage = grpcErr.Message
+			}
 			if errorMessage == "" {
 				errorMessage = err.Error()
 			}

--- a/protocol/rpcsmartrouter/direct_rpc_relay.go
+++ b/protocol/rpcsmartrouter/direct_rpc_relay.go
@@ -3,6 +3,7 @@ package rpcsmartrouter
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -759,8 +760,12 @@ func (d *DirectRPCRelaySender) sendGRPCRelay(
 			utils.LogAttr("latency", latency),
 		)
 
-		// Check if it's a gRPC status error (use comma-ok idiom to avoid panic)
-		_, isGRPCErr := err.(*lavasession.GRPCStatusError)
+		// errors.As rather than a bare type assertion: GRPCStatusError now implements
+		// Unwrap, so it is meant to be inspected through wrapping. A plain assertion
+		// would silently stop matching the moment anything wraps the error on its way
+		// here, rerouting node errors into classifyAndWrap with no visible cause.
+		var grpcErr *lavasession.GRPCStatusError
+		isGRPCErr := errors.As(err, &grpcErr)
 
 		if isGRPCErr && response != nil {
 			// A gRPC status error that still carried a response body: the node

--- a/protocol/rpcsmartrouter/grpc_relay_race_cancellation_test.go
+++ b/protocol/rpcsmartrouter/grpc_relay_race_cancellation_test.go
@@ -92,3 +92,45 @@ func TestGRPCRemoteStatusError_StillNotLocalCancellation(t *testing.T) {
 		})
 	}
 }
+
+// TestRemoteStatusGuard_AppliesAcrossTransports makes the reach of the guard change
+// explicit.
+//
+// stringConnectionFallbacks is a single package-level table and
+// detectConnectionErrorFromString takes no transport argument, so narrowing
+// "rpc error" to "rpc error: code =" changes classification for EVERY transport —
+// not just gRPC. That is intended (the discriminator is the remote status prefix,
+// which is transport-independent), but it was previously verified only on
+// gRPC-shaped inputs. These cases pin both directions on a non-gRPC transport.
+func TestRemoteStatusGuard_AppliesAcrossTransports(t *testing.T) {
+	for _, transport := range []common.TransportType{common.TransportJsonRPC, common.TransportREST} {
+		t.Run(transport.String()+"/remote-prefix-still-excluded", func(t *testing.T) {
+			wrapped := classifyAndWrap(
+				errors.New("rpc error: code = Canceled desc = context canceled"),
+				common.ChainFamily(-1), transport)
+			require.NotEqual(t, common.LavaErrorContextCanceled.Code, extractLavaError(wrapped).Code,
+				"the remote-status prefix must exclude on non-gRPC transports too")
+		})
+
+		t.Run(transport.String()+"/plain-local-cancel-still-matches", func(t *testing.T) {
+			wrapped := classifyAndWrap(
+				errors.New("context canceled"),
+				common.ChainFamily(-1), transport)
+			require.Equal(t, common.LavaErrorContextCanceled.Code, extractLavaError(wrapped).Code,
+				"a plain local cancellation must still classify as such")
+		})
+
+		// The discriminating case: contains "rpc error" but NOT "rpc error: code =".
+		// The two cases above pass under both the old and the new guard, so only this
+		// one actually detects the widening — and it does so on a non-gRPC transport,
+		// which is the reach this test exists to pin. GRPCStatusError's rendering is
+		// the concrete real-world instance of that string class.
+		t.Run(transport.String()+"/bare-rpc-error-substring-no-longer-excluded", func(t *testing.T) {
+			wrapped := classifyAndWrap(
+				errors.New("gRPC error 1: context canceled"),
+				common.ChainFamily(-1), transport)
+			require.Equal(t, common.LavaErrorContextCanceled.Code, extractLavaError(wrapped).Code,
+				"only the full remote-status prefix may exclude — a bare 'rpc error' substring must not, on any transport")
+		})
+	}
+}

--- a/protocol/rpcsmartrouter/grpc_relay_race_cancellation_test.go
+++ b/protocol/rpcsmartrouter/grpc_relay_race_cancellation_test.go
@@ -55,19 +55,48 @@ func TestGRPCRaceLoser_SurvivesClassification(t *testing.T) {
 	})
 }
 
-// TestGRPCLocalError_NotDisqualifiedByRpcErrorSubstring pins the substring
-// collision. GRPCStatusError renders as "gRPC error 1: context canceled", which
-// lowercased contains "rpc error" INSIDE the word "gRPC" — so a guard written to
-// exclude remote status errors was disqualifying our own local ones.
-func TestGRPCLocalError_NotDisqualifiedByRpcErrorSubstring(t *testing.T) {
-	local := &lavasession.GRPCStatusError{Code: 1, Message: "context canceled"}
+// TestGRPCStatusError_IsNeverReadAsLocalCancellation is the inverse of a test
+// that used to live here, and the inversion is the point.
+//
+// The earlier version asserted that a bare GRPCStatusError{Code: 1, Message:
+// "context canceled"} SHOULD classify as PROTOCOL_CONTEXT_CANCELED, and narrowed
+// the classifier guard from "rpc error" to "rpc error: code =" to make that pass.
+// The premise was wrong. GRPCStatusError is built by handleGRPCError only AFTER
+// the local-cancellation branch has already returned, so a value of this shape
+// describes a status the ENDPOINT reported — remote, or at minimum not proven
+// local. PROTOCOL_CONTEXT_CANCELED is Retryable=false, so reading it as local
+// suppresses the retry that would have reached a healthy endpoint.
+//
+// A genuinely local cancellation never needs this table: handleGRPCError returns
+// a nil response and an error wrapping the real context.Canceled sentinel, which
+// DetectConnectionError resolves structurally in layer 1. That path is pinned in
+// TestGRPCRaceLoser_SurvivesClassification above.
+func TestGRPCStatusError_IsNeverReadAsLocalCancellation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  *lavasession.GRPCStatusError
+	}{
+		{"canceled", &lavasession.GRPCStatusError{Code: 1, Message: "context canceled"}},
+		{"deadline", &lavasession.GRPCStatusError{Code: 4, Message: "context deadline exceeded"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Contains(t, strings.ToLower(tc.err.Error()), "rpc error",
+				"precondition: the rendering really does contain the substring the guard keys on")
 
-	require.Contains(t, strings.ToLower(local.Error()), "rpc error",
-		"precondition: the local error really does contain the substring the guard keys on")
+			wrapped := classifyAndWrap(tc.err, common.ChainFamily(-1), common.TransportGRPC)
+			got := extractLavaError(wrapped)
 
-	wrapped := classifyAndWrap(local, common.ChainFamily(-1), common.TransportGRPC)
-	require.Equal(t, common.LavaErrorContextCanceled.Code, extractLavaError(wrapped).Code,
-		"the guard must key on the full remote prefix, not the bare substring")
+			// got may be nil when nothing matched, which is itself a pass — the
+			// assertion is only that it is not one of the two LOCAL verdicts.
+			if got == nil {
+				return
+			}
+			require.NotEqual(t, common.LavaErrorContextCanceled.Code, got.Code,
+				"a status the endpoint reported must not be attributed to local orchestration")
+			require.NotEqual(t, common.LavaErrorContextDeadline.Code, got.Code,
+				"a status the endpoint reported must not be attributed to local orchestration")
+		})
+	}
 }
 
 // COLLATERAL GUARD — the most important test in this file.
@@ -93,15 +122,13 @@ func TestGRPCRemoteStatusError_StillNotLocalCancellation(t *testing.T) {
 	}
 }
 
-// TestRemoteStatusGuard_AppliesAcrossTransports makes the reach of the guard change
+// TestRemoteStatusGuard_AppliesAcrossTransports makes the reach of the guard
 // explicit.
 //
 // stringConnectionFallbacks is a single package-level table and
-// detectConnectionErrorFromString takes no transport argument, so narrowing
-// "rpc error" to "rpc error: code =" changes classification for EVERY transport —
-// not just gRPC. That is intended (the discriminator is the remote status prefix,
-// which is transport-independent), but it was previously verified only on
-// gRPC-shaped inputs. These cases pin both directions on a non-gRPC transport.
+// detectConnectionErrorFromString takes no transport argument, so the width of
+// the "rpc error" exclusion decides classification for EVERY transport, not just
+// gRPC. These cases pin all three directions on non-gRPC transports.
 func TestRemoteStatusGuard_AppliesAcrossTransports(t *testing.T) {
 	for _, transport := range []common.TransportType{common.TransportJsonRPC, common.TransportREST} {
 		t.Run(transport.String()+"/remote-prefix-still-excluded", func(t *testing.T) {
@@ -121,16 +148,21 @@ func TestRemoteStatusGuard_AppliesAcrossTransports(t *testing.T) {
 		})
 
 		// The discriminating case: contains "rpc error" but NOT "rpc error: code =".
-		// The two cases above pass under both the old and the new guard, so only this
-		// one actually detects the widening — and it does so on a non-gRPC transport,
-		// which is the reach this test exists to pin. GRPCStatusError's rendering is
-		// the concrete real-world instance of that string class.
-		t.Run(transport.String()+"/bare-rpc-error-substring-no-longer-excluded", func(t *testing.T) {
+		// The two cases above pass under EITHER guard width, so this is the only one
+		// that detects a widening — and it does so on a non-gRPC transport, which is
+		// the reach this test exists to pin. lavasession.GRPCStatusError's rendering
+		// ("gRPC error 1: ...") is the concrete real-world instance of that string
+		// class, and it denotes a status the endpoint reported.
+		t.Run(transport.String()+"/bare-rpc-error-substring-still-excluded", func(t *testing.T) {
 			wrapped := classifyAndWrap(
 				errors.New("gRPC error 1: context canceled"),
 				common.ChainFamily(-1), transport)
-			require.Equal(t, common.LavaErrorContextCanceled.Code, extractLavaError(wrapped).Code,
-				"only the full remote-status prefix may exclude — a bare 'rpc error' substring must not, on any transport")
+			got := extractLavaError(wrapped)
+			if got == nil {
+				return // nothing matched — the exclusion held
+			}
+			require.NotEqual(t, common.LavaErrorContextCanceled.Code, got.Code,
+				"any rpc-error marker must exclude on every transport — a remote status is not local orchestration")
 		})
 	}
 }

--- a/protocol/rpcsmartrouter/grpc_relay_race_cancellation_test.go
+++ b/protocol/rpcsmartrouter/grpc_relay_race_cancellation_test.go
@@ -1,0 +1,94 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+)
+
+// grpcRaceLoserError is the shape handleGRPCError returns once the router
+// cancels a gRPC relay.
+//
+// Deliberately NOT a *url.Error. Every test added for MAG-2648 — including the
+// one written to prove the fix was transport-general — built a *url.Error, which
+// is precisely why the identical bug on the gRPC transport stayed invisible
+// (MAG-2687). This file starts from the real gRPC shapes instead.
+func grpcRaceLoserError() error {
+	return fmt.Errorf("gRPC relay cancelled: %w", context.Canceled)
+}
+
+// TestGRPCRaceLoser_SurvivesClassification is the gRPC counterpart of
+// TestRaceLoser_SurvivesClassification: a relay the router itself cancelled must
+// reach the carve-out and must not be scored against the endpoint.
+func TestGRPCRaceLoser_SurvivesClassification(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // a sibling relay won the race
+
+	transportErr := grpcRaceLoserError()
+	require.True(t, common.IsClientCancellation(transportErr, ctx),
+		"precondition: the raw gRPC cancellation IS a client cancellation")
+
+	wrapped := classifyAndWrap(transportErr, common.ChainFamily(-1), common.TransportGRPC)
+
+	t.Run("classification is correct", func(t *testing.T) {
+		require.Equal(t, common.LavaErrorContextCanceled.Code, extractLavaError(wrapped).Code,
+			"a local gRPC cancellation must classify as context-canceled, not UNKNOWN_ERROR")
+	})
+	t.Run("sentinel survives wrapping", func(t *testing.T) {
+		require.True(t, errors.Is(wrapped, context.Canceled))
+	})
+	t.Run("carve-out fires", func(t *testing.T) {
+		require.True(t, common.IsClientCancellation(wrapped, ctx))
+	})
+	t.Run("endpoint is not blamed", func(t *testing.T) {
+		markUnhealthy, backoff := classifyEndpointHealth(
+			extractLavaError(wrapped), common.IsClientCancellation(wrapped, ctx))
+		require.False(t, markUnhealthy, "a gRPC relay-race loser must not mark the endpoint unhealthy")
+		require.False(t, backoff)
+	})
+}
+
+// TestGRPCLocalError_NotDisqualifiedByRpcErrorSubstring pins the substring
+// collision. GRPCStatusError renders as "gRPC error 1: context canceled", which
+// lowercased contains "rpc error" INSIDE the word "gRPC" — so a guard written to
+// exclude remote status errors was disqualifying our own local ones.
+func TestGRPCLocalError_NotDisqualifiedByRpcErrorSubstring(t *testing.T) {
+	local := &lavasession.GRPCStatusError{Code: 1, Message: "context canceled"}
+
+	require.Contains(t, strings.ToLower(local.Error()), "rpc error",
+		"precondition: the local error really does contain the substring the guard keys on")
+
+	wrapped := classifyAndWrap(local, common.ChainFamily(-1), common.TransportGRPC)
+	require.Equal(t, common.LavaErrorContextCanceled.Code, extractLavaError(wrapped).Code,
+		"the guard must key on the full remote prefix, not the bare substring")
+}
+
+// COLLATERAL GUARD — the most important test in this file.
+//
+// Narrowing the guard must not go too far: a genuinely REMOTE gRPC deadline or
+// cancel carries the upstream's fault, not ours, and must still fall through to
+// transport-scoped classification rather than being read as a local cancellation
+// (which would silently stop blaming a broken endpoint).
+func TestGRPCRemoteStatusError_StillNotLocalCancellation(t *testing.T) {
+	for _, tc := range []struct{ name, msg string }{
+		{"remote canceled", "rpc error: code = Canceled desc = context canceled"},
+		{"remote deadline", "rpc error: code = DeadlineExceeded desc = context deadline exceeded"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			wrapped := classifyAndWrap(errors.New(tc.msg), common.ChainFamily(-1), common.TransportGRPC)
+			got := extractLavaError(wrapped).Code
+
+			require.NotEqual(t, common.LavaErrorContextCanceled.Code, got,
+				"a remote cancel must not be attributed to local orchestration")
+			require.NotEqual(t, common.LavaErrorContextDeadline.Code, got,
+				"a remote deadline must not be attributed to local orchestration")
+		})
+	}
+}

--- a/protocol/rpcsmartrouter/grpc_status_error_classification_test.go
+++ b/protocol/rpcsmartrouter/grpc_status_error_classification_test.go
@@ -1,0 +1,230 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcInterfaceMessages"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+)
+
+// ---------------------------------------------------------------------------
+// MAG-2549 — the gRPC status-error arm of sendGRPCRelay, driven end to end.
+//
+// Every assertion in this file goes through the real sendGRPCRelay rather than
+// re-deriving flags from the registry. That distinction is the whole point: the
+// bug being pinned was never a bad classification, it was a call site that did
+// not USE the classification. A test that calls ClassifyNodeErrorForRetry
+// directly passes on the broken code.
+// ---------------------------------------------------------------------------
+
+// grpcStatusChainMessage is a ChainMessage on the gRPC interface whose
+// CheckResponseError delegates to the PRODUCTION rpcInterfaceMessages.GrpcMessage
+// implementation.
+//
+// Delegating rather than re-implementing is load-bearing. The real one decides
+// hasError from the status code alone and returns an EMPTY message — that empty
+// string is exactly what makes the classification message fallback in
+// sendGRPCRelay necessary, and a hand-written stub returning a helpful message
+// would hide the defect instead of exposing it.
+type grpcStatusChainMessage struct {
+	*mockChainMessage
+}
+
+func (m *grpcStatusChainMessage) CheckResponseError(data []byte, httpStatusCode int) (bool, string) {
+	return rpcInterfaceMessages.GrpcMessage{}.CheckResponseError(data, httpStatusCode)
+}
+
+// grpcStatusRelay drives sendGRPCRelay against an endpoint that answers with the
+// gRPC status error under test, and returns the RelayResult the router built.
+//
+// The connection is scripted with the exact pair
+// GRPCDirectRPCConnection.handleGRPCError returns for a remote status: a non-nil
+// DirectRPCResponse whose StatusCode is the gRPC code and whose body is the
+// marshalled GRPCNodeErrorResponse, alongside a *GRPCStatusError carrying the
+// same code and the node's own message.
+func grpcStatusRelay(t *testing.T, code codes.Code, nodeMessage string) *common.RelayResult {
+	t.Helper()
+
+	body, err := json.Marshal(lavasession.GRPCNodeErrorResponse{
+		ErrorMessage: nodeMessage,
+		ErrorCode:    uint32(code),
+	})
+	require.NoError(t, err)
+
+	conn := &fakeDirectConn{
+		resp: &lavasession.DirectRPCResponse{
+			Data:       body,
+			StatusCode: int(code),
+		},
+		err: &lavasession.GRPCStatusError{
+			Code:    uint32(code),
+			Message: nodeMessage,
+		},
+	}
+
+	sender := &DirectRPCRelaySender{
+		directConnection: conn,
+		endpointName:     "grpc-endpoint",
+		// ChainFamily(-1) is "unknown", which skips Tier-2 chain-specific
+		// matchers so these cases exercise the generic gRPC table alone.
+		chainFamily: common.ChainFamily(-1),
+	}
+
+	chainMessage := &grpcStatusChainMessage{
+		mockChainMessage: &mockChainMessage{
+			apiInterface: "grpc",
+			rpcMessage: &rpcInterfaceMessages.GrpcMessage{
+				Path: "cosmos.bank.v1beta1.Query/Balance",
+			},
+		},
+	}
+
+	result, relayErr := sender.sendGRPCRelay(context.Background(), chainMessage, time.Second)
+
+	// The arm under test deliberately returns err == nil: the node answered, and
+	// its answer is an error. If this ever starts returning an error the result
+	// stops reaching the availability gate at all and every case below is moot.
+	require.NoError(t, relayErr,
+		"a gRPC status error carrying a response body is a completed relay, not a transport failure")
+	require.NotNil(t, result)
+	return result
+}
+
+// TestSendGRPCRelay_StatusErrorClassification is the table of production gRPC
+// statuses and the policy each must produce.
+//
+// The four rows are chosen to separate axes that a single boolean cannot:
+// InvalidArgument is non-retryable and NOT the endpoint's fault; ResourceExhausted
+// is retryable and also not the endpoint's fault; Unimplemented is non-retryable
+// AND a capability gap; Unavailable is the only one the endpoint should be
+// demoted for. The old `Code >= 13` rule collapsed all four into two wrong
+// buckets.
+func TestSendGRPCRelay_StatusErrorClassification(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		code        codes.Code
+		nodeMessage string
+
+		wantNonRetryable      bool
+		wantRateLimited       bool
+		wantUnsupportedMethod bool
+		wantScored            bool // shouldFailSessionForResult — demotes the endpoint
+		why                   string
+	}{
+		{
+			name:             "InvalidArgument is the client's fault and must not demote the endpoint",
+			code:             codes.InvalidArgument,
+			nodeMessage:      "invalid address: decoding bech32 failed",
+			wantNonRetryable: true,
+			wantScored:       false,
+			why: "gRPC defines INVALID_ARGUMENT as problematic regardless of system state, so every " +
+				"endpoint rejects it identically; scoring it would demote the whole healthy pairing " +
+				"on a burst of malformed client requests",
+		},
+		{
+			name:            "ResourceExhausted saying rate limit is healthy-but-busy",
+			code:            codes.ResourceExhausted,
+			nodeMessage:     "rate limit exceeded, retry after 1s",
+			wantRateLimited: true,
+			wantScored:      false,
+			why: "SubCategoryRateLimit is contractually back-off-without-marking-unhealthy; this only " +
+				"matches because the classification message falls back to the node's own text when " +
+				"GrpcMessage.CheckResponseError returns the empty string",
+		},
+		{
+			name:                  "Unimplemented is a capability gap, not a failure",
+			code:                  codes.Unimplemented,
+			nodeMessage:           "unknown service cosmos.bank.v1beta1.Query",
+			wantNonRetryable:      true,
+			wantUnsupportedMethod: true,
+			wantScored:            false,
+			why: "IsUnsupportedMethod gates the zero-CU carve-out and caching policy; it is reachable " +
+				"only because ApplyNodeErrorClassification assigns the whole flag set, not IsNonRetryable alone",
+		},
+		{
+			name:        "Unavailable is the endpoint's fault and stays scoreable",
+			code:        codes.Unavailable,
+			nodeMessage: "upstream connect error",
+			wantScored:  true,
+			why: "the collateral guard — carving out caller-fault codes must not accidentally exempt " +
+				"a genuinely broken endpoint from the availability signal",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := grpcStatusRelay(t, tc.code, tc.nodeMessage)
+
+			// StatusCode is what results_manager.setValidResponse re-runs
+			// CheckResponseError against downstream. Left at its 0 default (the
+			// pre-fix behaviour) the node error was served to the client as a
+			// success and was cacheable.
+			require.Equal(t, int(tc.code), result.StatusCode,
+				"the gRPC status must survive onto the RelayResult")
+			require.True(t, result.IsNodeError,
+				"every non-OK gRPC status is a node error; `Code >= 13` wrongly excluded these")
+
+			require.Equal(t, tc.wantNonRetryable, result.IsNonRetryable, tc.why)
+			require.Equal(t, tc.wantRateLimited, result.IsRateLimited, tc.why)
+			require.Equal(t, tc.wantUnsupportedMethod, result.IsUnsupportedMethod, tc.why)
+
+			require.Equal(t, tc.wantScored, shouldFailSessionForResult(nil, result),
+				"availability gate: %s", tc.why)
+		})
+	}
+}
+
+// TestSendGRPCRelay_StatusErrorIsNotCacheable pins the second half of MAG-2549.
+//
+// tryCacheWrite skips on relayResult.IsNodeError. Before the fix this arm left
+// IsNodeError false for every code below 13, so an INVALID_ARGUMENT reply — a
+// deterministic rejection of one specific malformed request — was written to the
+// cache and then served to every subsequent caller of that method.
+func TestSendGRPCRelay_StatusErrorIsNotCacheable(t *testing.T) {
+	for _, code := range []codes.Code{
+		codes.InvalidArgument, // 3  — was below the old `Code >= 13` cutoff
+		codes.NotFound,        // 5
+		codes.ResourceExhausted,
+		codes.Unimplemented,
+		codes.Unavailable,
+	} {
+		t.Run(code.String(), func(t *testing.T) {
+			result := grpcStatusRelay(t, code, "node error")
+			require.True(t, result.IsNodeError,
+				"tryCacheWrite gates the cache write on exactly this flag — false here means the "+
+					"error response gets cached and replayed to later callers")
+		})
+	}
+}
+
+// TestSendGRPCRelay_ClassificationMessageIsTheNodesOwn pins the fallback that
+// makes message-based registry rows reachable at all on this path.
+//
+// GrpcMessage.CheckResponseError returns ("", true) — hasError with no message.
+// Handing that empty string to the classifier silently reduces the gRPC registry
+// to its three code matchers, so every message-based row ("rate limit",
+// "unimplemented", ENHANCE_YOUR_CALM) becomes dead code on the status-error arm.
+//
+// ResourceExhausted is the sharpest witness: code 8 has no registry row of its
+// own, so IsRateLimited can only come from the node's message surviving.
+func TestSendGRPCRelay_ClassificationMessageIsTheNodesOwn(t *testing.T) {
+	withRateLimitText := grpcStatusRelay(t, codes.ResourceExhausted, "rate limit exceeded")
+	require.True(t, withRateLimitText.IsRateLimited,
+		"the node's message must reach the classifier; an empty message would leave this false")
+	require.False(t, shouldFailSessionForResult(nil, withRateLimitText),
+		"a rate-limited endpoint is busy, not unhealthy, and must stay out of the availability signal")
+
+	// Same code, no rate-limit wording: nothing in the registry claims it, so it
+	// scores. That is the documented default for an uncatalogued failure, and it
+	// confirms the flag above came from the message rather than from the code.
+	withoutRateLimitText := grpcStatusRelay(t, codes.ResourceExhausted, "quota depleted for this key")
+	require.False(t, withoutRateLimitText.IsRateLimited,
+		"code 8 alone must not imply rate limiting — the gRPC spec also uses it for out-of-space")
+	require.True(t, shouldFailSessionForResult(nil, withoutRateLimitText),
+		"an unclassified node error is still a failure and stays scoreable")
+}

--- a/protocol/rpcsmartrouter/grpc_status_error_classification_test.go
+++ b/protocol/rpcsmartrouter/grpc_status_error_classification_test.go
@@ -100,12 +100,19 @@ func grpcStatusRelay(t *testing.T, code codes.Code, nodeMessage string) *common.
 // TestSendGRPCRelay_StatusErrorClassification is the table of production gRPC
 // statuses and the policy each must produce.
 //
-// The four rows are chosen to separate axes that a single boolean cannot:
+// The rows are chosen to separate axes that a single boolean cannot:
 // InvalidArgument is non-retryable and NOT the endpoint's fault; ResourceExhausted
-// is retryable and also not the endpoint's fault; Unimplemented is non-retryable
-// AND a capability gap; Unavailable is the only one the endpoint should be
-// demoted for. The old `Code >= 13` rule collapsed all four into two wrong
-// buckets.
+// is retryable and also not the endpoint's fault; NotFound and OutOfRange are
+// retryable, not the endpoint's fault, and yet must still reach another endpoint;
+// Unimplemented is non-retryable AND a capability gap; DeadlineExceeded and
+// Unavailable are the two the endpoint should be demoted for. The old
+// `Code >= 13` rule collapsed all of them into two wrong buckets.
+//
+// Codes 4, 5 and 11 are here because they are where the change is LARGEST: under
+// `Code >= 13` they were not node errors at all, so replacing that threshold with
+// CheckResponseError is what first exposes them to the availability gate. Pinning
+// only the codes that were already node errors would leave the newly-reachable
+// behaviour untested (MAG-2549 review, finding 4).
 func TestSendGRPCRelay_StatusErrorClassification(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
@@ -115,6 +122,7 @@ func TestSendGRPCRelay_StatusErrorClassification(t *testing.T) {
 		wantNonRetryable      bool
 		wantRateLimited       bool
 		wantUnsupportedMethod bool
+		wantDataScope         bool
 		wantScored            bool // shouldFailSessionForResult — demotes the endpoint
 		why                   string
 	}{
@@ -137,6 +145,34 @@ func TestSendGRPCRelay_StatusErrorClassification(t *testing.T) {
 			why: "SubCategoryRateLimit is contractually back-off-without-marking-unhealthy; this only " +
 				"matches because the classification message falls back to the node's own text when " +
 				"GrpcMessage.CheckResponseError returns the empty string",
+		},
+		{
+			name:          "NotFound is an ordinary query outcome and must not demote the endpoint",
+			code:          codes.NotFound,
+			nodeMessage:   "object 0xdeadbeef not found",
+			wantDataScope: true,
+			wantScored:    false,
+			why: "a missing object or account is the most common non-OK code on Cosmos and Sui gRPC; " +
+				"scoring it charges an availability failure to every endpoint asked, once per retry, " +
+				"for a query whose answer is simply \"no\"",
+		},
+		{
+			name:          "OutOfRange is the same shape as NotFound",
+			code:          codes.OutOfRange,
+			nodeMessage:   "height 100 is not available, lowest height is 8000000",
+			wantDataScope: true,
+			wantScored:    false,
+			why: "a height below the node's pruning window is a statement about its retention, " +
+				"not a fault — identical fault axis to NotFound",
+		},
+		{
+			name:        "DeadlineExceeded stays scoreable — this endpoint really was slow",
+			code:        codes.DeadlineExceeded,
+			nodeMessage: "context deadline exceeded",
+			wantScored:  true,
+			why: "the counterweight to the two rows above: carving out data-scope codes must not " +
+				"drag the rest of the sub-13 range out of the availability signal with them. A " +
+				"deadline is about THIS endpoint's latency and another may well be faster",
 		},
 		{
 			name:                  "Unimplemented is a capability gap, not a failure",
@@ -172,6 +208,7 @@ func TestSendGRPCRelay_StatusErrorClassification(t *testing.T) {
 			require.Equal(t, tc.wantNonRetryable, result.IsNonRetryable, tc.why)
 			require.Equal(t, tc.wantRateLimited, result.IsRateLimited, tc.why)
 			require.Equal(t, tc.wantUnsupportedMethod, result.IsUnsupportedMethod, tc.why)
+			require.Equal(t, tc.wantDataScope, result.IsDataScope, tc.why)
 
 			require.Equal(t, tc.wantScored, shouldFailSessionForResult(nil, result),
 				"availability gate: %s", tc.why)
@@ -189,6 +226,7 @@ func TestSendGRPCRelay_StatusErrorIsNotCacheable(t *testing.T) {
 	for _, code := range []codes.Code{
 		codes.InvalidArgument, // 3  — was below the old `Code >= 13` cutoff
 		codes.NotFound,        // 5
+		codes.OutOfRange,      // 11
 		codes.ResourceExhausted,
 		codes.Unimplemented,
 		codes.Unavailable,
@@ -227,4 +265,62 @@ func TestSendGRPCRelay_ClassificationMessageIsTheNodesOwn(t *testing.T) {
 		"code 8 alone must not imply rate limiting — the gRPC spec also uses it for out-of-space")
 	require.True(t, shouldFailSessionForResult(nil, withoutRateLimitText),
 		"an unclassified node error is still a failure and stays scoreable")
+}
+
+// TestSendGRPCRelay_DataScopeCodesStayRetryable is the other half of the
+// NOT_FOUND / OUT_OF_RANGE carve-out, and the reason it is a third fault axis
+// rather than a Retryable=false registry row.
+//
+// Marking these non-retryable would also keep them out of the availability signal
+// — IsNonRetryable is already a carve-out — but it would buy that by killing the
+// pruned-node-to-archive-node retry: a height a pruned endpoint discarded is a
+// height an archive endpoint still has, and hasNonRetryableNodeError short-circuits
+// the retry loop for the whole request. Both properties have to hold at once.
+func TestSendGRPCRelay_DataScopeCodesStayRetryable(t *testing.T) {
+	for _, code := range []codes.Code{codes.NotFound, codes.OutOfRange} {
+		t.Run(code.String(), func(t *testing.T) {
+			result := grpcStatusRelay(t, code, "not available at this node")
+
+			require.True(t, result.IsDataScope,
+				"the data-scope axis is what the availability gate reads")
+			require.False(t, result.IsNonRetryable,
+				"a pruned endpoint saying it lacks the data must not stop the retry that reaches "+
+					"an archive endpoint — relay_processor.hasNonRetryableNodeError ends the request")
+			require.False(t, shouldFailSessionForResult(nil, result),
+				"retryable and unscored at the same time is the point of the axis")
+		})
+	}
+}
+
+// TestHealthResetAgreesWithScoring pins the coherence fix in relayInnerDirect.
+//
+// The endpoint-health path and the QoS path read the same relay and used to reach
+// opposite conclusions about it: relayInnerDirect's `statusCode >= 500 || == 429`
+// gate cannot fire on a gRPC status (the codes are 0-16), so every gRPC node error
+// fell through to "Success — reset endpoint health" at the same moment
+// shouldFailSessionForResult was reporting it to the session manager as an
+// availability failure. The endpoint was demoted and certified healthy by one
+// relay.
+//
+// UNAVAILABLE is the witness because it is the one gRPC status this PR agrees
+// should demote — before the fix it also called ResetHealth.
+func TestHealthResetAgreesWithScoring(t *testing.T) {
+	scored := grpcStatusRelay(t, codes.Unavailable, "upstream connect error")
+	require.True(t, shouldFailSessionForResult(nil, scored),
+		"precondition: an UNAVAILABLE endpoint is scored against")
+	require.False(t, shouldResetEndpointHealth(scored),
+		"a relay the optimizer is told to score against the endpoint must not also certify it healthy")
+
+	// A carved-out node error is the mirror image: not scored, so health still
+	// resets. The endpoint answered correctly, it simply does not hold the data —
+	// and the carve-out must not cost it the recovery the answer earned.
+	carvedOut := grpcStatusRelay(t, codes.NotFound, "object not found")
+	require.False(t, shouldFailSessionForResult(nil, carvedOut))
+	require.True(t, shouldResetEndpointHealth(carvedOut),
+		"a data-scope answer proves the endpoint is working and must still restore its health")
+
+	// A plain success is unchanged — the gate that matters most, since it is the
+	// path virtually every relay takes.
+	require.True(t, shouldResetEndpointHealth(&common.RelayResult{StatusCode: 200}),
+		"a clean relay must still reset health; narrowing this gate would strand recovering endpoints")
 }

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -1443,7 +1443,7 @@ func promoteConsistencyFallback(
 // first-picked ~1/3 of the time no matter how long it kept failing. The classification itself was
 // never the problem: direct_rpc_relay.go tags these IsNodeError=true, the gate just didn't read it.
 //
-// The two carve-outs are load-bearing, not defensive, and they exclude on DIFFERENT axes:
+// The three carve-outs are load-bearing, not defensive, and they exclude on DIFFERENT axes:
 //
 //   - IsNonRetryable — "retrying elsewhere would not help". Deterministic caller-fault errors
 //     (unsupported method, invalid params, execution reverted) come back from EVERY endpoint for
@@ -1456,6 +1456,11 @@ func promoteConsistencyFallback(
 //     backoff-without-marking-unhealthy (common/error_registry.go), and it does NOT follow from
 //     retryability: NODE_RATE_LIMITED (2005) is Retryable=true, NODE_LIMIT_EXCEEDED (2011) is
 //     Retryable=false, and both must stay out of the availability signal.
+//   - IsDataScope — "the endpoint does not hold this data, and said so". SubCategoryDataScope
+//     (gRPC NOT_FOUND / OUT_OF_RANGE) is the case neither axis above can express: retrying IS
+//     worthwhile because a pruned node and an archive node genuinely disagree, yet the endpoint
+//     that answered did nothing wrong. Without this carve-out the most COMMON non-OK code on a
+//     Cosmos or Sui gRPC chain demotes every endpoint asked, once per retry (MAG-2549 review).
 //
 // KNOWN AND ACCEPTED — an unclassified error body scores. ClassifyNodeErrorForRetry returns all
 // flags false when nothing in the registry matches, and a false flag is an absence of information,
@@ -1472,7 +1477,9 @@ func promoteConsistencyFallback(
 //     the endpoint IS the differentiator and demoting it is defensible; when it is not — every
 //     endpoint lacks the tx — all of them demote equally and weighted_selector collapses to uniform
 //     random rather than starving. Tag these with a fault-axis SubCategory if that proves wrong in
-//     production; the gate reads the axis, so no change here would be needed.
+//     production — SubCategoryDataScope is exactly that escape hatch being used, and the JSON-RPC
+//     and REST codes listed here are deliberately left on the scoring side for now: only the gRPC
+//     status codes were shown to be a routine query outcome rather than an error the node raised.
 //
 // Every relay through this gate also feeds ConsecutiveErrors. An endpoint with ZERO successful
 // relays is blocklisted on its 16th consecutive failure (consumer_session_manager.go), so a
@@ -1489,11 +1496,36 @@ func shouldFailSessionForResult(err error, relayResult *common.RelayResult) bool
 		return false
 	}
 	// REST/HTTP transport failures: err == nil but the status still means the node failed us.
+	//
+	// Deliberately NOT extended to gRPC status codes even though RelayResult.StatusCode now
+	// carries them (0-16, so nothing here can fire on a gRPC relay). Every gRPC status reaches
+	// this gate through the IsNodeError branch below, where the carve-outs apply; teaching this
+	// clause that 13/14/15 are "gRPC 5xx" and 8 is "gRPC 429" would re-score them ahead of the
+	// carve-outs and undo the rate-limit exemption that direct_rpc_relay.go just classified.
 	if relayResult.StatusCode >= 500 || relayResult.StatusCode == 429 {
 		return true
 	}
 	// Node error delivered inside a 2xx body — scoreable unless a carve-out claims it.
-	return relayResult.IsNodeError && !relayResult.IsNonRetryable && !relayResult.IsRateLimited
+	return relayResult.IsNodeError &&
+		!relayResult.IsNonRetryable &&
+		!relayResult.IsRateLimited &&
+		!relayResult.IsDataScope
+}
+
+// shouldResetEndpointHealth reports whether a completed direct-RPC relay is proof that the endpoint
+// is working — the condition relayInnerDirect calls Endpoint.ResetHealth on.
+//
+// Defined as the exact negation of shouldFailSessionForResult so the endpoint-health path and the
+// QoS path cannot form different opinions about the same relay. They could before: relayInnerDirect
+// gated only on `statusCode >= 500 || == 429`, which no gRPC status can satisfy (the codes are
+// 0-16), so every gRPC node error fell through to "success — reset health" at the same moment
+// shouldFailSessionForResult was reporting it to the session manager as an availability failure.
+//
+// Keeping it a negation rather than a second rule is deliberate: a carve-out added to one gate is
+// then automatically honoured by the other, which is how a rate-limited or data-scope answer keeps
+// restoring health while an UNAVAILABLE one stops.
+func shouldResetEndpointHealth(relayResult *common.RelayResult) bool {
+	return !shouldFailSessionForResult(nil, relayResult)
 }
 
 // sendRelayToDirectEndpoints handles relay for direct RPC sessions (smart router direct mode)
@@ -3887,8 +3919,9 @@ func (rpcss *RPCSmartRouterServer) relayInnerDirect(
 		return relayLatency, fmt.Errorf("HTTP %d", statusCode), needsBackoff
 	}
 
-	// Success - reset endpoint health
-	if targetEndpoint != nil {
+	// Success - reset endpoint health. A node error the QoS path is scoring against this endpoint
+	// is not a success and must not certify it healthy; see shouldResetEndpointHealth.
+	if targetEndpoint != nil && shouldResetEndpointHealth(result) {
 		if targetEndpoint.ResetHealth() {
 			rpcss.smartRouterEndpointMetrics.SetEndpointOverallHealth(rpcss.listenEndpoint.ChainID, rpcss.listenEndpoint.ApiInterface, endpointName, true)
 		}
@@ -3900,11 +3933,13 @@ func (rpcss *RPCSmartRouterServer) relayInnerDirect(
 	relayResult.StatusCode = result.StatusCode
 	relayResult.IsNodeError = result.IsNodeError
 	relayResult.IsNonRetryable = result.IsNonRetryable
-	// IsUnsupportedMethod and IsRateLimited are the fault-axis flags direct_rpc_relay.go classifies
-	// alongside IsNonRetryable. Both were dropped here, so the zero-CU/caching carve-out and the
-	// availability gate's rate-limit exclusion could never see them on the direct path.
+	// IsUnsupportedMethod, IsRateLimited and IsDataScope are the fault-axis flags
+	// direct_rpc_relay.go classifies alongside IsNonRetryable. The first two were dropped here, so
+	// the zero-CU/caching carve-out and the availability gate's rate-limit exclusion could never see
+	// them on the direct path; IsDataScope would have the same fate if it were not copied too.
 	relayResult.IsUnsupportedMethod = result.IsUnsupportedMethod
 	relayResult.IsRateLimited = result.IsRateLimited
+	relayResult.IsDataScope = result.IsDataScope
 	relayResult.ProviderInfo = result.ProviderInfo
 	if relayResult.Reply != nil {
 		relayResult.Reply.Metadata = append(relayResult.Reply.Metadata, pairingtypes.Metadata{


### PR DESCRIPTION
# Description

Closes: N/A — tracked in Jira, not a GitHub issue.

**Two tickets, one PR: MAG-2549 and MAG-2687 are the same three lines of `sendGRPCRelay`.** The Jira gate accepts one key per PR, so MAG-2549 holds the gate line below; MAG-2687 is closed by this change too.

### MAG-2549 — a gRPC status error with a response was served as a success

The error branch left `StatusCode` at its zero default, and `GrpcMessage.CheckResponseError` reports "no error" whenever `StatusCode == 0`, so `results_manager.setValidResponse` routed it into the **success** results. Any upstream error — `INVALID_ARGUMENT` on a malformed transaction, `NOT_FOUND` on an object — reached the client as a success carrying the error payload, and was cacheable.

The same branch derived `IsNodeError` from `grpcErr.Code >= 13`, so every code below `INTERNAL` — `INVALID_ARGUMENT`, `DEADLINE_EXCEEDED`, `NOT_FOUND`, `RESOURCE_EXHAUSTED` — was marked not-a-node-error, which is what gates the cache write and the `lava-identified-node-error` header.

### MAG-2687 — cancelled relays recorded as successes with fabricated latency

A relay the router itself cancelled was recorded as a completed, successful relay carrying a latency sample that was never taken — feeding the optimizer and calling `ResetHealth()` on endpoints that were never measured. Two causes, both fixed:

1. grpc-go returns `status.Error(codes.Canceled, ...)`, which does **not** wrap `context.Canceled`, so the relay-race carve-out could never see it.
2. `handleGRPCError` rebuilt the error from a bare code and message, discarding the cause, so nothing downstream could recover the sentinel either.

> A third contributing cause was originally listed here — a substring collision in the classifier guard. On a closer look it turned out to be already covered by cause 1, and the classifier change made for it has been reverted. See "Review follow-up (round 2)" below.

## The four changes

| # | File | Change |
| --- | --- | --- |
| 1 | `lavasession/direct_rpc_connection.go` | `handleGRPCError` returns `(nil, …%w context.Canceled)` on a router-cancelled relay. The **nil response** is load-bearing: it makes the phantom-success arm unreachable, and it resolves local cancellation *structurally*, in `DetectConnectionError`'s layer-1 `errors.Is` check. |
| 2 | `lavasession/direct_rpc_connection.go` | `GRPCStatusError` gains `cause` + `Unwrap()`, so it stops being a dead end for `errors.Is` / `errors.As`. |
| 3 | `common/error_classifier.go` | `codes.InvalidArgument` (3) gets a registry row → `USER_INVALID_PARAMS`. The remaining gRPC codes are documented as deliberately unregistered, each with its own reason. **The canceled/deadline guard stays at the broad `"rpc error"` — see round 2.** |
| 4 | `rpcsmartrouter/direct_rpc_relay.go` | The error branch now mirrors its own success sibling: `StatusCode`, `CheckResponseError`, and `ApplyNodeErrorClassification` — the whole flag set, not `IsNonRetryable` alone. |

**Change 4 came out smaller than MAG-2549 described.** The success path 40 lines below already classified correctly, so the error branch simply adopts it. That also retires the `IsNodeError: Code >= 13` threshold — the open scope question on MAG-2687 — without inventing a new rule. Nothing is lost: `handleGRPCError` builds `response.StatusCode` and `GRPCStatusError.Code` from one `errorCode`, so they are equal by construction.

## Two findings reviewers should see

**MAG-2687's step 0 is a non-issue, and this PR pins why.** That step warns that adding `Unwrap` makes `status.Code(err)` resolve via `errors.As`, and that `IsSessionSyncLoss` reads it. It does not: `IsSessionSyncLoss` lives in `lavasession/common.go`, which imports **`github.com/gogo/status`**, not `google.golang.org/grpc/status` — and gogo's `Code()` does not unwrap. Measured directly: `status.Code(wrapped)` is 677 under grpc-go while `IsSessionSyncLoss(wrapped)` is `false`. The test now pins this as a tripwire for anyone swapping that import.

**There is a real side effect in the other direction.** `ExtractNodeErrorDetails` (`node_error_handler.go:95`) *does* use grpc-go's `status.FromError`, and the direct-RPC path reaches it via `error_mapper.go:37`. For a `*GRPCStatusError` it previously returned code `0`; it now returns the real code (`3`). That is the improvement — Tier-1 `CodeEquals` matchers can finally fire — and it is a behaviour change reviewers should see.

> **Corrected during review.** An earlier version of this description also claimed the *message* got cleaner (`"malformed transaction"` instead of `"gRPC error 3: malformed transaction"`). It does not. grpc-go's `status.FromError` overwrites the status message with the **outer** error's `Error()` when it resolves via `errors.As`, and `ExtractNodeErrorDetails` already defaulted `errorMessage` to `nodeError.Error()` — so the message is identical before and after. The code is the whole of the change. `TestGRPCStatusError_ResolvesThroughStatusFromError` pins both halves, including the message *not* changing, and is what caught the wrong claim.

## Testing

New tests start from **real gRPC error shapes**, not `*url.Error`. Every test added for MAG-2648 built a `*url.Error` — including one written to prove the fix was transport-general — which is exactly why the identical bug on the gRPC transport stayed invisible.

Every fix is verified **red-first** by reverting it in isolation and re-running:

| Reverted | Test that goes red | Observed |
| --- | --- | --- |
| ctx-cancel early return | `TestHandleGRPCError_CancelledContextReturnsNilResponse` | FAIL → PASS |
| `cause` preservation | `TestHandleGRPCError_PreservesCause` | FAIL → PASS |
| broad `"rpc error"` guard | `TestHandleGRPCError_RemoteCancellationIsNotLocal` | FAIL (classified 1008 / 1007) → PASS |
| broad `"rpc error"` guard | `TestGRPCStatusError_IsNeverReadAsLocalCancellation`, `TestRemoteStatusGuard_AppliesAcrossTransports` | FAIL (both transports) → PASS |
| gRPC code-3 row | `TestSendGRPCRelay_StatusErrorClassification/InvalidArgument` | FAIL → PASS |
| `ApplyNodeErrorClassification` → `IsNonRetryable` alone | `TestSendGRPCRelay_StatusErrorClassification/{ResourceExhausted,Unimplemented}` | FAIL → PASS |
| node-message fallback | `TestSendGRPCRelay_ClassificationMessageIsTheNodesOwn` | FAIL → PASS |
| `StatusCode` on `RelayResult` | `TestResultsManager_GRPCStatusResponseIsANodeError` | pinned by its own `REGRESSION` subtest |

`TestGRPCRemoteStatusError_StillNotLocalCancellation` and the `Unavailable` row of `TestSendGRPCRelay_StatusErrorClassification` are the collateral guards, and the most important tests here: carving out caller-fault codes must not go so far that a genuinely **remote** deadline, cancel, or `UNAVAILABLE` stops being blamed on the endpoint.

Full suites green: `common`, `lavasession`, `chainlib`, `rpcsmartrouter`, `relaycore`, `metrics`. Plus `go build ./...`, `gofmt -d`, `git diff --check`, and `go vet` on all four touched packages.

## Review follow-up (commit `40c6912`)

1. **`ctx.Err() != nil` → `errors.Is(ctx.Err(), context.Canceled)`** in `handleGRPCError`. The old guard also matched an *expired deadline*, so a timeout could have been relabelled a client cancellation — letting a slow endpoint escape blame.
2. **Bare type assertion → `errors.As`** in `sendGRPCRelay`. This PR adds `Unwrap` precisely to make the type inspectable through wrapping; its main consumer should use it.
3. **The classifier edit is transport-global and is pinned as such.** `stringConnectionFallbacks` is one package-level table and `detectConnectionErrorFromString` takes no transport argument, so the width of that guard changes classification for JSON-RPC and REST too. `TestRemoteStatusGuard_AppliesAcrossTransports` covers it. *(Partly superseded by round 2: the guard is no longer narrowed, but the reach argument stands and the test now pins the opposite direction.)*
4. **The `ExtractNodeErrorDetails` claim above was wrong and is corrected inline.**

## Review follow-up (round 2 — commit `2669397`)

Rebased onto current `main`; the branch is no longer conflicting.

**1. The classifier guard is restored to its original width.**

This PR had widened the canceled/deadline rows from `mustNotContain: "rpc error"` to `"rpc error: code ="` so that `GRPCStatusError`'s rendering — `"gRPC error 1: context canceled"`, which lowercased contains `"rpc error"` inside the word `"gRPC"` — would match them. Revisiting that: the wrapper is only built *after* `handleGRPCError`'s local-cancellation branch has returned, so in practice a value of that shape carries a status the **endpoint** reported. Since `PROTOCOL_CONTEXT_CANCELED` is `Retryable=false`, matching it on those rows would read an upstream fault as local orchestration and skip a retry that could have reached a healthy endpoint. Re-running with the narrower guard shows this directly: a remote `codes.Canceled` classifies as `1008 PROTOCOL_CONTEXT_CANCELED`, a remote `DeadlineExceeded` as `1007`.

The narrowing also turns out not to be needed. Change 1 above already handles local cancellation structurally: `DetectConnectionError` catches the real `context.Canceled` sentinel in its layer-1 `errors.Is` check, well before the string table is consulted. That table only sees errors whose sentinel chain was already lost, and for those the broader "contains an rpc-error marker" is the conservative reading. The guard is restored with the reasoning recorded inline, so the trade-off is visible to whoever looks at it next.

The two tests written against the narrower guard are replaced by their inverses — a cause-less `GRPCStatusError` should **not** read as a local cancellation, and a bare `"rpc error"` substring should **still** exclude on every transport.

**2. The rebase conflict reconciled two independent fixes to the same arm.** Each side had addressed a different half, so neither "ours" nor "theirs" alone was complete:

| | this branch | `main` |
| --- | --- | --- |
| what counts as a node error | `CheckResponseError`, every non-OK status | `grpcErr.Code >= 13` |
| what happens once it is one | `IsNonRetryable` alone | `ApplyNodeErrorClassification`, the full set |

The resolution takes `CheckResponseError` from this branch and `ApplyNodeErrorClassification` from `main`, so `IsRateLimited` and `IsUnsupportedMethod` survive.

**3. One detail the merged version depends on.** `GrpcMessage.CheckResponseError` decides `hasError` from the status code alone and always returns an **empty message**. Classifying on `""` would reduce the gRPC registry to its code matchers and leave every message-based row unreachable, so a `RESOURCE_EXHAUSTED` whose message says `"rate limit"` would be scored as an availability failure rather than exempted as healthy-but-busy. The classification message now falls back to the node's own status message, then to the wrapped rendering.

**4. `codes.InvalidArgument` gets a registry row.** gRPC defines it as arguments "problematic regardless of the state of the system", so every endpoint rejects the same malformed request identically. Left unregistered it classified `UNKNOWN_ERROR`, and a burst of malformed client requests demoted the whole healthy pairing toward the selection floor — blocklisting on the 16th consecutive one. `USER_INVALID_PARAMS` is `Retryable=false`, which both stops the pointless retry and keeps the availability gate off the endpoint.

The other codes are deliberately left unregistered rather than added as a range — registering by range is what the `Code >= 13` threshold did, and the aim here is to avoid repeating it. Each code's reasoning is recorded at the table: `4 DeadlineExceeded` (this endpoint was slow, demote it), `5 NotFound` / `11 OutOfRange` (pruned vs archive nodes genuinely disagree, so a retry elsewhere can succeed), `7 PermissionDenied` / `16 Unauthenticated` (credentials are per-endpoint, so demote), `8 ResourceExhausted` (ambiguous in the spec — quota vs out-of-disk; the `"rate limit"` message row catches the quota case), `1 Canceled` (a local cancel never reaches this table).

**5. New call-path tests drive the real `sendGRPCRelay`, not the registry.** That distinction matters here: most of what these changes fix is a call site not consuming a classification, so a test that calls `ClassifyNodeErrorForRetry` directly can pass while the relay path is still wrong.

| Case | Asserted |
| --- | --- |
| `InvalidArgument` | `StatusCode=3`, `IsNodeError`, `IsNonRetryable`, **not** scored |
| `ResourceExhausted` + "rate limit" | `IsRateLimited`, **not** scored |
| `ResourceExhausted`, no rate-limit wording | unclassified, **scored** — proves the flag came from the message, not the code |
| `Unimplemented` | `IsUnsupportedMethod`, non-retryable, **not** scored |
| `Unavailable` | retryable and **scored** — the collateral guard |

Plus `TestResultsManager_GRPCStatusResponseIsANodeError`, which drives the real `ResultsManager.SetResponse` and carries a `REGRESSION` subtest reproducing the pre-fix `StatusCode: 0` shape landing in `successResults`.

## Review follow-up (round 3 — commit `afaa30f`)

Rebased onto current `main` (`ec7c0a1`); the three commits it picked up touch only `direct_grpc_subscription_manager.go` and are disjoint from this change. Addresses all four findings in the review above; the point-by-point reply is in the comment thread.

**1. gRPC `NOT_FOUND` (5) and `OUT_OF_RANGE` (11) no longer demote the endpoint — and this supersedes two claims made above.**

Replacing `Code >= 13` with `CheckResponseError` does not only fix codes ≥ 13; it makes every non-OK code a node error, which newly exposed the most common codes on Cosmos and Sui gRPC to the availability gate. `NOT_FOUND` on a missing object scored one availability failure per endpoint asked, per retry, for a query whose answer is simply "no" — and `relayInnerDirect` called `ResetHealth()` on the same relay, because no gRPC code satisfies its `statusCode >= 500 || == 429` gate. The endpoint was demoted and certified healthy at once.

Resolved by adding a third fault axis rather than by registering 5 and 11 `Retryable=false`: non-retryable would keep them out of the availability signal, but only by ending the request at the first endpoint that answers — which is the pruned-node-to-archive-node retry.

* `SubCategoryDataScope` — "the endpoint answered truthfully that it does not hold this data".
* `NODE_DATA_NOT_HELD` (2017), `Retryable: true`, carrying that subcategory; gRPC 5 and 11 registered to it.
* `RelayResult.IsDataScope` plumbed through `ApplyNodeErrorClassification` and `relayInnerDirect`; `shouldFailSessionForResult` reads it as a third carve-out.
* `relayInnerDirect`'s `ResetHealth` is now gated on `shouldResetEndpointHealth`, defined as the exact negation of the scoring gate so the two cannot diverge.

Scoped to the gRPC rows on purpose: `NODE_RESOURCE_NOT_FOUND` (2012) and the `CHAIN_*_NOT_FOUND` codes stay on the scoring side, since only the gRPC status codes were shown to be a routine query outcome rather than an error the node raised.

> **Corrected.** Change 3's line above — "the remaining gRPC codes are documented as deliberately unregistered" — and round 2's item 4 entry for `5 NotFound` / `11 OutOfRange` are both superseded here. The pruned-vs-archive reasoning recorded there was right about retryability and wrong to conclude the codes therefore needed no row: it left them scoring against the endpoint. Codes 4, 7, 16 and message-less 8 are unchanged and still score.

**2. The cancellation guard drops its `status.Code(err) == codes.Canceled` conjunct.** grpc-go does not promise `Canceled` when the router cancels — a connection torn down in the same instant surfaces `Unavailable` — and on any other code the relay took the node-error arm, returned `err == nil`, and the `err != nil` guard at the relay-race carve-out never fired. Same bug class as MAG-2687, narrower window. The local context is authoritative on its own; the `context.Canceled` distinction from an expired deadline stays, with a collateral test now that the branch is wider. The originating status is wrapped alongside the sentinel (`%w` on both).

**3. `results_manager.setValidResponse` gets the empty-message fallback `sendGRPCRelay` already had.** `GrpcMessage.CheckResponseError` always returns `""`, so classifying on it left every message-based registry row unreachable one layer up — a `RESOURCE_EXHAUSTED` saying "rate limit" was filed as `UNKNOWN_ERROR` — and logged the node error with an empty error string. It now falls back to the node's own reply body, then to a synthetic description.

**4. Tests now cover the codes the change actually moved.** 4, 5 and 11 were not node errors at all under `Code >= 13`, so they were the untested half.

| Case | Asserted |
| --- | --- |
| `NotFound` / `OutOfRange` | `IsDataScope`, **not** scored, **still retryable** |
| `DeadlineExceeded` | scored — the counterweight, so the carve-out does not drag the sub-13 range out with it |
| health reset | agrees with the scoring gate in both directions, and a plain success still resets |

Plus `TestDataScopeCodesAreAllRetryable_MAG2549`, which fails the build if a data-scope code is ever registered non-retryable — at that point the axis has stopped buying anything and the archive fallback is gone.

**Smaller notes from the review**, all applied: the cancel branch keeps its cause; the "classify the way the success path does" comment now states outright that the success path's `hasError` branch is unreachable on this transport; and the code-3 row's cross-path reach into `GrpcErrorHandler.HandleNodeError` is recorded at the row, along with the same reach for the two new rows.

Every fix verified red-first by reverting it in isolation. `docs/ERROR-REGISTRY-DESIGN.md` updated for 2017 and the new subcategory.


## Jira ticket

Jira ticket: MAG-2549

---

## Author Checklist

I have...

* [ ] read the [contribution guide](https://github.com/magma-Devs/smart-router/blob/main/CONTRIBUTING.md)
* [x] included the correct type prefix in the PR title (`fix`)
* [x] confirmed `!` in the type prefix if API or client breaking change — not breaking, no `!`
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification — MAG-2549 and MAG-2687
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests
* [x] updated the relevant documentation or specification, including comments for documenting Go code
* [x] confirmed all CI checks have passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


