### PR TITLE
fix(smart-router): consult grpc-config's descriptor-source on every request path

### DIFF
--- a/config/smartrouter_examples/smartrouter_cosmos.yml
+++ b/config/smartrouter_examples/smartrouter_cosmos.yml
@@ -17,6 +17,23 @@
 # check is best-effort here. A real Cosmos Hub node (or a gateway that allows
 # full reflection) verifies gRPC cleanly; swap one in for production.
 #
+# If you must stay on a gateway that throttles or omits reflection, point the
+# gRPC endpoint at a pre-built descriptor set instead — descriptors then resolve
+# from disk and reflection is never queried:
+#
+#   node-urls:
+#     - url: "grpcs://cosmos-grpc.publicnode.com:443"
+#       grpc-config:
+#         descriptor-source: "file"     # or "hybrid" to fall back to reflection
+#         descriptor-set-path: "config/cosmoshub.protoset"
+#
+# Build the protoset from the chain's proto tree (either tool works):
+#   buf build -o cosmoshub.protoset
+#   protoc -I . --include_imports --descriptor_set_out=cosmoshub.protoset <root>.proto
+#
+# It is a static snapshot: rebuild it when a node upgrade adds rpcs or fields the
+# spec starts using, or those methods fail with "symbol not found" in file mode.
+#
 # Run it:
 #   smartrouter config/smartrouter_examples/smartrouter_cosmos.yml --use-static-spec specs/
 

--- a/config/smartrouter_examples/smartrouter_cosmos.yml
+++ b/config/smartrouter_examples/smartrouter_cosmos.yml
@@ -34,6 +34,11 @@
 # It is a static snapshot: rebuild it when a node upgrade adds rpcs or fields the
 # spec starts using, or those methods fail with "symbol not found" in file mode.
 #
+# All of a chain's gRPC node-urls must agree on descriptor-source and
+# descriptor-set-path. Block parsing resolves through one registry per chain, not
+# one per node-url, so a chain whose node-urls disagree is rejected at boot rather
+# than served by whichever one happened to be applied last.
+#
 # Run it:
 #   smartrouter config/smartrouter_examples/smartrouter_cosmos.yml --use-static-spec specs/
 

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/fileDescriptorSource.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/fileDescriptorSource.go
@@ -1,0 +1,203 @@
+package rpcInterfaceMessages
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/fullstorydev/grpcurl"
+	"github.com/jhump/protoreflect/desc"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/utils"
+)
+
+// protosetCache memoizes parsed descriptor sets by path.
+//
+// A protoset is a static artifact of the config — the Concordium one is ~335KB —
+// and descriptor lookups happen per connection, per uncached method. Without this
+// the same file is read and unmarshalled on every miss for the life of the process.
+//
+// Failures are cached alongside successes deliberately: a path that is missing or
+// corrupt at boot stays that way, and re-reading it on every relay turns one config
+// mistake into per-request filesystem traffic. Editing a protoset requires a router
+// restart, which is already true of every other field in the config.
+var protosetCache sync.Map // map[string]*protosetEntry
+
+type protosetEntry struct {
+	once   sync.Once
+	source grpcurl.DescriptorSource
+	err    error
+}
+
+// LoadProtoset returns the descriptor source backed by the protoset at path,
+// parsing it at most once per path per process.
+func LoadProtoset(path string) (grpcurl.DescriptorSource, error) {
+	cached, _ := protosetCache.LoadOrStore(path, &protosetEntry{})
+	entry, ok := cached.(*protosetEntry)
+	if !ok {
+		return nil, utils.LavaFormatError("corrupt protoset cache entry", nil,
+			utils.LogAttr("descriptor-set-path", path))
+	}
+
+	entry.once.Do(func() {
+		source, err := grpcurl.DescriptorSourceFromProtoSets(path)
+		if err != nil {
+			entry.err = utils.LavaFormatError("failed loading gRPC descriptor set", err,
+				utils.LogAttr("descriptor-set-path", path))
+			return
+		}
+		entry.source = source
+		utils.LavaFormatDebug("loaded gRPC descriptor set",
+			utils.LogAttr("descriptor-set-path", path))
+	})
+
+	return entry.source, entry.err
+}
+
+// ResetProtosetCacheForTest drops every memoized protoset. Tests that write a
+// descriptor set to a temp path and expect it to be re-read must call this;
+// production never does.
+func ResetProtosetCacheForTest() {
+	protosetCache.Range(func(key, _ any) bool {
+		protosetCache.Delete(key)
+		return true
+	})
+}
+
+// compositeDescriptorSource resolves symbols against a protoset first and falls
+// back to server reflection. This is "hybrid" mode.
+//
+// File-first, not reflection-first, is deliberate. The chains that need hybrid at
+// all are the ones whose upstream reflection is absent, partial, or rate-limited —
+// asking the node first would pay that cost on every lookup only to arrive at an
+// answer that was on local disk the whole time. File-first makes the common path
+// free and leaves reflection as what it actually is here: a supplement for symbols
+// the protoset predates.
+type compositeDescriptorSource struct {
+	file   grpcurl.DescriptorSource
+	server grpcurl.DescriptorSource
+}
+
+var _ grpcurl.DescriptorSource = compositeDescriptorSource{}
+
+func (c compositeDescriptorSource) ListServices() ([]string, error) {
+	services, err := c.file.ListServices()
+	if err != nil {
+		return c.server.ListServices()
+	}
+
+	// A reflection failure is not fatal in hybrid mode — the protoset already
+	// answered. Report what we have rather than losing it to the node being down.
+	serverServices, serverErr := c.server.ListServices()
+	if serverErr != nil {
+		utils.LavaFormatDebug("hybrid descriptor source: reflection ListServices failed, using protoset only",
+			utils.LogAttr("error", serverErr))
+		return services, nil
+	}
+
+	seen := make(map[string]struct{}, len(services)+len(serverServices))
+	merged := make([]string, 0, len(services)+len(serverServices))
+	for _, service := range append(services, serverServices...) {
+		if _, duplicate := seen[service]; duplicate {
+			continue
+		}
+		seen[service] = struct{}{}
+		merged = append(merged, service)
+	}
+	return merged, nil
+}
+
+func (c compositeDescriptorSource) FindSymbol(fullyQualifiedName string) (desc.Descriptor, error) {
+	descriptor, fileErr := c.file.FindSymbol(fullyQualifiedName)
+	if fileErr == nil {
+		return descriptor, nil
+	}
+
+	descriptor, serverErr := c.server.FindSymbol(fullyQualifiedName)
+	if serverErr == nil {
+		return descriptor, nil
+	}
+
+	// Both halves missed. Surface both causes: in practice one of them is the
+	// actionable one (stale protoset vs. node not serving reflection) and which
+	// it is depends on the deployment.
+	return nil, utils.LavaFormatError("symbol not found in protoset or via reflection", nil,
+		utils.LogAttr("symbol", fullyQualifiedName),
+		utils.LogAttr("protoset_error", fileErr),
+		utils.LogAttr("reflection_error", serverErr))
+}
+
+func (c compositeDescriptorSource) AllExtensionsForType(typeName string) ([]*desc.FieldDescriptor, error) {
+	fileExtensions, fileErr := c.file.AllExtensionsForType(typeName)
+	serverExtensions, serverErr := c.server.AllExtensionsForType(typeName)
+
+	if fileErr != nil && serverErr != nil {
+		return nil, fileErr
+	}
+
+	seen := make(map[string]struct{}, len(fileExtensions)+len(serverExtensions))
+	merged := make([]*desc.FieldDescriptor, 0, len(fileExtensions)+len(serverExtensions))
+	for _, extension := range append(fileExtensions, serverExtensions...) {
+		name := extension.GetFullyQualifiedName()
+		if _, duplicate := seen[name]; duplicate {
+			continue
+		}
+		seen[name] = struct{}{}
+		merged = append(merged, extension)
+	}
+	return merged, nil
+}
+
+// DescriptorSourceForNode picks the descriptor source implied by a node's
+// grpc-config. serverSource is the reflection-backed source the caller already
+// holds; in "file" mode it is never consulted, so a node that does not serve
+// reflection is never asked.
+//
+// This is chain-agnostic on purpose: nothing here knows which chain it is serving.
+// Concordium is the case that forced it (its gateways serve reflection for Health
+// only), but public Cosmos gateways that throttle reflection hit the same wall
+// through a different door.
+func DescriptorSourceForNode(mode, descriptorSetPath string, serverSource grpcurl.DescriptorSource) (grpcurl.DescriptorSource, error) {
+	switch mode {
+	case common.GrpcDescriptorSourceFile:
+		if descriptorSetPath == "" {
+			return nil, utils.LavaFormatError("descriptor-set-path is required for descriptor-source: file", nil)
+		}
+		return LoadProtoset(descriptorSetPath)
+
+	case common.GrpcDescriptorSourceHybrid:
+		if descriptorSetPath == "" {
+			// Config validation rejects this, but a hybrid node with no protoset is
+			// still meaningfully reflection-only rather than a hard failure.
+			return serverSource, nil
+		}
+		fileSource, err := LoadProtoset(descriptorSetPath)
+		if err != nil {
+			// Hybrid tolerates an unusable protoset — reflection is the other half.
+			// Degrading here is the whole point of the mode.
+			utils.LavaFormatWarning("hybrid descriptor source: protoset unusable, falling back to reflection only", err,
+				utils.LogAttr("descriptor-set-path", descriptorSetPath))
+			return serverSource, nil
+		}
+		return compositeDescriptorSource{file: fileSource, server: serverSource}, nil
+
+	case common.GrpcDescriptorSourceReflection, "":
+		return serverSource, nil
+
+	default:
+		return nil, utils.LavaFormatError("invalid gRPC descriptor-source", nil,
+			utils.LogAttr("descriptor-source", mode),
+			utils.LogAttr("valid_options", fmt.Sprintf("%s, %s, %s",
+				common.GrpcDescriptorSourceReflection,
+				common.GrpcDescriptorSourceFile,
+				common.GrpcDescriptorSourceHybrid)))
+	}
+}
+
+// DescriptorSourceForGrpcConfig is the call-site convenience over
+// DescriptorSourceForNode; a nil config means the reflection default.
+func DescriptorSourceForGrpcConfig(grpcConfig *common.GrpcConfig, serverSource grpcurl.DescriptorSource) (grpcurl.DescriptorSource, error) {
+	if grpcConfig == nil {
+		return serverSource, nil
+	}
+	return DescriptorSourceForNode(grpcConfig.GetDescriptorSource(), grpcConfig.DescriptorSetPath, serverSource)
+}

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/fileDescriptorSource_test.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/fileDescriptorSource_test.go
@@ -1,0 +1,307 @@
+package rpcInterfaceMessages
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/fullstorydev/grpcurl"
+	"github.com/jhump/protoreflect/desc"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/stretchr/testify/require"
+	protov2 "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// writeTestProtoset builds a one-file FileDescriptorSet declaring pkg.service with a
+// single unary Ping rpc, and writes it as a protoset. Hand-building the descriptors
+// keeps these tests free of protoc/buf.
+func writeTestProtoset(t *testing.T, dir, fileName, pkg, service string) string {
+	t.Helper()
+
+	fileDescriptor := &descriptorpb.FileDescriptorProto{
+		Name:    protov2.String(fileName + ".proto"),
+		Package: protov2.String(pkg),
+		Syntax:  protov2.String("proto3"),
+		MessageType: []*descriptorpb.DescriptorProto{
+			{Name: protov2.String("PingRequest")},
+			{Name: protov2.String("PingResponse")},
+		},
+		Service: []*descriptorpb.ServiceDescriptorProto{
+			{
+				Name: protov2.String(service),
+				Method: []*descriptorpb.MethodDescriptorProto{
+					{
+						Name:       protov2.String("Ping"),
+						InputType:  protov2.String("." + pkg + ".PingRequest"),
+						OutputType: protov2.String("." + pkg + ".PingResponse"),
+					},
+				},
+			},
+		},
+	}
+
+	raw, err := protov2.Marshal(&descriptorpb.FileDescriptorSet{
+		File: []*descriptorpb.FileDescriptorProto{fileDescriptor},
+	})
+	require.NoError(t, err)
+
+	path := filepath.Join(dir, fileName+".protoset")
+	require.NoError(t, os.WriteFile(path, raw, 0o600))
+	return path
+}
+
+// countingSource wraps a real DescriptorSource and records how often it is consulted.
+// The point of "file" mode is that a node which cannot answer is never asked, so the
+// counters are the assertion that matters — not just that resolution succeeded.
+type countingSource struct {
+	inner     grpcurl.DescriptorSource
+	findCalls atomic.Int32
+	listCalls atomic.Int32
+	forcedErr error
+}
+
+func (c *countingSource) ListServices() ([]string, error) {
+	c.listCalls.Add(1)
+	if c.forcedErr != nil {
+		return nil, c.forcedErr
+	}
+	return c.inner.ListServices()
+}
+
+func (c *countingSource) FindSymbol(name string) (desc.Descriptor, error) {
+	c.findCalls.Add(1)
+	if c.forcedErr != nil {
+		return nil, c.forcedErr
+	}
+	return c.inner.FindSymbol(name)
+}
+
+func (c *countingSource) AllExtensionsForType(typeName string) ([]*desc.FieldDescriptor, error) {
+	if c.forcedErr != nil {
+		return nil, c.forcedErr
+	}
+	return c.inner.AllExtensionsForType(typeName)
+}
+
+func newCountingSource(t *testing.T, protosetPath string) *countingSource {
+	t.Helper()
+	inner, err := grpcurl.DescriptorSourceFromProtoSets(protosetPath)
+	require.NoError(t, err)
+	return &countingSource{inner: inner}
+}
+
+func TestDescriptorSourceForNode_ReflectionModesPassServerSourceThrough(t *testing.T) {
+	ResetProtosetCacheForTest()
+	server := newCountingSource(t, writeTestProtoset(t, t.TempDir(), "server", "server.v1", "ServerQueries"))
+
+	for _, mode := range []string{common.GrpcDescriptorSourceReflection, ""} {
+		t.Run("mode="+mode, func(t *testing.T) {
+			source, err := DescriptorSourceForNode(mode, "", server)
+			require.NoError(t, err)
+			// Identity, not merely equivalence: reflection mode must not wrap or
+			// otherwise alter today's behaviour.
+			require.Same(t, server, source)
+		})
+	}
+}
+
+func TestDescriptorSourceForNode_FileModeNeverConsultsReflection(t *testing.T) {
+	ResetProtosetCacheForTest()
+	dir := t.TempDir()
+	// The node's reflection service knows a different API entirely — the Concordium
+	// shape, where reflection serves Health but not the service the spec needs.
+	server := newCountingSource(t, writeTestProtoset(t, dir, "health", "grpc.health.v1", "Health"))
+	protoset := writeTestProtoset(t, dir, "chain", "concordium.v2", "Queries")
+
+	source, err := DescriptorSourceForNode(common.GrpcDescriptorSourceFile, protoset, server)
+	require.NoError(t, err)
+
+	descriptor, err := source.FindSymbol("concordium.v2.Queries")
+	require.NoError(t, err)
+	serviceDescriptor, ok := descriptor.(*desc.ServiceDescriptor)
+	require.True(t, ok)
+	require.NotNil(t, serviceDescriptor.FindMethodByName("Ping"))
+
+	services, err := source.ListServices()
+	require.NoError(t, err)
+	require.Equal(t, []string{"concordium.v2.Queries"}, services)
+
+	require.Zero(t, server.findCalls.Load(), "file mode must not query reflection")
+	require.Zero(t, server.listCalls.Load(), "file mode must not query reflection")
+}
+
+func TestDescriptorSourceForNode_FileModeWorksWithNilServerSource(t *testing.T) {
+	// initializeDescriptorSource validates with a nil server source; that must not panic.
+	ResetProtosetCacheForTest()
+	protoset := writeTestProtoset(t, t.TempDir(), "chain", "concordium.v2", "Queries")
+
+	source, err := DescriptorSourceForNode(common.GrpcDescriptorSourceFile, protoset, nil)
+	require.NoError(t, err)
+	_, err = source.FindSymbol("concordium.v2.Queries")
+	require.NoError(t, err)
+}
+
+func TestDescriptorSourceForNode_FileModeErrors(t *testing.T) {
+	ResetProtosetCacheForTest()
+
+	t.Run("missing path", func(t *testing.T) {
+		_, err := DescriptorSourceForNode(common.GrpcDescriptorSourceFile, "", nil)
+		require.Error(t, err)
+	})
+
+	t.Run("unreadable path", func(t *testing.T) {
+		_, err := DescriptorSourceForNode(common.GrpcDescriptorSourceFile,
+			filepath.Join(t.TempDir(), "does-not-exist.protoset"), nil)
+		require.Error(t, err)
+	})
+
+	t.Run("corrupt protoset", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "corrupt.protoset")
+		require.NoError(t, os.WriteFile(path, []byte("this is not a FileDescriptorSet"), 0o600))
+		_, err := DescriptorSourceForNode(common.GrpcDescriptorSourceFile, path, nil)
+		require.Error(t, err)
+	})
+}
+
+func TestDescriptorSourceForNode_UnknownModeIsRejected(t *testing.T) {
+	_, err := DescriptorSourceForNode("telepathy", "", nil)
+	require.Error(t, err)
+}
+
+func TestDescriptorSourceForNode_HybridPrefersFileThenFallsBack(t *testing.T) {
+	ResetProtosetCacheForTest()
+	dir := t.TempDir()
+	server := newCountingSource(t, writeTestProtoset(t, dir, "server", "server.v1", "ServerOnly"))
+	protoset := writeTestProtoset(t, dir, "file", "file.v1", "FileOnly")
+
+	source, err := DescriptorSourceForNode(common.GrpcDescriptorSourceHybrid, protoset, server)
+	require.NoError(t, err)
+
+	t.Run("symbol in protoset does not reach reflection", func(t *testing.T) {
+		_, err := source.FindSymbol("file.v1.FileOnly")
+		require.NoError(t, err)
+		require.Zero(t, server.findCalls.Load())
+	})
+
+	t.Run("symbol missing from protoset falls back to reflection", func(t *testing.T) {
+		descriptor, err := source.FindSymbol("server.v1.ServerOnly")
+		require.NoError(t, err)
+		require.NotNil(t, descriptor)
+		require.Equal(t, int32(1), server.findCalls.Load())
+	})
+
+	t.Run("symbol in neither reports both causes", func(t *testing.T) {
+		_, err := source.FindSymbol("nowhere.v1.Missing")
+		require.Error(t, err)
+	})
+
+	t.Run("ListServices unions both halves", func(t *testing.T) {
+		services, err := source.ListServices()
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"file.v1.FileOnly", "server.v1.ServerOnly"}, services)
+	})
+}
+
+func TestDescriptorSourceForNode_HybridSurvivesReflectionOutage(t *testing.T) {
+	ResetProtosetCacheForTest()
+	dir := t.TempDir()
+	server := newCountingSource(t, writeTestProtoset(t, dir, "server", "server.v1", "ServerOnly"))
+	server.forcedErr = errors.New("server does not support the reflection API")
+	protoset := writeTestProtoset(t, dir, "file", "file.v1", "FileOnly")
+
+	source, err := DescriptorSourceForNode(common.GrpcDescriptorSourceHybrid, protoset, server)
+	require.NoError(t, err)
+
+	// The protoset answered; a dead reflection service must not erase that.
+	descriptor, err := source.FindSymbol("file.v1.FileOnly")
+	require.NoError(t, err)
+	require.NotNil(t, descriptor)
+
+	services, err := source.ListServices()
+	require.NoError(t, err)
+	require.Equal(t, []string{"file.v1.FileOnly"}, services)
+}
+
+func TestDescriptorSourceForNode_HybridDegradesToReflectionOnBadProtoset(t *testing.T) {
+	ResetProtosetCacheForTest()
+	dir := t.TempDir()
+	server := newCountingSource(t, writeTestProtoset(t, dir, "server", "server.v1", "ServerOnly"))
+
+	t.Run("unreadable protoset", func(t *testing.T) {
+		source, err := DescriptorSourceForNode(common.GrpcDescriptorSourceHybrid,
+			filepath.Join(dir, "missing.protoset"), server)
+		require.NoError(t, err, "hybrid tolerates an unusable protoset")
+		require.Same(t, server, source)
+	})
+
+	t.Run("no protoset configured", func(t *testing.T) {
+		source, err := DescriptorSourceForNode(common.GrpcDescriptorSourceHybrid, "", server)
+		require.NoError(t, err)
+		require.Same(t, server, source)
+	})
+}
+
+func TestLoadProtoset_ParsesOncePerPath(t *testing.T) {
+	ResetProtosetCacheForTest()
+	protoset := writeTestProtoset(t, t.TempDir(), "chain", "concordium.v2", "Queries")
+
+	first, err := LoadProtoset(protoset)
+	require.NoError(t, err)
+
+	// Same pointer on the second call proves the parse was memoized rather than
+	// repeated — the reason this cache exists at all for a 335KB file.
+	second, err := LoadProtoset(protoset)
+	require.NoError(t, err)
+	require.Same(t, first, second)
+
+	// Concurrent first-touch must also collapse to one parse.
+	ResetProtosetCacheForTest()
+	var wg sync.WaitGroup
+	sources := make([]grpcurl.DescriptorSource, 8)
+	for i := range sources {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			source, loadErr := LoadProtoset(protoset)
+			require.NoError(t, loadErr)
+			sources[idx] = source
+		}(i)
+	}
+	wg.Wait()
+	for _, source := range sources {
+		require.Same(t, sources[0], source)
+	}
+}
+
+func TestDescriptorSourceForGrpcConfig(t *testing.T) {
+	ResetProtosetCacheForTest()
+	dir := t.TempDir()
+	server := newCountingSource(t, writeTestProtoset(t, dir, "server", "server.v1", "ServerOnly"))
+	protoset := writeTestProtoset(t, dir, "file", "file.v1", "FileOnly")
+
+	t.Run("nil config defaults to reflection", func(t *testing.T) {
+		source, err := DescriptorSourceForGrpcConfig(nil, server)
+		require.NoError(t, err)
+		require.Same(t, server, source)
+	})
+
+	t.Run("zero config defaults to reflection", func(t *testing.T) {
+		source, err := DescriptorSourceForGrpcConfig(&common.GrpcConfig{}, server)
+		require.NoError(t, err)
+		require.Same(t, server, source)
+	})
+
+	t.Run("file config resolves from disk", func(t *testing.T) {
+		source, err := DescriptorSourceForGrpcConfig(&common.GrpcConfig{
+			DescriptorSource:  common.GrpcDescriptorSourceFile,
+			DescriptorSetPath: protoset,
+		}, server)
+		require.NoError(t, err)
+		_, err = source.FindSymbol("file.v1.FileOnly")
+		require.NoError(t, err)
+	})
+}

--- a/protocol/chainlib/grpc.go
+++ b/protocol/chainlib/grpc.go
@@ -128,8 +128,17 @@ func (apip *GrpcChainParser) setupForConsumer(relayer grpcproxy.ProxyCallBack) {
 	apip.codec = dyncodec.NewCodec(apip.registry)
 }
 
-func (apip *GrpcChainParser) setupForProvider(reflectionConnection *grpc.ClientConn) error {
-	remote := dyncodec.NewGRPCReflectionProtoFileRegistryFromConn(reflectionConnection)
+// setupForProvider builds the registry that backs GrpcMessage.dynamicResolve —
+// the path GetParams takes for binary-proto requests, and therefore what block
+// parsing depends on. It honours grpc-config for the same reason SendNodeMsg does:
+// a node that does not serve reflection would otherwise boot and then fail here,
+// at parse time, instead of at connect time (MAG-2350).
+func (apip *GrpcChainParser) setupForProvider(reflectionConnection *grpc.ClientConn, grpcConfig *common.GrpcConfig) error {
+	var remote dyncodec.ProtoFileRegistry = dyncodec.NewGRPCReflectionProtoFileRegistryFromConn(reflectionConnection)
+	remote, err := dyncodec.ProtoFileRegistryForGrpcConfig(grpcConfig, remote)
+	if err != nil {
+		return err
+	}
 	apip.registry = dyncodec.NewRegistry(remote)
 	apip.codec = dyncodec.NewCodec(apip.registry)
 	return nil
@@ -479,7 +488,10 @@ func NewGrpcChainProxy(ctx context.Context, nConns uint, rpcProviderEndpoint lav
 
 func newGrpcChainProxy(ctx context.Context, averageBlockTime time.Duration, parser ChainParser, conn grpcConnectorInterface, rpcProviderEndpoint lavasession.RPCProviderEndpoint) (ChainProxy, error) {
 	cp := &GrpcChainProxy{
-		BaseChainProxy:   BaseChainProxy{averageBlockTime: averageBlockTime, ErrorHandler: &GRPCErrorHandler{chainFamily: common.GetChainFamilyOrDefault(rpcProviderEndpoint.ChainID), chainID: rpcProviderEndpoint.ChainID}, ChainID: rpcProviderEndpoint.ChainID, HashedNodeUrl: chainproxy.HashURL(rpcProviderEndpoint.NodeUrls[0].Url)},
+		// NodeUrl is what carries grpc-config onto the request path; without it
+		// cp.NodeUrl.GrpcConfig is the zero value and descriptor-source is invisible
+		// here no matter what the config says (MAG-2350).
+		BaseChainProxy:   BaseChainProxy{averageBlockTime: averageBlockTime, ErrorHandler: &GRPCErrorHandler{chainFamily: common.GetChainFamilyOrDefault(rpcProviderEndpoint.ChainID), chainID: rpcProviderEndpoint.ChainID}, ChainID: rpcProviderEndpoint.ChainID, NodeUrl: rpcProviderEndpoint.NodeUrls[0], HashedNodeUrl: chainproxy.HashURL(rpcProviderEndpoint.NodeUrls[0].Url)},
 		descriptorsCache: &common.SafeSyncMap[string, *desc.MethodDescriptor]{},
 	}
 	cp.conn = conn
@@ -502,7 +514,7 @@ func newGrpcChainProxy(ctx context.Context, averageBlockTime time.Duration, pars
 	if !ok {
 		return nil, fmt.Errorf("grpc chain proxy: parser is not a GrpcChainParser")
 	}
-	err = grpcParser.setupForProvider(reflectionConnection)
+	err = grpcParser.setupForProvider(reflectionConnection, &cp.NodeUrl.GrpcConfig)
 	if err != nil {
 		return nil, fmt.Errorf("grpc chain proxy: failed to setup parser: %w", err)
 	}
@@ -541,7 +553,10 @@ func (cp *GrpcChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{}, 
 	}
 
 	cl := grpcreflect.NewClientAuto(ctx, conn)
-	descriptorSource := rpcInterfaceMessages.DescriptorSourceFromServer(cl)
+	descriptorSource, err := rpcInterfaceMessages.DescriptorSourceForGrpcConfig(&cp.NodeUrl.GrpcConfig, rpcInterfaceMessages.DescriptorSourceFromServer(cl))
+	if err != nil {
+		return nil, "", nil, utils.LavaFormatError("failed resolving grpc descriptor source", err, utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: utils.KEY_REQUEST_ID, Value: ctx}, utils.Attribute{Key: utils.KEY_TASK_ID, Value: ctx}, utils.Attribute{Key: utils.KEY_TRANSACTION_ID, Value: ctx})
+	}
 	svc, methodName := rpcInterfaceMessages.ParseSymbol(nodeMessage.Path)
 
 	// Check if we have method descriptor already cached.

--- a/protocol/chainlib/grpc.go
+++ b/protocol/chainlib/grpc.go
@@ -54,6 +54,24 @@ type GrpcChainParser struct {
 
 	registry *dyncodec.Registry
 	codec    *dyncodec.Codec
+
+	// descriptorConfig records which node-url's grpc-config produced registry/codec,
+	// so a second node-url asking for a different one is caught rather than silently
+	// winning. See setupForProvider.
+	descriptorConfig *grpcDescriptorConfig
+}
+
+// grpcDescriptorConfig is the descriptor resolution a single node-url asks for.
+type grpcDescriptorConfig struct {
+	source string
+	path   string
+}
+
+func (c grpcDescriptorConfig) String() string {
+	if c.path == "" {
+		return c.source
+	}
+	return c.source + " (" + c.path + ")"
 }
 
 // NewGrpcChainParser creates a new instance of GrpcChainParser
@@ -83,6 +101,12 @@ func NewGrpcChainParser() (chainParser *GrpcChainParser, err error) {
 //
 // registry/codec are aliased initially; setupForProvider on the clone will
 // replace the *clone's* fields, leaving the live parser untouched.
+//
+// descriptorConfig is deliberately NOT carried over: it records which node-url
+// produced the clone's registry, and the clone is built for a verification
+// endpoint whose node-url set is chosen by the caller. Starting it at nil lets
+// the clone record what it is actually given, and still catches a conflict
+// within that set.
 func (apip *GrpcChainParser) cloneForValidation() *GrpcChainParser {
 	return &GrpcChainParser{
 		BaseChainParser: BaseChainParser{
@@ -134,6 +158,22 @@ func (apip *GrpcChainParser) setupForConsumer(relayer grpcproxy.ProxyCallBack) {
 // a node that does not serve reflection would otherwise boot and then fail here,
 // at parse time, instead of at connect time (MAG-2350).
 func (apip *GrpcChainParser) setupForProvider(reflectionConnection *grpc.ClientConn, grpcConfig *common.GrpcConfig) error {
+	// registry/codec are per chain; grpc-config is per node-url. newChainRouter
+	// builds one proxy per node-url batch entry and hands every one of them THIS
+	// parser, so each call overwrites the last — and since the batch is a map, "last"
+	// is whatever Go's randomized iteration order picks that boot. That was benign
+	// while every iteration produced an equivalent reflection registry; now that the
+	// registry follows the node-url's grpc-config, a chain whose gRPC node-urls
+	// disagree would parse blocks against a different descriptor set on each restart.
+	// Refuse the config rather than pick one of them at random (MAG-2350).
+	wanted := grpcDescriptorConfig{source: grpcConfig.GetDescriptorSource(), path: grpcConfig.DescriptorSetPath}
+	if apip.descriptorConfig != nil && *apip.descriptorConfig != wanted {
+		return utils.LavaFormatError("conflicting gRPC descriptor-source across a chain's node-urls", nil,
+			utils.LogAttr("configured", apip.descriptorConfig.String()),
+			utils.LogAttr("conflicting", wanted.String()),
+			utils.LogAttr("resolution", "block parsing resolves through one registry per chain, so every gRPC node-url on a chain must declare the same descriptor-source and descriptor-set-path"))
+	}
+
 	var remote dyncodec.ProtoFileRegistry = dyncodec.NewGRPCReflectionProtoFileRegistryFromConn(reflectionConnection)
 	remote, err := dyncodec.ProtoFileRegistryForGrpcConfig(grpcConfig, remote)
 	if err != nil {
@@ -141,6 +181,7 @@ func (apip *GrpcChainParser) setupForProvider(reflectionConnection *grpc.ClientC
 	}
 	apip.registry = dyncodec.NewRegistry(remote)
 	apip.codec = dyncodec.NewCodec(apip.registry)
+	apip.descriptorConfig = &wanted
 	return nil
 }
 

--- a/protocol/chainlib/grpc_test.go
+++ b/protocol/chainlib/grpc_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcInterfaceMessages"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/extensionslib"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/grpcproxy/dyncodec"
+	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/parser"
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
 	spectypes "github.com/magma-Devs/smart-router/types/spec"
@@ -380,4 +381,100 @@ func TestCloneChainParserForValidation_NonGrpcReturnsOriginal(t *testing.T) {
 	tmParser, err := NewTendermintRpcChainParser()
 	require.NoError(t, err)
 	require.Same(t, ChainParser(tmParser), CloneChainParserForValidation(tmParser), "non-gRPC parser must be returned as-is")
+}
+
+// TestSetupForProvider_RejectsConflictingDescriptorSource pins the per-chain /
+// per-node-url mismatch that wiring descriptor-source into setupForProvider creates.
+//
+// newChainRouter builds one proxy per node-url batch entry and passes THIS parser to
+// every one of them, so each setupForProvider call overwrites registry/codec. The
+// batch is a map, so before this guard the winner was whatever Go's randomized
+// iteration order picked that boot — a chain with one "file" node-url and one
+// reflection node-url would parse blocks against a different descriptor set on each
+// restart. Refusing the config is the only outcome that is the same every boot.
+func TestSetupForProvider_RejectsConflictingDescriptorSource(t *testing.T) {
+	protosetPath := "/tmp/does-not-need-to-exist.pb"
+
+	t.Run("second node-url disagreeing is rejected", func(t *testing.T) {
+		parser := &GrpcChainParser{}
+		// reflectionConnection is nil throughout: the conflict is decided from config
+		// alone, before any registry is built, so no descriptor lookup happens here.
+		require.NoError(t, parser.setupForProvider(nil, &common.GrpcConfig{}))
+		registryAfterFirst := parser.registry
+
+		err := parser.setupForProvider(nil, &common.GrpcConfig{
+			DescriptorSource:  common.GrpcDescriptorSourceFile,
+			DescriptorSetPath: protosetPath,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "conflicting gRPC descriptor-source")
+		require.Same(t, registryAfterFirst, parser.registry,
+			"a rejected node-url must not have replaced the registry on its way out")
+	})
+
+	t.Run("the reverse direction is rejected too", func(t *testing.T) {
+		parser := &GrpcChainParser{}
+		require.NoError(t, parser.setupForProvider(nil, &common.GrpcConfig{
+			DescriptorSource:  common.GrpcDescriptorSourceHybrid,
+			DescriptorSetPath: protosetPath,
+		}))
+		require.Error(t, parser.setupForProvider(nil, &common.GrpcConfig{}))
+	})
+
+	t.Run("same path, different mode is rejected", func(t *testing.T) {
+		parser := &GrpcChainParser{}
+		require.NoError(t, parser.setupForProvider(nil, &common.GrpcConfig{
+			DescriptorSource:  common.GrpcDescriptorSourceHybrid,
+			DescriptorSetPath: protosetPath,
+		}))
+		require.Error(t, parser.setupForProvider(nil, &common.GrpcConfig{
+			DescriptorSource:  common.GrpcDescriptorSourceFile,
+			DescriptorSetPath: protosetPath,
+		}))
+	})
+
+	// The guard must stay invisible to every config that is actually consistent —
+	// above all the overwhelmingly common one, where no node-url mentions grpc-config
+	// at all and each batch entry builds an equivalent reflection registry.
+	t.Run("agreeing node-urls are accepted", func(t *testing.T) {
+		for _, agreeing := range [][2]common.GrpcConfig{
+			{{}, {}},
+			// An omitted descriptor-source and an explicit "reflection" are the same
+			// request; GetDescriptorSource normalizes before they are compared.
+			{{}, {DescriptorSource: common.GrpcDescriptorSourceReflection}},
+			{
+				{DescriptorSource: common.GrpcDescriptorSourceFile, DescriptorSetPath: protosetPath},
+				{DescriptorSource: common.GrpcDescriptorSourceFile, DescriptorSetPath: protosetPath},
+			},
+			// Fields the registry does not depend on must not read as a conflict.
+			{{}, {AllowInsecure: true, ReflectionTimeout: time.Second}},
+		} {
+			parser := &GrpcChainParser{}
+			first, second := agreeing[0], agreeing[1]
+			// "file" mode with a path that does not exist fails in the loader, not in
+			// the conflict guard — which is the distinction being asserted.
+			firstErr := parser.setupForProvider(nil, &first)
+			secondErr := parser.setupForProvider(nil, &second)
+			for _, err := range []error{firstErr, secondErr} {
+				if err != nil {
+					require.NotContains(t, err.Error(), "conflicting gRPC descriptor-source")
+				}
+			}
+		}
+	})
+
+	// cloneForValidation starts a fresh record on purpose: the clone serves whatever
+	// node-url subset the re-verification loop hands it, and must not inherit a
+	// conflict with a set it was never given.
+	t.Run("validation clone does not inherit the record", func(t *testing.T) {
+		live := &GrpcChainParser{}
+		require.NoError(t, live.setupForProvider(nil, &common.GrpcConfig{}))
+
+		clone := live.cloneForValidation()
+		require.NoError(t, clone.setupForProvider(nil, &common.GrpcConfig{
+			DescriptorSource:  common.GrpcDescriptorSourceHybrid,
+			DescriptorSetPath: protosetPath,
+		}))
+		require.NotNil(t, live.registry, "the clone must not have disturbed the live parser")
+	})
 }

--- a/protocol/chainlib/grpcproxy/dyncodec/proto_file_registry_source.go
+++ b/protocol/chainlib/grpcproxy/dyncodec/proto_file_registry_source.go
@@ -2,6 +2,7 @@ package dyncodec
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/magma-Devs/smart-router/protocol/common"
@@ -80,6 +81,31 @@ type compositeProtoFileRegistry struct {
 
 var _ ProtoFileRegistry = (*compositeProtoFileRegistry)(nil)
 
+// exactSymbolLookup is the strict half of a descriptor-set registry: does it declare
+// this symbol itself, as opposed to merely declaring one of its ancestors.
+//
+// FileDescriptorSetRegistry.ProtoFileContainingSymbol walks up the parent chain —
+// "pkg.Query.Ping" resolves through "pkg.Query" — and on a miss returns the
+// ancestor's file with a nil error. That is harmless in "file" mode, where the
+// lookup was going to fail either way, but in hybrid the nil error is precisely what
+// decides whether reflection gets asked. An rpc the node gained after the protoset
+// was cut resolves to the stale file, reflection is never consulted, and the
+// operator sees "not found" at the one point the mode exists to cover.
+type exactSymbolLookup interface {
+	HasSymbol(name string) bool
+}
+
+// fileHalfDeclares reports whether the descriptor-set half declares name itself. A
+// half that cannot answer strictly is taken at its word.
+func (c *compositeProtoFileRegistry) fileHalfDeclares(name protoreflect.FullName) bool {
+	strict, ok := c.file.(exactSymbolLookup)
+	if !ok {
+		return true
+	}
+	// ProtoFileContainingSymbol tolerates a leading dot; the symbol index does not.
+	return strict.HasSymbol(strings.TrimPrefix(string(name), "."))
+}
+
 func (c *compositeProtoFileRegistry) ProtoFileByPath(path string) (*descriptorpb.FileDescriptorProto, error) {
 	file, fileErr := c.file.ProtoFileByPath(path)
 	if fileErr == nil {
@@ -99,8 +125,13 @@ func (c *compositeProtoFileRegistry) ProtoFileByPath(path string) (*descriptorpb
 
 func (c *compositeProtoFileRegistry) ProtoFileContainingSymbol(name protoreflect.FullName) (*descriptorpb.FileDescriptorProto, error) {
 	file, fileErr := c.file.ProtoFileContainingSymbol(name)
-	if fileErr == nil {
+	if fileErr == nil && c.fileHalfDeclares(name) {
 		return file, nil
+	}
+	if fileErr == nil {
+		// An ancestor matched but the symbol itself is absent. Treating that as a hit
+		// is what made hybrid's fallback unreachable; treat it as the miss it is.
+		fileErr = fmt.Errorf("descriptor set declares an ancestor of %s but not the symbol itself", name)
 	}
 
 	file, serverErr := c.server.ProtoFileContainingSymbol(name)

--- a/protocol/chainlib/grpcproxy/dyncodec/proto_file_registry_source.go
+++ b/protocol/chainlib/grpcproxy/dyncodec/proto_file_registry_source.go
@@ -1,0 +1,185 @@
+package dyncodec
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/utils"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// This is the ProtoFileRegistry half of descriptor-source selection. The grpcurl
+// DescriptorSource half lives in rpcInterfaceMessages/fileDescriptorSource.go.
+//
+// Both exist because the router resolves descriptors through two unrelated
+// interfaces: grpcurl.DescriptorSource drives request/response marshalling, while
+// ProtoFileRegistry backs GrpcMessage.dynamicResolve — i.e. GetParams, i.e. block
+// parsing on binary-proto requests. Wiring only the first leaves a node that does
+// not serve reflection booting successfully and then failing at parse time.
+
+// fileRegistryCache memoizes parsed descriptor-set registries by path, for the same
+// reason the protoset cache exists: the file is static config and parsing it is not
+// free. Entries are shared across every proxy that names the same path.
+var fileRegistryCache sync.Map // map[string]*fileRegistryEntry
+
+type fileRegistryEntry struct {
+	once     sync.Once
+	registry *FileDescriptorSetRegistry
+	err      error
+}
+
+// loadCachedFileRegistry parses a descriptor set at most once per path per process.
+func loadCachedFileRegistry(path string) (*FileDescriptorSetRegistry, error) {
+	cached, _ := fileRegistryCache.LoadOrStore(path, &fileRegistryEntry{})
+	entry, ok := cached.(*fileRegistryEntry)
+	if !ok {
+		return nil, utils.LavaFormatError("corrupt descriptor set cache entry", nil,
+			utils.LogAttr("descriptor-set-path", path))
+	}
+
+	entry.once.Do(func() {
+		entry.registry, entry.err = NewFileDescriptorSetRegistryFromPath(path)
+	})
+
+	return entry.registry, entry.err
+}
+
+// ResetFileRegistryCacheForTest drops every memoized registry. Production never
+// calls this; tests that rewrite a descriptor set at a reused temp path must.
+func ResetFileRegistryCacheForTest() {
+	fileRegistryCache.Range(func(key, _ any) bool {
+		fileRegistryCache.Delete(key)
+		return true
+	})
+}
+
+// sharedFileRegistry adapts a cached registry to ProtoFileRegistry while dropping
+// Close on the floor.
+//
+// FileDescriptorSetRegistry.Close latches the registry shut and every subsequent
+// lookup returns "registry is closed". Since one parsed registry is now shared by
+// every proxy naming that path, honouring Close from any single consumer would
+// silently break the others. The underlying data is immutable and lives for the
+// process, so there is nothing to release.
+type sharedFileRegistry struct {
+	*FileDescriptorSetRegistry
+}
+
+func (sharedFileRegistry) Close() error { return nil }
+
+// compositeProtoFileRegistry resolves against a descriptor set first and falls back
+// to reflection — the ProtoFileRegistry form of "hybrid" mode. File-first for the
+// same reason as the grpcurl side: hybrid exists precisely for nodes whose
+// reflection is missing, partial, or throttled.
+type compositeProtoFileRegistry struct {
+	file   ProtoFileRegistry
+	server ProtoFileRegistry
+}
+
+var _ ProtoFileRegistry = (*compositeProtoFileRegistry)(nil)
+
+func (c *compositeProtoFileRegistry) ProtoFileByPath(path string) (*descriptorpb.FileDescriptorProto, error) {
+	file, fileErr := c.file.ProtoFileByPath(path)
+	if fileErr == nil {
+		return file, nil
+	}
+
+	file, serverErr := c.server.ProtoFileByPath(path)
+	if serverErr == nil {
+		return file, nil
+	}
+
+	return nil, utils.LavaFormatError("proto file not found in descriptor set or via reflection", nil,
+		utils.LogAttr("path", path),
+		utils.LogAttr("descriptor_set_error", fileErr),
+		utils.LogAttr("reflection_error", serverErr))
+}
+
+func (c *compositeProtoFileRegistry) ProtoFileContainingSymbol(name protoreflect.FullName) (*descriptorpb.FileDescriptorProto, error) {
+	file, fileErr := c.file.ProtoFileContainingSymbol(name)
+	if fileErr == nil {
+		return file, nil
+	}
+
+	file, serverErr := c.server.ProtoFileContainingSymbol(name)
+	if serverErr == nil {
+		return file, nil
+	}
+
+	return nil, utils.LavaFormatError("symbol not found in descriptor set or via reflection", nil,
+		utils.LogAttr("symbol", string(name)),
+		utils.LogAttr("descriptor_set_error", fileErr),
+		utils.LogAttr("reflection_error", serverErr))
+}
+
+// Close closes only the reflection half; the descriptor-set half is a shared
+// cached registry that must outlive any one consumer.
+func (c *compositeProtoFileRegistry) Close() error {
+	fileErr := c.file.Close()
+	serverErr := c.server.Close()
+	if serverErr != nil {
+		return serverErr
+	}
+	return fileErr
+}
+
+// ProtoFileRegistryForNode picks the ProtoFileRegistry implied by a node's
+// grpc-config. serverRemote is the reflection-backed registry the caller already
+// built; in "file" mode it is never consulted, and is closed here so the caller
+// does not leak it.
+func ProtoFileRegistryForNode(mode, descriptorSetPath string, serverRemote ProtoFileRegistry) (ProtoFileRegistry, error) {
+	switch mode {
+	case common.GrpcDescriptorSourceFile:
+		if descriptorSetPath == "" {
+			return nil, utils.LavaFormatError("descriptor-set-path is required for descriptor-source: file", nil)
+		}
+		registry, err := loadCachedFileRegistry(descriptorSetPath)
+		if err != nil {
+			return nil, err
+		}
+		if serverRemote != nil {
+			// Nothing will consult reflection in this mode; release it rather than
+			// hold an idle handle for the life of the proxy.
+			_ = serverRemote.Close()
+		}
+		return sharedFileRegistry{FileDescriptorSetRegistry: registry}, nil
+
+	case common.GrpcDescriptorSourceHybrid:
+		if descriptorSetPath == "" {
+			return serverRemote, nil
+		}
+		registry, err := loadCachedFileRegistry(descriptorSetPath)
+		if err != nil {
+			utils.LavaFormatWarning("hybrid descriptor source: descriptor set unusable, falling back to reflection only", err,
+				utils.LogAttr("descriptor-set-path", descriptorSetPath))
+			return serverRemote, nil
+		}
+		return &compositeProtoFileRegistry{
+			file:   sharedFileRegistry{FileDescriptorSetRegistry: registry},
+			server: serverRemote,
+		}, nil
+
+	case common.GrpcDescriptorSourceReflection, "":
+		return serverRemote, nil
+
+	default:
+		return nil, utils.LavaFormatError("invalid gRPC descriptor-source", nil,
+			utils.LogAttr("descriptor-source", mode),
+			utils.LogAttr("valid_options", fmt.Sprintf("%s, %s, %s",
+				common.GrpcDescriptorSourceReflection,
+				common.GrpcDescriptorSourceFile,
+				common.GrpcDescriptorSourceHybrid)))
+	}
+}
+
+// ProtoFileRegistryForGrpcConfig is the call-site convenience over
+// ProtoFileRegistryForNode; a nil config means the reflection default. It mirrors
+// rpcInterfaceMessages.DescriptorSourceForGrpcConfig on the other half.
+func ProtoFileRegistryForGrpcConfig(grpcConfig *common.GrpcConfig, serverRemote ProtoFileRegistry) (ProtoFileRegistry, error) {
+	if grpcConfig == nil {
+		return serverRemote, nil
+	}
+	return ProtoFileRegistryForNode(grpcConfig.GetDescriptorSource(), grpcConfig.DescriptorSetPath, serverRemote)
+}

--- a/protocol/chainlib/grpcproxy/dyncodec/proto_file_registry_source_test.go
+++ b/protocol/chainlib/grpcproxy/dyncodec/proto_file_registry_source_test.go
@@ -272,3 +272,74 @@ func TestCompositeProtoFileRegistry_CloseClosesReflectionHalf(t *testing.T) {
 	require.NoError(t, registry.Close())
 	require.True(t, remote.closed.Load())
 }
+
+// TestCompositeProtoFileRegistry_AncestorMatchDoesNotShadowReflection pins the bug
+// hybrid exists to avoid: a protoset that predates the node.
+//
+// FileDescriptorSetRegistry.ProtoFileContainingSymbol walks up the parent chain, so
+// "pkg.Query.Balance" resolves through "pkg.Query" and returns the stale file with a
+// NIL error even though the rpc is absent. The composite falls back on error alone,
+// so before this guard reflection was never consulted and the caller got NotFound
+// from Registry.FindDescriptorByName — at exactly the staleness case DescriptorSetPath's
+// doc comment warns about. dynamicResolve (GetParams → block parsing) passes a method
+// full name, so a node upgrade adding an rpc is the live trigger, not a rare nested type.
+func TestCompositeProtoFileRegistry_AncestorMatchDoesNotShadowReflection(t *testing.T) {
+	// The protoset knows service hybrid.v1.Query with a single rpc, Ping.
+	descriptorSet := writeTestDescriptorSet(t, t.TempDir(), "chain", "hybrid.v1", "Query")
+
+	t.Run("rpc added upstream falls through to reflection", func(t *testing.T) {
+		ResetFileRegistryCacheForTest()
+		remote := &countingRegistry{answers: map[string]string{"hybrid.v1.Query.Balance": "reflected.proto"}}
+
+		registry, err := ProtoFileRegistryForNode(common.GrpcDescriptorSourceHybrid, descriptorSet, remote)
+		require.NoError(t, err)
+
+		file, err := registry.ProtoFileContainingSymbol("hybrid.v1.Query.Balance")
+		require.NoError(t, err)
+		require.Equal(t, "reflected.proto", file.GetName(),
+			"an ancestor match must not be accepted as the symbol's file")
+		require.Equal(t, int32(1), remote.symbolCalls.Load(), "reflection must be consulted")
+	})
+
+	t.Run("nested type added upstream falls through to reflection", func(t *testing.T) {
+		ResetFileRegistryCacheForTest()
+		remote := &countingRegistry{answers: map[string]string{"hybrid.v1.PingRequest.Added": "reflected.proto"}}
+
+		registry, err := ProtoFileRegistryForNode(common.GrpcDescriptorSourceHybrid, descriptorSet, remote)
+		require.NoError(t, err)
+
+		file, err := registry.ProtoFileContainingSymbol("hybrid.v1.PingRequest.Added")
+		require.NoError(t, err)
+		require.Equal(t, "reflected.proto", file.GetName())
+		require.Equal(t, int32(1), remote.symbolCalls.Load())
+	})
+
+	// The other half of the guard: strictness must not cost the protoset its hits.
+	// A method the set DOES declare still resolves locally, reflection untouched.
+	for _, symbol := range []string{"hybrid.v1.Query", "hybrid.v1.Query.Ping", "hybrid.v1.PingRequest", ".hybrid.v1.Query.Ping"} {
+		t.Run("declared symbol stays local: "+symbol, func(t *testing.T) {
+			ResetFileRegistryCacheForTest()
+			remote := &countingRegistry{answers: map[string]string{symbol: "reflected.proto"}}
+
+			registry, err := ProtoFileRegistryForNode(common.GrpcDescriptorSourceHybrid, descriptorSet, remote)
+			require.NoError(t, err)
+
+			file, err := registry.ProtoFileContainingSymbol(protoreflect.FullName(symbol))
+			require.NoError(t, err)
+			require.Equal(t, "chain.proto", file.GetName())
+			require.Zero(t, remote.symbolCalls.Load(), "the protoset declares it; reflection must not be asked")
+		})
+	}
+
+	t.Run("absent everywhere reports both causes", func(t *testing.T) {
+		ResetFileRegistryCacheForTest()
+		remote := &countingRegistry{}
+
+		registry, err := ProtoFileRegistryForNode(common.GrpcDescriptorSourceHybrid, descriptorSet, remote)
+		require.NoError(t, err)
+
+		_, err = registry.ProtoFileContainingSymbol("hybrid.v1.Query.Balance")
+		require.Error(t, err)
+		require.Equal(t, int32(1), remote.symbolCalls.Load())
+	})
+}

--- a/protocol/chainlib/grpcproxy/dyncodec/proto_file_registry_source_test.go
+++ b/protocol/chainlib/grpcproxy/dyncodec/proto_file_registry_source_test.go
@@ -1,0 +1,274 @@
+package dyncodec
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// writeTestDescriptorSet builds a one-file FileDescriptorSet declaring pkg.service and
+// writes it to disk, so these tests need neither protoc nor buf.
+func writeTestDescriptorSet(t *testing.T, dir, fileName, pkg, service string) string {
+	t.Helper()
+
+	raw, err := proto.Marshal(&descriptorpb.FileDescriptorSet{
+		File: []*descriptorpb.FileDescriptorProto{
+			{
+				Name:    proto.String(fileName + ".proto"),
+				Package: proto.String(pkg),
+				Syntax:  proto.String("proto3"),
+				MessageType: []*descriptorpb.DescriptorProto{
+					{Name: proto.String("PingRequest")},
+					{Name: proto.String("PingResponse")},
+				},
+				Service: []*descriptorpb.ServiceDescriptorProto{
+					{
+						Name: proto.String(service),
+						Method: []*descriptorpb.MethodDescriptorProto{
+							{
+								Name:       proto.String("Ping"),
+								InputType:  proto.String("." + pkg + ".PingRequest"),
+								OutputType: proto.String("." + pkg + ".PingResponse"),
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	path := filepath.Join(dir, fileName+".pb")
+	require.NoError(t, os.WriteFile(path, raw, 0o600))
+	return path
+}
+
+// countingRegistry records how often the reflection half is consulted and whether it
+// was closed. "file" mode must never consult it and must not leak it.
+type countingRegistry struct {
+	symbolCalls atomic.Int32
+	pathCalls   atomic.Int32
+	closed      atomic.Bool
+	answers     map[string]string // symbol or path -> owning file name
+	forcedErr   error
+}
+
+func (c *countingRegistry) ProtoFileByPath(path string) (*descriptorpb.FileDescriptorProto, error) {
+	c.pathCalls.Add(1)
+	if c.forcedErr != nil {
+		return nil, c.forcedErr
+	}
+	if name, ok := c.answers[path]; ok {
+		return &descriptorpb.FileDescriptorProto{Name: proto.String(name)}, nil
+	}
+	return nil, errors.New("proto file not found")
+}
+
+func (c *countingRegistry) ProtoFileContainingSymbol(name protoreflect.FullName) (*descriptorpb.FileDescriptorProto, error) {
+	c.symbolCalls.Add(1)
+	if c.forcedErr != nil {
+		return nil, c.forcedErr
+	}
+	if fileName, ok := c.answers[string(name)]; ok {
+		return &descriptorpb.FileDescriptorProto{Name: proto.String(fileName)}, nil
+	}
+	return nil, errors.New("symbol not found")
+}
+
+func (c *countingRegistry) Close() error {
+	c.closed.Store(true)
+	return nil
+}
+
+func TestProtoFileRegistryForNode_ReflectionModesPassRemoteThrough(t *testing.T) {
+	ResetFileRegistryCacheForTest()
+	remote := &countingRegistry{}
+
+	for _, mode := range []string{common.GrpcDescriptorSourceReflection, ""} {
+		t.Run("mode="+mode, func(t *testing.T) {
+			registry, err := ProtoFileRegistryForNode(mode, "", remote)
+			require.NoError(t, err)
+			require.Same(t, remote, registry)
+			require.False(t, remote.closed.Load())
+		})
+	}
+}
+
+func TestProtoFileRegistryForNode_FileModeNeverConsultsReflection(t *testing.T) {
+	ResetFileRegistryCacheForTest()
+	dir := t.TempDir()
+	remote := &countingRegistry{answers: map[string]string{"concordium.v2.Queries": "reflected.proto"}}
+	descriptorSet := writeTestDescriptorSet(t, dir, "chain", "concordium.v2", "Queries")
+
+	registry, err := ProtoFileRegistryForNode(common.GrpcDescriptorSourceFile, descriptorSet, remote)
+	require.NoError(t, err)
+
+	file, err := registry.ProtoFileContainingSymbol("concordium.v2.Queries")
+	require.NoError(t, err)
+	require.Equal(t, "chain.proto", file.GetName(), "answer must come from the descriptor set, not reflection")
+
+	require.Zero(t, remote.symbolCalls.Load(), "file mode must not query reflection")
+	require.True(t, remote.closed.Load(), "file mode should release the unused reflection remote")
+}
+
+func TestProtoFileRegistryForNode_FileModeErrors(t *testing.T) {
+	ResetFileRegistryCacheForTest()
+
+	t.Run("missing path", func(t *testing.T) {
+		_, err := ProtoFileRegistryForNode(common.GrpcDescriptorSourceFile, "", nil)
+		require.Error(t, err)
+	})
+
+	t.Run("unreadable path", func(t *testing.T) {
+		_, err := ProtoFileRegistryForNode(common.GrpcDescriptorSourceFile,
+			filepath.Join(t.TempDir(), "nope.pb"), nil)
+		require.Error(t, err)
+	})
+}
+
+func TestProtoFileRegistryForNode_UnknownModeIsRejected(t *testing.T) {
+	_, err := ProtoFileRegistryForNode("astrology", "", nil)
+	require.Error(t, err)
+}
+
+func TestProtoFileRegistryForNode_HybridPrefersFileThenFallsBack(t *testing.T) {
+	ResetFileRegistryCacheForTest()
+	dir := t.TempDir()
+	remote := &countingRegistry{answers: map[string]string{"server.v1.ServerOnly": "reflected.proto"}}
+	descriptorSet := writeTestDescriptorSet(t, dir, "file", "file.v1", "FileOnly")
+
+	registry, err := ProtoFileRegistryForNode(common.GrpcDescriptorSourceHybrid, descriptorSet, remote)
+	require.NoError(t, err)
+
+	t.Run("symbol in descriptor set does not reach reflection", func(t *testing.T) {
+		file, err := registry.ProtoFileContainingSymbol("file.v1.FileOnly")
+		require.NoError(t, err)
+		require.Equal(t, "file.proto", file.GetName())
+		require.Zero(t, remote.symbolCalls.Load())
+	})
+
+	t.Run("symbol missing from descriptor set falls back to reflection", func(t *testing.T) {
+		file, err := registry.ProtoFileContainingSymbol("server.v1.ServerOnly")
+		require.NoError(t, err)
+		require.Equal(t, "reflected.proto", file.GetName())
+		require.Equal(t, int32(1), remote.symbolCalls.Load())
+	})
+
+	t.Run("symbol in neither is an error", func(t *testing.T) {
+		_, err := registry.ProtoFileContainingSymbol("nowhere.v1.Missing")
+		require.Error(t, err)
+	})
+}
+
+func TestProtoFileRegistryForNode_HybridDegradesToReflectionOnBadDescriptorSet(t *testing.T) {
+	ResetFileRegistryCacheForTest()
+	remote := &countingRegistry{}
+
+	registry, err := ProtoFileRegistryForNode(common.GrpcDescriptorSourceHybrid,
+		filepath.Join(t.TempDir(), "missing.pb"), remote)
+	require.NoError(t, err, "hybrid tolerates an unusable descriptor set")
+	require.Same(t, remote, registry)
+}
+
+// TestSharedFileRegistry_CloseDoesNotPoisonOtherConsumers guards the hazard the cache
+// introduces: FileDescriptorSetRegistry.Close latches the registry shut and every
+// later lookup returns "registry is closed". Since one parsed registry is now shared
+// by every proxy naming that path, an honoured Close would break the others.
+func TestSharedFileRegistry_CloseDoesNotPoisonOtherConsumers(t *testing.T) {
+	ResetFileRegistryCacheForTest()
+	descriptorSet := writeTestDescriptorSet(t, t.TempDir(), "chain", "concordium.v2", "Queries")
+
+	first, err := ProtoFileRegistryForNode(common.GrpcDescriptorSourceFile, descriptorSet, nil)
+	require.NoError(t, err)
+	second, err := ProtoFileRegistryForNode(common.GrpcDescriptorSourceFile, descriptorSet, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, first.Close())
+
+	// The second consumer still resolves. Without the sharedFileRegistry shim this
+	// returns "registry is closed" and a live chain stops parsing mid-flight.
+	file, err := second.ProtoFileContainingSymbol("concordium.v2.Queries")
+	require.NoError(t, err)
+	require.Equal(t, "chain.proto", file.GetName())
+
+	// And the closer itself keeps working, since Close is a no-op on a shared registry.
+	_, err = first.ProtoFileContainingSymbol("concordium.v2.Queries")
+	require.NoError(t, err)
+}
+
+func TestLoadCachedFileRegistry_ParsesOncePerPath(t *testing.T) {
+	ResetFileRegistryCacheForTest()
+	descriptorSet := writeTestDescriptorSet(t, t.TempDir(), "chain", "concordium.v2", "Queries")
+
+	first, err := loadCachedFileRegistry(descriptorSet)
+	require.NoError(t, err)
+	second, err := loadCachedFileRegistry(descriptorSet)
+	require.NoError(t, err)
+	require.Same(t, first, second)
+
+	ResetFileRegistryCacheForTest()
+	var wg sync.WaitGroup
+	registries := make([]*FileDescriptorSetRegistry, 8)
+	for i := range registries {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			registry, loadErr := loadCachedFileRegistry(descriptorSet)
+			require.NoError(t, loadErr)
+			registries[idx] = registry
+		}(i)
+	}
+	wg.Wait()
+	for _, registry := range registries {
+		require.Same(t, registries[0], registry)
+	}
+}
+
+func TestProtoFileRegistryForGrpcConfig(t *testing.T) {
+	ResetFileRegistryCacheForTest()
+	remote := &countingRegistry{}
+	descriptorSet := writeTestDescriptorSet(t, t.TempDir(), "file", "file.v1", "FileOnly")
+
+	t.Run("nil config defaults to reflection", func(t *testing.T) {
+		registry, err := ProtoFileRegistryForGrpcConfig(nil, remote)
+		require.NoError(t, err)
+		require.Same(t, remote, registry)
+	})
+
+	t.Run("zero config defaults to reflection", func(t *testing.T) {
+		registry, err := ProtoFileRegistryForGrpcConfig(&common.GrpcConfig{}, remote)
+		require.NoError(t, err)
+		require.Same(t, remote, registry)
+	})
+
+	t.Run("file config resolves from disk", func(t *testing.T) {
+		registry, err := ProtoFileRegistryForGrpcConfig(&common.GrpcConfig{
+			DescriptorSource:  common.GrpcDescriptorSourceFile,
+			DescriptorSetPath: descriptorSet,
+		}, nil)
+		require.NoError(t, err)
+		file, err := registry.ProtoFileContainingSymbol("file.v1.FileOnly")
+		require.NoError(t, err)
+		require.Equal(t, "file.proto", file.GetName())
+	})
+}
+
+func TestCompositeProtoFileRegistry_CloseClosesReflectionHalf(t *testing.T) {
+	ResetFileRegistryCacheForTest()
+	remote := &countingRegistry{}
+	descriptorSet := writeTestDescriptorSet(t, t.TempDir(), "file", "file.v1", "FileOnly")
+
+	registry, err := ProtoFileRegistryForNode(common.GrpcDescriptorSourceHybrid, descriptorSet, remote)
+	require.NoError(t, err)
+	require.NoError(t, registry.Close())
+	require.True(t, remote.closed.Load())
+}

--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -242,13 +242,25 @@ type GrpcConfig struct {
 	// DescriptorSource specifies how to obtain protobuf descriptors for dynamic message handling.
 	// Options:
 	//   - "reflection" (default): Use gRPC server reflection to auto-discover proto definitions
-	//   - "file": Load from a pre-compiled FileDescriptorSet (.pb file)
-	//   - "hybrid": Try reflection first, fallback to file if reflection is unavailable
+	//   - "file": Load from a pre-compiled FileDescriptorSet (.pb file). Reflection is
+	//     never queried, so this works against nodes that do not serve it at all.
+	//   - "hybrid": Resolve from the file first, fall back to reflection for symbols the
+	//     descriptor set does not contain.
+	//
+	// Hybrid is file-first, not reflection-first: the deployments that need it are the
+	// ones whose upstream reflection is absent, partial, or rate-limited, so asking the
+	// node first would pay that cost on every lookup before arriving at an answer that
+	// was on local disk the whole time.
 	DescriptorSource string `yaml:"descriptor-source,omitempty" json:"descriptor-source,omitempty" mapstructure:"descriptor-source"`
 
 	// DescriptorSetPath is the path to a FileDescriptorSet file (.pb or .prototxt).
 	// Required when DescriptorSource is "file" or "hybrid".
 	// Can be absolute path or relative to the working directory.
+	//
+	// The descriptor set is static — it describes the API as of the commit it was built
+	// from. If a node upgrade adds rpcs or fields the spec starts using, rebuild it, or
+	// those methods fail with "symbol not found" in "file" mode. Record the source repo
+	// and commit when building, and version the file next to the config referencing it.
 	DescriptorSetPath string `yaml:"descriptor-set-path,omitempty" json:"descriptor-set-path,omitempty" mapstructure:"descriptor-set-path"`
 
 	// ReflectionTimeout is the timeout for gRPC reflection queries.

--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -842,6 +842,13 @@ func (g *GRPCDirectRPCConnection) initialize(ctx context.Context) error {
 		return err
 	}
 
+	// Resolve the descriptor source before dialing. It needs no connection — it
+	// only reads config and the process-wide protoset cache — and failing here
+	// keeps a misconfigured endpoint from spending a dial budget it can never use.
+	if err := g.initializeDescriptorSource(); err != nil {
+		return err
+	}
+
 	// Create connection pool
 	// Extract host from URL for GRPCConnector (it expects host:port without scheme)
 	parsedURL, err := url.Parse(g.nodeUrl.Url)
@@ -905,13 +912,6 @@ func (g *GRPCDirectRPCConnection) initialize(ctx context.Context) error {
 	// an unsynchronized pointer write to a field getMethodDescriptor and
 	// GetCachedMethodDescriptor read without holding initMu.
 
-	// Initialize descriptor source based on config
-	if err := g.initializeDescriptorSource(); err != nil {
-		// Log warning but don't fail - we'll try reflection on first request
-		utils.LavaFormatWarning("failed to initialize descriptor source, will use reflection", err,
-			utils.LogAttr("url", g.nodeUrl.Url))
-	}
-
 	utils.LavaFormatInfo("gRPC direct connection initialized",
 		utils.LogAttr("url", g.nodeUrl.Url),
 		utils.LogAttr("tls", parsedURL.Scheme == "grpcs"))
@@ -954,6 +954,16 @@ func (g *GRPCDirectRPCConnection) validateURL() error {
 // what would actually be consumed, and in "file" mode nothing was consumed at all
 // (MAG-2350). Loading here now also warms the per-path cache, making the first
 // relay's descriptor lookup free.
+//
+// A failure is fatal to initialize(), not advisory. It used to be logged as "will
+// use reflection", which was true only while every path resolved through reflection
+// anyway: in "file" mode getMethodDescriptor and parseInputMessage now go through
+// this same loader and return this same error, and LoadProtoset caches failures, so
+// there is no fallback and nothing recovers. Warning and continuing buys one line at
+// boot followed by total relay failure on the endpoint — the silent-misconfiguration
+// shape MAG-2350 exists to remove. It cannot fire for the reflection default:
+// DescriptorSourceForGrpcConfig only errors for "file" and for an unrecognised
+// descriptor-source, both of which are operator config.
 //
 // The load is not retained on the struct: the cache is keyed by path and shared
 // process-wide, so re-resolving per request is a map hit.

--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -22,7 +22,6 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcInterfaceMessages"
 	rpcclient "github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcclient"
-	"github.com/magma-Devs/smart-router/protocol/chainlib/grpcproxy/dyncodec"
 	"github.com/magma-Devs/smart-router/protocol/common"
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
 	"github.com/magma-Devs/smart-router/utils"
@@ -907,7 +906,7 @@ func (g *GRPCDirectRPCConnection) initialize(ctx context.Context) error {
 	// GetCachedMethodDescriptor read without holding initMu.
 
 	// Initialize descriptor source based on config
-	if err := g.initializeDescriptorSource(ctx); err != nil {
+	if err := g.initializeDescriptorSource(); err != nil {
 		// Log warning but don't fail - we'll try reflection on first request
 		utils.LavaFormatWarning("failed to initialize descriptor source, will use reflection", err,
 			utils.LogAttr("url", g.nodeUrl.Url))
@@ -945,47 +944,33 @@ func (g *GRPCDirectRPCConnection) validateURL() error {
 	return nil
 }
 
-// initializeDescriptorSource validates the configured descriptor source.
+// initializeDescriptorSource loads and validates the configured descriptor source
+// at connect time, so a bad descriptor-set-path surfaces here rather than at the
+// first relay.
 //
-// Neither branch below keeps the loaded registry. Descriptor resolution goes
-// through reflection in getMethodDescriptor on every path, so the load is a
-// config check: a bad descriptor-set-path surfaces here, at initialization,
-// rather than at the first relay. The registry/codec fields that used to hold the
-// result were written here and nil'd in Close but never read anywhere in the
-// package, so they were removed (MAG-2808) along with the locking commentary that
-// claimed to protect them.
-func (g *GRPCDirectRPCConnection) initializeDescriptorSource(ctx context.Context) error {
+// It deliberately goes through the same loader the request path uses. The previous
+// version validated with dyncodec's parser and then threw the result away, while
+// resolution went through reflection regardless — so the check proved nothing about
+// what would actually be consumed, and in "file" mode nothing was consumed at all
+// (MAG-2350). Loading here now also warms the per-path cache, making the first
+// relay's descriptor lookup free.
+//
+// The load is not retained on the struct: the cache is keyed by path and shared
+// process-wide, so re-resolving per request is a map hit.
+func (g *GRPCDirectRPCConnection) initializeDescriptorSource() error {
 	grpcConfig := &g.nodeUrl.GrpcConfig
-	source := grpcConfig.GetDescriptorSource()
 
-	switch source {
-	case common.GrpcDescriptorSourceFile:
-		if grpcConfig.DescriptorSetPath == "" {
-			return fmt.Errorf("descriptor-set-path required for file descriptor source")
-		}
-		if _, err := dyncodec.NewFileDescriptorSetRegistryFromPath(grpcConfig.DescriptorSetPath); err != nil {
-			return err
-		}
-
-	case common.GrpcDescriptorSourceHybrid:
-		// The file half of hybrid mode is optional; only report a path that is set
-		// and unloadable.
-		if grpcConfig.DescriptorSetPath != "" {
-			if _, err := dyncodec.NewFileDescriptorSetRegistryFromPath(grpcConfig.DescriptorSetPath); err != nil {
-				utils.LavaFormatWarning("failed to load file descriptors for hybrid mode", err,
-					utils.LogAttr("path", grpcConfig.DescriptorSetPath))
-			}
-		}
-
-	case common.GrpcDescriptorSourceReflection, "":
-		// Reflection will be used on first request
-		// No initialization needed here
+	// A nil server source is safe to pass: reflection-mode returns it untouched and
+	// no descriptor lookup happens here. Only the file half is being exercised.
+	if _, err := rpcInterfaceMessages.DescriptorSourceForGrpcConfig(grpcConfig, nil); err != nil {
+		return err
 	}
 
 	return nil
 }
 
-// getMethodDescriptor retrieves the method descriptor, using cache or reflection
+// getMethodDescriptor retrieves the method descriptor from cache, or resolves it
+// through the node's configured descriptor source (reflection, file, or hybrid).
 func (g *GRPCDirectRPCConnection) getMethodDescriptor(
 	ctx context.Context,
 	conn *grpc.ClientConn,
@@ -998,16 +983,22 @@ func (g *GRPCDirectRPCConnection) getMethodDescriptor(
 		return methodDesc, nil
 	}
 
-	// Use reflection to get descriptor
+	// Resolve through the node's configured descriptor source. In "reflection" mode
+	// (the default) this is exactly the reflection client below; in "file" mode the
+	// client is built but never queried.
 	cl := grpcreflect.NewClientAuto(ctx, conn)
 	defer cl.Reset()
 
-	descriptorSource := rpcInterfaceMessages.DescriptorSourceFromServer(cl)
+	descriptorSource, err := rpcInterfaceMessages.DescriptorSourceForGrpcConfig(&g.nodeUrl.GrpcConfig, rpcInterfaceMessages.DescriptorSourceFromServer(cl))
+	if err != nil {
+		return nil, err
+	}
 
 	descriptor, err := descriptorSource.FindSymbol(service)
 	if err != nil {
-		return nil, utils.LavaFormatError("failed to find service via reflection", err,
-			utils.LogAttr("service", service))
+		return nil, utils.LavaFormatError("failed to find service descriptor", err,
+			utils.LogAttr("service", service),
+			utils.LogAttr("descriptor-source", g.nodeUrl.GrpcConfig.GetDescriptorSource()))
 	}
 
 	serviceDescriptor, ok := descriptor.(*desc.ServiceDescriptor)
@@ -1055,10 +1046,15 @@ func (g *GRPCDirectRPCConnection) parseInputMessage(
 ) error {
 	// Detect if input is JSON or binary proto
 	if len(data) > 0 && (data[0] == '{' || data[0] == '[') {
-		// JSON input - use grpcurl parser
+		// JSON input - use grpcurl parser. The parser resolves any message types the
+		// request references, so it needs the same descriptor source as the method
+		// lookup did — reflection-only here would defeat "file" mode (MAG-2350).
 		cl := grpcreflect.NewClientAuto(ctx, conn)
 		defer cl.Reset()
-		descriptorSource := rpcInterfaceMessages.DescriptorSourceFromServer(cl)
+		descriptorSource, err := rpcInterfaceMessages.DescriptorSourceForGrpcConfig(&g.nodeUrl.GrpcConfig, rpcInterfaceMessages.DescriptorSourceFromServer(cl))
+		if err != nil {
+			return err
+		}
 
 		rp, _, err := grpcurl.RequestParserAndFormatter(
 			grpcurl.FormatJSON,

--- a/protocol/lavasession/direct_rpc_connection_test.go
+++ b/protocol/lavasession/direct_rpc_connection_test.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -718,4 +720,99 @@ func TestDoHTTPRequest_PerRequestHeadersOverrideDefaultContentType(t *testing.T)
 			require.Equal(t, "tx=AAAAtest", gotBody, "the body must reach the node untouched")
 		})
 	}
+}
+
+// TestGRPCDirectRPCConnection_DescriptorSourceFailureIsFatal pins that a descriptor
+// source the node can never resolve fails the connection instead of warning past it.
+//
+// The old call site logged "will use reflection" and continued. That was true only
+// while every path resolved through reflection regardless; in "file" mode
+// getMethodDescriptor and parseInputMessage go through this same loader and return
+// this same error, and LoadProtoset caches failures — so continuing bought one WARN
+// at boot and then total relay failure on the endpoint, with no further signal and
+// no recovery. That is the silent-misconfiguration shape MAG-2350 removes, not one
+// to relocate.
+func TestGRPCDirectRPCConnection_DescriptorSourceFailureIsFatal(t *testing.T) {
+	newGrpcConn := func(t *testing.T, grpcConfig common.GrpcConfig) (*GRPCDirectRPCConnection, *atomic.Int32) {
+		t.Helper()
+		conn, err := NewDirectRPCConnection(context.Background(), common.NodeUrl{
+			Url:        "grpcs://localhost:9090",
+			GrpcConfig: grpcConfig,
+		}, 5, "")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = conn.Close() })
+
+		grpcConn, ok := conn.(*GRPCDirectRPCConnection)
+		require.True(t, ok)
+
+		// Fail the dial rather than perform it: reaching this at all is the bug.
+		var dials atomic.Int32
+		grpcConn.newConnector = func(lifetimeCtx, dialCtx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
+			dials.Add(1)
+			return nil, fmt.Errorf("dial must not be reached")
+		}
+		return grpcConn, &dials
+	}
+
+	for _, tt := range []struct {
+		name   string
+		config common.GrpcConfig
+	}{
+		{
+			name: "file mode with an unreadable descriptor set",
+			config: common.GrpcConfig{
+				DescriptorSource: common.GrpcDescriptorSourceFile,
+				// Unique per run: LoadProtoset caches by path, including failures.
+				DescriptorSetPath: filepath.Join(t.TempDir(), "missing.pb"),
+			},
+		},
+		{
+			name:   "file mode with no descriptor set at all",
+			config: common.GrpcConfig{DescriptorSource: common.GrpcDescriptorSourceFile},
+		},
+		{
+			// GrpcConfig.Validate has no callers, so an unrecognised mode reaches the
+			// request path. It resolves to nothing, which makes it fatal here too.
+			name:   "unrecognised descriptor-source",
+			config: common.GrpcConfig{DescriptorSource: "astrology"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			grpcConn, dials := newGrpcConn(t, tt.config)
+
+			require.Error(t, grpcConn.initialize(context.Background()))
+			require.Zero(t, dials.Load(),
+				"config that cannot resolve must fail before spending a dial budget on it")
+
+			grpcConn.connMu.Lock()
+			connector := grpcConn.connector
+			grpcConn.connMu.Unlock()
+			require.Nil(t, connector, "a failed initialize must leave no connector installed")
+
+			// Not latched: ensureInitialized surfaces the error and leaves the
+			// connection re-initializable, matching every other initialize() failure.
+			require.Error(t, grpcConn.ensureInitialized(context.Background()))
+			require.False(t, grpcConn.initialized.Load())
+		})
+	}
+
+	// The vacuity guard. Making this fatal is only safe because it cannot fire for
+	// the reflection default — which is every gRPC node-url in every config today.
+	t.Run("reflection default never trips it", func(t *testing.T) {
+		for _, config := range []common.GrpcConfig{
+			{},
+			{DescriptorSource: common.GrpcDescriptorSourceReflection},
+			{DescriptorSource: common.GrpcDescriptorSourceReflection, ReflectionTimeout: 2 * time.Second},
+			// Hybrid degrades to reflection rather than failing: an unusable protoset
+			// is exactly the case its other half covers.
+			{
+				DescriptorSource:  common.GrpcDescriptorSourceHybrid,
+				DescriptorSetPath: filepath.Join(t.TempDir(), "missing.pb"),
+			},
+			{DescriptorSource: common.GrpcDescriptorSourceHybrid},
+		} {
+			grpcConn, _ := newGrpcConn(t, config)
+			require.NoError(t, grpcConn.initializeDescriptorSource())
+		}
+	})
 }

--- a/protocol/rpcsmartrouter/upstream_grpc_pool.go
+++ b/protocol/rpcsmartrouter/upstream_grpc_pool.go
@@ -228,7 +228,8 @@ func (c *UpstreamGRPCStreamConnection) StreamCount() int32 {
 	return c.activeStreams.Load()
 }
 
-// GetMethodDescriptor retrieves a method descriptor, using cache or reflection
+// GetMethodDescriptor retrieves a method descriptor from cache, or resolves it
+// through the node's configured descriptor source (reflection, file, or hybrid).
 func (c *UpstreamGRPCStreamConnection) GetMethodDescriptor(
 	ctx context.Context,
 	service, methodName string,
@@ -248,16 +249,22 @@ func (c *UpstreamGRPCStreamConnection) GetMethodDescriptor(
 		return nil, fmt.Errorf("connection not available")
 	}
 
-	// Use reflection to get descriptor
+	// Resolve through the node's configured descriptor source. Streaming methods are
+	// exactly the ones a partial reflection service tends to omit, so this path needs
+	// the file escape hatch as much as the unary one does (MAG-2350).
 	cl := grpcreflect.NewClientAuto(ctx, conn)
 	defer cl.Reset()
 
-	descriptorSource := rpcInterfaceMessages.DescriptorSourceFromServer(cl)
+	descriptorSource, err := rpcInterfaceMessages.DescriptorSourceForGrpcConfig(&c.nodeUrl.GrpcConfig, rpcInterfaceMessages.DescriptorSourceFromServer(cl))
+	if err != nil {
+		return nil, err
+	}
 
 	descriptor, err := descriptorSource.FindSymbol(service)
 	if err != nil {
-		return nil, utils.LavaFormatError("failed to find service via reflection", err,
-			utils.LogAttr("service", service))
+		return nil, utils.LavaFormatError("failed to find service descriptor", err,
+			utils.LogAttr("service", service),
+			utils.LogAttr("descriptor-source", c.nodeUrl.GrpcConfig.GetDescriptorSource()))
 	}
 
 	serviceDescriptor, ok := descriptor.(*desc.ServiceDescriptor)


### PR DESCRIPTION
Jira ticket: MAG-2350

## Problem

`grpc-config`'s descriptor escape hatch — `descriptor-source: reflection|file|hybrid` plus `descriptor-set-path` — has been in the config schema with constants, a validator and docs, but **no request path ever read it**. Every gRPC descriptor lookup resolved through live server reflection.

The result is worse than a missing feature: `descriptor-source: file` passes validation at connect time and is then silently ignored on every request. A config that looks supported and does nothing is harder to diagnose than one that isn't there.

This blocks any chain whose nodes don't serve reflection for the services its spec uses. **Concordium** is the case that forced it — its public gateways expose reflection for `Health` only, so the router exits at boot with `Symbol not found: concordium.v2.Queries`.

## This is not Concordium-specific

There is no chain branching anywhere in the affected code. 32 specs declare a gRPC interface (~26 concrete chains once shared base specs are excluded), and every one of them depends on upstream reflection with no fallback.

`config/smartrouter_examples/smartrouter_cosmos.yml` already documents the milder form of the same failure in its own header: public Cosmos gateways *throttle* reflection, so the gRPC startup check degrades to best-effort. Same root cause, different trigger. Sui is unaffected today only because its mainnet node happens to serve full reflection — an upstream operational choice, not a router guarantee.

## The fix

Two selectors, one per descriptor abstraction, both memoized by path:

| Helper | Interface | Drives |
|---|---|---|
| `rpcInterfaceMessages.DescriptorSourceForNode` | `grpcurl.DescriptorSource` | request/response marshalling |
| `dyncodec.ProtoFileRegistryForNode` | `ProtoFileRegistry` | `dynamicResolve` → `GetParams` → block parsing |

Five reflection-only sites now select through them:

| # | Site | Path |
|---|---|---|
| 1 | `chainlib/grpc.go` `SendNodeMsg` | boot validation, verifications, chain fetcher |
| 2 | `direct_rpc_connection.go` `getMethodDescriptor` | unary relay |
| 3 | `direct_rpc_connection.go` `parseInputMessage` | JSON request parsing |
| 4 | `upstream_grpc_pool.go` `GetMethodDescriptor` | streaming |
| 5 | `chainlib/grpc.go` `setupForProvider` | parser registry |

**Site 5 is not in the ticket.** Without it, the first four let a reflection-less node boot clean and then fail at *parse* time on binary-proto requests — a worse failure than the loud one it replaces.

`newGrpcChainProxy` also never populated `NodeUrl` on its `BaseChainProxy` literal, so `cp.NodeUrl.GrpcConfig` was always the zero value and the config was invisible on path 1 no matter what the operator wrote.

## Usage

```yaml
node-urls:
  - url: "grpcs://grpc.mainnet.concordium.software:20000"
    auth-config: { use-tls: true }
    grpc-config:
      descriptor-source: "file"                        # or "hybrid"
      descriptor-set-path: "config/concordium.protoset"
```

All of a chain's gRPC node-urls must agree on `descriptor-source` and `descriptor-set-path` — see decision 4.

## Behaviour when `grpc-config` is omitted

Descriptor resolution is unchanged: reflection mode returns the server source untouched, and the reflection-mode tests assert identity (`require.Same`), not equivalence.

One exception, which an earlier revision of this description got wrong by claiming "byte-for-byte". Populating `NodeUrl` on the proxy also makes `BaseChainProxy.CapTimeoutForSend` → `NodeUrl.LowerContextTimeout` see a per-node-url `timeout:` on the gRPC provider path, where it previously always read the zero value. This is desirable — it matches jsonrpc/rest — but it is a behaviour change for any gRPC node-url that already sets `timeout:`, independent of `grpc-config`.

## Decisions worth reviewer attention

**1. `hybrid` is file-first, not reflection-first.** `GrpcConfig`'s doc comment claimed reflection-first; the ticket's acceptance criterion says file-then-reflection. I implemented file-first and corrected the comment. The deployments that need hybrid are precisely those whose reflection is absent, partial or rate-limited — asking the node first pays that cost on *every* lookup before arriving at an answer that was on local disk the whole time.

**2. Caching required a `Close()` guard.** `FileDescriptorSetRegistry.Close` latches the registry shut, and every later lookup returns `registry is closed`. Once one parsed registry is shared by every proxy naming that path, an honoured `Close` from any single consumer would poison the rest. `sharedFileRegistry` makes it a no-op — the data is immutable and process-lifetime, so there is nothing to release. `TestSharedFileRegistry_CloseDoesNotPoisonOtherConsumers` is the regression guard.

**3. A descriptor source that cannot resolve is fatal, not advisory.** `direct_rpc_connection.go` used to warn `"will use reflection"` and continue. That was accurate only *before* this PR: in `file` mode sites 2 and 3 now resolve through the same loader and return the same error, and `LoadProtoset` caches failures — so there is no fallback and nothing recovers. Continuing bought one WARN promising a fallback that does not exist, then total relay failure on that endpoint. The check also moved ahead of the dial, since it needs no connection; a config that can never work now fails before spending a dial budget. It cannot fire for the reflection default — `DescriptorSourceForGrpcConfig` only errors for `file` and for an unrecognised `descriptor-source`, both operator config — and the test pins that, because it is what makes fatality safe.

**4. gRPC node-urls on one chain that disagree are rejected at boot.** `registry`/`codec` live on the parser, which is per *chain*; `grpc-config` is per *node-url*. `newChainRouter` builds one proxy per batch entry and passes the same parser to each, so every `setupForProvider` call overwrites the last — and the batch is a `map`, so "last" is whatever Go's randomized iteration order picks that boot. That was benign while each iteration built an equivalent reflection registry; with site 5 wired, a chain with one `file` node-url and one reflection node-url parses blocks against a different descriptor set on each restart. Rejecting beats warning: a warning still leaves the router serving a randomly chosen descriptor set. Nothing that works today is affected, since `grpc-config` was never read before this PR. Normalization happens before the comparison, so an omitted `descriptor-source` and an explicit `"reflection"` do not conflict, and neither do `allow-insecure` / `reflection-timeout`.

**5. Hybrid's descriptor-set half is consulted strictly.** `FileDescriptorSetRegistry.ProtoFileContainingSymbol` walks up the parent chain and, on a miss, returns the *ancestor's* file with a nil error. Since `compositeProtoFileRegistry` falls back on error alone, reflection was never consulted and `Registry.FindDescriptorByName` returned NotFound — at exactly the staleness case hybrid exists to cover. The composite now confirms the descriptor-set half declares the symbol itself, via the registry's existing `HasSymbol` index. The live trigger is a **new rpc**, not a rare nested type: `dynamicResolve` passes a method full name (`grpcMessage.go:93`), so `pkg.Query.Balance` resolves through `pkg.Query` whenever a node gains an rpc after the protoset was cut. Strictness costs the protoset no hits — every symbol kind it contains is directly indexed, so the walk only ever fires on a genuine miss.

Also note `initializeDescriptorSource` is a net **deletion**: it had reimplemented mode dispatch locally, validated with a different parser than the request path used, and discarded the result — so a passing check proved nothing about what would actually be consumed. It now runs through the shared loader, which makes the boot check predictive *and* warms the cache.

## Testing

- **52 tests**, race-clean, no `protoc`/`buf` dependency — fixtures hand-build `FileDescriptorSet` protos in Go
- Covers mode selection, error paths (missing/unreadable/corrupt), cache identity under concurrent first-touch, hybrid fallback and reflection outage, the shared-`Close` regression, and **call-counter assertions that `file` mode never queries reflection at all**
- The three tests added for decisions 3–5 were each run against a deliberately broken version of their own fix, to confirm they catch the bug rather than merely pass
- `go build ./...`, `go vet`, and the `chainlib` / `common` / `lavasession` / `rpcsmartrouter` suites all pass
- `gofmt`/`gofumpt` clean

## Not in this PR

- **No Concordium protoset.** That belongs in `lava-specs` next to `config/concordium.yml`; this PR is the router-side unblock.
- **No live-gateway verification.** Booting `config/concordium.yml` against `grpc.mainnet.concordium.software:20000` remains the acceptance test and needs a reviewer with network access to that endpoint.
- **The protoset cache still latches failures.** Raised in review and deliberately deferred pending a scope call. Decision 3 makes the failure loud instead of silent, but a transient first-touch failure — a protoset not yet mounted, an `EMFILE`, an NFS blip — still poisons that path for the process. Caching successes but not failures keeps the perf win without the latch. Note `083605d`, two commits below this branch point, is the same anti-pattern one layer up.
- **`GrpcConfig.Validate()` has zero callers repo-wide**, so an invalid `descriptor-source` string is only caught at request time (decision 3 makes that fatal). Wiring the validator in is a separate change.
- **Two advisory `SA1019` lint warnings** for `jhump/protoreflect/desc` in the new files — unavoidable, since `grpcurl.DescriptorSource` is built on it. There are already 7 identical ones on `main`, and `.golangci.yml` excludes the sibling files by path. A targeted exclusion mirroring the existing `golang/protobuf/proto` rule would clear all 9; I left shared lint config alone. Lint is advisory on this repo per `lint.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
