### PR TITLE
fix(smart-router): guard gRPC connector against use after Close

### DIFF
--- a/protocol/chainlib/chainproxy/connector.go
+++ b/protocol/chainlib/chainproxy/connector.go
@@ -177,7 +177,19 @@ type GRPCConnector struct {
 	usedClients int64
 	credentials credentials.TransportCredentials
 	nodeUrl     common.NodeUrl
+
+	// closed is set by Close and never cleared. Unlike the HTTP Connector's atomic
+	// flag it is guarded by lock, because every reader already holds lock: that
+	// makes "is the pool alive" and "take a client" a single atomic step, which a
+	// separate atomic could not guarantee.
+	closed bool
 }
+
+// ErrGRPCConnectorClosed is returned by GetRpc once Close has run. The HTTP
+// Connector has always reported this; GRPCConnector had no closed state at all,
+// so callers racing a Close either blocked forever on a pool that would never
+// refill or had their retry goroutines repopulate it (MAG-2808).
+var ErrGRPCConnectorClosed = errors.New("grpc connector is closed")
 
 func NewGRPCConnector(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) (*GRPCConnector, error) {
 	NumberOfParallelConnections = nConns // set number of parallel connections requested by user (or default.)
@@ -268,6 +280,9 @@ func (connector *GRPCConnector) getTransportCredentials() grpc.DialOption {
 func (connector *GRPCConnector) increaseNumberOfClients(ctx context.Context, numberOfFreeClients int) {
 	utils.LavaFormatDebug("increasing number of clients", utils.Attribute{Key: "numberOfFreeClients", Value: numberOfFreeClients},
 		utils.Attribute{Key: "url", Value: connector.nodeUrl.Url})
+	if connector.isClosed() {
+		return // the pool is being torn down; dialing now would only resurrect it
+	}
 	var grpcClient *grpc.ClientConn
 	var err error
 	for connectionAttempt := 0; connectionAttempt < MaximumNumberOfParallelConnectionsAttempts; connectionAttempt++ {
@@ -282,6 +297,13 @@ func (connector *GRPCConnector) increaseNumberOfClients(ctx context.Context, num
 
 		connector.lock.Lock() // add connection to free list.
 		defer connector.lock.Unlock()
+		if connector.closed {
+			// Close drained the pool while this dial was in flight. Appending now
+			// would hand a live client to a closed connector that nobody will ever
+			// borrow from again, so close it here instead.
+			grpcClient.Close()
+			return
+		}
 		connector.freeClients = append(connector.freeClients, grpcClient)
 		return
 	}
@@ -292,6 +314,10 @@ func (connector *GRPCConnector) GetRpc(ctx context.Context, block bool) (*grpc.C
 	connector.lock.Lock()
 	defer connector.lock.Unlock()
 
+	if connector.closed {
+		return nil, ErrGRPCConnectorClosed
+	}
+
 	numberOfFreeClients := len(connector.freeClients)
 	if numberOfFreeClients <= int(connector.usedClients) { // if we reached half of the free clients start creating new connections
 		go connector.increaseNumberOfClients(ctx, numberOfFreeClients) // increase asynchronously the free list.
@@ -300,18 +326,35 @@ func (connector *GRPCConnector) GetRpc(ctx context.Context, block bool) (*grpc.C
 	if numberOfFreeClients == 0 {
 		if !block {
 			return nil, errors.New("out of clients")
-		} else {
-			for {
-				connector.lock.Unlock()
-				// if we reached 0 connections we need to create more connections
-				// before sleeping, increase asynchronously the free list.
-				go connector.increaseNumberOfClients(ctx, numberOfFreeClients)
-				time.Sleep(50 * time.Millisecond)
-				connector.lock.Lock()
-				numberOfFreeClients = len(connector.freeClients)
-				if numberOfFreeClients != 0 {
-					break
-				}
+		}
+		// Wait for the async fill to produce a client. Both exits below are new:
+		// this loop used to spin unconditionally, so a caller waiting on a pool
+		// that would never refill was stuck forever even after its context was
+		// cancelled, and the goroutines it kept spawning could repopulate a pool
+		// Close had just drained (MAG-2808).
+		for {
+			connector.lock.Unlock()
+			// if we reached 0 connections we need to create more connections
+			// before sleeping, increase asynchronously the free list.
+			go connector.increaseNumberOfClients(ctx, numberOfFreeClients)
+
+			var ctxDone bool
+			select {
+			case <-ctx.Done():
+				ctxDone = true
+			case <-time.After(50 * time.Millisecond):
+			}
+
+			connector.lock.Lock()
+			if ctxDone {
+				return nil, fmt.Errorf("waiting for a free grpc client: %w", ctx.Err())
+			}
+			if connector.closed {
+				return nil, ErrGRPCConnectorClosed
+			}
+			numberOfFreeClients = len(connector.freeClients)
+			if numberOfFreeClients != 0 {
+				break
 			}
 		}
 	}
@@ -328,6 +371,15 @@ func (connector *GRPCConnector) ReturnRpc(rpc *grpc.ClientConn) {
 	defer connector.lock.Unlock()
 
 	connector.usedClients--
+	if connector.closed {
+		// Close is blocked waiting for usedClients to reach zero, so the decrement
+		// above must happen either way. Drop the conn rather than appending it to a
+		// pool that is being torn down, which would leave a live client behind.
+		if rpc != nil {
+			rpc.Close()
+		}
+		return
+	}
 	if len(connector.freeClients) > (int(connector.usedClients) + int(NumberOfParallelConnections) /* the number we started with */) {
 		rpc.Close() // close connection
 		return      // return without appending back to decrease idle connections
@@ -344,6 +396,11 @@ func (connector *GRPCConnector) connectorLoop(ctx context.Context) {
 func (connector *GRPCConnector) Close() {
 	for i := 0; ; i++ {
 		connector.lock.Lock()
+		// Mark closed under the same lock GetRpc, ReturnRpc and
+		// increaseNumberOfClients take. From here on no client can be handed out
+		// and no in-flight dial can refill the pool we are about to drain, so the
+		// usedClients wait below is guaranteed to make progress.
+		connector.closed = true
 		for i := 0; i < len(connector.freeClients); i++ {
 			connector.freeClients[i].Close()
 		}
@@ -364,6 +421,9 @@ func (connector *GRPCConnector) Close() {
 
 func addClientsAsynchronouslyGrpc(ctx context.Context, connector *GRPCConnector, nConns uint, nodeUrl common.NodeUrl) {
 	for i := uint(0); i < nConns; i++ {
+		if connector.isClosed() {
+			break // Close is draining; further dials would only be thrown away
+		}
 		rpcClient, err := connector.createConnection(ctx, nodeUrl, connector.numberOfFreeClients())
 		if err != nil {
 			break
@@ -371,7 +431,14 @@ func addClientsAsynchronouslyGrpc(ctx context.Context, connector *GRPCConnector,
 		connector.addClient(rpcClient)
 	}
 	if (connector.numberOfFreeClients() + connector.numberOfUsedClients()) == 0 {
-		if ctx.Err() != nil {
+		if connector.isClosed() {
+			// A connector closed this early legitimately has no clients — Close
+			// drained them. Reaching the fatal below would turn an ordinary
+			// teardown during startup into a process exit.
+			utils.LavaFormatWarning("gRPC connector closed before the async fill finished", nil,
+				utils.LogAttr("address", nodeUrl.UrlStr()),
+			)
+		} else if ctx.Err() != nil {
 			// Probe-scoped ctx (validateProvider, etc.) was cancelled before
 			// the async fill produced any client. Caller will treat the
 			// returned error as a probe failure; the process must not exit.
@@ -393,7 +460,20 @@ func addClientsAsynchronouslyGrpc(ctx context.Context, connector *GRPCConnector,
 func (connector *GRPCConnector) addClient(client *grpc.ClientConn) {
 	connector.lock.Lock()
 	defer connector.lock.Unlock()
+	if connector.closed {
+		// The startup fill is still running while Close drains. Appending here
+		// would refill the pool behind Close's back, exactly as the retry path in
+		// increaseNumberOfClients could (MAG-2808).
+		client.Close()
+		return
+	}
 	connector.freeClients = append(connector.freeClients, client)
+}
+
+func (connector *GRPCConnector) isClosed() bool {
+	connector.lock.RLock()
+	defer connector.lock.RUnlock()
+	return connector.closed
 }
 
 func (connector *GRPCConnector) numberOfFreeClients() int {

--- a/protocol/chainlib/chainproxy/connector.go
+++ b/protocol/chainlib/chainproxy/connector.go
@@ -191,7 +191,26 @@ type GRPCConnector struct {
 // refill or had their retry goroutines repopulate it (MAG-2808).
 var ErrGRPCConnectorClosed = errors.New("grpc connector is closed")
 
-func NewGRPCConnector(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) (*GRPCConnector, error) {
+// NewGRPCConnector builds a pooled gRPC connector.
+//
+// The two contexts are deliberately separate, because a single one was three
+// different things at once and callers could only get two of them right
+// (MAG-2808):
+//
+//	lifetimeCtx  owns the pool. connectorLoop parks on it and closes the connector
+//	             when it ends, and the async fill dials under it — that fill is
+//	             background work which should finish, not work that belongs to
+//	             whoever happened to call this.
+//	dialCtx      bounds ONLY the initial blocking dial below, which runs in the
+//	             caller's critical path. It is the caller's own deadline, so a
+//	             relay does not wait materially past the point it would have given
+//	             up anyway.
+//
+// Callers with nothing to distinguish (a startup path, where the process's
+// context is both) pass the same context twice. Callers building a pool inside a
+// request — the direct-RPC path — must NOT: passing the request's context as
+// lifetimeCtx tears the pool down the moment that request returns.
+func NewGRPCConnector(lifetimeCtx, dialCtx context.Context, nConns uint, nodeUrl common.NodeUrl) (*GRPCConnector, error) {
 	NumberOfParallelConnections = nConns // set number of parallel connections requested by user (or default.)
 	connector := &GRPCConnector{
 		freeClients: make([]*grpc.ClientConn, 0, nConns),
@@ -202,12 +221,12 @@ func NewGRPCConnector(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) 
 	// unconfigured endpoint to TLS on retry, so this reflects the configured intent.
 	nodeUrl.TokenOverInsecureWarning(nodeUrl.AuthConfig.GetUseTls() || strings.HasPrefix(nodeUrl.Url, "grpcs://"))
 
-	rpcClient, err := connector.createConnection(ctx, nodeUrl, connector.numberOfFreeClients())
+	rpcClient, err := connector.createConnection(dialCtx, nodeUrl, connector.numberOfFreeClients())
 	if err != nil {
 		return nil, utils.LavaFormatError("grpc failed to create the first connection", err, utils.Attribute{Key: "address", Value: nodeUrl.UrlStr()})
 	}
 	connector.addClient(rpcClient)
-	go addClientsAsynchronouslyGrpc(ctx, connector, nConns-1, nodeUrl)
+	go addClientsAsynchronouslyGrpc(lifetimeCtx, connector, nConns-1, nodeUrl)
 	return connector, nil
 }
 
@@ -425,12 +444,17 @@ func (connector *GRPCConnector) Close() {
 	}
 }
 
-func addClientsAsynchronouslyGrpc(ctx context.Context, connector *GRPCConnector, nConns uint, nodeUrl common.NodeUrl) {
+// addClientsAsynchronouslyGrpc fills the pool behind the caller and then hands the
+// connector to connectorLoop. Both halves run under lifetimeCtx, never the dial
+// context: the fill is background work that should finish even after the caller
+// has moved on, and connectorLoop parked on a caller's context is precisely the
+// bug MAG-2808 fixed.
+func addClientsAsynchronouslyGrpc(lifetimeCtx context.Context, connector *GRPCConnector, nConns uint, nodeUrl common.NodeUrl) {
 	for i := uint(0); i < nConns; i++ {
 		if connector.isClosed() {
 			break // Close is draining; further dials would only be thrown away
 		}
-		rpcClient, err := connector.createConnection(ctx, nodeUrl, connector.numberOfFreeClients())
+		rpcClient, err := connector.createConnection(lifetimeCtx, nodeUrl, connector.numberOfFreeClients())
 		if err != nil {
 			break
 		}
@@ -444,11 +468,11 @@ func addClientsAsynchronouslyGrpc(ctx context.Context, connector *GRPCConnector,
 			utils.LavaFormatWarning("gRPC connector closed before the async fill finished", nil,
 				utils.LogAttr("address", nodeUrl.UrlStr()),
 			)
-		} else if ctx.Err() != nil {
+		} else if lifetimeCtx.Err() != nil {
 			// Probe-scoped ctx (validateProvider, etc.) was cancelled before
 			// the async fill produced any client. Caller will treat the
 			// returned error as a probe failure; the process must not exit.
-			utils.LavaFormatWarning("gRPC connector aborted before any connection was built", ctx.Err(),
+			utils.LavaFormatWarning("gRPC connector aborted before any connection was built", lifetimeCtx.Err(),
 				utils.LogAttr("address", nodeUrl.UrlStr()),
 			)
 		} else {
@@ -460,7 +484,7 @@ func addClientsAsynchronouslyGrpc(ctx context.Context, connector *GRPCConnector,
 	// Read the count through the locked accessor: addClient / GetRpc mutate freeClients under the lock
 	// concurrently, so a bare len(connector.freeClients) here is a data race.
 	utils.LavaFormatInfo("Finished adding clients asynchronously", utils.LogAttr("count", connector.numberOfFreeClients()))
-	go connector.connectorLoop(ctx)
+	go connector.connectorLoop(lifetimeCtx)
 }
 
 func (connector *GRPCConnector) addClient(client *grpc.ClientConn) {

--- a/protocol/chainlib/chainproxy/connector.go
+++ b/protocol/chainlib/chainproxy/connector.go
@@ -370,14 +370,20 @@ func (connector *GRPCConnector) ReturnRpc(rpc *grpc.ClientConn) {
 	connector.lock.Lock()
 	defer connector.lock.Unlock()
 
+	// The decrement happens on every path below, including the nil handback: Close
+	// is blocked waiting for usedClients to reach zero, so skipping it would leave
+	// teardown spinning forever.
 	connector.usedClients--
+	if rpc == nil {
+		// Defensive — a successful GetRpc never yields nil, and callers must not
+		// hand back what they did not borrow. Checked once here so no path below
+		// dereferences it.
+		return
+	}
 	if connector.closed {
-		// Close is blocked waiting for usedClients to reach zero, so the decrement
-		// above must happen either way. Drop the conn rather than appending it to a
-		// pool that is being torn down, which would leave a live client behind.
-		if rpc != nil {
-			rpc.Close()
-		}
+		// Drop the conn rather than appending it to a pool that is being torn down,
+		// which would leave a live client behind.
+		rpc.Close()
 		return
 	}
 	if len(connector.freeClients) > (int(connector.usedClients) + int(NumberOfParallelConnections) /* the number we started with */) {

--- a/protocol/chainlib/chainproxy/connector_test.go
+++ b/protocol/chainlib/chainproxy/connector_test.go
@@ -210,7 +210,7 @@ func TestConnectorGrpc(t *testing.T) {
 	server := createGRPCServer(t) // create a grpcServer so we can connect to its endpoint and validate everything works.
 	defer server.Stop()
 	ctx := context.Background()
-	conn, err := NewGRPCConnector(ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
+	conn, err := NewGRPCConnector(ctx, ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
 	require.NoError(t, err)
 	for { // wait for the routine to finish connecting
 		if conn.numberOfFreeClients() == numberOfClients {
@@ -237,7 +237,7 @@ func TestConnectorGrpcAndInvoke(t *testing.T) {
 	server := createGRPCServerWithRegisteredProto(t) // create a grpcServer so we can connect to its endpoint and validate everything works.
 	defer server.Stop()
 	ctx := context.Background()
-	conn, err := NewGRPCConnector(ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
+	conn, err := NewGRPCConnector(ctx, ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
 	require.NoError(t, err)
 	for { // wait for the routine to finish connecting
 		if conn.numberOfFreeClients() == numberOfClients {
@@ -286,7 +286,7 @@ func TestConnectorPoolSurvivesProbeCancellation(t *testing.T) {
 	defer server.Stop()
 
 	ctx := context.Background()
-	conn, err := NewGRPCConnector(ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
+	conn, err := NewGRPCConnector(ctx, ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
 	require.NoError(t, err)
 	for { // wait for the async fill goroutine to finish populating the pool
 		if conn.numberOfFreeClients() == numberOfClients {

--- a/protocol/chainlib/chainproxy/grpc_auth_connector_test.go
+++ b/protocol/chainlib/chainproxy/grpc_auth_connector_test.go
@@ -92,7 +92,7 @@ func TestGRPCConnector_SendsAuthHeadersOnUnaryCall(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	connector, err := NewGRPCConnector(ctx, 1, common.NodeUrl{
+	connector, err := NewGRPCConnector(ctx, ctx, 1, common.NodeUrl{
 		Url:        addr,
 		AuthConfig: common.AuthConfig{AuthHeaders: map[string]string{"Authorization": "Bearer unit-test-token"}},
 	})
@@ -126,7 +126,7 @@ func TestGRPCConnector_SendsAuthHeadersOnReflection(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	connector, err := NewGRPCConnector(ctx, 1, common.NodeUrl{
+	connector, err := NewGRPCConnector(ctx, ctx, 1, common.NodeUrl{
 		Url:        addr,
 		AuthConfig: common.AuthConfig{AuthHeaders: map[string]string{"Authorization": "Bearer reflect-token"}},
 	})
@@ -157,7 +157,7 @@ func TestGRPCConnector_NoAuthHeadersSendsNone(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	connector, err := NewGRPCConnector(ctx, 1, common.NodeUrl{Url: addr})
+	connector, err := NewGRPCConnector(ctx, ctx, 1, common.NodeUrl{Url: addr})
 	if err != nil {
 		t.Fatalf("NewGRPCConnector: %v", err)
 	}

--- a/protocol/chainlib/chainproxy/grpc_connector_close_test.go
+++ b/protocol/chainlib/chainproxy/grpc_connector_close_test.go
@@ -22,7 +22,7 @@ func TestGRPCConnectorGetRpcAfterCloseReturnsError(t *testing.T) {
 	defer server.Stop()
 
 	ctx := context.Background()
-	conn, err := NewGRPCConnector(ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
+	conn, err := NewGRPCConnector(ctx, ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
 	require.NoError(t, err)
 
 	conn.Close()
@@ -107,7 +107,7 @@ func TestGRPCConnectorCloseDrainsBorrowedClient(t *testing.T) {
 	defer server.Stop()
 
 	ctx := context.Background()
-	conn, err := NewGRPCConnector(ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
+	conn, err := NewGRPCConnector(ctx, ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
 	require.NoError(t, err)
 
 	rpc, err := conn.GetRpc(ctx, true)
@@ -140,39 +140,90 @@ func TestGRPCConnectorCloseDrainsBorrowedClient(t *testing.T) {
 		"a client returned to a closing connector must be dropped, not pooled")
 }
 
-// TestGRPCConnectorLifetimeIsItsConstructorContext pins the contract that made
-// MAG-2808's second failure possible: the context handed to NewGRPCConnector is
-// the connector's LIFETIME, not merely a dial deadline. addClientsAsynchronouslyGrpc
-// ends with `go connectorLoop(ctx)`, and connectorLoop is `<-ctx.Done(); Close()`.
+// TestGRPCConnectorLifetimeIsItsLifetimeContext pins the contract that made
+// MAG-2808's second failure possible: one of NewGRPCConnector's contexts is the
+// connector's LIFETIME. addClientsAsynchronouslyGrpc ends with
+// `go connectorLoop(lifetimeCtx)`, and connectorLoop is `<-ctx.Done(); Close()`.
 //
 // Nothing covered this. Every other test here builds a connector and calls Close()
 // on it directly, never reaching connectorLoop — so a caller that passed a
 // request-scoped context, as the direct-RPC path did, tore its own pool down on
-// every relay with no test noticing. Callers must pass a context that lives as
-// long as the pool should; see lavasession.newGRPCDirectRPCConnection.
-func TestGRPCConnectorLifetimeIsItsConstructorContext(t *testing.T) {
+// every relay with no test noticing.
+func TestGRPCConnectorLifetimeIsItsLifetimeContext(t *testing.T) {
 	server := createGRPCServer(t)
 	defer server.Stop()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	conn, err := NewGRPCConnector(ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
+	lifetimeCtx, endLifetime := context.WithCancel(context.Background())
+	conn, err := NewGRPCConnector(lifetimeCtx, context.Background(), numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
 	require.NoError(t, err)
 	defer conn.Close()
 
-	rpc, err := conn.GetRpc(ctx, true)
+	rpc, err := conn.GetRpc(context.Background(), true)
 	require.NoError(t, err)
 	conn.ReturnRpc(rpc)
 
-	cancel()
+	endLifetime()
 
 	require.Eventually(t, conn.isClosed, 10*time.Second, 5*time.Millisecond,
-		"connectorLoop must close the connector when its constructor context ends")
+		"connectorLoop must close the connector when its lifetime context ends")
 
 	// And the closure is permanent, which is what turns a caller's short-lived
 	// context from a wasteful re-dial into a dead endpoint.
 	rpc, err = conn.GetRpc(context.Background(), true)
 	require.Nil(t, rpc)
 	require.ErrorIs(t, err, ErrGRPCConnectorClosed)
+}
+
+// TestGRPCConnectorDialContextDoesNotEndTheConnector is the other half of that
+// contract, and the reason the two contexts are separate at all.
+//
+// dialCtx exists to bound the caller's wait on the one blocking dial in
+// NewGRPCConnector. It is the caller's own context — on the direct-RPC path, a
+// single relay's — so it ends almost immediately. If it reached connectorLoop or
+// the async fill, the pool would die with that caller, which is exactly the bug.
+func TestGRPCConnectorDialContextDoesNotEndTheConnector(t *testing.T) {
+	server := createGRPCServer(t)
+	defer server.Stop()
+
+	dialCtx, endDial := context.WithCancel(context.Background())
+	conn, err := NewGRPCConnector(context.Background(), dialCtx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	endDial() // the caller that built the pool has returned
+
+	// A regressed implementation closes within microseconds of the cancellation,
+	// so it loses this by the full margin rather than by a hair.
+	time.Sleep(100 * time.Millisecond)
+
+	require.False(t, conn.isClosed(), "the dial context must not end the connector")
+	rpc, err := conn.GetRpc(context.Background(), true)
+	require.NoError(t, err, "the pool must outlive the caller that dialed it")
+	conn.ReturnRpc(rpc)
+}
+
+// TestGRPCConnectorDialContextBoundsTheBlockingDial is the point of restoring a
+// caller deadline: NewGRPCConnector's first dial runs in the caller's critical
+// path, and createConnection retries it up to
+// MaximumNumberOfParallelConnectionsAttempts times at AverageWorldLatency*2 each
+// (doubling again on the TLS-upgrade retry). Against a dead address that is
+// several seconds of a relay's life, and — because the direct-RPC layer holds
+// initMu across this call — several seconds for every relay queued behind it too.
+//
+// With only a lifetime context to dial under, this test takes the full budget.
+func TestGRPCConnectorDialContextBoundsTheBlockingDial(t *testing.T) {
+	dialCtx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	// Port 1 is never listened on. WithBlock keeps retrying rather than failing on
+	// the first refusal, so the dial runs until a deadline stops it.
+	_, err := NewGRPCConnector(context.Background(), dialCtx, 1, common.NodeUrl{Url: "127.0.0.1:1"})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Less(t, elapsed, 2*time.Second,
+		"the blocking dial must honour the caller's deadline, not createConnection's full retry budget")
 }
 
 // TestGRPCConnectorReturnRpcNilStillDecrements covers the defensive branch in
@@ -184,7 +235,7 @@ func TestGRPCConnectorReturnRpcNilStillDecrements(t *testing.T) {
 	defer server.Stop()
 
 	ctx := context.Background()
-	conn, err := NewGRPCConnector(ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
+	conn, err := NewGRPCConnector(ctx, ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
 	require.NoError(t, err)
 
 	rpc, err := conn.GetRpc(ctx, true)
@@ -216,7 +267,7 @@ func TestGRPCConnectorRefillAfterCloseIsDropped(t *testing.T) {
 	defer server.Stop()
 
 	ctx := context.Background()
-	conn, err := NewGRPCConnector(ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
+	conn, err := NewGRPCConnector(ctx, ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
 	require.NoError(t, err)
 	conn.Close()
 

--- a/protocol/chainlib/chainproxy/grpc_connector_close_test.go
+++ b/protocol/chainlib/chainproxy/grpc_connector_close_test.go
@@ -140,6 +140,73 @@ func TestGRPCConnectorCloseDrainsBorrowedClient(t *testing.T) {
 		"a client returned to a closing connector must be dropped, not pooled")
 }
 
+// TestGRPCConnectorLifetimeIsItsConstructorContext pins the contract that made
+// MAG-2808's second failure possible: the context handed to NewGRPCConnector is
+// the connector's LIFETIME, not merely a dial deadline. addClientsAsynchronouslyGrpc
+// ends with `go connectorLoop(ctx)`, and connectorLoop is `<-ctx.Done(); Close()`.
+//
+// Nothing covered this. Every other test here builds a connector and calls Close()
+// on it directly, never reaching connectorLoop — so a caller that passed a
+// request-scoped context, as the direct-RPC path did, tore its own pool down on
+// every relay with no test noticing. Callers must pass a context that lives as
+// long as the pool should; see lavasession.newGRPCDirectRPCConnection.
+func TestGRPCConnectorLifetimeIsItsConstructorContext(t *testing.T) {
+	server := createGRPCServer(t)
+	defer server.Stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	conn, err := NewGRPCConnector(ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	rpc, err := conn.GetRpc(ctx, true)
+	require.NoError(t, err)
+	conn.ReturnRpc(rpc)
+
+	cancel()
+
+	require.Eventually(t, conn.isClosed, 10*time.Second, 5*time.Millisecond,
+		"connectorLoop must close the connector when its constructor context ends")
+
+	// And the closure is permanent, which is what turns a caller's short-lived
+	// context from a wasteful re-dial into a dead endpoint.
+	rpc, err = conn.GetRpc(context.Background(), true)
+	require.Nil(t, rpc)
+	require.ErrorIs(t, err, ErrGRPCConnectorClosed)
+}
+
+// TestGRPCConnectorReturnRpcNilStillDecrements covers the defensive branch in
+// ReturnRpc. The nil check guards every rpc.Close() below it, but it must not
+// skip the usedClients decrement: Close spins until that count reaches zero, so
+// an early return there would wedge teardown for the life of the process.
+func TestGRPCConnectorReturnRpcNilStillDecrements(t *testing.T) {
+	server := createGRPCServer(t)
+	defer server.Stop()
+
+	ctx := context.Background()
+	conn, err := NewGRPCConnector(ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
+	require.NoError(t, err)
+
+	rpc, err := conn.GetRpc(ctx, true)
+	require.NoError(t, err)
+	require.NotNil(t, rpc)
+	require.Equal(t, 1, conn.numberOfUsedClients())
+
+	require.NotPanics(t, func() { conn.ReturnRpc(nil) })
+	require.Equal(t, 0, conn.numberOfUsedClients())
+
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		conn.Close()
+	}()
+	select {
+	case <-closed:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Close hung: the borrow count was never decremented")
+	}
+}
+
 // TestGRPCConnectorRefillAfterCloseIsDropped covers the two paths that append to
 // the pool without going through GetRpc: the startup fill and the retry fill.
 // Both ran with no notion of Close, so a dial in flight when Close drained the

--- a/protocol/chainlib/chainproxy/grpc_connector_close_test.go
+++ b/protocol/chainlib/chainproxy/grpc_connector_close_test.go
@@ -1,0 +1,165 @@
+package chainproxy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// GRPCConnector had no closed state at all, unlike its HTTP sibling. The tests
+// below pin the three consequences that had (MAG-2808): a closed pool could hand
+// out clients, a blocked caller could never be woken, and the async fill could
+// repopulate a pool Close had just drained.
+
+// TestGRPCConnectorGetRpcAfterCloseReturnsError is the gRPC counterpart of
+// TestConnectorCloseWhileInUse, which has always pinned this for HTTP.
+func TestGRPCConnectorGetRpcAfterCloseReturnsError(t *testing.T) {
+	server := createGRPCServer(t)
+	defer server.Stop()
+
+	ctx := context.Background()
+	conn, err := NewGRPCConnector(ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
+	require.NoError(t, err)
+
+	conn.Close()
+
+	rpc, err := conn.GetRpc(ctx, true)
+	require.Nil(t, rpc)
+	require.ErrorIs(t, err, ErrGRPCConnectorClosed)
+
+	// Non-blocking callers must get the same verdict, not "out of clients".
+	rpc, err = conn.GetRpc(ctx, false)
+	require.Nil(t, rpc)
+	require.ErrorIs(t, err, ErrGRPCConnectorClosed)
+}
+
+// TestGRPCConnectorGetRpcHonoursContextCancellation covers the blocking wait.
+//
+// The loop used to spin on a 50ms sleep with no exit condition other than a
+// client appearing, so a caller waiting on a pool that would never refill was
+// stuck for the life of the process — the request's context being cancelled made
+// no difference. That is what turned a nil-pointer panic into an unbounded wait
+// once the nil dereference was guarded.
+func TestGRPCConnectorGetRpcHonoursContextCancellation(t *testing.T) {
+	// Built by hand rather than via NewGRPCConnector: the point is an empty pool
+	// pointed at an address that will never answer, which the constructor
+	// (rightly) refuses to produce.
+	conn := &GRPCConnector{
+		freeClients: []*grpc.ClientConn{},
+		nodeUrl:     common.NodeUrl{Url: "127.0.0.1:1"},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := conn.GetRpc(ctx, true)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(10 * time.Second):
+		t.Fatal("GetRpc ignored its context and blocked past the deadline")
+	}
+}
+
+// TestGRPCConnectorGetRpcWakesOnClose is the same wait, ended by a Close rather
+// than by a deadline: teardown must not leave callers parked on a dead pool.
+func TestGRPCConnectorGetRpcWakesOnClose(t *testing.T) {
+	conn := &GRPCConnector{
+		freeClients: []*grpc.ClientConn{},
+		nodeUrl:     common.NodeUrl{Url: "127.0.0.1:1"},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := conn.GetRpc(ctx, true)
+		done <- err
+	}()
+
+	// Let the caller reach the wait loop before closing underneath it.
+	time.Sleep(100 * time.Millisecond)
+	conn.Close()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, ErrGRPCConnectorClosed)
+	case <-time.After(10 * time.Second):
+		t.Fatal("GetRpc kept waiting on a closed connector")
+	}
+}
+
+// TestGRPCConnectorCloseDrainsBorrowedClient pins the property the direct-RPC
+// layer leans on: Close does not return while a client is out on loan, so a
+// request holding one can finish using it.
+func TestGRPCConnectorCloseDrainsBorrowedClient(t *testing.T) {
+	server := createGRPCServer(t)
+	defer server.Stop()
+
+	ctx := context.Background()
+	conn, err := NewGRPCConnector(ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
+	require.NoError(t, err)
+
+	rpc, err := conn.GetRpc(ctx, true)
+	require.NoError(t, err)
+	require.NotNil(t, rpc)
+	require.Equal(t, 1, conn.numberOfUsedClients())
+
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		conn.Close()
+	}()
+
+	select {
+	case <-closed:
+		t.Fatal("Close returned while a client was still borrowed")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	conn.ReturnRpc(rpc)
+
+	select {
+	case <-closed:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Close did not finish after the borrowed client was returned")
+	}
+
+	require.Equal(t, 0, conn.numberOfUsedClients())
+	require.Equal(t, 0, conn.numberOfFreeClients(),
+		"a client returned to a closing connector must be dropped, not pooled")
+}
+
+// TestGRPCConnectorRefillAfterCloseIsDropped covers the two paths that append to
+// the pool without going through GetRpc: the startup fill and the retry fill.
+// Both ran with no notion of Close, so a dial in flight when Close drained the
+// pool put a live client back into it.
+func TestGRPCConnectorRefillAfterCloseIsDropped(t *testing.T) {
+	server := createGRPCServer(t)
+	defer server.Stop()
+
+	ctx := context.Background()
+	conn, err := NewGRPCConnector(ctx, numberOfClients, common.NodeUrl{Url: listenerAddressGrpc})
+	require.NoError(t, err)
+	conn.Close()
+
+	// Stand in for a dial that completed after Close drained the pool.
+	client, err := conn.createConnection(ctx, common.NodeUrl{Url: listenerAddressGrpc}, 0)
+	require.NoError(t, err)
+	conn.addClient(client)
+	require.Equal(t, 0, conn.numberOfFreeClients(), "addClient refilled a closed pool")
+
+	// And the retry path, which dials for itself.
+	conn.increaseNumberOfClients(ctx, 0)
+	require.Equal(t, 0, conn.numberOfFreeClients(), "increaseNumberOfClients refilled a closed pool")
+}

--- a/protocol/chainlib/grpc.go
+++ b/protocol/chainlib/grpc.go
@@ -467,7 +467,10 @@ func NewGrpcChainProxy(ctx context.Context, nConns uint, rpcProviderEndpoint lav
 	_, averageBlockTime, _, _ := parser.ChainBlockStats()
 	nodeUrl := rpcProviderEndpoint.NodeUrls[0]
 	nodeUrl.Url = strings.TrimSuffix(nodeUrl.Url, "/") // remove suffix if exists
-	conn, err := chainproxy.NewGRPCConnector(ctx, nConns, nodeUrl)
+	// Same context for lifetime and dial: this is a startup path, and ctx is the
+	// process's. There is nothing to distinguish — unlike the direct-RPC path,
+	// which builds its pool inside a relay (MAG-2808).
+	conn, err := chainproxy.NewGRPCConnector(ctx, ctx, nConns, nodeUrl)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/lavasession/direct_rpc_close_race_test.go
+++ b/protocol/lavasession/direct_rpc_close_race_test.go
@@ -3,43 +3,151 @@ package lavasession
 import (
 	"context"
 	"errors"
+	"net"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
 )
+
+// blockedFor is how long a test waits before concluding that an operation which
+// must not complete has indeed not completed. It is not a scheduler lottery: a
+// regressed implementation does not block at all, so it loses the race by the
+// full margin rather than by a few microseconds.
+const blockedFor = 100 * time.Millisecond
 
 // fakeGRPCConnector stands in for chainproxy.GRPCConnector.
 //
-// GetRpc always fails, and that is deliberate: these tests are about the
-// connection LIFECYCLE, not about issuing a real RPC. Returning (nil, err) makes
-// SendRequest bail out before it would touch a real *grpc.ClientConn, so the
-// test needs no server and no dialing.
+// It reproduces the two behaviours the connection lifecycle leans on:
+//
+//	GetRpc  hands out a client and records it as outstanding.
+//	Close   does not return until every client it handed out has come back.
+//
+// The second one carries the test's weight. The real GRPCConnector.Close spins
+// on usedClients, so a fake that closed instantly could not distinguish a
+// genuine drain from a Close that walked away from an in-flight request.
 type fakeGRPCConnector struct {
-	mu     sync.Mutex
-	closed bool
+	mu          sync.Mutex
+	drained     sync.Cond
+	closed      bool
+	outstanding int
+	returned    []*grpc.ClientConn
+
+	// conn is what GetRpc hands out. Leaving it nil makes the checkout fail,
+	// which is what most lifecycle tests want: SendRequest then bails before it
+	// would touch a real *grpc.ClientConn, so they need no server and no dialing.
+	conn *grpc.ClientConn
+
+	// gate, when set, runs inside GetRpc before it returns. Tests use it to hold
+	// a checkout open across a concurrent Close.
+	gate func()
+}
+
+func newFakeGRPCConnector() *fakeGRPCConnector {
+	f := &fakeGRPCConnector{}
+	f.drained.L = &f.mu
+	return f
 }
 
 func (f *fakeGRPCConnector) GetRpc(ctx context.Context, block bool) (*grpc.ClientConn, error) {
-	return nil, errors.New("fake connector: no real connection")
+	f.mu.Lock()
+	gate, conn := f.gate, f.conn
+	f.mu.Unlock()
+
+	if gate != nil {
+		gate()
+	}
+
+	if conn == nil {
+		return nil, errors.New("fake connector: no real connection")
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.outstanding++
+	return conn, nil
 }
 
-func (f *fakeGRPCConnector) ReturnRpc(rpc *grpc.ClientConn) {}
+func (f *fakeGRPCConnector) ReturnRpc(rpc *grpc.ClientConn) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.returned = append(f.returned, rpc)
+	f.outstanding--
+	f.drained.Broadcast()
+}
 
 func (f *fakeGRPCConnector) Close() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.closed = true
+	for f.outstanding > 0 {
+		f.drained.Wait()
+	}
+}
+
+func (f *fakeGRPCConnector) isClosed() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.closed
+}
+
+func (f *fakeGRPCConnector) returnedConns() []*grpc.ClientConn {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]*grpc.ClientConn(nil), f.returned...)
 }
 
 // newInitializedGRPCConn builds a connection that behaves as though lazy
 // initialization had already succeeded, without dialing anything.
 func newInitializedGRPCConn(connector grpcConnectorInterface) *GRPCDirectRPCConnection {
-	g := &GRPCDirectRPCConnection{}
+	g := newGRPCDirectRPCConnection(common.NodeUrl{Url: "grpc://127.0.0.1:1"})
 	g.connector = connector
 	g.initialized.Store(true)
 	return g
+}
+
+// newUninitializedGRPCConn builds a connection whose first request will run lazy
+// initialization, with newConnector standing in for the dial.
+func newUninitializedGRPCConn(factory grpcConnectorFactory) *GRPCDirectRPCConnection {
+	// Port 1 is never listened on, but nothing dials it: the factory replaces the
+	// dial entirely. The URL only has to survive validateURL.
+	g := newGRPCDirectRPCConnection(common.NodeUrl{
+		Url:        "grpc://127.0.0.1:1",
+		GrpcConfig: common.GrpcConfig{AllowInsecure: true},
+	})
+	g.newConnector = factory
+	return g
+}
+
+// newLoopbackClientConn returns a real *grpc.ClientConn wired to an in-process
+// server over bufconn — no ports, no dialing, no flakiness.
+//
+// The server registers no services, so the reflection lookup that SendRequest
+// performs after a successful checkout fails fast. That is deliberate: these
+// tests are about the borrow/return accounting around the call, not about the
+// call succeeding, and a zero-value ClientConn would panic there instead.
+func newLoopbackClientConn(t *testing.T) *grpc.ClientConn {
+	t.Helper()
+
+	lis := bufconn.Listen(1024 * 1024)
+	srv := grpc.NewServer()
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
 }
 
 func grpcTestHeaders() map[string]string {
@@ -52,7 +160,7 @@ func grpcTestHeaders() map[string]string {
 // short-circuits and SendRequest dereferenced the nil — taking the whole process
 // down, and with it every chain served by that pod, not just the gRPC one.
 func TestSendRequest_AfterClose_ReturnsErrorNotPanic(t *testing.T) {
-	g := newInitializedGRPCConn(&fakeGRPCConnector{})
+	g := newInitializedGRPCConn(newFakeGRPCConnector())
 	require.NoError(t, g.Close())
 
 	require.NotPanics(t, func() {
@@ -67,42 +175,201 @@ func TestSendRequest_AfterClose_ReturnsErrorNotPanic(t *testing.T) {
 // a connection closed BEFORE its first request must not lazily build a fresh
 // connector and quietly come back to life.
 func TestSendRequest_CloseBeforeInit_DoesNotResurrect(t *testing.T) {
-	g := &GRPCDirectRPCConnection{} // never initialized
+	built := 0
+	g := newUninitializedGRPCConn(func(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
+		built++
+		return newFakeGRPCConnector(), nil
+	})
 	require.NoError(t, g.Close())
 
 	resp, err := g.SendRequest(context.Background(), []byte("{}"), grpcTestHeaders())
 	require.Nil(t, resp)
 	require.ErrorIs(t, err, ErrGRPCConnectionClosed)
 
+	require.Zero(t, built, "a closed connection must not dial")
 	g.connMu.RLock()
 	defer g.connMu.RUnlock()
 	require.Nil(t, g.connector, "a closed connection must not re-create its connector")
 }
 
-// SECOND PANIC SITE — deliberately NOT unit-tested, and here is why.
+// TestClose_WaitsForPoolCheckout covers the hazard a pointer snapshot does not:
+// copying g.connector under connMu keeps the POINTER alive, not the pool behind
+// it. Releasing the lock before GetRpc let Close drain and close that pool while
+// the request was still trying to borrow from it.
 //
-// `defer g.connector.ReturnRpc(conn)` re-read the field at function EXIT rather
-// than at defer registration, so a request that had already read a valid
-// connector still panicked on the way out if Close landed mid-RPC. The `closed`
-// flag cannot cover that window — by then the request is past every guard — which
-// is why SendRequest snapshots the connector into a local.
+// SendRequest now holds connMu in read mode for the whole checkout, so Close
+// cannot detach or close the connector until the checkout finishes.
+func TestClose_WaitsForPoolCheckout(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+
+	fake := newFakeGRPCConnector()
+	fake.gate = func() {
+		close(entered)
+		<-release
+	}
+	g := newInitializedGRPCConn(fake)
+
+	requestDone := make(chan struct{})
+	go func() {
+		defer close(requestDone)
+		_, _ = g.SendRequest(context.Background(), []byte("{}"), grpcTestHeaders())
+	}()
+	<-entered // the checkout is in flight
+
+	closeReturned := make(chan struct{})
+	go func() {
+		defer close(closeReturned)
+		_ = g.Close()
+	}()
+
+	select {
+	case <-closeReturned:
+		t.Fatal("Close returned while a pool checkout was still in flight")
+	case <-time.After(blockedFor):
+	}
+	require.False(t, fake.isClosed(), "the pool was closed underneath an in-flight checkout")
+
+	close(release)
+	<-requestDone
+	<-closeReturned
+
+	require.True(t, fake.isClosed(), "Close must tear the connector down once the checkout is done")
+	g.connMu.RLock()
+	defer g.connMu.RUnlock()
+	require.Nil(t, g.connector)
+}
+
+// TestClose_DuringCheckout_BorrowedClientIsReturnedOnce is the same race with a
+// checkout that SUCCEEDS: the request must keep using the client it borrowed
+// even though Close is tearing the connection down behind it, and must hand that
+// client back exactly once, to the connector that issued it.
 //
-// Reaching that window in a unit test requires GetRpc to SUCCEED, and everything
-// after it (getMethodDescriptor -> grpcreflect.NewClientAuto) dereferences the
-// returned *grpc.ClientConn. A zero-value ClientConn panics there, so the test
-// would fail identically with and without the fix — measuring the stub, not the
-// bug. Covering this properly needs an integration test against a live gRPC
-// server, which belongs with the automated repro the ticket already asks for.
+// It also pins the shape of Close itself. Close drains outside connMu, so the
+// connector's own Close can wait on the borrowed client while the request runs
+// to completion; draining under connMu would deadlock here instead.
+func TestClose_DuringCheckout_BorrowedClientIsReturnedOnce(t *testing.T) {
+	conn := newLoopbackClientConn(t)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+
+	fake := newFakeGRPCConnector()
+	fake.conn = conn
+	fake.gate = func() {
+		close(entered)
+		<-release
+	}
+	g := newInitializedGRPCConn(fake)
+
+	// Bounded so a hung reflection lookup fails the test instead of hanging it;
+	// the descriptor call is expected to fail fast against the loopback server.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	requestDone := make(chan struct{})
+	go func() {
+		defer close(requestDone)
+		_, _ = g.SendRequest(ctx, []byte("{}"), grpcTestHeaders())
+	}()
+	<-entered
+
+	closeReturned := make(chan struct{})
+	go func() {
+		defer close(closeReturned)
+		_ = g.Close()
+	}()
+
+	select {
+	case <-closeReturned:
+		t.Fatal("Close returned while a pool checkout was still in flight")
+	case <-time.After(blockedFor):
+	}
+
+	close(release)
+	<-requestDone
+	<-closeReturned
+
+	returned := fake.returnedConns()
+	require.Len(t, returned, 1, "the borrowed client must be handed back exactly once")
+	require.Same(t, conn, returned[0], "must be returned to the connector that issued it")
+}
+
+// TestSendRequest_ReturnsBorrowedClientExactlyOnce is the same accounting on the
+// ordinary path, with no Close in play — the baseline the race tests are read
+// against.
+func TestSendRequest_ReturnsBorrowedClientExactlyOnce(t *testing.T) {
+	conn := newLoopbackClientConn(t)
+
+	fake := newFakeGRPCConnector()
+	fake.conn = conn
+	g := newInitializedGRPCConn(fake)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// The loopback server exposes no reflection service, so the descriptor lookup
+	// fails and SendRequest returns an error. The borrow happened either way.
+	_, err := g.SendRequest(ctx, []byte("{}"), grpcTestHeaders())
+	require.Error(t, err)
+
+	returned := fake.returnedConns()
+	require.Len(t, returned, 1)
+	require.Same(t, conn, returned[0])
+}
+
+// TestClose_DuringFirstInitialization_DoesNotPublishConnector closes the window
+// the `closed` flag alone could not.
 //
-// What IS covered: TestSendRequest_AfterClose_ReturnsErrorNotPanic reproduces
-// the exact production panic ("invalid memory address or nil pointer
-// dereference") when both this fix and the closed-flag guard are reverted to
-// main's behaviour.
+// ensureInitialized checked closed BEFORE taking initMu, so a request that had
+// already passed that check and was blocked building its connector could publish
+// it AFTER Close had observed a nil connector and returned — leaving a live pool
+// behind a closed connection, and a request walking on past the guard.
+func TestClose_DuringFirstInitialization_DoesNotPublishConnector(t *testing.T) {
+	building := make(chan struct{})
+	release := make(chan struct{})
+	built := newFakeGRPCConnector()
+
+	g := newUninitializedGRPCConn(func(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
+		close(building)
+		<-release
+		return built, nil
+	})
+
+	requestErr := make(chan error, 1)
+	go func() {
+		_, err := g.SendRequest(context.Background(), []byte("{}"), grpcTestHeaders())
+		requestErr <- err
+	}()
+	<-building // initialization is in flight, already past ensureInitialized's check
+
+	closeReturned := make(chan struct{})
+	go func() {
+		defer close(closeReturned)
+		_ = g.Close()
+	}()
+
+	// Wait for Close to publish its intent rather than sleeping a fixed amount:
+	// from here the initializer is guaranteed to observe closed at its re-check,
+	// so the "constructed but never installed" path is the one under test.
+	require.Eventually(t, g.closed.Load, time.Second, time.Millisecond,
+		"Close must mark the connection closed before it blocks on initMu")
+
+	close(release)
+	<-closeReturned
+
+	g.connMu.RLock()
+	connector := g.connector
+	g.connMu.RUnlock()
+	require.Nil(t, connector, "initialization must not publish a connector after Close")
+	require.True(t, built.isClosed(), "a connector built during Close must be closed, not leaked")
+	require.ErrorIs(t, <-requestErr, ErrGRPCConnectionClosed)
+}
 
 // TestClose_IsIdempotent — Close runs on teardown paths that can fire more than
 // once; a second call must not panic on the already-nil connector.
 func TestClose_IsIdempotent(t *testing.T) {
-	g := newInitializedGRPCConn(&fakeGRPCConnector{})
+	g := newInitializedGRPCConn(newFakeGRPCConnector())
 
 	require.NotPanics(t, func() {
 		require.NoError(t, g.Close())
@@ -110,17 +377,11 @@ func TestClose_IsIdempotent(t *testing.T) {
 	})
 }
 
-// TestSendRequest_ConcurrentWithClose_NeverPanics is the regression test the
-// ticket asks for: relays in flight while Close lands. Run it under -race.
+// TestSendRequest_ConcurrentWithClose_NeverPanics is the broad regression net:
+// relays in flight while Close lands. Run it under -race.
 //
-// COVERAGE GAP, stated rather than implied: this exercises the read side only.
-// It cannot reach the third fix in this change — publishing g.connector under
-// connMu in initialize() — because reaching initialize() means dialing a real
-// gRPC server, and NewGRPCConnector blocks on its first connection and fails
-// before the write is reached. That write was guarded by initMu while Close
-// guarded the same field with connMu (no lock in common); the fix is justified
-// by inspection, not by this test. Closing that gap needs an integration test
-// with a live server.
+// The gated tests above pin the specific orderings; this one covers the ones
+// nobody thought to name.
 func TestSendRequest_ConcurrentWithClose_NeverPanics(t *testing.T) {
 	const (
 		goroutines = 50
@@ -128,7 +389,7 @@ func TestSendRequest_ConcurrentWithClose_NeverPanics(t *testing.T) {
 	)
 
 	for attempt := 0; attempt < attempts; attempt++ {
-		g := newInitializedGRPCConn(&fakeGRPCConnector{})
+		g := newInitializedGRPCConn(newFakeGRPCConnector())
 
 		var wg sync.WaitGroup
 		start := make(chan struct{})
@@ -152,5 +413,61 @@ func TestSendRequest_ConcurrentWithClose_NeverPanics(t *testing.T) {
 
 		close(start) // release everything at once to widen the race window
 		wg.Wait()
+	}
+}
+
+// TestInitialization_ConcurrentWithClose_NeverLeaksConnector is the same shape on
+// the initialization path: many first-requests racing a Close. Whichever ordering
+// wins, no connector may survive the Close.
+func TestInitialization_ConcurrentWithClose_NeverLeaksConnector(t *testing.T) {
+	const (
+		goroutines = 20
+		attempts   = 20
+	)
+
+	for attempt := 0; attempt < attempts; attempt++ {
+		var (
+			mu    sync.Mutex
+			built []*fakeGRPCConnector
+		)
+		g := newUninitializedGRPCConn(func(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
+			connector := newFakeGRPCConnector()
+			mu.Lock()
+			built = append(built, connector)
+			mu.Unlock()
+			return connector, nil
+		})
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+
+		for i := 0; i < goroutines; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				_, _ = g.SendRequest(context.Background(), []byte("{}"), grpcTestHeaders())
+			}()
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = g.Close()
+		}()
+
+		close(start)
+		wg.Wait()
+
+		g.connMu.RLock()
+		require.Nil(t, g.connector, "a connector survived Close")
+		g.connMu.RUnlock()
+
+		mu.Lock()
+		for _, connector := range built {
+			require.True(t, connector.isClosed(), "a connector built around Close was left open")
+		}
+		mu.Unlock()
 	}
 }

--- a/protocol/lavasession/direct_rpc_close_race_test.go
+++ b/protocol/lavasession/direct_rpc_close_race_test.go
@@ -1,0 +1,156 @@
+package lavasession
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// fakeGRPCConnector stands in for chainproxy.GRPCConnector.
+//
+// GetRpc always fails, and that is deliberate: these tests are about the
+// connection LIFECYCLE, not about issuing a real RPC. Returning (nil, err) makes
+// SendRequest bail out before it would touch a real *grpc.ClientConn, so the
+// test needs no server and no dialing.
+type fakeGRPCConnector struct {
+	mu     sync.Mutex
+	closed bool
+}
+
+func (f *fakeGRPCConnector) GetRpc(ctx context.Context, block bool) (*grpc.ClientConn, error) {
+	return nil, errors.New("fake connector: no real connection")
+}
+
+func (f *fakeGRPCConnector) ReturnRpc(rpc *grpc.ClientConn) {}
+
+func (f *fakeGRPCConnector) Close() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = true
+}
+
+// newInitializedGRPCConn builds a connection that behaves as though lazy
+// initialization had already succeeded, without dialing anything.
+func newInitializedGRPCConn(connector grpcConnectorInterface) *GRPCDirectRPCConnection {
+	g := &GRPCDirectRPCConnection{}
+	g.connector = connector
+	g.initialized.Store(true)
+	return g
+}
+
+func grpcTestHeaders() map[string]string {
+	return map[string]string{GRPCMethodHeader: "pkg.Service/Method"}
+}
+
+// TestSendRequest_AfterClose_ReturnsErrorNotPanic is the MAG-2808 pin.
+//
+// Close() nils the connector but leaves `initialized` true, so ensureInitialized
+// short-circuits and SendRequest dereferenced the nil — taking the whole process
+// down, and with it every chain served by that pod, not just the gRPC one.
+func TestSendRequest_AfterClose_ReturnsErrorNotPanic(t *testing.T) {
+	g := newInitializedGRPCConn(&fakeGRPCConnector{})
+	require.NoError(t, g.Close())
+
+	require.NotPanics(t, func() {
+		resp, err := g.SendRequest(context.Background(), []byte("{}"), grpcTestHeaders())
+		require.Nil(t, resp)
+		require.ErrorIs(t, err, ErrGRPCConnectionClosed,
+			"a request on a closed connection must fail over, not crash")
+	})
+}
+
+// TestSendRequest_CloseBeforeInit_DoesNotResurrect covers the opposite ordering:
+// a connection closed BEFORE its first request must not lazily build a fresh
+// connector and quietly come back to life.
+func TestSendRequest_CloseBeforeInit_DoesNotResurrect(t *testing.T) {
+	g := &GRPCDirectRPCConnection{} // never initialized
+	require.NoError(t, g.Close())
+
+	resp, err := g.SendRequest(context.Background(), []byte("{}"), grpcTestHeaders())
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, ErrGRPCConnectionClosed)
+
+	g.connMu.RLock()
+	defer g.connMu.RUnlock()
+	require.Nil(t, g.connector, "a closed connection must not re-create its connector")
+}
+
+// SECOND PANIC SITE — deliberately NOT unit-tested, and here is why.
+//
+// `defer g.connector.ReturnRpc(conn)` re-read the field at function EXIT rather
+// than at defer registration, so a request that had already read a valid
+// connector still panicked on the way out if Close landed mid-RPC. The `closed`
+// flag cannot cover that window — by then the request is past every guard — which
+// is why SendRequest snapshots the connector into a local.
+//
+// Reaching that window in a unit test requires GetRpc to SUCCEED, and everything
+// after it (getMethodDescriptor -> grpcreflect.NewClientAuto) dereferences the
+// returned *grpc.ClientConn. A zero-value ClientConn panics there, so the test
+// would fail identically with and without the fix — measuring the stub, not the
+// bug. Covering this properly needs an integration test against a live gRPC
+// server, which belongs with the automated repro the ticket already asks for.
+//
+// What IS covered: TestSendRequest_AfterClose_ReturnsErrorNotPanic reproduces
+// the exact production panic ("invalid memory address or nil pointer
+// dereference") when both this fix and the closed-flag guard are reverted to
+// main's behaviour.
+
+// TestClose_IsIdempotent — Close runs on teardown paths that can fire more than
+// once; a second call must not panic on the already-nil connector.
+func TestClose_IsIdempotent(t *testing.T) {
+	g := newInitializedGRPCConn(&fakeGRPCConnector{})
+
+	require.NotPanics(t, func() {
+		require.NoError(t, g.Close())
+		require.NoError(t, g.Close())
+	})
+}
+
+// TestSendRequest_ConcurrentWithClose_NeverPanics is the regression test the
+// ticket asks for: relays in flight while Close lands. Run it under -race.
+//
+// COVERAGE GAP, stated rather than implied: this exercises the read side only.
+// It cannot reach the third fix in this change — publishing g.connector under
+// connMu in initialize() — because reaching initialize() means dialing a real
+// gRPC server, and NewGRPCConnector blocks on its first connection and fails
+// before the write is reached. That write was guarded by initMu while Close
+// guarded the same field with connMu (no lock in common); the fix is justified
+// by inspection, not by this test. Closing that gap needs an integration test
+// with a live server.
+func TestSendRequest_ConcurrentWithClose_NeverPanics(t *testing.T) {
+	const (
+		goroutines = 50
+		attempts   = 20
+	)
+
+	for attempt := 0; attempt < attempts; attempt++ {
+		g := newInitializedGRPCConn(&fakeGRPCConnector{})
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+
+		for i := 0; i < goroutines; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				// Any error is acceptable; a panic is not.
+				_, _ = g.SendRequest(context.Background(), []byte("{}"), grpcTestHeaders())
+			}()
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = g.Close()
+		}()
+
+		close(start) // release everything at once to widen the race window
+		wg.Wait()
+	}
+}

--- a/protocol/lavasession/direct_rpc_close_race_test.go
+++ b/protocol/lavasession/direct_rpc_close_race_test.go
@@ -197,7 +197,7 @@ func TestSendRequest_AfterClose_ReturnsErrorNotPanic(t *testing.T) {
 // connector and quietly come back to life.
 func TestSendRequest_CloseBeforeInit_DoesNotResurrect(t *testing.T) {
 	built := 0
-	g := newUninitializedGRPCConn(func(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
+	g := newUninitializedGRPCConn(func(lifetimeCtx, dialCtx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
 		built++
 		return newFakeGRPCConnector(), nil
 	})
@@ -351,7 +351,7 @@ func TestClose_DuringFirstInitialization_DoesNotPublishConnector(t *testing.T) {
 	release := make(chan struct{})
 	built := newFakeGRPCConnector()
 
-	g := newUninitializedGRPCConn(func(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
+	g := newUninitializedGRPCConn(func(lifetimeCtx, dialCtx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
 		close(building)
 		<-release
 		return built, nil
@@ -451,7 +451,7 @@ func TestInitialization_ConcurrentWithClose_NeverLeaksConnector(t *testing.T) {
 			mu    sync.Mutex
 			built []*fakeGRPCConnector
 		)
-		g := newUninitializedGRPCConn(func(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
+		g := newUninitializedGRPCConn(func(lifetimeCtx, dialCtx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
 			connector := newFakeGRPCConnector()
 			mu.Lock()
 			built = append(built, connector)
@@ -504,7 +504,7 @@ func TestInitialization_ConcurrentWithClose_NeverLeaksConnector(t *testing.T) {
 // connector-lifetime bug, reached by a different route.
 func TestInitialization_FailureIsRetriedNotLatched(t *testing.T) {
 	var attempts atomic.Int32
-	g := newUninitializedGRPCConn(func(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
+	g := newUninitializedGRPCConn(func(lifetimeCtx, dialCtx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
 		if attempts.Add(1) == 1 {
 			return nil, errors.New("node is down")
 		}
@@ -540,7 +540,7 @@ func TestInitialization_SpentContextDoesNotQueueAnotherDial(t *testing.T) {
 	release := make(chan struct{})
 	dialing := make(chan struct{})
 
-	g := newUninitializedGRPCConn(func(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
+	g := newUninitializedGRPCConn(func(lifetimeCtx, dialCtx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
 		attempts.Add(1)
 		close(dialing)
 		<-release
@@ -578,6 +578,46 @@ func TestInitialization_SpentContextDoesNotQueueAnotherDial(t *testing.T) {
 
 	require.Equal(t, int32(1), attempts.Load(),
 		"a relay whose context expired while queued must not start its own dial")
+}
+
+// TestInitialization_RelayDeadlineBoundsTheDial is the counterweight to giving
+// the connector its own lifetime context.
+//
+// Handing that context to the factory fixes the pool's lifetime, but if it were
+// also the dial context the caller would wait out createConnection's whole retry
+// budget — MaximumNumberOfParallelConnectionsAttempts attempts at
+// AverageWorldLatency*2 each, doubling again on the TLS-upgrade retry — instead
+// of its own deadline. Several seconds against a dead node, which delays failover
+// to another endpoint, which is the thing the router exists to do quickly.
+//
+// Worse, initMu is held across initialize(), so it is not just the dialing relay:
+// every relay that arrives during the dial blocks on that lock for its full
+// duration regardless of its own deadline. The ctx.Err() check in
+// ensureInitialized stops them starting a SECOND dial, but only after they have
+// already waited out the first.
+//
+// So initialize passes both: g.connectorCtx for the lifetime, the relay's ctx for
+// the dial.
+func TestInitialization_RelayDeadlineBoundsTheDial(t *testing.T) {
+	// Port 1 is never listened on. grpc.WithBlock keeps retrying rather than
+	// failing on the first refusal, so the dial runs until a deadline stops it.
+	g := newGRPCDirectRPCConnection(common.NodeUrl{
+		Url:        "grpc://127.0.0.1:1",
+		GrpcConfig: common.GrpcConfig{AllowInsecure: true},
+	})
+	require.Nil(t, g.newConnector, "this test must exercise the production factory")
+	t.Cleanup(func() { _ = g.Close() })
+
+	relayCtx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := g.SendRequest(relayCtx, []byte("{}"), grpcTestHeaders())
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Less(t, elapsed, 2*time.Second,
+		"a relay must not wait out the connector's dial budget past its own deadline")
 }
 
 // TestConnector_OutlivesTheRelayThatInitializedIt is the second MAG-2808 pin, and

--- a/protocol/lavasession/direct_rpc_close_race_test.go
+++ b/protocol/lavasession/direct_rpc_close_race_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy"
 	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -148,6 +149,25 @@ func newLoopbackClientConn(t *testing.T) *grpc.ClientConn {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = conn.Close() })
 	return conn
+}
+
+// startLocalGRPCServer brings up a real gRPC server on a loopback port and
+// returns its host:port.
+//
+// bufconn is not usable here. The one test that needs this goes through the
+// PRODUCTION connector factory on purpose, and chainproxy.NewGRPCConnector dials
+// the node URL itself with no dialer seam. A real listener is the point.
+func startLocalGRPCServer(t *testing.T) string {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := grpc.NewServer()
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	return lis.Addr().String()
 }
 
 func grpcTestHeaders() map[string]string {
@@ -470,4 +490,70 @@ func TestInitialization_ConcurrentWithClose_NeverLeaksConnector(t *testing.T) {
 		}
 		mu.Unlock()
 	}
+}
+
+// TestConnector_OutlivesTheRelayThatInitializedIt is the second MAG-2808 pin, and
+// the one every other test in this file routes around.
+//
+// The pool is built lazily inside the FIRST relay, so initialize() used to hand
+// chainproxy.NewGRPCConnector that relay's context. NewGRPCConnector treats its
+// context as the connector's lifetime — addClientsAsynchronouslyGrpc ends with
+// `go connectorLoop(ctx)`, which is `<-ctx.Done(); connector.Close()` — so the
+// pool died with the relay that happened to build it, and sendGRPCRelay's own
+// `defer cancel()` fired that on every single request.
+//
+// On main that was survivable: Close was a pool drain and the next GetRpc
+// silently re-dialled, costing a reconnect per relay. With the closed flag this
+// PR adds, the same teardown is terminal — every later checkout returns
+// ErrGRPCConnectorClosed and the refill paths discard the dials that would have
+// healed it. endpoint.DirectConnections caches this object for the whole pairing,
+// so the endpoint stays dead until the pairing is rebuilt. That is the direct
+// gRPC path this change exists to protect.
+//
+// Every other test here injects a fake through grpcConnectorFactory and so never
+// constructs a real GRPCConnector; the seam that made this code testable is
+// exactly what hid the defect. This one runs the production factory against a
+// real server.
+func TestConnector_OutlivesTheRelayThatInitializedIt(t *testing.T) {
+	addr := startLocalGRPCServer(t)
+
+	g := newGRPCDirectRPCConnection(common.NodeUrl{
+		Url:        "grpc://" + addr,
+		GrpcConfig: common.GrpcConfig{AllowInsecure: true},
+	})
+	require.Nil(t, g.newConnector, "this test must exercise the production factory")
+	t.Cleanup(func() { _ = g.Close() })
+
+	// Act as sendGRPCRelay does: a per-relay context, cancelled when the relay
+	// returns. The request itself fails at the reflection lookup — the server
+	// registers no services — which is beside the point: initialization has
+	// already happened by then, and that is what we are here for.
+	relayCtx, cancelRelay := context.WithCancel(context.Background())
+	_, err := g.SendRequest(relayCtx, []byte("{}"), grpcTestHeaders())
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrGRPCConnectionClosed, "the first relay must reach a live pool")
+
+	g.connMu.RLock()
+	connector := g.connector
+	g.connMu.RUnlock()
+	require.NotNil(t, connector, "the first relay must have published a connector")
+
+	cancelRelay() // the relay returns
+
+	// connectorLoop acts on cancellation in microseconds, so a regression loses
+	// this by the full margin rather than by a hair.
+	time.Sleep(blockedFor)
+
+	conn, err := connector.GetRpc(context.Background(), true)
+	require.NoError(t, err, "the pool must not die with the relay that built it")
+	connector.ReturnRpc(conn)
+
+	// The other half of the contract: the connector's life must still END, and end
+	// with the connection. Cancelling connectorCtx is also what releases the
+	// connectorLoop goroutine parked on it.
+	require.NoError(t, g.Close())
+	require.ErrorIs(t, g.connectorCtx.Err(), context.Canceled,
+		"Close must end the connector's lifetime context")
+	_, err = connector.GetRpc(context.Background(), true)
+	require.ErrorIs(t, err, chainproxy.ErrGRPCConnectorClosed)
 }

--- a/protocol/lavasession/direct_rpc_close_race_test.go
+++ b/protocol/lavasession/direct_rpc_close_race_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -490,6 +491,93 @@ func TestInitialization_ConcurrentWithClose_NeverLeaksConnector(t *testing.T) {
 		}
 		mu.Unlock()
 	}
+}
+
+// TestInitialization_FailureIsRetriedNotLatched pins the third way this
+// connection could end up permanently dead (MAG-2808).
+//
+// ensureInitialized used to store `initialized = true` whatever initialize()
+// returned, cache the error in an initErr field, and replay it to every later
+// request. A node that happened to be down when the FIRST relay arrived poisoned
+// the connection for the life of the pairing, because endpoint.DirectConnections
+// caches this object until the pairing is rebuilt — the same failure shape as the
+// connector-lifetime bug, reached by a different route.
+func TestInitialization_FailureIsRetriedNotLatched(t *testing.T) {
+	var attempts atomic.Int32
+	g := newUninitializedGRPCConn(func(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
+		if attempts.Add(1) == 1 {
+			return nil, errors.New("node is down")
+		}
+		return newFakeGRPCConnector(), nil
+	})
+
+	_, err := g.SendRequest(context.Background(), []byte("{}"), grpcTestHeaders())
+	require.Error(t, err, "the first relay must see the failed dial")
+	require.False(t, g.initialized.Load(), "a failed initialize must not latch")
+
+	// The second relay fails too — the fake hands out no usable client — but it
+	// must fail at the CHECKOUT, having dialled again, rather than replaying a
+	// cached initialization error.
+	_, err = g.SendRequest(context.Background(), []byte("{}"), grpcTestHeaders())
+	require.Error(t, err)
+	require.Equal(t, int32(2), attempts.Load(), "the second relay must retry the dial")
+
+	require.True(t, g.initialized.Load(), "a successful initialize must latch")
+	g.connMu.RLock()
+	defer g.connMu.RUnlock()
+	require.NotNil(t, g.connector, "the retry must publish its connector")
+}
+
+// TestInitialization_SpentContextDoesNotQueueAnotherDial is the guard that keeps
+// the retry above from becoming a serialized dial storm against a dead endpoint.
+//
+// initialize() dials with grpc.WithBlock() under initMu, so relays arriving
+// during a failing dial queue behind it. Without this check each of them would
+// then start its own full dial budget on a context that had already expired while
+// it waited — every relay paying the full cost, one after another.
+func TestInitialization_SpentContextDoesNotQueueAnotherDial(t *testing.T) {
+	var attempts atomic.Int32
+	release := make(chan struct{})
+	dialing := make(chan struct{})
+
+	g := newUninitializedGRPCConn(func(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
+		attempts.Add(1)
+		close(dialing)
+		<-release
+		return nil, errors.New("node is down")
+	})
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		_, _ = g.SendRequest(context.Background(), []byte("{}"), grpcTestHeaders())
+	}()
+
+	<-dialing // the first relay now holds initMu inside the factory
+
+	// A second relay arrives and blocks on initMu with a context that dies while
+	// it waits.
+	spentCtx, cancel := context.WithCancel(context.Background())
+	secondErr := make(chan error, 1)
+	go func() {
+		_, err := g.SendRequest(spentCtx, []byte("{}"), grpcTestHeaders())
+		secondErr <- err
+	}()
+	time.Sleep(blockedFor) // let it reach the lock
+	cancel()
+
+	close(release)
+	<-firstDone
+
+	select {
+	case err := <-secondErr:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(10 * time.Second):
+		t.Fatal("the queued relay never returned")
+	}
+
+	require.Equal(t, int32(1), attempts.Load(),
+		"a relay whose context expired while queued must not start its own dial")
 }
 
 // TestConnector_OutlivesTheRelayThatInitializedIt is the second MAG-2808 pin, and

--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -163,6 +163,21 @@ type WebSocketDirectRPCConnection struct {
 //   - Dynamic protobuf handling via reflection or file descriptors
 //   - Method descriptor caching for performance
 //   - Proper error handling with gRPC status codes
+//
+// # Lifecycle and locking (MAG-2808)
+//
+// Lock order is initMu -> connMu. connMu is never held while acquiring initMu.
+//
+//	initMu  serializes lazy initialization against itself and against Close, so
+//	        registry/codec/descriptorsCache are never written while Close tears
+//	        them down. Those fields have no lock of their own.
+//	connMu  guards the connector field. Requests hold it in read mode for the
+//	        whole pool checkout, which turns "pick a connector" and "borrow one of
+//	        its clients" into one step that Close must wait behind.
+//
+// After Close returns: connector is nil, no later write can install one, every
+// borrowed client has been returned, and further requests get
+// ErrGRPCConnectionClosed.
 type GRPCDirectRPCConnection struct {
 	nodeUrl common.NodeUrl
 
@@ -186,6 +201,39 @@ type GRPCDirectRPCConnection struct {
 	// the not-yet-initialized case it would instead silently resurrect the
 	// connection by building a fresh connector (MAG-2808).
 	closed atomic.Bool
+
+	// newConnector builds the pooled connector. Production leaves it nil and gets
+	// newGRPCConnector; tests substitute a fake, or one that blocks mid-construction
+	// to pin down the Close-during-initialization ordering. It is read under initMu
+	// and must be set before the first request.
+	newConnector grpcConnectorFactory
+}
+
+// newGRPCDirectRPCConnection builds a gRPC connection with its descriptor cache in
+// place. The cache is a pointer with no lazy initialization, so every construction
+// site has to set it or the first descriptor lookup dereferences nil.
+func newGRPCDirectRPCConnection(nodeUrl common.NodeUrl) *GRPCDirectRPCConnection {
+	return &GRPCDirectRPCConnection{
+		nodeUrl:          nodeUrl,
+		descriptorsCache: &common.SafeSyncMap[string, *desc.MethodDescriptor]{},
+	}
+}
+
+// grpcConnectorFactory mirrors chainproxy.NewGRPCConnector. It completes the seam
+// grpcConnectorInterface already opens: without it, reaching initialize() in a test
+// means dialing a real node.
+type grpcConnectorFactory func(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error)
+
+// newGRPCConnector is the production factory. It returns an explicit nil interface
+// on failure: returning the (*GRPCConnector)(nil) that NewGRPCConnector hands back
+// alongside an error would produce a non-nil interface holding a nil pointer, and
+// every downstream nil check would silently pass.
+func newGRPCConnector(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
+	connector, err := chainproxy.NewGRPCConnector(ctx, nConns, nodeUrl)
+	if err != nil {
+		return nil, err
+	}
+	return connector, nil
 }
 
 // ErrGRPCConnectionClosed is returned when a request is attempted on a gRPC
@@ -261,11 +309,7 @@ func NewDirectRPCConnection(
 		}, nil
 
 	case DirectRPCProtocolGRPC:
-		conn := &GRPCDirectRPCConnection{
-			nodeUrl:          nodeUrl,
-			descriptorsCache: &common.SafeSyncMap[string, *desc.MethodDescriptor]{},
-		}
-		return conn, nil
+		return newGRPCDirectRPCConnection(nodeUrl), nil
 
 	default:
 		return nil, fmt.Errorf("unsupported protocol: %s", protocol)
@@ -605,30 +649,37 @@ func (g *GRPCDirectRPCConnection) SendRequest(
 		return nil, err
 	}
 
-	// Snapshot the connector under the lock rather than dereferencing g.connector
-	// directly. Close() nils it under connMu while requests may be in flight, and
-	// an unguarded read raced that write straight into a nil dereference — which
-	// takes the whole process down, every chain on the pod with it (MAG-2808).
+	// Hold connMu in read mode across the whole checkout, not just the field read.
+	// A bare `g.connector.GetRpc(...)` raced Close()'s write straight into a nil
+	// dereference, which takes the whole process down and every chain on the pod
+	// with it — but snapshotting the pointer alone is not enough either: it keeps
+	// the pointer alive without keeping the pool alive, so Close could still drain
+	// the connector in the gap before GetRpc reached it (MAG-2808).
 	//
-	// The snapshot also fixes a second, subtler hazard: `defer g.connector.X()`
-	// re-reads the field at function EXIT, so a Close landing mid-RPC panicked on
-	// the way out even when the initial read had succeeded. Returning the pooled
-	// conn to the same connector we borrowed it from is the correct behaviour
-	// independently of the race.
+	// Keeping the read lock until GetRpc returns closes that gap. Close blocks on
+	// the write lock until the checkout finishes, and by then GRPCConnector has
+	// incremented usedClients, which makes its own Close wait for the ReturnRpc
+	// below. The borrowed conn is therefore valid for the entire request. GetRpc
+	// honours ctx, so this bounds Close by the caller's deadline rather than
+	// indefinitely.
 	g.connMu.RLock()
 	connector := g.connector
-	g.connMu.RUnlock()
-
 	if connector == nil {
+		g.connMu.RUnlock()
 		return nil, ErrGRPCConnectionClosed
 	}
-
-	// Get gRPC connection from pool
 	conn, err := connector.GetRpc(ctx, true)
+	g.connMu.RUnlock()
+
 	if err != nil {
 		return nil, utils.LavaFormatError("gRPC get connection failed", err,
 			utils.LogAttr("url", g.nodeUrl.Url))
 	}
+
+	// Return the conn to the same connector that issued it. Go evaluates and saves
+	// a deferred call's receiver when the defer statement runs, so this pins the
+	// local — the hazard in `defer g.connector.ReturnRpc(conn)` was the second
+	// unguarded read of the field here at registration time, not a re-read at exit.
 	defer connector.ReturnRpc(conn)
 
 	// Build metadata context from headers
@@ -716,6 +767,13 @@ func (g *GRPCDirectRPCConnection) ensureInitialized(ctx context.Context) error {
 	g.initMu.Lock()
 	defer g.initMu.Unlock()
 
+	// Re-check closed now that we hold initMu. The load above is only a fast path:
+	// Close may have run in full while we waited here, and initializing behind it
+	// would publish a connector nobody is left to tear down.
+	if g.closed.Load() {
+		return ErrGRPCConnectionClosed
+	}
+
 	// Double-check after acquiring lock
 	if g.initialized.Load() {
 		return g.initErr
@@ -753,7 +811,11 @@ func (g *GRPCDirectRPCConnection) initialize(ctx context.Context) error {
 		connectorNodeUrl.AuthConfig.UseTLS = true
 	}
 
-	connector, err := chainproxy.NewGRPCConnector(ctx, 10, connectorNodeUrl)
+	newConnector := g.newConnector
+	if newConnector == nil {
+		newConnector = newGRPCConnector
+	}
+	connector, err := newConnector(ctx, 10, connectorNodeUrl)
 	if err != nil {
 		return utils.LavaFormatError("failed to create gRPC connector", err,
 			utils.LogAttr("url", g.nodeUrl.Url))
@@ -762,7 +824,18 @@ func (g *GRPCDirectRPCConnection) initialize(ctx context.Context) error {
 	// Publish under connMu: this write is serialized against other initializers by
 	// initMu, but Close() guards the same field with connMu only — so without this
 	// the two had no lock in common and raced on g.connector outright.
+	//
+	// Constructing the connector can take a while (NewGRPCConnector dials), so
+	// re-check closed while holding connMu before installing it. Close waits on
+	// initMu and would tear this connector down anyway, but bailing here means a
+	// connection closed mid-construction never sets up a descriptor source it will
+	// not use, and never leaves a dialed pool alive for the length of that setup.
 	g.connMu.Lock()
+	if g.closed.Load() {
+		g.connMu.Unlock()
+		connector.Close()
+		return ErrGRPCConnectionClosed
+	}
 	g.connector = connector
 	g.connMu.Unlock()
 
@@ -1046,24 +1119,35 @@ func (g *GRPCDirectRPCConnection) GetProtocol() DirectRPCProtocol {
 }
 
 func (g *GRPCDirectRPCConnection) Close() error {
-	// Mark closed BEFORE taking the lock so a racing ensureInitialized cannot slip
-	// a freshly built connector in behind us. A request that gets past this point
-	// still holds a valid connector snapshot; GetRpc/ReturnRpc on a closing
-	// connector degrade to an error rather than a panic, which is the intended
-	// failure mode — the relay then fails over.
+	// 1. Publish the intent first, so ensureInitialized turns away every request
+	//    that has not yet started initializing.
 	g.closed.Store(true)
 
+	// 2. Wait out any initialization already in flight. Setting closed does not
+	//    stop an initializer that is already past its own check, and that
+	//    initializer still writes registry/codec/descriptorsCache — fields with no
+	//    lock of their own. Taking initMu makes those writes strictly happen before
+	//    the teardown below instead of racing it; the initializer either bails at
+	//    its closed re-check or publishes a connector we then tear down here.
+	g.initMu.Lock()
+	defer g.initMu.Unlock()
+
+	// 3. Detach under connMu. The write lock waits for every in-flight pool
+	//    checkout to finish, so once it is acquired no GetRpc can be running, and
+	//    once the field is nil none can start.
 	g.connMu.Lock()
-	defer g.connMu.Unlock()
+	connector := g.connector
+	g.connector = nil
+	g.registry = nil
+	g.codec = nil
+	g.connMu.Unlock()
 
-	if g.connector != nil {
-		g.connector.Close()
-		g.connector = nil
-	}
-
-	if g.registry != nil {
-		// Registry cleanup if needed
-		g.registry = nil
+	// 4. Drain outside connMu. GRPCConnector.Close blocks until every borrowed
+	//    client has been handed back, which can take as long as the requests
+	//    holding them; holding connMu across that would stall new requests instead
+	//    of letting them fail fast with ErrGRPCConnectionClosed.
+	if connector != nil {
+		connector.Close()
 	}
 
 	return nil

--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -179,7 +179,19 @@ type GRPCDirectRPCConnection struct {
 	initialized atomic.Bool
 	initMu      sync.Mutex
 	initErr     error
+
+	// closed is set by Close and never cleared: a closed connection stays closed.
+	// Without it, Close leaves `initialized` true with a nil connector, so
+	// ensureInitialized short-circuits and SendRequest walks into the nil — and in
+	// the not-yet-initialized case it would instead silently resurrect the
+	// connection by building a fresh connector (MAG-2808).
+	closed atomic.Bool
 }
+
+// ErrGRPCConnectionClosed is returned when a request is attempted on a gRPC
+// direct connection that has been closed. Callers should treat it as a normal
+// relay failure and fail over, not as a fatal condition.
+var ErrGRPCConnectionClosed = errors.New("gRPC connection is closed")
 
 // grpcConnectorInterface abstracts GRPCConnector for testing
 type grpcConnectorInterface interface {
@@ -593,13 +605,31 @@ func (g *GRPCDirectRPCConnection) SendRequest(
 		return nil, err
 	}
 
+	// Snapshot the connector under the lock rather than dereferencing g.connector
+	// directly. Close() nils it under connMu while requests may be in flight, and
+	// an unguarded read raced that write straight into a nil dereference — which
+	// takes the whole process down, every chain on the pod with it (MAG-2808).
+	//
+	// The snapshot also fixes a second, subtler hazard: `defer g.connector.X()`
+	// re-reads the field at function EXIT, so a Close landing mid-RPC panicked on
+	// the way out even when the initial read had succeeded. Returning the pooled
+	// conn to the same connector we borrowed it from is the correct behaviour
+	// independently of the race.
+	g.connMu.RLock()
+	connector := g.connector
+	g.connMu.RUnlock()
+
+	if connector == nil {
+		return nil, ErrGRPCConnectionClosed
+	}
+
 	// Get gRPC connection from pool
-	conn, err := g.connector.GetRpc(ctx, true)
+	conn, err := connector.GetRpc(ctx, true)
 	if err != nil {
 		return nil, utils.LavaFormatError("gRPC get connection failed", err,
 			utils.LogAttr("url", g.nodeUrl.Url))
 	}
-	defer g.connector.ReturnRpc(conn)
+	defer connector.ReturnRpc(conn)
 
 	// Build metadata context from headers
 	metadataMap := make(map[string]string)
@@ -670,6 +700,15 @@ func (g *GRPCDirectRPCConnection) SendRequest(
 // ensureInitialized performs lazy initialization of the gRPC connection.
 // This includes creating the connection pool and setting up descriptor sources.
 func (g *GRPCDirectRPCConnection) ensureInitialized(ctx context.Context) error {
+	// A closed connection must never lazily re-initialize itself. Close() does not
+	// clear `initialized`, so a connection closed AFTER init short-circuits below
+	// and is caught by the nil-connector check in SendRequest; but one closed
+	// BEFORE its first request would otherwise build a fresh connector here and
+	// silently come back to life (MAG-2808).
+	if g.closed.Load() {
+		return ErrGRPCConnectionClosed
+	}
+
 	if g.initialized.Load() {
 		return g.initErr
 	}
@@ -719,7 +758,13 @@ func (g *GRPCDirectRPCConnection) initialize(ctx context.Context) error {
 		return utils.LavaFormatError("failed to create gRPC connector", err,
 			utils.LogAttr("url", g.nodeUrl.Url))
 	}
+
+	// Publish under connMu: this write is serialized against other initializers by
+	// initMu, but Close() guards the same field with connMu only — so without this
+	// the two had no lock in common and raced on g.connector outright.
+	g.connMu.Lock()
 	g.connector = connector
+	g.connMu.Unlock()
 
 	// Initialize descriptor cache
 	g.descriptorsCache = &common.SafeSyncMap[string, *desc.MethodDescriptor]{}
@@ -1001,6 +1046,13 @@ func (g *GRPCDirectRPCConnection) GetProtocol() DirectRPCProtocol {
 }
 
 func (g *GRPCDirectRPCConnection) Close() error {
+	// Mark closed BEFORE taking the lock so a racing ensureInitialized cannot slip
+	// a freshly built connector in behind us. A request that gets past this point
+	// still holds a valid connector snapshot; GetRpc/ReturnRpc on a closing
+	// connector degrade to an error rather than a panic, which is the intended
+	// failure mode — the relay then fails over.
+	g.closed.Store(true)
+
 	g.connMu.Lock()
 	defer g.connMu.Unlock()
 

--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -245,17 +245,18 @@ func newGRPCDirectRPCConnection(nodeUrl common.NodeUrl) *GRPCDirectRPCConnection
 	}
 }
 
-// grpcConnectorFactory mirrors chainproxy.NewGRPCConnector. It completes the seam
-// grpcConnectorInterface already opens: without it, reaching initialize() in a test
-// means dialing a real node.
-type grpcConnectorFactory func(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error)
+// grpcConnectorFactory mirrors chainproxy.NewGRPCConnector, including its two
+// contexts: lifetimeCtx owns the pool, dialCtx bounds only the initial blocking
+// dial. It completes the seam grpcConnectorInterface already opens — without it,
+// reaching initialize() in a test means dialing a real node.
+type grpcConnectorFactory func(lifetimeCtx, dialCtx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error)
 
 // newGRPCConnector is the production factory. It returns an explicit nil interface
 // on failure: returning the (*GRPCConnector)(nil) that NewGRPCConnector hands back
 // alongside an error would produce a non-nil interface holding a nil pointer, and
 // every downstream nil check would silently pass.
-func newGRPCConnector(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
-	connector, err := chainproxy.NewGRPCConnector(ctx, nConns, nodeUrl)
+func newGRPCConnector(lifetimeCtx, dialCtx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
+	connector, err := chainproxy.NewGRPCConnector(lifetimeCtx, dialCtx, nConns, nodeUrl)
 	if err != nil {
 		return nil, err
 	}
@@ -866,13 +867,18 @@ func (g *GRPCDirectRPCConnection) initialize(ctx context.Context) error {
 	if newConnector == nil {
 		newConnector = newGRPCConnector
 	}
-	// g.connectorCtx, NOT ctx: the argument is this relay's context and would make
-	// the pool die with this relay (MAG-2808, see newGRPCDirectRPCConnection). The
-	// dial is still bounded — createConnection caps every attempt and gives up
-	// after MaximumNumberOfParallelConnectionsAttempts — and Close cancels
-	// g.connectorCtx, so a teardown racing this call aborts it rather than waiting
-	// it out.
-	connector, err := newConnector(g.connectorCtx, 10, connectorNodeUrl)
+	// The two contexts are the whole point of MAG-2808's second half:
+	//
+	//	g.connectorCtx  owns the pool. The relay's context here is what tore the
+	//	                connector down the moment that relay returned; Close cancels
+	//	                this one instead, so a teardown racing this call aborts it
+	//	                rather than waiting it out.
+	//	ctx             is this relay's, and bounds only the blocking dial below.
+	//	                Without it the caller waits out createConnection's own retry
+	//	                budget instead of its own deadline — and because initMu is
+	//	                held across this call, every relay queued behind waits too,
+	//	                which delays failover for all of them.
+	connector, err := newConnector(g.connectorCtx, ctx, 10, connectorNodeUrl)
 	if err != nil {
 		return utils.LavaFormatError("failed to create gRPC connector", err,
 			utils.LogAttr("url", g.nodeUrl.Url))

--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -169,8 +169,10 @@ type WebSocketDirectRPCConnection struct {
 // Lock order is initMu -> connMu. connMu is never held while acquiring initMu.
 //
 //	initMu  serializes lazy initialization against itself and against Close, so
-//	        registry/codec/descriptorsCache are never written while Close tears
-//	        them down. Those fields have no lock of their own.
+//	        that once Close returns no initializer is still running: one already
+//	        in flight has had its fate decided (it bails at the closed re-check
+//	        under connMu and tears its own connector down) before Close's caller
+//	        moves on.
 //	connMu  guards the connector field. Requests hold it in read mode for the
 //	        whole pool checkout, which turns "pick a connector" and "borrow one of
 //	        its clients" into one step that Close must wait behind.
@@ -185,9 +187,13 @@ type GRPCDirectRPCConnection struct {
 	connector grpcConnectorInterface
 	connMu    sync.RWMutex
 
+	// connectorCtx bounds the pooled connector's life to THIS connection's, and
+	// connectorCancel is what ends it — see newGRPCDirectRPCConnection for why it
+	// cannot be the relay's context (MAG-2808).
+	connectorCtx    context.Context
+	connectorCancel context.CancelFunc
+
 	// Descriptor handling
-	registry         *dyncodec.Registry
-	codec            *dyncodec.Codec
 	descriptorsCache *common.SafeSyncMap[string, *desc.MethodDescriptor]
 
 	// Initialization state
@@ -212,10 +218,29 @@ type GRPCDirectRPCConnection struct {
 // newGRPCDirectRPCConnection builds a gRPC connection with its descriptor cache in
 // place. The cache is a pointer with no lazy initialization, so every construction
 // site has to set it or the first descriptor lookup dereferences nil.
+//
+// It also gives the connection its own context, which is the connector's lifetime
+// (MAG-2808). chainproxy.NewGRPCConnector treats the context it is handed as
+// exactly that: addClientsAsynchronouslyGrpc ends with `go connectorLoop(ctx)`,
+// and connectorLoop is `<-ctx.Done(); connector.Close()`. Because the pool is
+// built lazily inside the FIRST relay, passing that relay's context down bound
+// the pool's life to one request — the connector was torn down the moment the
+// relay that happened to initialize it returned.
+//
+// That used to be merely wasteful: Close was a pool drain, and the next GetRpc
+// silently re-dialled, costing a reconnect per relay. Once Close became permanent
+// it turned terminal — every subsequent checkout returns ErrGRPCConnectorClosed
+// and the refill paths discard the dials that would have healed it, while
+// endpoint.DirectConnections caches this object for the whole pairing. The
+// context is deliberately rooted at Background rather than at any caller's:
+// re-parenting it on a context this connection does not own is the bug.
 func newGRPCDirectRPCConnection(nodeUrl common.NodeUrl) *GRPCDirectRPCConnection {
+	connectorCtx, connectorCancel := context.WithCancel(context.Background())
 	return &GRPCDirectRPCConnection{
 		nodeUrl:          nodeUrl,
 		descriptorsCache: &common.SafeSyncMap[string, *desc.MethodDescriptor]{},
+		connectorCtx:     connectorCtx,
+		connectorCancel:  connectorCancel,
 	}
 }
 
@@ -815,7 +840,13 @@ func (g *GRPCDirectRPCConnection) initialize(ctx context.Context) error {
 	if newConnector == nil {
 		newConnector = newGRPCConnector
 	}
-	connector, err := newConnector(ctx, 10, connectorNodeUrl)
+	// g.connectorCtx, NOT ctx: the argument is this relay's context and would make
+	// the pool die with this relay (MAG-2808, see newGRPCDirectRPCConnection). The
+	// dial is still bounded — createConnection caps every attempt and gives up
+	// after MaximumNumberOfParallelConnectionsAttempts — and Close cancels
+	// g.connectorCtx, so a teardown racing this call aborts it rather than waiting
+	// it out.
+	connector, err := newConnector(g.connectorCtx, 10, connectorNodeUrl)
 	if err != nil {
 		return utils.LavaFormatError("failed to create gRPC connector", err,
 			utils.LogAttr("url", g.nodeUrl.Url))
@@ -839,8 +870,9 @@ func (g *GRPCDirectRPCConnection) initialize(ctx context.Context) error {
 	g.connector = connector
 	g.connMu.Unlock()
 
-	// Initialize descriptor cache
-	g.descriptorsCache = &common.SafeSyncMap[string, *desc.MethodDescriptor]{}
+	// descriptorsCache is set at construction, not here: re-assigning it would be
+	// an unsynchronized pointer write to a field getMethodDescriptor and
+	// GetCachedMethodDescriptor read without holding initMu.
 
 	// Initialize descriptor source based on config
 	if err := g.initializeDescriptorSource(ctx); err != nil {
@@ -881,7 +913,15 @@ func (g *GRPCDirectRPCConnection) validateURL() error {
 	return nil
 }
 
-// initializeDescriptorSource sets up the descriptor source based on config
+// initializeDescriptorSource validates the configured descriptor source.
+//
+// Neither branch below keeps the loaded registry. Descriptor resolution goes
+// through reflection in getMethodDescriptor on every path, so the load is a
+// config check: a bad descriptor-set-path surfaces here, at initialization,
+// rather than at the first relay. The registry/codec fields that used to hold the
+// result were written here and nil'd in Close but never read anywhere in the
+// package, so they were removed (MAG-2808) along with the locking commentary that
+// claimed to protect them.
 func (g *GRPCDirectRPCConnection) initializeDescriptorSource(ctx context.Context) error {
 	grpcConfig := &g.nodeUrl.GrpcConfig
 	source := grpcConfig.GetDescriptorSource()
@@ -891,24 +931,17 @@ func (g *GRPCDirectRPCConnection) initializeDescriptorSource(ctx context.Context
 		if grpcConfig.DescriptorSetPath == "" {
 			return fmt.Errorf("descriptor-set-path required for file descriptor source")
 		}
-		fileReg, err := dyncodec.NewFileDescriptorSetRegistryFromPath(grpcConfig.DescriptorSetPath)
-		if err != nil {
+		if _, err := dyncodec.NewFileDescriptorSetRegistryFromPath(grpcConfig.DescriptorSetPath); err != nil {
 			return err
 		}
-		g.registry = dyncodec.NewRegistry(fileReg)
-		g.codec = dyncodec.NewCodec(g.registry)
 
 	case common.GrpcDescriptorSourceHybrid:
-		// Will be set up on first connection with hybrid source
-		// For now, try to load file if available
+		// The file half of hybrid mode is optional; only report a path that is set
+		// and unloadable.
 		if grpcConfig.DescriptorSetPath != "" {
-			fileReg, err := dyncodec.NewFileDescriptorSetRegistryFromPath(grpcConfig.DescriptorSetPath)
-			if err != nil {
+			if _, err := dyncodec.NewFileDescriptorSetRegistryFromPath(grpcConfig.DescriptorSetPath); err != nil {
 				utils.LavaFormatWarning("failed to load file descriptors for hybrid mode", err,
 					utils.LogAttr("path", grpcConfig.DescriptorSetPath))
-			} else {
-				g.registry = dyncodec.NewRegistry(fileReg)
-				g.codec = dyncodec.NewCodec(g.registry)
 			}
 		}
 
@@ -1123,29 +1156,37 @@ func (g *GRPCDirectRPCConnection) Close() error {
 	//    that has not yet started initializing.
 	g.closed.Store(true)
 
-	// 2. Wait out any initialization already in flight. Setting closed does not
-	//    stop an initializer that is already past its own check, and that
-	//    initializer still writes registry/codec/descriptorsCache — fields with no
-	//    lock of their own. Taking initMu makes those writes strictly happen before
-	//    the teardown below instead of racing it; the initializer either bails at
-	//    its closed re-check or publishes a connector we then tear down here.
+	// 2. End the connector's lifetime. This is what closing the connection means
+	//    to the pool: connectorLoop is parked on this context and closes the
+	//    connector when it ends, which also releases that goroutine. Doing it
+	//    before taking initMu keeps teardown prompt — an initializer already
+	//    dialing with grpc.WithBlock() aborts on the cancellation instead of making
+	//    step 3 wait out a full dial. Cancel is idempotent, so repeated Close calls
+	//    are fine.
+	g.connectorCancel()
+
+	// 3. Wait out any initialization already in flight. Setting closed does not
+	//    stop an initializer that is already past its own check. Taking initMu
+	//    means that once Close returns, no initialization is still running: the
+	//    initializer either bailed at its closed re-check under connMu, tearing its
+	//    own fresh connector down, or published one that we tear down below.
 	g.initMu.Lock()
 	defer g.initMu.Unlock()
 
-	// 3. Detach under connMu. The write lock waits for every in-flight pool
+	// 4. Detach under connMu. The write lock waits for every in-flight pool
 	//    checkout to finish, so once it is acquired no GetRpc can be running, and
 	//    once the field is nil none can start.
 	g.connMu.Lock()
 	connector := g.connector
 	g.connector = nil
-	g.registry = nil
-	g.codec = nil
 	g.connMu.Unlock()
 
-	// 4. Drain outside connMu. GRPCConnector.Close blocks until every borrowed
+	// 5. Drain outside connMu. GRPCConnector.Close blocks until every borrowed
 	//    client has been handed back, which can take as long as the requests
 	//    holding them; holding connMu across that would stall new requests instead
-	//    of letting them fail fast with ErrGRPCConnectionClosed.
+	//    of letting them fail fast with ErrGRPCConnectionClosed. Closing here
+	//    rather than leaving it to connectorLoop makes the drain synchronous with
+	//    this call; the loop's own Close then finds nothing left to do.
 	if connector != nil {
 		connector.Close()
 	}

--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -196,10 +196,11 @@ type GRPCDirectRPCConnection struct {
 	// Descriptor handling
 	descriptorsCache *common.SafeSyncMap[string, *desc.MethodDescriptor]
 
-	// Initialization state
+	// Initialization state. `initialized` latches on SUCCESS only: a failed
+	// initialize is retried by the next relay rather than replayed from a cached
+	// error, which would strand the connection for the life of the pairing.
 	initialized atomic.Bool
 	initMu      sync.Mutex
-	initErr     error
 
 	// closed is set by Close and never cleared: a closed connection stays closed.
 	// Without it, Close leaves `initialized` true with a nil connector, so
@@ -786,7 +787,7 @@ func (g *GRPCDirectRPCConnection) ensureInitialized(ctx context.Context) error {
 	}
 
 	if g.initialized.Load() {
-		return g.initErr
+		return nil
 	}
 
 	g.initMu.Lock()
@@ -801,12 +802,37 @@ func (g *GRPCDirectRPCConnection) ensureInitialized(ctx context.Context) error {
 
 	// Double-check after acquiring lock
 	if g.initialized.Load() {
-		return g.initErr
+		return nil
 	}
 
-	g.initErr = g.initialize(ctx)
+	// This relay may have spent its whole budget queued behind another
+	// initializer's dial. Starting a fresh one on a context that is already spent
+	// would hold initMu for a full dial budget while every relay behind us waits,
+	// so fail this one and leave the attempt to a relay that still has time. This
+	// is what keeps the retry below from turning a dead endpoint into a serialized
+	// dial storm.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if err := g.initialize(ctx); err != nil {
+		// Deliberately NOT latched. `initialized` used to be stored regardless of
+		// outcome, with the error cached in an initErr field and replayed to every
+		// later request — so a node that happened to be down when the FIRST relay
+		// arrived poisoned the connection permanently, and endpoint.DirectConnections
+		// caches this object until the pairing is rebuilt. Same "dead until the
+		// pairing changes" shape as the connector-lifetime bug (MAG-2808).
+		//
+		// A failed dial is transient, so the next relay retries it. Every error path
+		// in initialize() leaves no connector installed — the one that dials
+		// successfully and then finds the connection closed tears its own connector
+		// down — so retrying cannot leak a pool or publish twice. Taking a genuinely
+		// dead endpoint out of rotation is consumer_session_manager's job (endpoint
+		// health, connection refusals, probe re-enable), not a latch here.
+		return err
+	}
 	g.initialized.Store(true)
-	return g.initErr
+	return nil
 }
 
 // initialize performs the actual initialization


### PR DESCRIPTION
# Description

Closes: N/A — tracked in Jira, not a GitHub issue.

A gRPC relay racing (or following) `Close()` dereferenced a nil connector and took the **whole process** down — every chain served by that pod, not just the gRPC one. Split out of MAG-2332 as its Bug 2; it is a DFNS Phase 2 blocker (Sui is the only gRPC chain in DFNS scope).

**Reported as one unguarded read. The connection had no coherent lifecycle at all.**

| # | Site | Problem |
| --- | --- | --- |
| 1 | `SendRequest` — `g.connector.GetRpc` | Unguarded read. `Close()` nils the field under `connMu` and does **not** clear `initialized`, so `ensureInitialized` short-circuits and the request walks into the nil. **This is the reported panic.** |
| 2 | `SendRequest` — `defer g.connector.ReturnRpc(conn)` | A *second* unguarded read of the field, at the point the `defer` statement executes. Same nil, one line later. |
| 3 | `initialize()` — `g.connector = connector` | Published under `initMu`, while `Close()` guards the same field with `connMu`. **No lock in common** — the two raced outright. |
| 4 | `ensureInitialized` / `Close` ordering | `closed` was read *before* `initMu` was taken. An initializer already past that check could publish its connector **after** `Close` had seen a nil connector and returned — a live pool behind a closed connection. |
| 5 | `GRPCConnector` (chainproxy) | No closed state at all, unlike the HTTP `Connector` beside it. `GetRpc` looped on an empty pool ignoring context cancellation, and every refill path could repopulate a pool `Close` had just drained. |
| 6 | `initialize()` — the connector's lifetime | The pool is built lazily inside the **first relay**, so `NewGRPCConnector` was handed that relay's context — and it treats its context as the connector's *lifetime*, not a dial deadline: `addClientsAsynchronouslyGrpc` ends with `go connectorLoop(ctx)`, which is `<-ctx.Done(); connector.Close()`. `sendGRPCRelay`'s own `defer cancel()` therefore closed the connector on **every** request. |
| 7 | `ensureInitialized` — cached init failure | `initialized` was stored `true` whatever `initialize()` returned, with the error cached in an `initErr` field and replayed forever. A node that was merely down when the first relay arrived poisoned the connection permanently. |

Problems 4 and 5 were found in review of the first pass; they are why a `closed` flag plus a pointer snapshot was not enough. Problem 6 was found by @AnnaR-prog in review of the second pass, and it is why the `closed` flag alone was not enough either. Problem 7 was found while fixing 6 — it is the same defect shape reached by a different route, and it is fixed here because it lands on the same function.

### Why problem 6 mattered

It was latent on `main` and survivable there: `Close()` was effectively a pool drain, and the next `GetRpc` spawned `increaseNumberOfClients` and silently refilled it, so the bug showed up only as a re-dial per relay. The `closed` flag makes the same teardown **terminal** — `GetRpc` returns `ErrGRPCConnectorClosed` forever and the refill paths discard every dial that would have healed it. `GRPCDirectRPCConnection` does not notice (its own `closed` is false, `initialized` is true), and `endpoint.DirectConnections[0]` is cached for the whole pairing, so the endpoint stays dead until the pairing is rebuilt. That is the direct gRPC path — i.e. Sui and the DFNS Phase 2 scope this PR names as its motivation.

The `chainlib` chain-proxy path was never affected: `NewGrpcChainProxy` passes a long-lived startup context, so its `connectorLoop` does not fire in normal operation.

## The fix

**Lock order is `initMu` -> `connMu`**, documented on the type. After `Close` returns: the connector is nil, no later write can install one, every borrowed client has been handed back, and further requests get `ErrGRPCConnectionClosed`.

- **The connector's lifetime and its dial deadline are now separate contexts.** `NewGRPCConnector(lifetimeCtx, dialCtx, ...)`. The root defect was that one `ctx` parameter meant three things inside it — the blocking dial's deadline, the async fill's dial deadline, and the connector's lifetime — and problem 6 was conflating the first with the third. `lifetimeCtx` owns the pool: `connectorLoop` parks on it, and the async fill dials under it, because that fill is background work which should finish rather than work belonging to whoever called. `dialCtx` bounds only the initial blocking dial, which runs in the caller's critical path.
- **The connection owns its lifetime context.** `newGRPCDirectRPCConnection` creates a `connectorCtx` rooted at `context.Background()`, and `Close()` cancels it. Rooting it at `Background` is deliberate — re-parenting on any caller-supplied context is the bug. `initialize()` passes `(g.connectorCtx, relayCtx)`: it is the one caller that genuinely has two. `chainlib`'s `NewGrpcChainProxy` passes the same startup context twice, which the call site now documents rather than hides.
- **Checkout is a lease, not a snapshot.** `SendRequest` holds `connMu` in read mode for the whole of `GetRpc`, not just the field read. Copying the pointer keeps the *pointer* alive, not the *pool* behind it — `Close` could still drain the connector in the gap before `GetRpc` reached it. With the lock held, `Close` waits behind the checkout, and by the time it proceeds the connector has counted the borrowed client and its own `Close` drains it.
- **`Close` serializes with in-flight initialization.** It publishes `closed`, cancels `connectorCtx`, then takes `initMu` to wait out any initializer already running, then detaches under `connMu`. The publish in `initialize()` re-checks `closed` under `connMu` and closes the fresh connector rather than installing it. Cancelling *before* taking `initMu` is what keeps teardown prompt: an initializer already inside a `grpc.WithBlock()` dial aborts on the cancellation instead of making `Close` wait out a full dial.
- **`Close` drains outside `connMu`,** so waiting for borrowed clients does not stall new requests; they fail fast instead.
- **Initialization latches on success only.** A failed `initialize()` is retried by the next relay instead of being replayed from a cache, and `initErr` is gone. Retrying is safe: every error path in `initialize()` leaves no connector installed, including the one that dials successfully and then finds the connection closed, which tears its own connector down. Taking a genuinely dead endpoint out of rotation is `consumer_session_manager`'s job — endpoint health, connection refusals, probe re-enable — not a latch here.
- **A relay whose context expired while queued does not start its own dial.** Retrying alone would trade a permanently dead endpoint for a serialized dial storm, since `initialize()` dials with `grpc.WithBlock()` under `initMu` and every waiter would then run a full dial budget on a context that had already expired. `ensureInitialized` checks `ctx.Err()` after acquiring `initMu`, so the queue drains rather than compounding.
- **`GRPCConnector` becomes closed- and context-aware.** `GetRpc` returns `ErrGRPCConnectorClosed`, honours `ctx`, and the fill paths (`addClient`, `increaseNumberOfClients`) drop clients dialed after `Close` instead of resurrecting the pool. `ReturnRpc` drops rather than pools a client handed back to a closing connector. The startup fill's zero-client check also no longer treats an early teardown as a reason to `LavaFormatFatal` the process.

### Cleanups from the second review round

- `registry` and `codec` were written in `initialize` and nil'd in `Close`, but read nowhere in the package. Removed, along with the locking commentary that claimed to protect them. The descriptor-set load stays as a config check, which is all it ever was — resolution goes through reflection in `getMethodDescriptor` on every path.
- `initialize` no longer re-assigns `descriptorsCache`, which `newGRPCDirectRPCConnection` already sets at construction: it was a redundant, unsynchronized pointer write to a field other methods read.
- `GRPCConnector.ReturnRpc` nil-checked `rpc` in the new closed branch but not in the pre-existing path below it. Hoisted to a single check, placed after the `usedClients` decrement that `Close`'s drain depends on.

### Correction to the earlier description of problem 2

An earlier revision of this PR claimed the deferred call re-reads `g.connector` at function *exit*. It does not: Go evaluates and saves a deferred call's receiver when the `defer` statement executes. The hazard was simply a second unguarded read at that point. Keeping the local snapshot is still correct — a pooled conn must go back to the connector that issued it — but the reasoning in the code comments has been fixed to match Go's actual semantics.

## Testing

Gated with channels and barriers rather than sleeps or scheduler luck. **Every regression test below was verified to fail against the previous behaviour** before being kept:

| Test | Reverting the fix produces |
| --- | --- |
| `TestClose_WaitsForPoolCheckout` | `Close returned while a pool checkout was still in flight` |
| `TestClose_DuringCheckout_BorrowedClientIsReturnedOnce` | same, plus the borrowed client is orphaned |
| `TestClose_DuringFirstInitialization_DoesNotPublishConnector` | a live connector installed after `Close` returned |
| `TestInitialization_ConcurrentWithClose_NeverLeaksConnector` | `Expected nil, but got: &fakeGRPCConnector{closed:false}` |
| `TestGRPCConnectorGetRpcHonoursContextCancellation` | **hangs** — test binary killed at the 60s timeout |
| `TestGRPCConnectorRefillAfterCloseIsDropped` | pool refilled after `Close` |
| `TestConnector_OutlivesTheRelayThatInitializedIt` | `connectorLoop ctx.Done` in the log, then `grpc connector is closed` — *"the pool must not die with the relay that built it"* |
| `TestInitialization_FailureIsRetriedNotLatched` | *"a failed initialize must not latch"* |
| `TestInitialization_SpentContextDoesNotQueueAnotherDial` | the queued relay dials anyway — `context.Canceled` not in the error chain |
| `TestInitialization_RelayDeadlineBoundsTheDial` | **12.02s** against a 300ms relay deadline — *"a relay must not wait out the connector's dial budget past its own deadline"* |

### Why the tests did not catch problem 6, and what closes the gap

Every `lavasession` test injects a `fakeGRPCConnector` through the `grpcConnectorFactory` seam, so none of them ever construct a real `GRPCConnector`; the `chainproxy` tests build connectors and call `Close()` directly, never through `connectorLoop`. Neither combination reached `NewGRPCConnector`'s own context handling — the seam that made this code testable is exactly what routed every test around the defect.

- `TestConnector_OutlivesTheRelayThatInitializedIt` runs the **production** factory against a real loopback gRPC server, cancels the relay context the way `sendGRPCRelay` does, and asserts the pool is still usable — then asserts `g.Close()` *does* end it, so the fix cannot degenerate into "never cancel". This is the regression pin, verified failing above.
- `TestGRPCConnectorLifetimeIsItsLifetimeContext` pins the contract itself: `lifetimeCtx` is the connector's life. New coverage rather than a regression pin — nothing exercised this before, which is the point.
- `TestGRPCConnectorDialContextDoesNotEndTheConnector` pins the other half of the split. `dialCtx` is the caller's own context and ends almost immediately; if it reached `connectorLoop` or the async fill, the split would just reintroduce problem 6.
- `TestGRPCConnectorDialContextBoundsTheBlockingDial` pins the deadline at the connector level, as `TestInitialization_RelayDeadlineBoundsTheDial` does end-to-end.
- `TestGRPCConnectorReturnRpcNilStillDecrements` covers the hoisted nil check, pinning that it does not skip the `usedClients` decrement `Close` spins on.

The two windows the first revision documented as untestable are also covered. Both needed `GetRpc` to *succeed*, which a zero-value `*grpc.ClientConn` cannot survive; a `bufconn` loopback server supplies a real one, and the connector-factory seam (completing the abstraction `grpcConnectorInterface` already opened) makes `initialize()` reachable without dialing a node. `TestSendRequest_ReturnsBorrowedClientExactlyOnce` pins that the client goes back to the connector that issued it, exactly once.

Retained from the first pass: close-before-init, close-after-init, idempotent `Close`, and 50 concurrent relays against a `Close` over 20 rounds.

Green under `-race`: `./protocol/lavasession` and `./protocol/chainlib/...` in full, plus `-run 'Test.*Close|TestConnector_|TestInitialization|TestGRPCConnector' -count=20`. Also `go build ./...`, `go vet ./...`, `git diff --check`, and `golangci-lint` output identical to the pre-change baseline (53 issues over `lavasession` + `chainlib` before and after; the three in touched files are pre-existing and on untouched lines).

## Related loose threads (not addressed here)

- The `ERR "got to setValidResponse with nil Reply"` that preceded the original panic is still on main at `protocol/relaycore/results_manager.go:112`. A relay result with nil Reply and no error suggests another path returns `(nil, nil)` on this failure mode.
- `GetRpc` spawns `go increaseNumberOfClients(ctx, ...)` with the *request's* context, so background refills die with the request that triggered them. Same class as problem 6 — background work bounded by a caller — but benign, since the next `GetRpc` retries.

Both left alone deliberately — separate defects, separate changes.

## Jira ticket

Jira ticket: MAG-2808

---

## Author Checklist

I have...

* [ ] read the [contribution guide](https://github.com/magma-Devs/smart-router/blob/main/CONTRIBUTING.md)
* [x] included the correct type prefix in the PR title (`fix`)
* [x] confirmed `!` in the type prefix if API or client breaking change — not breaking, no `!`
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification — MAG-2808
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests — the previously documented coverage gaps are now closed
* [ ] confirmed all CI checks have passed — pending CI run on the rebased head

🤖 Generated with [Claude Code](https://claude.com/claude-code)

