### PR TITLE
fix(smart-router): stop gRPC reconnect from tearing down its own subscription

### DIFF
--- a/protocol/rpcsmartrouter/direct_grpc_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_grpc_subscription_manager.go
@@ -52,6 +52,11 @@ type grpcActiveSubscription struct {
 	// Restoration state
 	restoring atomic.Bool
 
+	// Set once cleanupSubscription has released this subscription's resources. Keyed on
+	// the subscription object rather than on its presence in activeSubscriptions, so
+	// release runs exactly once no matter who reaches cleanup first.
+	cleanedUp atomic.Bool
+
 	// Message sequence counter
 	messageSeq atomic.Uint64
 
@@ -273,29 +278,39 @@ func (dgm *DirectGRPCSubscriptionManager) cleanupLoop(ctx context.Context) {
 	}
 }
 
-// cleanupStaleSubscriptions removes subscriptions with cancelled contexts
+// cleanupStaleSubscriptions removes subscriptions with cancelled contexts.
+//
+// It delegates to cleanupSubscription rather than deleting the entry itself. A partial
+// reap — map delete plus counter, and nothing else — leaves the client channels open,
+// the connection's stream count inflated so the pool cannot scale down, and the idMapper
+// entries live, with no one left to release them: the listener's own cleanup arrives to
+// find the key already gone (MAG-2540).
+//
+// The window is not narrow. removeClientFromSubscription cancels the subscription when
+// its last client leaves and leaves cleanup to the listener, which may be parked in
+// RecvMsg indefinitely — ctx.Done() is only checked between receives — so on a quiet
+// stream this sweep routinely gets there first.
 func (dgm *DirectGRPCSubscriptionManager) cleanupStaleSubscriptions() {
-	dgm.lock.Lock()
-	defer dgm.lock.Unlock()
-
-	var toRemove []string
-	for hashedParams, sub := range dgm.activeSubscriptions {
+	dgm.lock.RLock()
+	var stale []*grpcActiveSubscription
+	for _, sub := range dgm.activeSubscriptions {
 		select {
 		case <-sub.ctx.Done():
-			toRemove = append(toRemove, hashedParams)
+			stale = append(stale, sub)
 		default:
 			// Still active
 		}
 	}
+	dgm.lock.RUnlock()
 
-	for _, hashedParams := range toRemove {
-		delete(dgm.activeSubscriptions, hashedParams)
-		dgm.totalSubscriptions.Add(-1)
+	// Called unlocked: cleanupSubscription takes dgm.lock itself.
+	for _, sub := range stale {
+		dgm.cleanupSubscription(sub.hashedParams, sub)
 	}
 
-	if len(toRemove) > 0 {
+	if len(stale) > 0 {
 		utils.LavaFormatDebug("DirectGRPC: cleaned up stale subscriptions",
-			utils.LogAttr("count", len(toRemove)),
+			utils.LogAttr("count", len(stale)),
 		)
 	}
 }
@@ -623,18 +638,14 @@ func (dgm *DirectGRPCSubscriptionManager) createUpstreamStream(
 	return stream, nil
 }
 
-// listenForUpstreamMessages listens for messages from upstream gRPC stream
-// On an upstream error we hand off to handleUpstreamDisconnect, which either restores the
-// subscription (mutating activeSub in place and spawning a fresh listener) or tears it down.
-// Cleanup must NOT run from this goroutine in that case: it deletes the entry from
-// dgm.activeSubscriptions, closes every client channel and nils connectedClients — so a
-// successful restoration would route into nobody, leak the new upstream stream, and
-// decrement totalSubscriptions a second time when the restarted listener later exits,
-// driving the counter below zero and disabling the max-subscriptions limit (MAG-2540).
+// listenForUpstreamMessages listens for messages from upstream gRPC stream.
 //
-// Cleanup ownership: once reconnectInFlight is set, handleUpstreamDisconnect owns
-// cleanupSubscription on every failure path, so a failed restoration still releases the
-// subscription. This mirrors the contract DirectWSSubscriptionManager already documents.
+// On an upstream error, ownership of the subscription transfers to
+// handleUpstreamDisconnect, which restores it in place or releases it. Cleanup must not
+// also run here: it closes every client channel and nils connectedClients, so a
+// successful restoration would route into nobody and leak the new stream (MAG-2540).
+// Once reconnectInFlight is set, handleUpstreamDisconnect owns cleanup on every failure
+// path — the same contract DirectWSSubscriptionManager documents.
 func (dgm *DirectGRPCSubscriptionManager) listenForUpstreamMessages(
 	ctx context.Context,
 	hashedParams string,
@@ -733,9 +744,13 @@ func (dgm *DirectGRPCSubscriptionManager) handleUpstreamDisconnect(
 ) {
 	// Prevent concurrent restoration.
 	//
-	// Returning here without cleanup is correct: another handleUpstreamDisconnect is
-	// already in flight for this subscription and holds cleanup ownership, so cleaning
-	// up here would tear down a restoration that is still in progress.
+	// Returning here without cleanup is correct: another handleUpstreamDisconnect holds
+	// the latch and owns cleanup for this subscription, so tearing down here would kill a
+	// restoration still in progress. That is only true because the latch is released
+	// before the restarted listener is spawned (see the end of this function) — if it
+	// outlived the hand-off, a handler spawned by that listener would lose the CAS and
+	// return, leaving the subscription registered with no listener, nobody reconnecting,
+	// and an uncancelled ctx that keeps the stale sweep from collecting it.
 	if !activeSub.restoring.CompareAndSwap(false, true) {
 		return
 	}
@@ -745,6 +760,7 @@ func (dgm *DirectGRPCSubscriptionManager) handleUpstreamDisconnect(
 	// that handed off skipped its own deferred cleanup, so every way out of this
 	// function short of a completed restoration must release the subscription — and a
 	// failure path added later gets that for free instead of having to remember it.
+	// cleanupSubscription cancels, so the failure paths below do not.
 	restored := false
 	defer func() {
 		if !restored {
@@ -759,7 +775,6 @@ func (dgm *DirectGRPCSubscriptionManager) handleUpstreamDisconnect(
 	// Reconnect pool
 	if err := activeSub.upstreamPool.ReconnectWithBackoff(ctx); err != nil {
 		utils.LavaFormatWarning("DirectGRPC: failed to reconnect", err)
-		activeSub.cancel()
 		return
 	}
 
@@ -767,7 +782,6 @@ func (dgm *DirectGRPCSubscriptionManager) handleUpstreamDisconnect(
 	newConn, err := activeSub.upstreamPool.GetConnectionForStream(ctx)
 	if err != nil {
 		utils.LavaFormatWarning("DirectGRPC: failed to get new connection", err)
-		activeSub.cancel()
 		return
 	}
 
@@ -781,7 +795,6 @@ func (dgm *DirectGRPCSubscriptionManager) handleUpstreamDisconnect(
 	)
 	if err != nil {
 		utils.LavaFormatWarning("DirectGRPC: failed to create new stream", err)
-		activeSub.cancel()
 		return
 	}
 
@@ -806,50 +819,80 @@ func (dgm *DirectGRPCSubscriptionManager) handleUpstreamDisconnect(
 	// so the cleanup defer above must stand down.
 	restored = true
 
+	// Release the latch BEFORE the hand-off, not on the way out via defer: if the new
+	// listener errors immediately, its handler has to win the CAS. The trailing defer
+	// is then a no-op.
+	activeSub.restoring.Store(false)
+
 	// Restart listener
 	go dgm.listenForUpstreamMessages(activeSub.ctx, hashedParams, activeSub)
 }
 
-// cleanupSubscription removes a subscription and notifies clients
-// Idempotent: cleaning up a subscription that is already gone is a no-op, matching
-// DirectWSSubscriptionManager.cleanupSubscription. Without the existence check the
-// counter decrement was unconditional while the map delete was not, so a second call
-// for the same subscription drove totalSubscriptions below zero — which is what
-// disables the max-subscriptions limit (MAG-2540).
+// cleanupSubscription releases a subscription: deregisters it, cancels it, closes every
+// client channel, returns the stream slot to the pool and drops the per-client tracking
+// and ID mappings.
 //
-// That is not hypothetical even after the ownership fix: cleanupStaleSubscriptions
-// removes any subscription whose ctx is done, and handleUpstreamDisconnect's failure
-// paths call activeSub.cancel() BEFORE cleaning up. A sweep landing in that window
-// would decrement, and this function would decrement again. The guard, not the call
-// ordering, is what makes that safe.
+// Two guards, answering two different questions (MAG-2540):
 //
-// The early return covers more than the counter: NotifyStreamRemoved and
-// RemoveMapping are also not safe to run twice for one subscription.
+//   - cleanedUp makes the release run exactly once per subscription. Guarding on the map
+//     entry instead would fix the counter and create a leak: a caller arriving after the
+//     entry is gone would skip closing the client channels too.
+//   - The map entry is only removed when this is still the registered subscription.
+//     hashedParams is deterministic — a client re-subscribing to the same method reuses
+//     the key — so a handler parked in ReconnectWithBackoff must not come back seconds
+//     later and evict its own successor.
+//
+// Cancellation lives here, not at the call sites, so the stale sweep can never observe a
+// cancelled-but-unreleased subscription. Same placement as
+// DirectWSSubscriptionManager.cleanupSubscription.
 func (dgm *DirectGRPCSubscriptionManager) cleanupSubscription(hashedParams string, activeSub *grpcActiveSubscription) {
-	dgm.lock.Lock()
-	if _, found := dgm.activeSubscriptions[hashedParams]; !found {
-		dgm.lock.Unlock()
+	if !activeSub.cleanedUp.CompareAndSwap(false, true) {
 		return
 	}
-	delete(dgm.activeSubscriptions, hashedParams)
+
+	dgm.lock.Lock()
+	if current, found := dgm.activeSubscriptions[hashedParams]; found && current == activeSub {
+		delete(dgm.activeSubscriptions, hashedParams)
+	}
+	// Decremented per subscription object, not per map entry: createNewSubscription
+	// increments once when it registers, and the cleanedUp latch above makes this the
+	// matching decrement. Gating it on the identity check instead would strand the slot
+	// of any subscription that left the map by another route.
 	dgm.totalSubscriptions.Add(-1)
 	dgm.lock.Unlock()
 
-	// Close client channels
+	activeSub.cancel()
+
+	// Close client channels, and snapshot what the release below needs — upstreamConnection
+	// is written under this lock by handleUpstreamDisconnect.
 	activeSub.lock.Lock()
-	for _, sender := range activeSub.connectedClients {
+	clientKeys := make([]string, 0, len(activeSub.connectedClients))
+	for clientKey, sender := range activeSub.connectedClients {
 		sender.Close()
+		clientKeys = append(clientKeys, clientKey)
 	}
 	activeSub.connectedClients = nil
+	routerIDs := make([]string, 0, len(activeSub.clientRouterIDs))
+	for _, routerID := range activeSub.clientRouterIDs {
+		routerIDs = append(routerIDs, routerID)
+	}
+	upstreamConnection := activeSub.upstreamConnection
 	activeSub.lock.Unlock()
 
+	// Untrack per client, or checkClientSubscriptionLimit keeps counting a dead
+	// subscription and ratchets the client toward its cap. Outside activeSub.lock —
+	// untrackClientSubscription takes dgm.lock.
+	for _, clientKey := range clientKeys {
+		dgm.untrackClientSubscription(clientKey, hashedParams)
+	}
+
 	// Return connection to pool
-	if activeSub.upstreamConnection != nil {
-		activeSub.upstreamPool.NotifyStreamRemoved(activeSub.upstreamConnection)
+	if upstreamConnection != nil {
+		activeSub.upstreamPool.NotifyStreamRemoved(upstreamConnection)
 	}
 
 	// Clean up ID mappings
-	for _, routerID := range activeSub.clientRouterIDs {
+	for _, routerID := range routerIDs {
 		dgm.idMapper.RemoveMapping(routerID)
 	}
 

--- a/protocol/rpcsmartrouter/direct_grpc_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_grpc_subscription_manager.go
@@ -741,6 +741,17 @@ func (dgm *DirectGRPCSubscriptionManager) handleUpstreamDisconnect(
 	}
 	defer activeSub.restoring.Store(false)
 
+	// Cleanup ownership, expressed once rather than at each early return. The listener
+	// that handed off skipped its own deferred cleanup, so every way out of this
+	// function short of a completed restoration must release the subscription — and a
+	// failure path added later gets that for free instead of having to remember it.
+	restored := false
+	defer func() {
+		if !restored {
+			dgm.cleanupSubscription(hashedParams, activeSub)
+		}
+	}()
+
 	utils.LavaFormatInfo("DirectGRPC: attempting to restore subscription",
 		utils.LogAttr("hashedParams", utils.ToHexString(hashedParams)),
 	)
@@ -749,9 +760,6 @@ func (dgm *DirectGRPCSubscriptionManager) handleUpstreamDisconnect(
 	if err := activeSub.upstreamPool.ReconnectWithBackoff(ctx); err != nil {
 		utils.LavaFormatWarning("DirectGRPC: failed to reconnect", err)
 		activeSub.cancel()
-		// Restoration failed: this goroutine owns cleanup, because the listener that
-		// handed off skipped its own deferred cleanup (MAG-2540).
-		dgm.cleanupSubscription(hashedParams, activeSub)
 		return
 	}
 
@@ -760,7 +768,6 @@ func (dgm *DirectGRPCSubscriptionManager) handleUpstreamDisconnect(
 	if err != nil {
 		utils.LavaFormatWarning("DirectGRPC: failed to get new connection", err)
 		activeSub.cancel()
-		dgm.cleanupSubscription(hashedParams, activeSub)
 		return
 	}
 
@@ -775,7 +782,6 @@ func (dgm *DirectGRPCSubscriptionManager) handleUpstreamDisconnect(
 	if err != nil {
 		utils.LavaFormatWarning("DirectGRPC: failed to create new stream", err)
 		activeSub.cancel()
-		dgm.cleanupSubscription(hashedParams, activeSub)
 		return
 	}
 
@@ -796,13 +802,35 @@ func (dgm *DirectGRPCSubscriptionManager) handleUpstreamDisconnect(
 		utils.LogAttr("hashedParams", utils.ToHexString(hashedParams)),
 	)
 
+	// Restoration completed — the new listener now owns this subscription's lifecycle,
+	// so the cleanup defer above must stand down.
+	restored = true
+
 	// Restart listener
 	go dgm.listenForUpstreamMessages(activeSub.ctx, hashedParams, activeSub)
 }
 
 // cleanupSubscription removes a subscription and notifies clients
+// Idempotent: cleaning up a subscription that is already gone is a no-op, matching
+// DirectWSSubscriptionManager.cleanupSubscription. Without the existence check the
+// counter decrement was unconditional while the map delete was not, so a second call
+// for the same subscription drove totalSubscriptions below zero — which is what
+// disables the max-subscriptions limit (MAG-2540).
+//
+// That is not hypothetical even after the ownership fix: cleanupStaleSubscriptions
+// removes any subscription whose ctx is done, and handleUpstreamDisconnect's failure
+// paths call activeSub.cancel() BEFORE cleaning up. A sweep landing in that window
+// would decrement, and this function would decrement again. The guard, not the call
+// ordering, is what makes that safe.
+//
+// The early return covers more than the counter: NotifyStreamRemoved and
+// RemoveMapping are also not safe to run twice for one subscription.
 func (dgm *DirectGRPCSubscriptionManager) cleanupSubscription(hashedParams string, activeSub *grpcActiveSubscription) {
 	dgm.lock.Lock()
+	if _, found := dgm.activeSubscriptions[hashedParams]; !found {
+		dgm.lock.Unlock()
+		return
+	}
 	delete(dgm.activeSubscriptions, hashedParams)
 	dgm.totalSubscriptions.Add(-1)
 	dgm.lock.Unlock()

--- a/protocol/rpcsmartrouter/direct_grpc_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_grpc_subscription_manager.go
@@ -624,13 +624,27 @@ func (dgm *DirectGRPCSubscriptionManager) createUpstreamStream(
 }
 
 // listenForUpstreamMessages listens for messages from upstream gRPC stream
+// On an upstream error we hand off to handleUpstreamDisconnect, which either restores the
+// subscription (mutating activeSub in place and spawning a fresh listener) or tears it down.
+// Cleanup must NOT run from this goroutine in that case: it deletes the entry from
+// dgm.activeSubscriptions, closes every client channel and nils connectedClients — so a
+// successful restoration would route into nobody, leak the new upstream stream, and
+// decrement totalSubscriptions a second time when the restarted listener later exits,
+// driving the counter below zero and disabling the max-subscriptions limit (MAG-2540).
+//
+// Cleanup ownership: once reconnectInFlight is set, handleUpstreamDisconnect owns
+// cleanupSubscription on every failure path, so a failed restoration still releases the
+// subscription. This mirrors the contract DirectWSSubscriptionManager already documents.
 func (dgm *DirectGRPCSubscriptionManager) listenForUpstreamMessages(
 	ctx context.Context,
 	hashedParams string,
 	activeSub *grpcActiveSubscription,
 ) {
+	reconnectInFlight := false
 	defer func() {
-		dgm.cleanupSubscription(hashedParams, activeSub)
+		if !reconnectInFlight {
+			dgm.cleanupSubscription(hashedParams, activeSub)
+		}
 	}()
 
 	msgFactory := dynamic.NewMessageFactoryWithDefaults()
@@ -658,7 +672,9 @@ func (dgm *DirectGRPCSubscriptionManager) listenForUpstreamMessages(
 					err,
 					utils.LogAttr("hashedParams", utils.ToHexString(hashedParams)),
 				)
-				// Attempt reconnection
+				// Hand ownership of this subscription to the reconnect goroutine —
+				// including responsibility for cleanup if restoration fails.
+				reconnectInFlight = true
 				go dgm.handleUpstreamDisconnect(ctx, hashedParams, activeSub)
 				return
 			}
@@ -715,7 +731,11 @@ func (dgm *DirectGRPCSubscriptionManager) handleUpstreamDisconnect(
 	hashedParams string,
 	activeSub *grpcActiveSubscription,
 ) {
-	// Prevent concurrent restoration
+	// Prevent concurrent restoration.
+	//
+	// Returning here without cleanup is correct: another handleUpstreamDisconnect is
+	// already in flight for this subscription and holds cleanup ownership, so cleaning
+	// up here would tear down a restoration that is still in progress.
 	if !activeSub.restoring.CompareAndSwap(false, true) {
 		return
 	}
@@ -729,6 +749,9 @@ func (dgm *DirectGRPCSubscriptionManager) handleUpstreamDisconnect(
 	if err := activeSub.upstreamPool.ReconnectWithBackoff(ctx); err != nil {
 		utils.LavaFormatWarning("DirectGRPC: failed to reconnect", err)
 		activeSub.cancel()
+		// Restoration failed: this goroutine owns cleanup, because the listener that
+		// handed off skipped its own deferred cleanup (MAG-2540).
+		dgm.cleanupSubscription(hashedParams, activeSub)
 		return
 	}
 
@@ -737,6 +760,7 @@ func (dgm *DirectGRPCSubscriptionManager) handleUpstreamDisconnect(
 	if err != nil {
 		utils.LavaFormatWarning("DirectGRPC: failed to get new connection", err)
 		activeSub.cancel()
+		dgm.cleanupSubscription(hashedParams, activeSub)
 		return
 	}
 
@@ -751,6 +775,7 @@ func (dgm *DirectGRPCSubscriptionManager) handleUpstreamDisconnect(
 	if err != nil {
 		utils.LavaFormatWarning("DirectGRPC: failed to create new stream", err)
 		activeSub.cancel()
+		dgm.cleanupSubscription(hashedParams, activeSub)
 		return
 	}
 

--- a/protocol/rpcsmartrouter/direct_grpc_subscription_reconnect_test.go
+++ b/protocol/rpcsmartrouter/direct_grpc_subscription_reconnect_test.go
@@ -1,0 +1,152 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestGRPCManagerWithSub registers one active subscription on a fresh manager and
+// returns both, with totalSubscriptions seeded to 1 so the accounting is observable.
+//
+// The subscription deliberately carries no upstreamConnection and no clients:
+// cleanupSubscription nil-checks the former and range-loops the latter, so this reaches
+// the map-and-counter bookkeeping — which is where MAG-2540's damage lands — without
+// needing a live stream.
+func newTestGRPCManagerWithSub(t *testing.T, ctx context.Context, cancel context.CancelFunc) (*DirectGRPCSubscriptionManager, *grpcActiveSubscription, string) {
+	t.Helper()
+
+	manager := NewDirectGRPCSubscriptionManager(
+		nil,
+		"ETH",
+		"grpc",
+		[]*common.NodeUrl{{Url: "grpc://localhost:9090"}},
+		nil,
+		nil,
+		nil,
+	)
+
+	const hashedParams = "test-hashed-params"
+	activeSub := &grpcActiveSubscription{
+		upstreamPool:     NewUpstreamGRPCPool(&common.NodeUrl{Url: "grpc://127.0.0.1:1"}),
+		hashedParams:     hashedParams,
+		clientRouterIDs:  map[string]string{},
+		connectedClients: map[string]*common.SafeChannelSender[*pairingtypes.RelayReply]{},
+		ctx:              ctx,
+		cancel:           cancel,
+		closeSubChan:     make(chan struct{}),
+	}
+
+	manager.lock.Lock()
+	manager.activeSubscriptions[hashedParams] = activeSub
+	manager.lock.Unlock()
+	manager.totalSubscriptions.Add(1)
+
+	return manager, activeSub, hashedParams
+}
+
+// TestGRPCListenForUpstreamMessages_NormalExitStillCleansUp is the collateral guard for
+// MAG-2540.
+//
+// The fix makes the deferred cleanup conditional on reconnectInFlight. The hazard in
+// that change is the opposite of the bug it fixes: if the flag were ever set on a path
+// that does NOT hand off, the subscription would leak instead of being torn down. Every
+// exit that is not an upstream error must still clean up.
+func TestGRPCListenForUpstreamMessages_NormalExitStillCleansUp(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	manager, activeSub, hashedParams := newTestGRPCManagerWithSub(t, ctx, cancel)
+
+	cancel() // context-done exit: returns before touching the stream or descriptor
+
+	manager.listenForUpstreamMessages(ctx, hashedParams, activeSub)
+
+	manager.lock.Lock()
+	_, stillRegistered := manager.activeSubscriptions[hashedParams]
+	manager.lock.Unlock()
+
+	require.False(t, stillRegistered,
+		"a normal exit must still remove the subscription — the guard is only for hand-offs")
+	require.Equal(t, int64(0), manager.totalSubscriptions.Load(),
+		"a normal exit must still release its slot in the subscription count")
+}
+
+// TestGRPCHandleUpstreamDisconnect_ReconnectFailureCleansUp pins the other half of the
+// MAG-2540 contract: cleanup ownership.
+//
+// Once the listener sets reconnectInFlight it no longer cleans up, so a restoration that
+// FAILS must clean up here instead. Before this fix handleUpstreamDisconnect only called
+// activeSub.cancel() on its failure paths — which was survivable only because the listener
+// unconditionally cleaned up behind it. With the guard in place, that would leak the
+// subscription and its slot in the counter forever.
+func TestGRPCHandleUpstreamDisconnect_ReconnectFailureCleansUp(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	manager, activeSub, hashedParams := newTestGRPCManagerWithSub(t, ctx, cancel)
+
+	// Cancelled context makes ReconnectWithBackoff return ctx.Err() immediately,
+	// exercising the first of the three failure paths without waiting on backoff.
+	cancel()
+
+	manager.handleUpstreamDisconnect(ctx, hashedParams, activeSub)
+
+	manager.lock.Lock()
+	_, stillRegistered := manager.activeSubscriptions[hashedParams]
+	manager.lock.Unlock()
+
+	require.False(t, stillRegistered,
+		"a failed restoration must remove the subscription — the listener no longer does it")
+	require.Equal(t, int64(0), manager.totalSubscriptions.Load(),
+		"a failed restoration must release its slot; leaking it erodes the max-subscriptions limit")
+}
+
+// TestGRPCHandleUpstreamDisconnect_ConcurrentRestorationDoesNotDoubleClean guards the
+// restoring CAS early-return. A second handler must NOT clean up: the first one holds
+// ownership and may still be restoring successfully.
+func TestGRPCHandleUpstreamDisconnect_ConcurrentRestorationDoesNotDoubleClean(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	manager, activeSub, hashedParams := newTestGRPCManagerWithSub(t, ctx, cancel)
+
+	// Simulate a restoration already in flight.
+	require.True(t, activeSub.restoring.CompareAndSwap(false, true))
+
+	manager.handleUpstreamDisconnect(ctx, hashedParams, activeSub)
+
+	manager.lock.Lock()
+	_, stillRegistered := manager.activeSubscriptions[hashedParams]
+	manager.lock.Unlock()
+
+	require.True(t, stillRegistered,
+		"the in-flight handler owns this subscription; a second one must not tear it down")
+	require.Equal(t, int64(1), manager.totalSubscriptions.Load(),
+		"the count must not be decremented twice for one subscription")
+}
+
+// NOT COVERED, stated rather than implied: the upstream-error hand-off itself, and the
+// reconnect-SUCCESS path behind it.
+//
+// The success path is where the original bug did its worst — the listener's unconditional
+// cleanup closed every client channel and nilled connectedClients while the restoration
+// was mutating activeSub in place, so the restored stream routed to nobody, leaked, and
+// double-decremented totalSubscriptions when the restarted listener later exited.
+//
+// The WebSocket manager DOES have the equivalent test
+// (TestListenForUpstreamMessages_ReconnectSkipsCleanup), so the asymmetry deserves an
+// explanation rather than silence. Two reasons it does not transfer:
+//
+//  1. WS made its error source injectable on purpose — upstreamErrSource is an interface
+//     introduced, per its own comment, so tests can drive the error branch with a local
+//     fake. gRPC's error source is upstreamStream.RecvMsg; grpc.ClientStream is also an
+//     interface, so that half would in fact be fakeable.
+//  2. The blocker is the statement BEFORE it:
+//     msgFactory.NewMessage(activeSub.methodDescriptor.GetOutputType()) runs first and
+//     nil-derefs without a real *desc.MethodDescriptor. This repo has no generated
+//     grpc.ServiceDesc anywhere — protos are resolved dynamically through reflection —
+//     so there is nothing to load a descriptor from, and one would have to be authored
+//     by hand (protoparse over a .proto literal).
+//
+// Closing this properly means giving the gRPC listener the same kind of seam WS already
+// has, which is a production change for testability and belongs with MAG-2643 — the work
+// that makes this path reachable in production at all.

--- a/protocol/rpcsmartrouter/direct_grpc_subscription_reconnect_test.go
+++ b/protocol/rpcsmartrouter/direct_grpc_subscription_reconnect_test.go
@@ -9,14 +9,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newTestGRPCManagerWithSub registers one active subscription on a fresh manager and
-// returns both, with totalSubscriptions seeded to 1 so the accounting is observable.
-//
-// The subscription deliberately carries no upstreamConnection and no clients:
-// cleanupSubscription nil-checks the former and range-loops the latter, so this reaches
-// the map-and-counter bookkeeping — which is where MAG-2540's damage lands — without
-// needing a live stream.
-func newTestGRPCManagerWithSub(t *testing.T, ctx context.Context, cancel context.CancelFunc) (*DirectGRPCSubscriptionManager, *grpcActiveSubscription, string) {
+const (
+	testGRPCClientKey    = "dapp:1.2.3.4:conn-1"
+	testGRPCHashedParams = "test-hashed-params"
+)
+
+// grpcSubFixture is a manager with one registered subscription, one connected client, and
+// a handle on that client's channel — enough to observe resource release, not just the
+// map and counter bookkeeping.
+type grpcSubFixture struct {
+	manager      *DirectGRPCSubscriptionManager
+	sub          *grpcActiveSubscription
+	hashedParams string
+	replyChan    <-chan *pairingtypes.RelayReply
+}
+
+// newTestGRPCSub builds a subscription that reaches every branch of cleanupSubscription
+// except the pool notify — upstreamConnection stays nil, which cleanup nil-checks, so no
+// live stream is needed.
+func newTestGRPCSub(ctx context.Context, cancel context.CancelFunc, clientKey string) (*grpcActiveSubscription, <-chan *pairingtypes.RelayReply) {
+	replyChan := make(chan *pairingtypes.RelayReply, 1)
+	return &grpcActiveSubscription{
+		upstreamPool:    NewUpstreamGRPCPool(&common.NodeUrl{Url: "grpc://127.0.0.1:1"}),
+		hashedParams:    testGRPCHashedParams,
+		clientRouterIDs: map[string]string{clientKey: "router-id-" + clientKey},
+		connectedClients: map[string]*common.SafeChannelSender[*pairingtypes.RelayReply]{
+			clientKey: common.NewSafeChannelSender(ctx, replyChan),
+		},
+		ctx:          ctx,
+		cancel:       cancel,
+		closeSubChan: make(chan struct{}),
+	}, replyChan
+}
+
+// newTestGRPCManagerWithSub registers one subscription on a fresh manager, with
+// totalSubscriptions seeded to 1 and the client tracked, so the accounting each guard is
+// responsible for is observable.
+func newTestGRPCManagerWithSub(t *testing.T, ctx context.Context, cancel context.CancelFunc) grpcSubFixture {
 	t.Helper()
 
 	manager := NewDirectGRPCSubscriptionManager(
@@ -29,23 +58,51 @@ func newTestGRPCManagerWithSub(t *testing.T, ctx context.Context, cancel context
 		nil,
 	)
 
-	const hashedParams = "test-hashed-params"
-	activeSub := &grpcActiveSubscription{
-		upstreamPool:     NewUpstreamGRPCPool(&common.NodeUrl{Url: "grpc://127.0.0.1:1"}),
-		hashedParams:     hashedParams,
-		clientRouterIDs:  map[string]string{},
-		connectedClients: map[string]*common.SafeChannelSender[*pairingtypes.RelayReply]{},
-		ctx:              ctx,
-		cancel:           cancel,
-		closeSubChan:     make(chan struct{}),
-	}
+	activeSub, replyChan := newTestGRPCSub(ctx, cancel, testGRPCClientKey)
 
 	manager.lock.Lock()
-	manager.activeSubscriptions[hashedParams] = activeSub
+	manager.activeSubscriptions[testGRPCHashedParams] = activeSub
 	manager.lock.Unlock()
 	manager.totalSubscriptions.Add(1)
+	manager.trackClientSubscription(testGRPCClientKey, testGRPCHashedParams)
 
-	return manager, activeSub, hashedParams
+	return grpcSubFixture{
+		manager:      manager,
+		sub:          activeSub,
+		hashedParams: testGRPCHashedParams,
+		replyChan:    replyChan,
+	}
+}
+
+func (f grpcSubFixture) isRegistered(t *testing.T) bool {
+	t.Helper()
+	f.manager.lock.Lock()
+	defer f.manager.lock.Unlock()
+	_, found := f.manager.activeSubscriptions[f.hashedParams]
+	return found
+}
+
+// requireGRPCSubReleased asserts the whole release, not just the counter: a guard placed
+// to protect the counter can silently skip everything after it.
+func requireGRPCSubReleased(t *testing.T, f grpcSubFixture) {
+	t.Helper()
+
+	select {
+	case _, ok := <-f.replyChan:
+		require.False(t, ok, "the client channel must be closed, not merely drained")
+	default:
+		t.Fatal("client channel still open: cleanup returned before releasing resources")
+	}
+
+	f.sub.lock.RLock()
+	clients := f.sub.connectedClients
+	f.sub.lock.RUnlock()
+	require.Nil(t, clients, "connectedClients must be nilled so late routing is a no-op")
+
+	require.Equal(t, 0, f.manager.GetClientSubscriptionCount(testGRPCClientKey),
+		"the client must be untracked, or checkClientSubscriptionLimit ratchets toward the cap on dead subscriptions")
+
+	require.Error(t, f.sub.ctx.Err(), "cleanup owns cancellation")
 }
 
 // TestGRPCListenForUpstreamMessages_NormalExitStillCleansUp is the collateral guard for
@@ -57,20 +114,17 @@ func newTestGRPCManagerWithSub(t *testing.T, ctx context.Context, cancel context
 // exit that is not an upstream error must still clean up.
 func TestGRPCListenForUpstreamMessages_NormalExitStillCleansUp(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	manager, activeSub, hashedParams := newTestGRPCManagerWithSub(t, ctx, cancel)
+	f := newTestGRPCManagerWithSub(t, ctx, cancel)
 
 	cancel() // context-done exit: returns before touching the stream or descriptor
 
-	manager.listenForUpstreamMessages(ctx, hashedParams, activeSub)
+	f.manager.listenForUpstreamMessages(ctx, f.hashedParams, f.sub)
 
-	manager.lock.Lock()
-	_, stillRegistered := manager.activeSubscriptions[hashedParams]
-	manager.lock.Unlock()
-
-	require.False(t, stillRegistered,
+	require.False(t, f.isRegistered(t),
 		"a normal exit must still remove the subscription — the guard is only for hand-offs")
-	require.Equal(t, int64(0), manager.totalSubscriptions.Load(),
+	require.Equal(t, int64(0), f.manager.totalSubscriptions.Load(),
 		"a normal exit must still release its slot in the subscription count")
+	requireGRPCSubReleased(t, f)
 }
 
 // TestGRPCHandleUpstreamDisconnect_ReconnectFailureCleansUp pins the other half of the
@@ -83,52 +137,118 @@ func TestGRPCListenForUpstreamMessages_NormalExitStillCleansUp(t *testing.T) {
 // subscription and its slot in the counter forever.
 func TestGRPCHandleUpstreamDisconnect_ReconnectFailureCleansUp(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	manager, activeSub, hashedParams := newTestGRPCManagerWithSub(t, ctx, cancel)
+	f := newTestGRPCManagerWithSub(t, ctx, cancel)
 
 	// Cancelled context makes ReconnectWithBackoff return ctx.Err() immediately,
 	// exercising the first of the three failure paths without waiting on backoff.
 	cancel()
 
-	manager.handleUpstreamDisconnect(ctx, hashedParams, activeSub)
+	f.manager.handleUpstreamDisconnect(ctx, f.hashedParams, f.sub)
 
-	manager.lock.Lock()
-	_, stillRegistered := manager.activeSubscriptions[hashedParams]
-	manager.lock.Unlock()
-
-	require.False(t, stillRegistered,
+	require.False(t, f.isRegistered(t),
 		"a failed restoration must remove the subscription — the listener no longer does it")
-	require.Equal(t, int64(0), manager.totalSubscriptions.Load(),
+	require.Equal(t, int64(0), f.manager.totalSubscriptions.Load(),
 		"a failed restoration must release its slot; leaking it erodes the max-subscriptions limit")
+	requireGRPCSubReleased(t, f)
+	require.False(t, f.sub.restoring.Load(), "the restoring latch must not outlive the handler")
 }
 
-// TestGRPCCleanupSubscription_IsIdempotent pins the guard that makes the whole
-// MAG-2540 damage class impossible rather than merely avoided.
+// TestGRPCCleanupSubscription_IsIdempotent pins the guard that makes the whole MAG-2540
+// damage class impossible rather than merely avoided.
 //
-// The map delete was already a no-op on a missing key, but the counter decrement was
-// unconditional — so any second cleanup for one subscription drove totalSubscriptions
-// below zero, which is precisely what disables the max-subscriptions limit. Fixing the
-// double-CALL (the listener/reconnect hand-off) is not sufficient on its own: there is
-// a live second path, since cleanupStaleSubscriptions removes anything whose ctx is
-// done and handleUpstreamDisconnect's failure paths call activeSub.cancel() before
-// cleaning up. A sweep landing in that window decrements, and cleanup decrements again.
-//
-// DirectWSSubscriptionManager.cleanupSubscription has had this guard all along.
+// The counter decrement used to be unconditional while the map delete was not, so any
+// second cleanup for one subscription drove totalSubscriptions below zero — which is
+// precisely what disables the max-subscriptions limit. The guard is keyed on the
+// subscription object rather than on its presence in the map: an existence check would
+// fix the counter and introduce a leak, since a caller arriving after the entry is gone
+// would skip closing the client channels too. So this asserts the full release on the
+// first call, and no double-release after it.
 func TestGRPCCleanupSubscription_IsIdempotent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	manager, activeSub, hashedParams := newTestGRPCManagerWithSub(t, ctx, cancel)
+	f := newTestGRPCManagerWithSub(t, ctx, cancel)
 
-	manager.cleanupSubscription(hashedParams, activeSub)
-	require.Equal(t, int64(0), manager.totalSubscriptions.Load(),
+	f.manager.cleanupSubscription(f.hashedParams, f.sub)
+	require.Equal(t, int64(0), f.manager.totalSubscriptions.Load(),
 		"first cleanup releases the slot")
+	requireGRPCSubReleased(t, f)
 
-	manager.cleanupSubscription(hashedParams, activeSub)
-	require.Equal(t, int64(0), manager.totalSubscriptions.Load(),
+	// Repeats must be no-ops on the counter, and must not panic re-closing the channel.
+	f.manager.cleanupSubscription(f.hashedParams, f.sub)
+	require.Equal(t, int64(0), f.manager.totalSubscriptions.Load(),
 		"a second cleanup must be a no-op — a negative counter disables the subscription limit")
 
-	// And a third, to be explicit that this is a property rather than an off-by-one.
-	manager.cleanupSubscription(hashedParams, activeSub)
-	require.Equal(t, int64(0), manager.totalSubscriptions.Load())
+	f.manager.cleanupSubscription(f.hashedParams, f.sub)
+	require.Equal(t, int64(0), f.manager.totalSubscriptions.Load(),
+		"a property, not an off-by-one")
+}
+
+// TestGRPCCleanupStaleSubscriptions_ReleasesResources pins the sweep against partial reap.
+//
+// It used to delete the map entry and decrement the counter and nothing else, so a
+// subscription it collected left its client channels open, its stream slot held and its
+// idMapper entries live — and the listener's own cleanup, arriving later, found the key
+// gone. This is the widest path to that state: removeClientFromSubscription cancels when
+// the last client leaves and defers cleanup to a listener that can be parked in RecvMsg
+// indefinitely, so on a quiet stream the sweep wins routinely.
+func TestGRPCCleanupStaleSubscriptions_ReleasesResources(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	f := newTestGRPCManagerWithSub(t, ctx, cancel)
+
+	cancel() // what removeClientFromSubscription does when the last client leaves
+
+	f.manager.cleanupStaleSubscriptions()
+
+	require.False(t, f.isRegistered(t), "the sweep must collect a cancelled subscription")
+	require.Equal(t, int64(0), f.manager.totalSubscriptions.Load())
+	requireGRPCSubReleased(t, f)
+
+	// The listener arriving afterwards must stay a no-op rather than double-decrement.
+	f.manager.cleanupSubscription(f.hashedParams, f.sub)
+	require.Equal(t, int64(0), f.manager.totalSubscriptions.Load(),
+		"cleanup after a sweep must not drive the counter negative")
+}
+
+// TestGRPCCleanupSubscription_DoesNotEvictSuccessor pins the identity guard.
+//
+// hashedParams is hash(methodPath + requestData) — deterministic, so a client
+// re-subscribing to the same method lands on the same key. Cleanup now runs AFTER
+// ReconnectWithBackoff, so a superseded handler can sit for seconds and then tear down a
+// newer subscription registered under that key, closing its clients' channels. It must
+// release its own resources and its own counter slot, and touch nothing else.
+func TestGRPCCleanupSubscription_DoesNotEvictSuccessor(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := newTestGRPCManagerWithSub(t, ctx, cancel)
+
+	successorCtx, successorCancel := context.WithCancel(context.Background())
+	defer successorCancel()
+	successor, successorChan := newTestGRPCSub(successorCtx, successorCancel, "dapp:5.6.7.8:conn-2")
+
+	f.manager.lock.Lock()
+	f.manager.activeSubscriptions[f.hashedParams] = successor
+	f.manager.lock.Unlock()
+	f.manager.totalSubscriptions.Add(1)
+
+	// The superseded handler finally returns from backoff and cleans up.
+	f.manager.cleanupSubscription(f.hashedParams, f.sub)
+
+	f.manager.lock.Lock()
+	current := f.manager.activeSubscriptions[f.hashedParams]
+	f.manager.lock.Unlock()
+
+	require.Same(t, successor, current,
+		"a superseded handler must not evict the subscription that replaced it")
+	require.Equal(t, int64(1), f.manager.totalSubscriptions.Load(),
+		"it releases its own slot and only its own")
+	requireGRPCSubReleased(t, f)
+
+	select {
+	case _, ok := <-successorChan:
+		require.True(t, ok, "the successor's client channel must not be closed")
+	default:
+	}
+	require.NoError(t, successor.ctx.Err(), "the successor must not be cancelled")
 }
 
 // TestGRPCHandleUpstreamDisconnect_ConcurrentRestorationDoesNotDoubleClean guards the
@@ -137,30 +257,31 @@ func TestGRPCCleanupSubscription_IsIdempotent(t *testing.T) {
 func TestGRPCHandleUpstreamDisconnect_ConcurrentRestorationDoesNotDoubleClean(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	manager, activeSub, hashedParams := newTestGRPCManagerWithSub(t, ctx, cancel)
+	f := newTestGRPCManagerWithSub(t, ctx, cancel)
 
 	// Simulate a restoration already in flight.
-	require.True(t, activeSub.restoring.CompareAndSwap(false, true))
+	require.True(t, f.sub.restoring.CompareAndSwap(false, true))
 
-	manager.handleUpstreamDisconnect(ctx, hashedParams, activeSub)
+	f.manager.handleUpstreamDisconnect(ctx, f.hashedParams, f.sub)
 
-	manager.lock.Lock()
-	_, stillRegistered := manager.activeSubscriptions[hashedParams]
-	manager.lock.Unlock()
-
-	require.True(t, stillRegistered,
+	require.True(t, f.isRegistered(t),
 		"the in-flight handler owns this subscription; a second one must not tear it down")
-	require.Equal(t, int64(1), manager.totalSubscriptions.Load(),
+	require.Equal(t, int64(1), f.manager.totalSubscriptions.Load(),
 		"the count must not be decremented twice for one subscription")
 }
 
-// NOT COVERED, stated rather than implied: the upstream-error hand-off itself, and the
-// reconnect-SUCCESS path behind it.
+// NOT COVERED, stated rather than implied: the upstream-error hand-off itself, the
+// reconnect-SUCCESS path behind it, and the latch release that precedes the restarted
+// listener.
 //
 // The success path is where the original bug did its worst — the listener's unconditional
 // cleanup closed every client channel and nilled connectedClients while the restoration
 // was mutating activeSub in place, so the restored stream routed to nobody, leaked, and
-// double-decremented totalSubscriptions when the restarted listener later exited.
+// double-decremented totalSubscriptions when the restarted listener later exited. It is
+// also where the restoring latch has to be dropped before the hand-off: as a trailing
+// defer it outlives the spawn, so a handler from a listener that errors immediately loses
+// the CAS and returns, orphaning a registered subscription with no listener and an
+// uncancelled ctx the stale sweep will not collect.
 //
 // The WebSocket manager DOES have the equivalent test
 // (TestListenForUpstreamMessages_ReconnectSkipsCleanup), so the asymmetry deserves an

--- a/protocol/rpcsmartrouter/direct_grpc_subscription_reconnect_test.go
+++ b/protocol/rpcsmartrouter/direct_grpc_subscription_reconnect_test.go
@@ -101,6 +101,36 @@ func TestGRPCHandleUpstreamDisconnect_ReconnectFailureCleansUp(t *testing.T) {
 		"a failed restoration must release its slot; leaking it erodes the max-subscriptions limit")
 }
 
+// TestGRPCCleanupSubscription_IsIdempotent pins the guard that makes the whole
+// MAG-2540 damage class impossible rather than merely avoided.
+//
+// The map delete was already a no-op on a missing key, but the counter decrement was
+// unconditional — so any second cleanup for one subscription drove totalSubscriptions
+// below zero, which is precisely what disables the max-subscriptions limit. Fixing the
+// double-CALL (the listener/reconnect hand-off) is not sufficient on its own: there is
+// a live second path, since cleanupStaleSubscriptions removes anything whose ctx is
+// done and handleUpstreamDisconnect's failure paths call activeSub.cancel() before
+// cleaning up. A sweep landing in that window decrements, and cleanup decrements again.
+//
+// DirectWSSubscriptionManager.cleanupSubscription has had this guard all along.
+func TestGRPCCleanupSubscription_IsIdempotent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	manager, activeSub, hashedParams := newTestGRPCManagerWithSub(t, ctx, cancel)
+
+	manager.cleanupSubscription(hashedParams, activeSub)
+	require.Equal(t, int64(0), manager.totalSubscriptions.Load(),
+		"first cleanup releases the slot")
+
+	manager.cleanupSubscription(hashedParams, activeSub)
+	require.Equal(t, int64(0), manager.totalSubscriptions.Load(),
+		"a second cleanup must be a no-op — a negative counter disables the subscription limit")
+
+	// And a third, to be explicit that this is a property rather than an off-by-one.
+	manager.cleanupSubscription(hashedParams, activeSub)
+	require.Equal(t, int64(0), manager.totalSubscriptions.Load())
+}
+
 // TestGRPCHandleUpstreamDisconnect_ConcurrentRestorationDoesNotDoubleClean guards the
 // restoring CAS early-return. A second handler must NOT clean up: the first one holds
 // ownership and may still be restoring successfully.


### PR DESCRIPTION
# Description

Closes: N/A — tracked in Jira, not a GitHub issue.

A transient error on a gRPC upstream stream started a reconnect **and then ran the listener's deferred cleanup anyway.** Cleanup deletes the subscription from the manager's map, closes every client channel and nils `connectedClients` — so on a *successful* restoration:

| Step | Listener goroutine | Reconnect goroutine |
| --- | --- | --- |
| 1 | sees error, spawns reconnect, returns | — |
| 2 | defer → `cleanupSubscription`: deletes from map, `Add(-1)`, **closes all client channels** | reconnecting… |
| 3 | — | succeeds, mutates `activeSub` in place, **restarts the listener** |
| 4 | restarted listener eventually exits → `cleanupSubscription` **again** → `Add(-1)` a second time | — |

Result: the restored stream routes to nobody, the upstream stream leaks, and `totalSubscriptions` double-decrements — below zero, which disables the max-subscriptions limit.

## The fix adopts the WebSocket manager's contract in full, not just its flag

`DirectWSSubscriptionManager` already solved this, and documents it as an **ownership transfer** rather than a flag:

> once `reconnectInFlight` is set, `handleUpstreamDisconnect` is responsible for calling `cleanupSubscription` on every failure path … so a failed restoration does not leak the subscription

The gRPC manager had neither half. So this changes both:

1. `listenForUpstreamMessages` sets `reconnectInFlight` before spawning the reconnect and skips its deferred cleanup when set.
2. `handleUpstreamDisconnect` now owns cleanup on **all three** failure paths — `ReconnectWithBackoff`, `GetConnectionForStream`, `createUpstreamStream` — which previously called only `activeSub.cancel()`.

**Adding the flag alone would have traded a teardown bug for a leak.** The listener stops cleaning up, and nothing else was doing it on those failure paths. The `restoring`-CAS early return deliberately does *not* clean up — another handler is in flight and holds ownership — and now says so in a comment.

Net **+28 / −3** in production code.

## Testing

| Reverted | Test | Result |
| --- | --- | --- |
| cleanup-ownership | `TestGRPCHandleUpstreamDisconnect_ReconnectFailureCleansUp` | **FAIL** ✓ |
| `reconnectInFlight` guard | `TestGRPCListenForUpstreamMessages_NormalExitStillCleansUp` | passes — expected; see below |

That second row is stated rather than hidden: the normal-exit test is a **collateral guard**, there to prove the new flag cannot leak on non-hand-off paths. It should stay green either way. A third test pins the concurrent-restoration early return.

Full `rpcsmartrouter` suite green under `-race` (98s). Tests renamed to a `TestGRPC…` prefix because they otherwise collide with the WebSocket manager's identically-named tests in `-run` patterns.

## The gap, and why it is narrower than it looks

The WS manager *does* have the analogous `TestListenForUpstreamMessages_ReconnectSkipsCleanup`, so the asymmetry needs an explanation rather than silence. Two reasons it does not transfer, both recorded in the test file:

1. WS made its error source injectable **on purpose** — `upstreamErrSource` exists, per its own comment, so tests can drive the error branch with a fake. gRPC's error source is `upstreamStream.RecvMsg`, and `grpc.ClientStream` is also an interface, so that half would fake fine.
2. The blocker is the statement *before* it: `msgFactory.NewMessage(activeSub.methodDescriptor.GetOutputType())` nil-derefs without a real `*desc.MethodDescriptor`, and **this repo has no generated `grpc.ServiceDesc` anywhere** — protos resolve dynamically through reflection, so there is nothing to load one from.

Giving the gRPC listener the same seam WS has is a production change for testability and belongs with MAG-2643 — the work that makes this code reachable in production at all.

## Sequencing note for reviewers

This code is **currently unreachable in production**: `DirectGRPCSubscriptionManager.StartSubscription` has zero callers, and the relay path refuses gRPC streaming at `rpcsmartrouter_server.go:3675`. That makes this a zero-risk merge, and it is deliberately landing *before* MAG-2643 rather than after — wiring streaming first would ship it with a known teardown-and-leak bug on the first transient error.

The `Blocks` link (MAG-2643 blocks this) is about **verification** — this cannot be reproduced end-to-end until streaming is wired — not about implementation order.

## Review follow-up (commit `dd6e6b9`)

Three findings from a review pass. The original change removed the one *known* double-call path; these make the damage class structurally impossible.

1. **`cleanupSubscription` is now idempotent**, matching the guard `DirectWSSubscriptionManager.cleanupSubscription` has had all along. The map `delete` was already a no-op on a missing key, but `totalSubscriptions.Add(-1)` was unconditional — so any second call drove the counter below zero, which is precisely what disables the max-subscriptions limit.

   **This is not merely defensive.** There is a live second path even after the ownership fix: `cleanupStaleSubscriptions` removes any subscription whose ctx is done, and `handleUpstreamDisconnect`'s failure paths call `activeSub.cancel()` **before** cleaning up. A sweep landing in that window decrements, and cleanup decrements again. The guard — not the call ordering — is what closes it.

   It also protects the reconnect-**success** path this PR cannot reach with a test: even if the listener's cleanup did run alongside a restoration, the counter would stay correct.

2. **Cleanup ownership is expressed once**, as a deferred `restored` check, instead of repeated at three early returns. A fourth failure path added later is covered by construction — the same shape of mistake as MAG-2538, where a sequence was copied and one copy missed the fix.

3. **The other `totalSubscriptions.Add(-1)`** (in `cleanupStaleSubscriptions`) is safe as written — it only decrements keys found while iterating the map — and its interaction with `cancel()`-then-cleanup is now documented on `cleanupSubscription` rather than left to be rediscovered.

Both new guards verified **red-first**: reverting the idempotence check makes the counter read `-1`; reverting the deferred ownership leaves the subscription registered after a failed restoration.

## Review follow-up 2 (commit `7020d59`)

Five findings from @AnnaR-prog's review. The through-line: the previous commit made
`cleanupSubscription` idempotent with an early return on a missing map key — but that
early return exits the *whole* function, so it guarded the counter by skipping the
release. Each fix moves a guard onto the thing it is actually a property of.

| # | Finding | Fix |
| --- | --- | --- |
| 1 | Idempotence guard skipped resource release | `cleanupStaleSubscriptions` delegates to `cleanupSubscription` instead of partial-reaping; guard moves onto the subscription object (`cleanedUp`) |
| 2 | Guard checked key presence, not identity | Map delete is gated on `current == activeSub`; counter is decremented per object |
| 3 | CAS early-return could orphan a subscription | `restoring.Store(false)` moved ahead of the restarted listener's spawn |
| 4 | `IsIdempotent` only asserted the counter | New `requireGRPCSubReleased` asserts channel closed, `connectedClients` nil, client untracked, ctx cancelled |
| 5 | Cleanup never untracked `clientSubscriptions` | Untrack loop added |

Two things worth calling out beyond the table.

**The sweep was the real second decrement path.** Finding 1's interleaving is not narrow:
`removeClientFromSubscription` cancels when the last client leaves and defers cleanup to a
listener that can be parked in `RecvMsg` indefinitely — `ctx.Done()` is only checked
*between* receives. On a quiet stream the sweep wins routinely. With the sweep delegating,
there is now exactly one release site and one decrement site, matching
`createNewSubscription`'s single increment.

**`cancel()` moved into `cleanupSubscription`** and off the three `handleUpstreamDisconnect`
failure paths, so the sweep can never observe a cancelled-but-unreleased subscription. Same
placement as `DirectWSSubscriptionManager.cleanupSubscription`.

The diff also takes `clientRouterIDs` and `upstreamConnection` under `activeSub.lock` —
both were read unsynchronised while `handleUpstreamDisconnect` writes them under it.

### Verification

All five guards verified red-first:

| Reverted | Test that goes red |
| --- | --- |
| sweep delegates to cleanup | `CleanupStaleSubscriptions_ReleasesResources` |
| identity check on map delete | `CleanupSubscription_DoesNotEvictSuccessor` |
| identity check as a whole-function early return | `DoesNotEvictSuccessor` — counter reads 2, not 1 |
| `cleanedUp` latch → map-existence guard | `DoesNotEvictSuccessor` |
| per-client untrack | `CleanupSubscription_IsIdempotent` |
| `cancel()` in cleanup | `CleanupSubscription_IsIdempotent` |

Full `rpcsmartrouter` suite green under `-race` (104s) on the rebased base.

**Not covered:** finding 3. The latch-release ordering only matters on the
reconnect-*success* path, which is unreachable in a unit test for the reason already
documented in the test file — `methodDescriptor` nil-derefs and this repo has no generated
`grpc.ServiceDesc` to build one from. Stated in the test file's NOT COVERED block rather
than left implied.

**Still open, deliberately:** the AB-BA lock inversion between `Unsubscribe` (dgm→sub) and
`removeClientFromSubscription` (sub→dgm). Out of scope here and left for MAG-2643; the new
untrack loop is placed *outside* `activeSub.lock` specifically so it does not add a third
site to that inversion.

**On CI:** correct that no workflow in `.github/workflows/` runs `go test` — verified. The
checklist item below is about the configured checks passing and should not be read as
evidence these tests run in CI. They do not; the `-race` runs above are the only evidence.

## Jira ticket

Jira ticket: MAG-2540

---

## Author Checklist

I have...

* [ ] read the [contribution guide](https://github.com/magma-Devs/smart-router/blob/main/CONTRIBUTING.md)
* [x] included the correct type prefix in the PR title (`fix`)
* [x] confirmed `!` in the type prefix if API or client breaking change — not breaking, no `!`
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification — MAG-2540
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests — unit tests added; the one integration-only gap is documented above and in the test file
* [x] updated the relevant documentation or specification, including comments for documenting Go code
* [ ] confirmed all CI checks have passed — pending first CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)


