### PR TITLE
fix(smart-router): scope gRPC connector pool capacity per instance, and pin MAG-2538 parser isolation

### DIFF
--- a/protocol/chainlib/chainproxy/connector.go
+++ b/protocol/chainlib/chainproxy/connector.go
@@ -36,7 +36,19 @@ const (
 	MaxCallRecvMsgSize                         = 1024 * 1024 * 512 // setting receive size to 512mb for large debug responses
 )
 
-var NumberOfParallelConnections uint = 10
+// NumberOfParallelConnections is the DEFAULT pool size — the default value of the
+// --parallel-connections flag. It is configuration, not state, and const is what
+// makes that a guarantee rather than a convention: no future caller can reintroduce
+// the write below, because the assignment no longer compiles.
+//
+// It used to be both. NewConnector and NewGRPCConnector each wrote it with their own
+// nConns, and GRPCConnector.ReturnRpc read it back as "the number we started with",
+// so a connector's idle-trim threshold was whichever connector happened to be built
+// last, process-wide. With one connector that is invisible; with two it is a data
+// race (MAG-2538 tears a verification connector down while the next is constructed),
+// and across differing nConns it trims the wrong pool. Capacity belongs to a
+// connector, so it now lives on the connector.
+const NumberOfParallelConnections uint = 10
 
 // Connector manages HTTP/JSON-RPC connections to blockchain nodes.
 // For HTTP connections, a single shared rpcclient.Client is used since
@@ -66,7 +78,11 @@ func HashURL(url string) string {
 // pooling internally). The parameter is kept for API compatibility with
 // gRPC connector which still uses connection pooling.
 func NewConnector(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) (*Connector, error) {
-	NumberOfParallelConnections = nConns // used by gRPC connector, ignored for HTTP
+	// nConns is deliberately not recorded anywhere: HTTP pools inside http.Transport.
+	// This used to assign NumberOfParallelConnections "for the gRPC connector", which
+	// made building an HTTP connector silently reset an unrelated gRPC connector's
+	// idle-trim threshold — and race its ReturnRpc. That constant is now const, so
+	// the assignment cannot come back.
 	connector := &Connector{
 		nodeUrl:       nodeUrl,
 		hashedNodeUrl: HashURL(nodeUrl.Url),
@@ -178,6 +194,15 @@ type GRPCConnector struct {
 	credentials credentials.TransportCredentials
 	nodeUrl     common.NodeUrl
 
+	// capacity is the pool size this connector was built with — the nConns its
+	// caller asked for, not whatever the last-constructed connector asked for.
+	// ReturnRpc trims idle clients against it.
+	//
+	// Written once in NewGRPCConnector before the connector is published and never
+	// again, so readers need no synchronization beyond the happens-before that
+	// publishing already gives them.
+	capacity uint
+
 	// closed is set by Close and never cleared. Unlike the HTTP Connector's atomic
 	// flag it is guarded by lock, because every reader already holds lock: that
 	// makes "is the pool alive" and "take a client" a single atomic step, which a
@@ -211,10 +236,10 @@ var ErrGRPCConnectorClosed = errors.New("grpc connector is closed")
 // request — the direct-RPC path — must NOT: passing the request's context as
 // lifetimeCtx tears the pool down the moment that request returns.
 func NewGRPCConnector(lifetimeCtx, dialCtx context.Context, nConns uint, nodeUrl common.NodeUrl) (*GRPCConnector, error) {
-	NumberOfParallelConnections = nConns // set number of parallel connections requested by user (or default.)
 	connector := &GRPCConnector{
 		freeClients: make([]*grpc.ClientConn, 0, nConns),
 		nodeUrl:     nodeUrl,
+		capacity:    nConns,
 	}
 
 	// MAG-2218: warn once per connector, not per dial. createConnection may still upgrade an
@@ -405,7 +430,7 @@ func (connector *GRPCConnector) ReturnRpc(rpc *grpc.ClientConn) {
 		rpc.Close()
 		return
 	}
-	if len(connector.freeClients) > (int(connector.usedClients) + int(NumberOfParallelConnections) /* the number we started with */) {
+	if len(connector.freeClients) > (int(connector.usedClients) + int(connector.capacity) /* the number THIS connector started with */) {
 		rpc.Close() // close connection
 		return      // return without appending back to decrease idle connections
 	}

--- a/protocol/chainlib/chainproxy/connector_capacity_test.go
+++ b/protocol/chainlib/chainproxy/connector_capacity_test.go
@@ -1,0 +1,155 @@
+package chainproxy
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// Pool capacity used to live in the package-global NumberOfParallelConnections,
+// which every constructor wrote and GRPCConnector.ReturnRpc read back. Two
+// connectors existing at once was enough to break that in both directions: the
+// second constructor silently redefined the first's idle-trim threshold, and the
+// write raced the read outright. MAG-2538's recovery test is what surfaced it —
+// validateProvider tears its verification connector down while the next connector
+// is being built — but nothing about the hazard is specific to that path.
+
+// TestGRPCConnectorCapacityIsPerInstance pins the ownership half: a connector's
+// trim threshold is the nConns IT was built with, and building another connector
+// does not move it.
+func TestGRPCConnectorCapacityIsPerInstance(t *testing.T) {
+	server := createGRPCServer(t)
+	defer server.Stop()
+
+	ctx := context.Background()
+	url := common.NodeUrl{Url: listenerAddressGrpc}
+
+	small, err := NewGRPCConnector(ctx, ctx, 1, url)
+	require.NoError(t, err)
+	defer small.Close()
+
+	// Built second and larger: under the global this reassigned the threshold that
+	// `small` had already been constructed with.
+	big, err := NewGRPCConnector(ctx, ctx, numberOfClients, url)
+	require.NoError(t, err)
+	defer big.Close()
+
+	require.Equal(t, uint(1), small.capacity, "the first connector must keep its own capacity")
+	require.Equal(t, uint(numberOfClients), big.capacity)
+	// Nothing here asserts NumberOfParallelConnections survived construction: it is a
+	// const, so "no constructor rewrites it" is enforced by the compiler for every
+	// caller rather than by one test for the two constructors it happens to exercise.
+}
+
+// TestGRPCConnectorReturnRpcTrimsAgainstOwnCapacity is the same ownership property
+// asserted through behaviour rather than the field: identical pool state, two
+// capacities, opposite decisions about whether a returned client is worth keeping.
+func TestGRPCConnectorReturnRpcTrimsAgainstOwnCapacity(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tt := range []struct {
+		name     string
+		capacity uint
+		wantFree int
+	}{
+		// freeClients already holds 2 and the borrow count drops to 0 on return, so
+		// the surplus test is `2 > 0 + capacity`.
+		{name: "capacity below the surplus trims", capacity: 1, wantFree: 2},
+		{name: "capacity above the surplus keeps", capacity: 5, wantFree: 3},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			// A real client to hand back, since the trim path closes it. Dialled
+			// standalone rather than borrowed from a connector: a borrow this test
+			// never returns would leave that connector's Close waiting on it forever.
+			returned, err := grpc.DialContext(ctx, listenerAddressGrpc,
+				grpc.WithTransportCredentials(insecure.NewCredentials()))
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = returned.Close() })
+
+			// Hand-built so pool state is identical across the two cases and capacity
+			// is the only variable. Only len(freeClients) feeds the decision, so the
+			// placeholders are never dereferenced.
+			connector := &GRPCConnector{
+				capacity:    tt.capacity,
+				usedClients: 1,
+				freeClients: []*grpc.ClientConn{nil, nil},
+			}
+			connector.ReturnRpc(returned)
+
+			require.Len(t, connector.freeClients, tt.wantFree)
+			require.Equal(t, 0, connector.numberOfUsedClients())
+		})
+	}
+}
+
+// TestConnectorConstructionDoesNotRaceReturnRpc pins the race half. It is only
+// meaningful under -race: before capacity moved onto the connector, constructing
+// any connector wrote the global that ReturnRpc was reading.
+//
+// Both constructors are exercised. NewConnector is HTTP and ignores nConns for its
+// own purposes, but it wrote the same global "for the gRPC connector", so building
+// an HTTP connector raced a gRPC connector's teardown just as readily.
+func TestConnectorConstructionDoesNotRaceReturnRpc(t *testing.T) {
+	server := createGRPCServer(t)
+	defer server.Stop()
+
+	ctx := context.Background()
+	url := common.NodeUrl{Url: listenerAddressGrpc}
+
+	serving, err := NewGRPCConnector(ctx, ctx, numberOfClients, url)
+	require.NoError(t, err)
+	defer serving.Close()
+
+	const rounds = 25
+	var wg sync.WaitGroup
+
+	// Borrowers: keep ReturnRpc reading the trim threshold throughout.
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range rounds {
+				rpc, err := serving.GetRpc(ctx, true)
+				if err != nil {
+					return
+				}
+				serving.ReturnRpc(rpc)
+			}
+		}()
+	}
+
+	// Builders: construct and tear down connectors alongside those returns.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := range rounds {
+			transient, err := NewGRPCConnector(ctx, ctx, uint(1+i%3), url)
+			if err != nil {
+				continue
+			}
+			transient.Close()
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range rounds {
+			httpConnector, err := NewConnector(ctx, 7, common.NodeUrl{Url: listenerAddressTcp})
+			if err != nil {
+				continue
+			}
+			httpConnector.Close()
+		}
+	}()
+
+	wg.Wait()
+
+	require.Equal(t, uint(numberOfClients), serving.capacity,
+		"the serving connector's capacity must survive every connector built alongside it")
+}

--- a/protocol/chainlib/chainproxy/grpc_auth_connector_test.go
+++ b/protocol/chainlib/chainproxy/grpc_auth_connector_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/jhump/protoreflect/grpcreflect"
+	"github.com/magma-Devs/smart-router/protocol/common"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"

--- a/protocol/chainlib/grpc_test.go
+++ b/protocol/chainlib/grpc_test.go
@@ -478,3 +478,53 @@ func TestSetupForProvider_RejectsConflictingDescriptorSource(t *testing.T) {
 		require.NotNil(t, live.registry, "the clone must not have disturbed the live parser")
 	})
 }
+
+// TestCloneChainParserForValidation_AbsorbsRealSetupForProvider is the other half
+// of MAG-2538, and the half TestCloneChainParserForValidation_GrpcIsolation cannot
+// cover: that one stands in for the mutation by assigning registry/codec directly,
+// so it proves the clone is a distinct struct but not that the clone actually
+// absorbs what NewGrpcChainProxy does to it.
+//
+// The distinction matters for anyone editing cloneForValidation. It aliases most of
+// BaseChainParser deliberately; the invariant is that nothing setupForProvider
+// touches is shared. A field added to the clone that aliases mutable state would
+// sail past the simulated version and be caught here, because this drives the real
+// GetChainRouter -> newGrpcChainProxy -> setupForProvider path against a live
+// reflection server.
+func TestCloneChainParserForValidation_AbsorbsRealSetupForProvider(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	noop := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	chainParser, _, _, closeServer, endpoint, err := CreateChainLibMocks(
+		ctx, "GRPCTEST", spectypes.APIInterfaceGrpc, noop, nil, "../../", nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if closeServer != nil {
+			closeServer()
+		}
+	})
+
+	live, ok := chainParser.(*GrpcChainParser)
+	require.True(t, ok)
+	// CreateChainLibMocks builds the parser through GetChainRouter, so it arrives
+	// bound the way boot leaves it — which is the state recovery has to preserve.
+	servingRegistry, servingCodec := live.registry, live.codec
+	require.NotNil(t, servingRegistry)
+	require.NotNil(t, servingCodec)
+
+	_, err = GetChainRouter(ctx, 1, endpoint, CloneChainParserForValidation(live))
+	require.NoError(t, err)
+
+	require.Same(t, servingRegistry, live.registry,
+		"MAG-2538: a verification pass through the clone must not rebind the live registry")
+	require.Same(t, servingCodec, live.codec, "nor the live codec")
+
+	// Control, last so it cannot disturb the assertions above: the same call without
+	// the clone does rebind the live parser. Without this the test would still pass
+	// if GetChainRouter had stopped reaching setupForProvider at all.
+	_, err = GetChainRouter(ctx, 1, endpoint, live)
+	require.NoError(t, err)
+	require.NotSame(t, servingRegistry, live.registry,
+		"control: an unprotected GetChainRouter must rebind the live registry")
+}

--- a/protocol/rpcsmartrouter/provider_recovery_parser_isolation_test.go
+++ b/protocol/rpcsmartrouter/provider_recovery_parser_isolation_test.go
@@ -1,0 +1,153 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/chainlib"
+	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcInterfaceMessages"
+	"github.com/magma-Devs/smart-router/protocol/chainlib/extensionslib"
+	"github.com/magma-Devs/smart-router/protocol/chainlib/grpcproxy/dyncodec"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// craftGetBlockMessage builds the GRPCTEST get-block request the way a relay would:
+// through the spec's own parse directive, so the message is genuinely sendable
+// rather than a hand-assembled stand-in.
+func craftGetBlockMessage(t *testing.T, parser chainlib.ChainParser) chainlib.ChainMessage {
+	t.Helper()
+	parsing, apiCollection, ok := parser.GetParsingByTag(spectypes.FUNCTION_TAG_GET_BLOCKNUM)
+	require.True(t, ok, "GRPCTEST must declare a get-blocknum directive")
+
+	message, err := parser.ParseMsg(parsing.ApiName, []byte{},
+		apiCollection.CollectionData.Type, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+	require.NoError(t, err)
+	return message
+}
+
+// boundRegistry reports which registry a parser is currently bound to, through
+// exported API only: ParseMsg copies apip.registry onto every message it builds, and
+// that registry is what GetParams -> block parsing resolves through. It is the same
+// pointer live relays use, so comparing it across an event answers "did that event
+// rebind the live parser".
+func boundRegistry(t *testing.T, message chainlib.ChainMessage) *dyncodec.Registry {
+	t.Helper()
+	grpcMessage, ok := message.GetRPCMessage().(*rpcInterfaceMessages.GrpcMessage)
+	require.True(t, ok, "GRPCTEST messages must be gRPC messages")
+	return grpcMessage.Registry
+}
+
+// TestRevalidateTier_DoesNotRebindLiveGrpcParser is MAG-2538's regression pin.
+//
+// Background provider recovery used to hand the live chainParser straight to
+// GetChainRouter under a per-attempt timeout. For gRPC, newGrpcChainProxy ->
+// setupForProvider rebinds that parser's registry/codec to the verification
+// connection, so when the attempt context was cancelled the live parser was left
+// resolving descriptors through a dead reflection connection: every subsequent
+// gRPC relay on that provider failed in dynamicResolve with "proto file containing
+// symbol: ..." until the pod restarted. The retry runs on a timer, so the outage
+// recurred every few minutes.
+//
+// The ticket's Expected clause is "a recovering provider is validated against a
+// copy of the parser, not the live one", and that is what this asserts — against
+// the real recovery path, not a stand-in. revalidateTier is the production
+// function; it calls the real retryValidateFn -> validateProvider, which is where
+// CloneChainParserForValidation is applied. Deleting that one call fails this test.
+//
+// TestCloneChainParserForValidation_GrpcIsolation in chainlib covers the helper in
+// isolation, but simulates the mutation by assigning registry/codec directly. It
+// therefore cannot see a caller that stops cloning, which is exactly the defect
+// this ticket was filed for.
+//
+// This is NOT the end-to-end repro the ticket also asks for. It does not drive the
+// 3-minute retry timer and it does not serve a relay through external gRPC ingress;
+// both remain blocked on MAG-2477 / MAG-2093. What it does cover is the mutation
+// that caused the outage, on the path that performs it, asserted both as a binding
+// and as the descriptor resolution that binding feeds.
+func TestRevalidateTier_DoesNotRebindLiveGrpcParser(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	// CreateChainLibMocks stands up a gRPC server that serves both reflection and
+	// the GRPCTEST block service, then builds the parser through GetChainRouter —
+	// i.e. the parser arrives already bound the way boot leaves it in production.
+	// The router it returns is the SERVING router, the one live relays would use.
+	noop := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	chainParser, servingRouter, _, closeServer, endpoint, err := chainlib.CreateChainLibMocks(
+		ctx, "GRPCTEST", spectypes.APIInterfaceGrpc, noop, nil, "../../", nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if closeServer != nil {
+			closeServer()
+		}
+	})
+
+	servingRegistry := boundRegistry(t, craftGetBlockMessage(t, chainParser))
+	require.NotNil(t, servingRegistry,
+		"precondition: boot must leave the live parser bound, or there is nothing for recovery to break")
+
+	provider := &lavasession.RPCStaticProviderEndpoint{
+		Name:         "recovering-provider",
+		ChainID:      endpoint.ChainID,
+		ApiInterface: endpoint.ApiInterface,
+		NodeUrls:     endpoint.NodeUrls,
+	}
+	rpcEndpoint := &lavasession.RPCEndpoint{
+		ChainID:      endpoint.ChainID,
+		ApiInterface: endpoint.ApiInterface,
+	}
+
+	// The production recovery pass, verbatim: revalidateTier -> retryValidateFn ->
+	// validateProvider -> CloneChainParserForValidation -> GetChainRouter, with
+	// validateProvider's own attemptCtx cancelled on the way out.
+	recovered, stillFailed := (&RPCSmartRouter{}).revalidateTier(
+		ctx,
+		[]*lavasession.RPCStaticProviderEndpoint{provider},
+		chainParser,
+		rpcEndpoint,
+		reverifyTierStatic,
+	)
+
+	// Verification has to have reached the mutation for the assertions below to mean
+	// anything: if GetChainRouter had failed early, setupForProvider would never run
+	// and the live parser would be untouched for the wrong reason. A recovered
+	// provider proves the router AND the fetcher were built against this endpoint.
+	require.Empty(t, stillFailed, "the mock upstream should verify; otherwise this test proves nothing")
+	require.Len(t, recovered, 1)
+
+	require.Same(t, servingRegistry, boundRegistry(t, craftGetBlockMessage(t, chainParser)),
+		"MAG-2538: background recovery must validate against a clone, leaving the live parser bound to the serving connection")
+
+	// The same binding as above, asserted through behaviour instead of pointer
+	// identity. GetParams -> dynamicResolve is the ONLY consumer of the parser's
+	// registry, and it is what block parsing runs through; against a registry left
+	// bound to recovery's torn-down reflection connection it logs "failed to
+	// dynamicResolve" and returns nil. Worth keeping alongside require.Same because
+	// it also catches a rebind to a different-but-equally-dead registry, which
+	// pointer identity would flag only by accident.
+	require.NotNil(t, craftGetBlockMessage(t, chainParser).GetRPCMessage().GetParams(),
+		"MAG-2538: the live parser's registry must still resolve descriptors after recovery")
+
+	// Smoke check, NOT a regression assertion. SendNodeMsg builds its descriptor
+	// source from the ChainProxy's own connector and never reads GrpcMessage.Registry,
+	// so it cannot observe this ticket's defect — verified: it passes with the clone
+	// removed from validateProvider. What it does prove is the adjacent property that
+	// the serving connector itself outlived recovery's teardown.
+	reply, _, _, _, _, err := servingRouter.SendNodeMsg(ctx, nil, craftGetBlockMessage(t, chainParser), nil)
+	require.NoError(t, err, "the serving connector must survive background recovery")
+	require.NotNil(t, reply)
+
+	// Vacuity guard, deliberately last so it cannot disturb the assertions above.
+	// The same endpoint DOES rebind the parser when handed it directly, which is
+	// what makes the require.Same above a real constraint rather than a tautology.
+	// (An earlier attempt at this test pointed at an unreachable address; the dial
+	// failed before setupForProvider ran, so it passed against the broken code too.)
+	_, err = chainlib.GetChainRouter(ctx, 1, endpoint, chainParser)
+	require.NoError(t, err)
+	require.NotSame(t, servingRegistry, boundRegistry(t, craftGetBlockMessage(t, chainParser)),
+		"control: an unprotected GetChainRouter must rebind the live parser")
+}


### PR DESCRIPTION
Jira ticket: MAG-2538

Rebased onto current `main` (`e9f7c66`). The `grpc_test.go` conflict was both sides appending to the end of the file; both are kept — main's `TestSetupForProvider_RejectsConflictingDescriptorSource` and this PR's `TestCloneChainParserForValidation_AbsorbsRealSetupForProvider`. No descriptor-source / `grpc-config` behaviour was dropped.

> **Scope note.** An earlier revision of this description said "tests only, no production code changes". That is no longer true, and the change that made it untrue is the more important half of the PR — hence `fix(...)`, not `test(...)`. See §2.

## 1. Why the test half exists

The router fix for MAG-2538 already landed, with MAG-2525. `retryFailedProviders` routes verification through `retryValidateFn` → `validateProvider`, and `validateProvider` clones via `CloneChainParserForValidation` before handing the parser to `GetChainRouter`. Verified rather than assumed: there is **no** `GetChainRouter` call left in `rpcsmartrouter.go`, and the only non-test caller of `CloneChainParserForValidation` is `spec_reverifier.go:429`.

The ticket was reopened because the regression test was never written.

`TestCloneChainParserForValidation_GrpcIsolation` stands in for the mutation by assigning `registry`/`codec` directly, so it proves the helper returns a distinct struct but not that a clone absorbs what `newGrpcChainProxy` does to it — and nothing at all about whether callers still clone. A caller dropping the clone is exactly what the outage was.

**`TestRevalidateTier_DoesNotRebindLiveGrpcParser`** (`protocol/rpcsmartrouter`) runs the production recovery pass — `revalidateTier` → `retryValidateFn` → `validateProvider`, with `validateProvider`'s own `attemptCtx` cancelled on the way out — and asserts the live parser is still bound to its serving registry two ways:

1. **pointer identity** — `require.Same` on the registry `ParseMsg` copies onto every message it builds;
2. **behaviour** — `GetParams` → `dynamicResolve`, the *only* consumer of that registry and what block parsing runs through. Against a registry left bound to recovery's torn-down reflection connection it logs `failed to dynamicResolve` and returns nil.

The second is not redundant with the first: it also catches a rebind to a different-but-equally-dead registry, which pointer identity would flag only by accident. The registry is observed through exported API only — no unexported access and no new test-only exports.

**`TestCloneChainParserForValidation_AbsorbsRealSetupForProvider`** (`protocol/chainlib`) covers the helper against the real mutation, so a field added to `cloneForValidation` that aliases mutable state is caught in the package that owns it.

Both end with a control asserting the same call **without** the clone *does* rebind the live parser. That is load-bearing: the ticket records that the first attempt at this test (in the superseded #287) pointed at an unreachable address, `NewGRPCConnector` errored before `newGrpcChainProxy` ran, and it passed against fixed **and** broken code.

## 2. The production change: pool capacity moves onto the connector

Running the recovery test under `-race` surfaced a real defect, not a test artifact:

```
WARNING: DATA RACE
Write at 0x000107484b20 by goroutine 28:
  chainproxy.NewGRPCConnector()            connector.go:214
Previous read at 0x000107484b20 by goroutine 57:
  chainproxy.(*GRPCConnector).ReturnRpc()  connector.go:408
```

`NumberOfParallelConnections` was both configuration and state. `NewConnector` and `NewGRPCConnector` each wrote it with their own `nConns`, and `GRPCConnector.ReturnRpc` read it back as *"the number we started with"*. Two connectors alive at once broke that in both directions:

- **Silent misbehaviour** — the second constructor redefined the first's idle-trim threshold, process-wide. Across differing `nConns` the wrong pool gets trimmed. An HTTP connector could reset a gRPC connector's threshold despite never reading it.
- **Data race** — the write and the read are unsynchronized.

MAG-2538's recovery path is one way in (`validateProvider` tears its verification connector down while the next is constructed) but nothing about the hazard is specific to recovery; any two overlapping connectors reach it.

`GRPCConnector` now owns a `capacity` field, written once in `NewGRPCConnector` before publication and read by `ReturnRpc`. Neither constructor mutates the global, which is now **`const`** — so "configuration, not state" is a compiler guarantee rather than a convention, and no future caller can reintroduce either constructor's write. Its one remaining use is the default for `--parallel-connections` at `testing.go:207`.

Three chainproxy tests pin it, all of which **fail against the old model** — two on assertions, the third with three data races:

| Test | Pins |
|---|---|
| `TestGRPCConnectorCapacityIsPerInstance` | capacity survives a later, larger connector |
| `TestGRPCConnectorReturnRpcTrimsAgainstOwnCapacity` | same pool state, two capacities, opposite trim decisions |
| `TestConnectorConstructionDoesNotRaceReturnRpc` | both constructors concurrent with `ReturnRpc`, race-free |

### Live behaviour change

`validateProvider` passes `100` (`DefaultMaximumStreamsOverASingleConnection`, `spec_reverifier.go:431`), while direct-RPC builds its connectors with a hardcoded `nConns=10` on the **request** path (`direct_rpc_connection.go:887`). Under the old model a serving connector's trim threshold was whichever constructor ran most recently, so it oscillated between 10 and 100 depending on relay/retry interleaving. After this PR every connector trims against its own `nConns`.

That is the intended behaviour and the practical delta is small — a 10-connection pool rarely exceeds `used + 10` free — but it is a live change, so it is called out here rather than left implicit.

## Verification

All clean, run from a `git worktree` checkout of the committed sha:

```
gofmt -l <touched files>
go build ./...
go vet ./protocol/chainlib/... ./protocol/rpcsmartrouter/... ./protocol/lavasession/...
git diff --check
go test -race ./protocol/chainlib/chainproxy ./protocol/chainlib ./protocol/rpcsmartrouter -count=1
go test -race ./protocol/lavasession -count=1
go test -race ./protocol/chainlib/chainproxy -count=3 -shuffle=on
go test -race ./protocol/rpcsmartrouter -run '^TestRevalidateTier_DoesNotRebindLiveGrpcParser$' -count=25
```

Deliberate broken-implementation checks still fail as intended:

| Revert | Fails |
|---|---|
| `validationParser := chainParser` in `validateProvider` | `TestRevalidateTier_DoesNotRebindLiveGrpcParser` — at `require.Same`, and independently at the `GetParams` probe with `require.Same` disabled |
| `CloneChainParserForValidation` returns its argument | `TestCloneChainParserForValidation_AbsorbsRealSetupForProvider` |
| `NumberOfParallelConnections = nConns` in either constructor | does not compile: `cannot assign to NumberOfParallelConnections` |

The one-line import reordering in `grpc_auth_connector_test.go` is `gofmt` output on a file that was already unformatted on main.

## Not in this PR

The end-to-end repro the ticket describes — let the 3-minute retry timer fire, then serve a live gRPC relay through **external ingress** — is still blocked on MAG-2477 (gRPC ingress) or MAG-2093 (sim-aware gRPC test client). The assertions in §1 are not that test: they drive the in-process recovery path directly and do not exercise the timer or ingress. Not worked around; the gate is real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
