### PR TITLE
fix(smart-router): skip the cache write for unresolved block tags (MAG-2842)

### DIFF
--- a/ecosystem/cache/set_relay_negative_block_test.go
+++ b/ecosystem/cache/set_relay_negative_block_test.go
@@ -1,0 +1,84 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	relaytypes "github.com/magma-Devs/smart-router/types/relay"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+	emptypb "google.golang.org/protobuf/types/known/emptypb"
+)
+
+func newCacheServerForTest(t *testing.T) *RelayerCacheServer {
+	t.Helper()
+	return &RelayerCacheServer{CacheServer: &CacheServer{
+		tempCache:                  newRistrettoForTest(t),
+		finalizedCache:             newRistrettoForTest(t),
+		blocksHashesToHeightsCache: newRistrettoForTest(t),
+		ExpirationFinalized:        time.Hour,
+		ExpirationNonFinalized:     500 * time.Millisecond,
+	}}
+}
+
+// TestSetRelay_RejectsNegativeRequestedBlock pins the cache-server contract that
+// the smart router's tryCacheWrite guard relies on: SetRelay refuses every
+// negative RequestedBlock, so a block tag the router did not resolve to a height
+// can only ever come back as an error. EARLIEST/PENDING/SAFE/FINALIZED all land
+// here, and that rejection was surfacing as one "cache write failed" warning per
+// relay in production until the router learned to skip the call outright.
+func TestSetRelay_RejectsNegativeRequestedBlock(t *testing.T) {
+	cases := []struct {
+		name  string
+		block int64
+	}{
+		{"NOT_APPLICABLE", spectypes.NOT_APPLICABLE},
+		{"LATEST_BLOCK", spectypes.LATEST_BLOCK},
+		{"EARLIEST_BLOCK", spectypes.EARLIEST_BLOCK},
+		{"PENDING_BLOCK", spectypes.PENDING_BLOCK},
+		{"SAFE_BLOCK", spectypes.SAFE_BLOCK},
+		{"FINALIZED_BLOCK", spectypes.FINALIZED_BLOCK},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newCacheServerForTest(t)
+
+			// Response is deliberately nil: SetRelay only dereferences it after the
+			// negative-block guard, so a panic here means the guard stopped firing.
+			var (
+				resp *emptypb.Empty
+				err  error
+			)
+			require.NotPanics(t, func() {
+				resp, err = srv.SetRelay(context.Background(), &relaytypes.RelayCacheSet{
+					ChainId:        "BASE",
+					RequestHash:    []byte("req-hash"),
+					RequestedBlock: tc.block,
+				})
+			})
+			require.Error(t, err)
+			require.Nil(t, resp)
+			require.Contains(t, err.Error(), "request block is negative")
+		})
+	}
+}
+
+// TestSetRelay_AcceptsNonNegativeRequestedBlock is the positive control for the
+// case above, so that test cannot pass because SetRelay rejects everything. It
+// also covers block 0 (genesis), the boundary the guard is written against.
+func TestSetRelay_AcceptsNonNegativeRequestedBlock(t *testing.T) {
+	for _, block := range []int64{0, 12345} {
+		srv := newCacheServerForTest(t)
+		resp, err := srv.SetRelay(context.Background(), &relaytypes.RelayCacheSet{
+			ChainId:          "BASE",
+			RequestHash:      []byte("req-hash"),
+			RequestedBlock:   block,
+			Response:         &relaytypes.RelayReply{Data: []byte(`{"result":"0x1"}`), LatestBlock: 12345},
+			AverageBlockTime: int64(2 * time.Second),
+		})
+		require.NoError(t, err, "block %d must be accepted", block)
+		require.NotNil(t, resp)
+	}
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -3172,6 +3172,7 @@ func (rpcss *RPCSmartRouterServer) adoptSharedStateTip(ctx context.Context, peer
 // - Quorum is enabled (quorum requires fresh endpoint validation)
 // - Response is a node error
 // - Requested block is NOT_APPLICABLE
+// - Requested block is a tag the resolution above leaves negative (EARLIEST/PENDING/SAFE/FINALIZED)
 func (rpcss *RPCSmartRouterServer) tryCacheWrite(
 	ctx context.Context,
 	protocolMessage chainlib.ProtocolMessage,
@@ -3282,6 +3283,19 @@ func (rpcss *RPCSmartRouterServer) tryCacheWrite(
 			)
 			return
 		}
+	}
+
+	// EARLIEST (-3), PENDING (-4), SAFE (-5) and FINALIZED (-6) are never resolved to a
+	// height above, so they would reach SetRelay as a negative RequestedBlock, which it
+	// rejects outright — one "cache write failed" warning per relay for no possible gain.
+	// Skipping loses nothing: SetRelay's guard returns before it publishes the chain tip,
+	// so that side effect is already forgone today. NOT_APPLICABLE (-1) is filtered above.
+	if requestedBlockForCache < 0 {
+		utils.LavaFormatDebug("cache write skipped: unresolved block tag",
+			utils.LogAttr("requestedBlock", requestedBlockForCache),
+			utils.LogAttr("GUID", ctx),
+		)
+		return
 	}
 
 	// Get seen block


### PR DESCRIPTION
## Jira ticket

Jira ticket: MAG-2842

---

## Problem

A customer running smart-routers at log level `warn` reported significant log volume on BASE:

```
{"level":"warn","error":"rpc error: code = Unknown desc = invalid relay cache set data, request block is negative {requestBlock:-6}","chainId":"BASE","requestedBlock":"-6","message":"cache write failed"}
```

One line per relay. Their logging vendor bills by ingest volume.

`-6` is `FINALIZED_BLOCK` — i.e. `eth_getBlockByNumber("finalized")`, polled continuously by bridges and indexers on BASE.

`tryCacheWrite` resolves only `LATEST_BLOCK` to a concrete height. `EARLIEST_BLOCK` (-3), `PENDING_BLOCK` (-4), `SAFE_BLOCK` (-5) and `FINALIZED_BLOCK` (-6) fell through raw to the cache server, where `SetRelay` rejects any negative `RequestedBlock` and returns an error. Each of those relays cost a goroutine, a `CacheWriteTimeout` context and a gRPC round-trip purely to be refused, and emitted one warning on the router plus one error on cache-be.

## Fix

Guard the write rather than demote the log.

Demoting `cache write failed` to debug would have silenced the noise, but it is a generic handler — it would also hide cache-be being unreachable, write timeouts and gRPC errors. Skipping the call removes only the case that can never succeed, so the warning keeps its level and its meaning.

Nothing else is lost: `SetRelay`'s own guard returns before it publishes the chain tip via `setSeenBlockOnSharedStateMode` and `setLatestBlock`, so those side effects were already forgone for these requests.

## Scope

This is the noise fix only. Deliberately **not** in scope:

- Responses for these four tags are still never cached.
- The read path still sends the raw negative block to cache-be, which resolves it against its own tip and looks up a key nothing ever wrote — a guaranteed miss on every relay, inline on the critical path. Latency only, no logs.

Making the tags cacheable means resolving them to a height on both paths through one shared helper, so the two sides cannot disagree on the key. Tracked separately.

## Tests

`ecosystem/cache/set_relay_negative_block_test.go` pins the cache-server contract the guard depends on:

- `TestSetRelay_RejectsNegativeRequestedBlock` — all six negative sentinels are refused. `Response` is deliberately nil, since `SetRelay` only dereferences it after the guard; a panic would mean the guard stopped firing.
- `TestSetRelay_AcceptsNonNegativeRequestedBlock` — positive control at blocks 0 and 12345, so the rejection test cannot pass vacuously.

`go build ./...`, `go vet`, `./ecosystem/cache/...` and the smart-router `Cache` tests all pass.

**Known gap:** the router-side guard itself has no unit test. `rpcss.cache` is a concrete `*performance.Cache` whose client sits behind an unexported store, so with a nil cache `CacheActive()` short-circuits before the guard is reached. Covering it needs either an interface on the field or a test-only client injector in `protocol/performance` — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
