### PR TITLE
fix(smart-router): scope health-probe state per endpoint and normalize gRPC dial addresses (MAG-2333)

### DIFF
--- a/protocol/chainlib/base_chain_parser.go
+++ b/protocol/chainlib/base_chain_parser.go
@@ -22,8 +22,20 @@ import (
 )
 
 var (
-	SkipWebsocketVerification = false
-	DefaultApiName            = "Default-"
+	// SkipWebsocketVerificationDefault seeds every parser built by NewChainParser and
+	// is bound to --skip-websocket-verification. It is written once during flag parsing,
+	// before any parser or goroutine exists, and is read-only from then on.
+	//
+	// It is deliberately NOT consulted at the point of use. The `health` command probes
+	// each direct-rpc entry concurrently and needs a different answer per entry (ws
+	// augmentation only routes for an entry that actually has a ws:// URL), so it used to
+	// flip a package global under a mutex around ValidateCollect. That missed the second
+	// reader — newChainRouter — which runs outside that mutex, so entries raced each other
+	// into the wrong ws enforcement and healthy legs reported red (MAG-2333). Per-parser
+	// state removes the shared cell entirely.
+	SkipWebsocketVerificationDefault = false
+
+	DefaultApiName = "Default-"
 )
 
 type PolicyInf interface {
@@ -52,6 +64,30 @@ type BaseChainParser struct {
 	allowedExtensions map[string]struct{}
 	extensionParser   extensionslib.ExtensionParser
 	active            bool
+
+	// skipWebsocketVerification is this parser's own answer to "should verifications be
+	// augmented with the websocket extension, and should the router enforce ws support".
+	// Seeded from SkipWebsocketVerificationDefault; overridden per-endpoint by callers
+	// that probe several endpoints concurrently. Guarded by rwLock like every other
+	// mutable field here.
+	skipWebsocketVerification bool
+}
+
+// SkipWebsocketVerification reports whether this parser's endpoint opts out of
+// websocket augmentation and enforcement.
+func (bcp *BaseChainParser) SkipWebsocketVerification() bool {
+	bcp.rwLock.RLock()
+	defer bcp.rwLock.RUnlock()
+	return bcp.skipWebsocketVerification
+}
+
+// SetSkipWebsocketVerification overrides the process default for this parser only.
+// Callers probing multiple endpoints concurrently must build one parser per endpoint
+// and set it here rather than reaching for the package-level default.
+func (bcp *BaseChainParser) SetSkipWebsocketVerification(skip bool) {
+	bcp.rwLock.Lock()
+	defer bcp.rwLock.Unlock()
+	bcp.skipWebsocketVerification = skip
 }
 
 func (bcp *BaseChainParser) Activate() {

--- a/protocol/chainlib/chain_fetcher.go
+++ b/protocol/chainlib/chain_fetcher.go
@@ -281,7 +281,7 @@ func getExtensionsForVerification(verification VerificationContainer, chainParse
 		ConnectionType: verification.ConnectionType,
 	}
 
-	if chainParser.IsTagInCollection(spectypes.FUNCTION_TAG_SUBSCRIBE, collectionKey) && !SkipWebsocketVerification {
+	if chainParser.IsTagInCollection(spectypes.FUNCTION_TAG_SUBSCRIBE, collectionKey) && !chainParser.SkipWebsocketVerification() {
 		if verification.Extension == "" {
 			extensions = []string{WebSocketExtension}
 		} else {

--- a/protocol/chainlib/chain_router.go
+++ b/protocol/chainlib/chain_router.go
@@ -325,7 +325,7 @@ func newChainRouter(ctx context.Context, nConns uint, rpcProviderEndpoint lavase
 			break
 		}
 	}
-	if !IgnoreWsEnforcementForTestCommands && hasSubscriptionInSpec && apiCollection.Enabled && !webSocketSupported && !SkipWebsocketVerification {
+	if !IgnoreWsEnforcementForTestCommands && hasSubscriptionInSpec && apiCollection.Enabled && !webSocketSupported && !chainParser.SkipWebsocketVerification() {
 		return nil, utils.LavaFormatError("subscriptions are applicable for this chain, but websocket is not provided in 'supported' map. By not setting ws/wss your provider wont be able to accept ws subscriptions, therefore might receive less rewards and lower QOS score.", nil,
 			utils.LogAttr("apiInterface", apiCollection.CollectionData.ApiInterface),
 			utils.LogAttr("supportedMap", supportedMap),

--- a/protocol/chainlib/chain_router_test.go
+++ b/protocol/chainlib/chain_router_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -387,6 +388,70 @@ func TestChainRouterWithDisabledWebSocketInSpec(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSkipWebsocketVerificationIsPerParser pins the fix for MAG-2333.
+//
+// newChainRouter's websocket-enforcement branch used to read a package global that
+// `smartrouter health` flipped per endpoint while probing endpoints concurrently. Two
+// endpoints wanting opposite answers raced, and whichever wrote last decided for both —
+// so healthy legs reported red. The flag now lives on the parser and health builds one
+// parser per endpoint, so concurrent routers must each get the answer they asked for.
+//
+// The endpoint is deliberately http-only against a subscribe-capable spec: that is the
+// exact shape that trips enforcement, and the shape the existing ws tests never reach
+// because they always pair an http URL with a ws URL.
+func TestSkipWebsocketVerificationIsPerParser(t *testing.T) {
+	newSubscribeParser := func(skip bool) ChainParser {
+		t.Helper()
+		parser, err := NewChainParser(spectypes.APIInterfaceJsonRPC)
+		require.NoError(t, err)
+
+		spec := CreateMockSpec()
+		spec.ApiCollections = []*spectypes.ApiCollection{{
+			Enabled:        true,
+			CollectionData: spectypes.CollectionData{ApiInterface: spectypes.APIInterfaceJsonRPC},
+			ParseDirectives: []*spectypes.ParseDirective{{
+				FunctionTag: spectypes.FUNCTION_TAG_SUBSCRIBE,
+			}},
+		}}
+		parser.SetSpec(spec)
+		parser.SetSkipWebsocketVerification(skip)
+		return parser
+	}
+
+	httpOnlyEndpoint := func() *lavasession.RPCProviderEndpoint {
+		return &lavasession.RPCProviderEndpoint{
+			ChainID:      CreateMockSpec().Index,
+			ApiInterface: spectypes.APIInterfaceJsonRPC,
+			NodeUrls:     []common.NodeUrl{{Url: listenerAddressHttp}},
+		}
+	}
+
+	skipping := newSubscribeParser(true)
+	enforcing := newSubscribeParser(false)
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	var skipErr, enforceErr error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, skipErr = GetChainRouter(ctx, 1, httpOnlyEndpoint(), skipping)
+	}()
+	go func() {
+		defer wg.Done()
+		_, enforceErr = GetChainRouter(ctx, 1, httpOnlyEndpoint(), enforcing)
+	}()
+	wg.Wait()
+
+	require.NoError(t, skipErr, "a parser that opted out of ws verification must accept an http-only endpoint")
+	require.Error(t, enforceErr, "a parser that did not opt out must still refuse an http-only endpoint for a subscribe-capable spec")
+
+	// Neither router run may have leaked into the other parser or into the process default.
+	require.True(t, skipping.SkipWebsocketVerification())
+	require.False(t, enforcing.SkipWebsocketVerification())
+	require.False(t, SkipWebsocketVerificationDefault, "GetChainRouter must not write the package default")
 }
 
 func TestChainRouterWithEnabledWebSocketInSpec(t *testing.T) {

--- a/protocol/chainlib/chainlib.go
+++ b/protocol/chainlib/chainlib.go
@@ -85,6 +85,8 @@ type ChainParser interface {
 	ExtractDataFromRequest(*http.Request) (url string, data string, connectionType string, metadata []pairingtypes.Metadata, err error)
 	SetResponseFromRelayResult(*common.RelayResult) (*http.Response, error)
 	ParseDirectiveEnabled() bool
+	SkipWebsocketVerification() bool
+	SetSkipWebsocketVerification(skip bool)
 }
 
 // CloneChainParserForValidation returns a parser instance safe to pass into

--- a/protocol/chainlib/chainlib_mock.go
+++ b/protocol/chainlib/chainlib_mock.go
@@ -311,6 +311,18 @@ func (mr *MockChainParserMockRecorder) SetResponseFromRelayResult(arg0 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetResponseFromRelayResult", reflect.TypeOf((*MockChainParser)(nil).SetResponseFromRelayResult), arg0)
 }
 
+// SetSkipWebsocketVerification mocks base method.
+func (m *MockChainParser) SetSkipWebsocketVerification(skip bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSkipWebsocketVerification", skip)
+}
+
+// SetSkipWebsocketVerification indicates an expected call of SetSkipWebsocketVerification.
+func (mr *MockChainParserMockRecorder) SetSkipWebsocketVerification(skip interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSkipWebsocketVerification", reflect.TypeOf((*MockChainParser)(nil).SetSkipWebsocketVerification), skip)
+}
+
 // SetSpec mocks base method.
 func (m *MockChainParser) SetSpec(spec spec.Spec) {
 	m.ctrl.T.Helper()
@@ -321,6 +333,20 @@ func (m *MockChainParser) SetSpec(spec spec.Spec) {
 func (mr *MockChainParserMockRecorder) SetSpec(spec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSpec", reflect.TypeOf((*MockChainParser)(nil).SetSpec), spec)
+}
+
+// SkipWebsocketVerification mocks base method.
+func (m *MockChainParser) SkipWebsocketVerification() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SkipWebsocketVerification")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SkipWebsocketVerification indicates an expected call of SkipWebsocketVerification.
+func (mr *MockChainParserMockRecorder) SkipWebsocketVerification() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SkipWebsocketVerification", reflect.TypeOf((*MockChainParser)(nil).SkipWebsocketVerification))
 }
 
 // UpdateBlockTime mocks base method.

--- a/protocol/chainlib/chainproxy/connector.go
+++ b/protocol/chainlib/chainproxy/connector.go
@@ -321,6 +321,26 @@ func (connector *GRPCConnector) getTransportCredentials() grpc.DialOption {
 	return grpc.WithTransportCredentials(insecure.NewCredentials())
 }
 
+// grpcDialAddress converts a configured node URL into what grpc.DialContext expects.
+// DialContext takes host:port; the grpc:// / grpcs:// prefixes are a config-time
+// convention enforced by the direct-RPC validator (see
+// protocol/lavasession/direct_rpc_connection.go validateURL). The grpcs:// form also
+// implies TLS.
+//
+// EVERY dial site must go through this. increaseNumberOfClients used to dial the raw
+// configured URL while createConnection stripped the scheme locally, so a grpcs://
+// endpoint opened its first connection and then could never refill its pool: GetRpc
+// spawns a refill every 50ms while a caller waits, each one failed on the unresolvable
+// scheme-prefixed target, and the caller blocked until its context expired. On a
+// one-connection pool whose single client is held for reflection, that is every relay
+// (MAG-2333).
+func grpcDialAddress(url string) (addr string, impliesTLS bool) {
+	if strings.HasPrefix(url, "grpcs://") {
+		return strings.TrimPrefix(url, "grpcs://"), true
+	}
+	return strings.TrimPrefix(url, "grpc://"), false
+}
+
 func (connector *GRPCConnector) increaseNumberOfClients(ctx context.Context, numberOfFreeClients int) {
 	utils.LavaFormatDebug("increasing number of clients", utils.Attribute{Key: "numberOfFreeClients", Value: numberOfFreeClients},
 		utils.Attribute{Key: "url", Value: connector.nodeUrl.Url})
@@ -331,7 +351,8 @@ func (connector *GRPCConnector) increaseNumberOfClients(ctx context.Context, num
 	var err error
 	for connectionAttempt := 0; connectionAttempt < MaximumNumberOfParallelConnectionsAttempts; connectionAttempt++ {
 		nctx, cancel := connector.nodeUrl.LowerContextTimeoutWithDuration(ctx, common.AverageWorldLatency*2)
-		grpcClient, err = grpc.DialContext(nctx, connector.nodeUrl.Url, connector.grpcDialOptions(connector.getTransportCredentials())...)
+		dialAddr, _ := grpcDialAddress(connector.nodeUrl.Url)
+		grpcClient, err = grpc.DialContext(nctx, dialAddr, connector.grpcDialOptions(connector.getTransportCredentials())...)
 		if err != nil {
 			utils.LavaFormatDebug("increaseNumberOfClients, Could not connect to the node, retrying", []utils.Attribute{{Key: "err", Value: err.Error()}, {Key: "Number Of Attempts", Value: connectionAttempt}, {Key: "nodeUrl", Value: connector.nodeUrl.UrlStr()}}...)
 			cancel()
@@ -548,17 +569,11 @@ func (connector *GRPCConnector) numberOfUsedClients() int {
 }
 
 func (connector *GRPCConnector) createConnection(ctx context.Context, nodeUrl common.NodeUrl, currentNumberOfConnections int) (*grpc.ClientConn, error) {
-	// grpc.DialContext expects host:port, not a URL with scheme. The grpc:// /
-	// grpcs:// prefixes are a config-time convention enforced by the direct-RPC
-	// validator (see protocol/lavasession/direct_rpc_connection.go validateURL).
-	// When the grpcs:// prefix is present, also auto-enable TLS on the local
-	// nodeUrl copy so config can rely on the scheme alone.
-	addr := nodeUrl.Url
-	if strings.HasPrefix(addr, "grpcs://") {
-		addr = strings.TrimPrefix(addr, "grpcs://")
+	// Auto-enable TLS on the local nodeUrl copy when the scheme implies it, so config
+	// can rely on the scheme alone.
+	addr, impliesTLS := grpcDialAddress(nodeUrl.Url)
+	if impliesTLS {
 		nodeUrl.AuthConfig.UseTLS = true
-	} else if strings.HasPrefix(addr, "grpc://") {
-		addr = strings.TrimPrefix(addr, "grpc://")
 	}
 	var rpcClient *grpc.ClientConn
 	var err error

--- a/protocol/chainlib/chainproxy/grpc_dial_address_test.go
+++ b/protocol/chainlib/chainproxy/grpc_dial_address_test.go
@@ -1,0 +1,169 @@
+package chainproxy
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+)
+
+// MAG-2333 regression cover.
+//
+// grpc.DialContext takes host:port. createConnection stripped the grpc:// / grpcs://
+// prefix locally, but increaseNumberOfClients — the on-demand pool refill GetRpc spawns
+// — dialed connector.nodeUrl.Url raw. A scheme-prefixed endpoint could therefore open
+// its first connection and never grow the pool again: GetRpc respawned a refill every
+// 50ms, each dial failed on the unresolvable target, and the caller blocked until its
+// context expired.
+//
+// A one-connection pool makes that fatal rather than merely slow, because the single
+// client is retained for reflection and every relay then waits on a refill that cannot
+// land. That is the shape `smartrouter health` uses (it builds a router with nConns=1),
+// which is why a healthy grpcs:// endpoint reported ok:false while the same host with
+// no scheme prefix reported ok:true.
+
+func TestGrpcDialAddress(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		url       string
+		wantAddr  string
+		wantIsTLS bool
+	}{
+		{name: "grpcs scheme is stripped and implies TLS", url: "grpcs://akash.example.com:443", wantAddr: "akash.example.com:443", wantIsTLS: true},
+		{name: "grpc scheme is stripped and does not imply TLS", url: "grpc://akash.example.com:9090", wantAddr: "akash.example.com:9090", wantIsTLS: false},
+		{name: "bare host:port is untouched", url: "akash.example.com:443", wantAddr: "akash.example.com:443", wantIsTLS: false},
+		{name: "host containing grpc in its name is not mangled", url: "akash-grpc.example.com:443", wantAddr: "akash-grpc.example.com:443", wantIsTLS: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			addr, isTLS := grpcDialAddress(tc.url)
+			require.Equal(t, tc.wantAddr, addr)
+			require.Equal(t, tc.wantIsTLS, isTLS)
+		})
+	}
+}
+
+// exhaustPoolThenRefill drives the exact sequence that broke: build a one-connection
+// pool, borrow its only client so the free list is empty, then ask for another and
+// require that the async refill actually produces one. The second GetRpc is what dies
+// with DeadlineExceeded when the refill dials a scheme-prefixed target.
+func exhaustPoolThenRefill(t *testing.T, nodeUrl common.NodeUrl) {
+	t.Helper()
+
+	lifetimeCtx, cancelLifetime := context.WithCancel(context.Background())
+	defer cancelLifetime()
+
+	dialCtx, cancelDial := context.WithTimeout(lifetimeCtx, 20*time.Second)
+	defer cancelDial()
+
+	connector, err := NewGRPCConnector(lifetimeCtx, dialCtx, 1, nodeUrl)
+	require.NoError(t, err, "the initial dial normalizes the scheme and must succeed")
+	defer connector.Close()
+
+	first, err := connector.GetRpc(dialCtx, true)
+	require.NoError(t, err)
+	require.NotNil(t, first, "the pool starts with exactly one client")
+
+	// The pool is now empty. Bound this well under the 20s dial ctx so a failure
+	// reports as "refill never landed" rather than as the whole test timing out.
+	refillCtx, cancelRefill := context.WithTimeout(lifetimeCtx, 10*time.Second)
+	defer cancelRefill()
+
+	second, err := connector.GetRpc(refillCtx, true)
+
+	// Hand back every borrowed client BEFORE asserting. require.NoError aborts via
+	// FailNow, which runs the deferred Close — and Close spins while usedClients > 0.
+	// Asserting while still holding `first` would hang teardown instead of reporting
+	// the failure, which is exactly what happens on the unfixed code.
+	if second != nil {
+		connector.ReturnRpc(second)
+	}
+	connector.ReturnRpc(first)
+
+	require.NoError(t, err, "GetRpc blocked until its deadline: the async refill never produced a client")
+	require.NotNil(t, second)
+}
+
+func TestGRPCConnectorRefillsPoolForSchemePrefixedURL(t *testing.T) {
+	addr, _ := startRecordingGRPCServer(t)
+	exhaustPoolThenRefill(t, common.NodeUrl{Url: "grpc://" + addr})
+}
+
+func TestGRPCConnectorRefillsPoolForTLSSchemePrefixedURL(t *testing.T) {
+	addr, caCertPath := startTLSReflectionServer(t)
+	exhaustPoolThenRefill(t, common.NodeUrl{
+		Url: "grpcs://" + addr,
+		// The scheme alone is what turns TLS on (createConnection sets UseTLS from it);
+		// CaCert is only here so the self-signed test cert is accepted.
+		AuthConfig: common.AuthConfig{CaCert: caCertPath},
+	})
+}
+
+// startTLSReflectionServer starts a gRPC server behind a self-signed cert, with
+// reflection registered so it matches the shape of the upstream the router probes.
+// It returns the listen address and the path to the CA cert to trust.
+func startTLSReflectionServer(t *testing.T) (addr, caCertPath string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	serverCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	require.NoError(t, err)
+
+	caCertPath = filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(caCertPath, certPEM, 0o600))
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := grpc.NewServer(grpc.Creds(credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		MinVersion:   tls.VersionTLS12,
+	})))
+	healthpb.RegisterHealthServer(srv, health.NewServer())
+	reflection.Register(srv)
+	go srv.Serve(lis)
+	t.Cleanup(func() {
+		srv.Stop()
+		lis.Close()
+	})
+
+	return lis.Addr().String(), caCertPath
+}

--- a/protocol/chainlib/grpc.go
+++ b/protocol/chainlib/grpc.go
@@ -76,7 +76,9 @@ func (c grpcDescriptorConfig) String() string {
 
 // NewGrpcChainParser creates a new instance of GrpcChainParser
 func NewGrpcChainParser() (chainParser *GrpcChainParser, err error) {
-	return &GrpcChainParser{}, nil
+	parser := &GrpcChainParser{}
+	parser.skipWebsocketVerification = SkipWebsocketVerificationDefault
+	return parser, nil
 }
 
 // cloneForValidation returns a *GrpcChainParser with isolated registry/codec
@@ -121,6 +123,10 @@ func (apip *GrpcChainParser) cloneForValidation() *GrpcChainParser {
 			allowedExtensions: apip.allowedExtensions,
 			extensionParser:   apip.extensionParser,
 			active:            apip.active,
+
+			// Carried, not re-seeded from the package default: the clone must verify
+			// under the same ws policy as the parser it stands in for.
+			skipWebsocketVerification: apip.SkipWebsocketVerification(),
 		},
 		registry: apip.registry,
 		codec:    apip.codec,

--- a/protocol/chainlib/jsonRPC.go
+++ b/protocol/chainlib/jsonRPC.go
@@ -46,7 +46,9 @@ type JsonRPCChainParser struct {
 
 // NewJrpcChainParser creates a new instance of JsonRPCChainParser
 func NewJrpcChainParser() (chainParser *JsonRPCChainParser, err error) {
-	return &JsonRPCChainParser{}, nil
+	parser := &JsonRPCChainParser{}
+	parser.skipWebsocketVerification = SkipWebsocketVerificationDefault
+	return parser, nil
 }
 
 func (bcp *JsonRPCChainParser) GetUniqueName() string {

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -36,7 +36,9 @@ type RestChainParser struct {
 
 // NewRestChainParser creates a new instance of RestChainParser
 func NewRestChainParser() (chainParser *RestChainParser, err error) {
-	return &RestChainParser{}, nil
+	parser := &RestChainParser{}
+	parser.skipWebsocketVerification = SkipWebsocketVerificationDefault
+	return parser, nil
 }
 
 func (bcp *RestChainParser) GetUniqueName() string {

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -38,7 +38,9 @@ type TendermintChainParser struct {
 
 // NewTendermintRpcChainParser creates a new instance of TendermintChainParser
 func NewTendermintRpcChainParser() (chainParser *TendermintChainParser, err error) {
-	return &TendermintChainParser{}, nil
+	parser := &TendermintChainParser{}
+	parser.skipWebsocketVerification = SkipWebsocketVerificationDefault
+	return parser, nil
 }
 
 func (bcp *TendermintChainParser) GetUniqueName() string {

--- a/protocol/rpcsmartrouter/health_cmd.go
+++ b/protocol/rpcsmartrouter/health_cmd.go
@@ -485,7 +485,40 @@ func probeProvider(ctx context.Context, provider healthProvider, staticSpecPaths
 		applyValidation(&row, validations[i])
 		rows = append(rows, row)
 	}
+
+	backfillLatestBlock(rows, func() (int64, error) { return chainFetcher.FetchLatestBlockNum(ctx) })
+
 	return append(rows, wsSkippedRows()...)
+}
+
+// backfillLatestBlock gives rows that came back without a block height a reporting-only
+// value from fetch.
+//
+// ValidateCollect fetches the latest block only when some verification needs it to
+// compute a LatestDistance. A spec with no such verification therefore reports
+// latestBlock 0 on legs that passed every check, which reads as a dead node — the
+// "known related quirk" in MAG-2333.
+//
+// fetch is called at most once per endpoint and only if some row actually needs it, so
+// a spec that already reports a height costs no extra relay. A fetch failure leaves the
+// rows untouched: this is a reporting field and must never change a leg's ok verdict.
+func backfillLatestBlock(rows []healthEndpointResult, fetch func() (int64, error)) {
+	var block int64
+	fetched := false
+	for i := range rows {
+		if rows[i].LatestBlock > 0 {
+			continue
+		}
+		if !fetched {
+			fetched = true
+			if fetchedBlock, err := fetch(); err == nil {
+				block = fetchedBlock
+			}
+		}
+		if block > 0 {
+			rows[i].LatestBlock = block
+		}
+	}
 }
 
 // applyValidation folds one node-URL's spec-verification results into its result row:

--- a/protocol/rpcsmartrouter/health_cmd.go
+++ b/protocol/rpcsmartrouter/health_cmd.go
@@ -32,14 +32,17 @@ type healthVerification struct {
 // One provider with multiple node-urls (e.g. an https + a wss endpoint) yields one
 // row per url, distinguished by `url`/`transport`.
 type healthEndpointResult struct {
-	Name          string               `json:"name"`
-	ChainID       string               `json:"chainId"`
-	APIInterface  string               `json:"apiInterface"`
-	URL           string               `json:"url"`
-	Transport     string               `json:"transport"`
-	Addons        []string             `json:"addons"`
-	Extensions    []string             `json:"extensions"`
-	SpecValid     bool                 `json:"specValid"`
+	Name         string   `json:"name"`
+	ChainID      string   `json:"chainId"`
+	APIInterface string   `json:"apiInterface"`
+	URL          string   `json:"url"`
+	Transport    string   `json:"transport"`
+	Addons       []string `json:"addons"`
+	Extensions   []string `json:"extensions"`
+	SpecValid    bool     `json:"specValid"`
+	// LatestBlock is this URL's own height when a verification measured one. When it was
+	// backfilled instead (see backfillLatestBlock) it is the ENDPOINT's height, obtained
+	// through the router spanning every probed URL. Reporting only — never a verdict.
 	LatestBlock   int64                `json:"latestBlock"`
 	Ok            bool                 `json:"ok"`
 	Error         string               `json:"error,omitempty"`
@@ -375,14 +378,21 @@ func probeProvider(ctx context.Context, provider healthProvider, staticSpecPaths
 	// `address chain-id api-interface` probe) would otherwise fail EVERY check with
 	// "no chain proxy supporting requested extensions {websocket}".
 	//
-	// This is set on our own parser, which nothing else shares, and set here — before
-	// GetChainRouter, which reads it too. It used to be a package global flipped under a
-	// mutex held only around ValidateCollect: that left GetChainRouter reading whatever
-	// value a concurrently-probed endpoint had last written, and serialized every
-	// endpoint's verification phase behind one lock while each endpoint's own timeout kept
-	// running — so late endpoints entered ValidateCollect with most of their budget gone,
-	// their context expired mid-probe, and connectorLoop closed the connector out from
-	// under the remaining relays ("connector is closed" on healthy nodes, MAG-2333).
+	// This is set on our own parser, which nothing else shares. It used to be a package
+	// global flipped under a mutex held around ValidateCollect, and that lock is what
+	// produced the reported symptom: it serialized every endpoint's verification phase
+	// while each endpoint's own timeout kept running from goroutine launch, so late
+	// endpoints entered ValidateCollect with most of their budget gone, their context
+	// expired mid-probe, and connectorLoop closed the connector out from under the
+	// remaining relays ("connector is closed" on healthy nodes, MAG-2333).
+	//
+	// The global's other reader, newChainRouter (chain_router.go:328), was NOT part of
+	// that symptom under `health`: this command sets IgnoreWsEnforcementForTestCommands
+	// before any probing, and that guard is the first operand of the same &&, so the ws
+	// check short-circuits before SkipWebsocketVerification is ever evaluated there.
+	// Per-parser state is still the right shape — it removes the shared cell instead of
+	// synchronizing it, and newChainRouter does read it on the serving path, where the
+	// guard is false — but a cross-endpoint race on that bool is not what `health` hit.
 	chainParser.SetSkipWebsocketVerification(!(verifyWs && providerHasWebSocketURL(provider.nodeUrls)))
 
 	rpcEndpoint := lavasession.RPCEndpoint{ChainID: provider.chainID, ApiInterface: provider.apiInterface}
@@ -502,11 +512,22 @@ func probeProvider(ctx context.Context, provider healthProvider, staticSpecPaths
 // fetch is called at most once per endpoint and only if some row actually needs it, so
 // a spec that already reports a height costs no extra relay. A fetch failure leaves the
 // rows untouched: this is a reporting field and must never change a leg's ok verdict.
+//
+// Two limits follow from the value being ENDPOINT-level while the rows are per-URL:
+//
+//   - Only rows that passed are filled. fetch cannot say anything about a leg that failed
+//     its checks, and a plausible height printed beside those failures reads as if the URL
+//     were reachable. This also matches what the change set out to do — report a real
+//     height on passing legs.
+//   - fetch routes through the router built over ALL of this endpoint's probed URLs, so
+//     the height belongs to the endpoint, not necessarily to the row it lands on. That is
+//     acceptable for a field that never feeds a verdict, but it is not a per-URL
+//     measurement and must not be read as one.
 func backfillLatestBlock(rows []healthEndpointResult, fetch func() (int64, error)) {
 	var block int64
 	fetched := false
 	for i := range rows {
-		if rows[i].LatestBlock > 0 {
+		if !rows[i].Ok || rows[i].LatestBlock > 0 {
 			continue
 		}
 		if !fetched {

--- a/protocol/rpcsmartrouter/health_cmd.go
+++ b/protocol/rpcsmartrouter/health_cmd.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/magma-Devs/smart-router/protocol/chainlib"
@@ -143,8 +142,9 @@ or from inline "address chain-id api-interface" triplets like the rpcsmartrouter
 			// sanity check, or when ws nodes are known-unreachable and you don't want them probed).
 			skipWs, _ := cmd.Flags().GetBool(commonlib.SkipWebsocketVerificationFlag)
 			verifyWs := !skipWs
-			// chainlib.SkipWebsocketVerification is set per-provider inside probeProvider
-			// (a provider with no ws URL can't have ws verified) — see the note there.
+			// This is only the run-wide default; probeProvider narrows it per endpoint on
+			// that endpoint's own parser (an endpoint with no ws URL can't have ws
+			// verified) — see the note there.
 
 			timeout, _ := cmd.Flags().GetDuration("timeout")
 			results := runHealthProbes(ctx, providers, staticSpecPaths, timeout, verifyWs)
@@ -369,6 +369,22 @@ func probeProvider(ctx context.Context, provider healthProvider, staticSpecPaths
 		return rowsFromError(fmt.Errorf("create chain parser: %w", err))
 	}
 
+	// Per-endpoint websocket gating. For a chain whose spec supports subscriptions every
+	// verification is augmented with the websocket extension — which can only route if this
+	// endpoint actually has a ws:// URL. An http-only endpoint (e.g. an inline
+	// `address chain-id api-interface` probe) would otherwise fail EVERY check with
+	// "no chain proxy supporting requested extensions {websocket}".
+	//
+	// This is set on our own parser, which nothing else shares, and set here — before
+	// GetChainRouter, which reads it too. It used to be a package global flipped under a
+	// mutex held only around ValidateCollect: that left GetChainRouter reading whatever
+	// value a concurrently-probed endpoint had last written, and serialized every
+	// endpoint's verification phase behind one lock while each endpoint's own timeout kept
+	// running — so late endpoints entered ValidateCollect with most of their budget gone,
+	// their context expired mid-probe, and connectorLoop closed the connector out from
+	// under the remaining relays ("connector is closed" on healthy nodes, MAG-2333).
+	chainParser.SetSkipWebsocketVerification(!(verifyWs && providerHasWebSocketURL(provider.nodeUrls)))
+
 	rpcEndpoint := lavasession.RPCEndpoint{ChainID: provider.chainID, ApiInterface: provider.apiInterface}
 	if err := statetracker.RegisterForSpecUpdatesOrSetStaticSpecsWithToken(ctx, chainParser, staticSpecPaths, rpcEndpoint, "", ""); err != nil {
 		return rowsFromError(fmt.Errorf("load spec: %w", err))
@@ -452,19 +468,9 @@ func probeProvider(ctx context.Context, provider healthProvider, staticSpecPaths
 	// provider can list the same URL twice with different addons (e.g. a base URL and an
 	// `addons:[archive]` URL), which would otherwise collide in a url-keyed map.
 	//
-	// Per-provider websocket gating: for a chain whose spec supports subscriptions, every
-	// verification is augmented with the websocket extension — which can only route if this
-	// provider actually has a ws:// URL. A provider with only http URLs (e.g. an inline
-	// `address chain-id api-interface` probe) would otherwise fail EVERY check with
-	// "no chain proxy supporting requested extensions {websocket}". So we disable ws
-	// augmentation for providers that have no ws URL, even when ws is globally on.
-	// chainlib.SkipWebsocketVerification is a package global read inside ValidateCollect,
-	// so set it under a mutex around the call to stay correct under concurrent providers.
-	wsForThisProvider := verifyWs && providerHasWebSocketURL(provider.nodeUrls)
-	wsVerificationMu.Lock()
-	chainlib.SkipWebsocketVerification = !wsForThisProvider
+	// ws gating for this endpoint was applied to chainParser above, so nothing here is
+	// shared with the endpoints probed concurrently alongside it.
 	validations := chainFetcher.ValidateCollect(ctx)
-	wsVerificationMu.Unlock()
 
 	rows := make([]healthEndpointResult, 0, len(provider.nodeUrls))
 	for i, url := range probedUrls {
@@ -548,11 +554,6 @@ func emitFatal(err error) error {
 	writeHealthReport(buildHealthReport(nil, err))
 	return err
 }
-
-// wsVerificationMu serializes the per-provider mutation of the package-global
-// chainlib.SkipWebsocketVerification (read inside ValidateCollect) so concurrent provider
-// probes don't race on it.
-var wsVerificationMu sync.Mutex
 
 // providerHasWebSocketURL reports whether any of the provider's node URLs is ws://wss://.
 func providerHasWebSocketURL(urls []commonlib.NodeUrl) bool {

--- a/protocol/rpcsmartrouter/health_cmd_test.go
+++ b/protocol/rpcsmartrouter/health_cmd_test.go
@@ -126,6 +126,53 @@ func TestApplyValidation_FailedCheckSetsNotOk(t *testing.T) {
 	assert.Equal(t, "expected and received are different", row.Verifications[0].Error)
 }
 
+// MAG-2333: legs that passed every check reported latestBlock 0 whenever the spec had no
+// verification needing a LatestDistance, which reads as a dead node in the JSON report.
+func TestBackfillLatestBlock_FillsOnlyMissingAndFetchesOnce(t *testing.T) {
+	rows := []healthEndpointResult{
+		{URL: "https://a", LatestBlock: 0},
+		{URL: "https://b", LatestBlock: 5324700}, // already has a height — must not be touched
+		{URL: "https://c", LatestBlock: 0},
+	}
+
+	calls := 0
+	backfillLatestBlock(rows, func() (int64, error) {
+		calls++
+		return 9000001, nil
+	})
+
+	assert.Equal(t, 1, calls, "the block must be fetched once per endpoint, not once per row")
+	assert.Equal(t, int64(9000001), rows[0].LatestBlock)
+	assert.Equal(t, int64(5324700), rows[1].LatestBlock, "a row that already reported a height must keep it")
+	assert.Equal(t, int64(9000001), rows[2].LatestBlock)
+}
+
+func TestBackfillLatestBlock_NoFetchWhenNothingMissing(t *testing.T) {
+	rows := []healthEndpointResult{{URL: "https://a", LatestBlock: 42}}
+
+	calls := 0
+	backfillLatestBlock(rows, func() (int64, error) {
+		calls++
+		return 9000001, nil
+	})
+
+	assert.Zero(t, calls, "a spec that already reports a height must not cost an extra relay")
+	assert.Equal(t, int64(42), rows[0].LatestBlock)
+}
+
+// A failed fetch must stay invisible: latestBlock is a reporting field and cannot be
+// allowed to flip any leg's ok verdict.
+func TestBackfillLatestBlock_FetchFailureLeavesRowsAlone(t *testing.T) {
+	rows := []healthEndpointResult{{URL: "https://a", LatestBlock: 0, Ok: true}}
+
+	backfillLatestBlock(rows, func() (int64, error) {
+		return 0, assert.AnError
+	})
+
+	assert.Equal(t, int64(0), rows[0].LatestBlock)
+	assert.True(t, rows[0].Ok, "a reporting-only fetch failure must not change the verdict")
+}
+
 func TestTransportForURL(t *testing.T) {
 	cases := map[string]string{
 		"https://eth1.lava.build":         "http",

--- a/protocol/rpcsmartrouter/health_cmd_test.go
+++ b/protocol/rpcsmartrouter/health_cmd_test.go
@@ -130,9 +130,9 @@ func TestApplyValidation_FailedCheckSetsNotOk(t *testing.T) {
 // verification needing a LatestDistance, which reads as a dead node in the JSON report.
 func TestBackfillLatestBlock_FillsOnlyMissingAndFetchesOnce(t *testing.T) {
 	rows := []healthEndpointResult{
-		{URL: "https://a", LatestBlock: 0},
-		{URL: "https://b", LatestBlock: 5324700}, // already has a height — must not be touched
-		{URL: "https://c", LatestBlock: 0},
+		{URL: "https://a", LatestBlock: 0, Ok: true},
+		{URL: "https://b", LatestBlock: 5324700, Ok: true}, // already has a height — must not be touched
+		{URL: "https://c", LatestBlock: 0, Ok: true},
 	}
 
 	calls := 0
@@ -148,7 +148,7 @@ func TestBackfillLatestBlock_FillsOnlyMissingAndFetchesOnce(t *testing.T) {
 }
 
 func TestBackfillLatestBlock_NoFetchWhenNothingMissing(t *testing.T) {
-	rows := []healthEndpointResult{{URL: "https://a", LatestBlock: 42}}
+	rows := []healthEndpointResult{{URL: "https://a", LatestBlock: 42, Ok: true}}
 
 	calls := 0
 	backfillLatestBlock(rows, func() (int64, error) {
@@ -158,6 +158,36 @@ func TestBackfillLatestBlock_NoFetchWhenNothingMissing(t *testing.T) {
 
 	assert.Zero(t, calls, "a spec that already reports a height must not cost an extra relay")
 	assert.Equal(t, int64(42), rows[0].LatestBlock)
+}
+
+// A leg that failed its checks must not advertise a height. fetch routes through the
+// router spanning every probed URL, so the value it returns says nothing about the URL
+// on a failed row — printing it there reads as if that URL were reachable.
+func TestBackfillLatestBlock_SkipsFailedRows(t *testing.T) {
+	rows := []healthEndpointResult{
+		{URL: "https://dead", LatestBlock: 0, Ok: false},
+		{URL: "https://live", LatestBlock: 0, Ok: true},
+	}
+
+	backfillLatestBlock(rows, func() (int64, error) { return 9000001, nil })
+
+	assert.Zero(t, rows[0].LatestBlock, "a failed leg must not report a height fetched via another URL")
+	assert.Equal(t, int64(9000001), rows[1].LatestBlock, "a passing leg is still backfilled")
+}
+
+// The fetch is skipped entirely when every row that lacks a height also failed, so a
+// fully-dead endpoint costs no extra relay.
+func TestBackfillLatestBlock_NoFetchWhenOnlyFailedRowsAreMissing(t *testing.T) {
+	rows := []healthEndpointResult{{URL: "https://dead", LatestBlock: 0, Ok: false}}
+
+	calls := 0
+	backfillLatestBlock(rows, func() (int64, error) {
+		calls++
+		return 9000001, nil
+	})
+
+	assert.Zero(t, calls, "no passing row needs a height, so nothing should be fetched")
+	assert.Zero(t, rows[0].LatestBlock)
 }
 
 // A failed fetch must stay invisible: latestBlock is a reporting field and cannot be

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -3048,7 +3048,7 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	cmdRPCSmartRouter.Flags().Int64Var(&chainlib.MaxIdleTimeInSeconds, common.LimitWebsocketIdleTimeFlag, chainlib.MaxIdleTimeInSeconds, "limit the idle time in seconds for a websocket connection, default is 20 minutes ( 20 * 60 )")
 	cmdRPCSmartRouter.Flags().DurationVar(&chainlib.WebSocketBanDuration, common.BanDurationForWebsocketRateLimitExceededFlag, chainlib.WebSocketBanDuration, "once websocket rate limit is reached, user will be banned Xfor a duration, default no ban")
 
-	cmdRPCSmartRouter.Flags().BoolVar(&chainlib.SkipWebsocketVerification, common.SkipWebsocketVerificationFlag, chainlib.SkipWebsocketVerification, "skip websocket verification for chains that require ws/wss endpoints")
+	cmdRPCSmartRouter.Flags().BoolVar(&chainlib.SkipWebsocketVerificationDefault, common.SkipWebsocketVerificationFlag, chainlib.SkipWebsocketVerificationDefault, "skip websocket verification for chains that require ws/wss endpoints")
 
 	cmdRPCSmartRouter.Flags().DurationVar(&lavasession.ProbeLoopInterval, common.ProbeLoopIntervalFlagName, lavasession.ProbeLoopInterval, "cadence of the proactive health prober (MAG-2161 Topic D); must be > 0, default 5s")
 	cmdRPCSmartRouter.Flags().Float64(common.ProbeUpdateWeightFlagName, scoreutils.DefaultProbeUpdateWeight, "weight multiplier for provider-optimizer probe updates (liveness/latency); must be > 0")


### PR DESCRIPTION
Jira ticket: MAG-2333

Rebased onto `main` at `d03d1a4`. The connector pool-size commit that used to lead this branch has been **dropped**: #294 landed the same fix independently, naming the field `capacity` and making the global `const`, with three dedicated connector tests. Keeping both would have produced a struct carrying `capacity` *and* `nConns` — the two declarations sat in non-conflicting hunks, so a naive resolution wouldn't have shown it. `TestSkipWebsocketVerificationIsPerParser` still passes clean under `-race` on main's version.

## Problem

`smartrouter health` reported endpoints as unhealthy that the live router verifies and serves fine. The ticket recorded two symptoms; they turned out to be two independent defects.

**Bug A — `connector is closed` on every tendermintrpc URL.** `chainlib.SkipWebsocketVerification` was a process global that `health` flipped per endpoint under a mutex held around `ValidateCollect`. **That lock is the defect.** Holding it serialized every endpoint's verification phase while each endpoint's own `context.WithTimeout` kept running from goroutine launch. An endpoint late in the queue entered `ValidateCollect` with most of its budget already spent, its context expired mid-probe, and `connectorLoop` closed the connector out from under the remaining relays. The same premature expiry on the gRPC path surfaces as the reported `descriptorSource.FindSymbol DeadlineExceeded`, and it explains the ticket's flakiness signature — the archive-tagged leg of an identical URL passing while the plain leg failed in the same run.

> **Correction.** An earlier revision of this description also blamed a cross-endpoint race on the global via its second reader, `newChainRouter`. That is **not reachable under `health`**: the command sets `IgnoreWsEnforcementForTestCommands = true` (`health_cmd.go:115`) before any probing, and that guard is the first operand of the same `&&` as the `SkipWebsocketVerification()` call (`chain_router.go:328`), so Go short-circuits before the flag is ever evaluated there. Within `health` the only remaining reader is `getExtensionsForVerification`, reached from `ValidateCollect`, which is fully synchronous. Thanks to @AnnaR-prog for catching it.
>
> Moving the flag onto the parser is still the right change — it removes the shared cell instead of synchronizing it, and `newChainRouter` does read it on the serving path where the guard is `false`. But the lock's cost, not a torn read, is what users hit.

**Bug B — `descriptorSource.FindSymbol DeadlineExceeded` on gRPC.** `grpc.DialContext` takes `host:port`. `createConnection` stripped the `grpc://` / `grpcs://` prefix into a local `addr`, but `increaseNumberOfClients` — the on-demand pool refill — dialed `connector.nodeUrl.Url` raw. A scheme-prefixed endpoint opened its first connection and then never grew its pool again: `GetRpc` respawns a refill every 50ms while a caller waits, each dial failed on the unresolvable target, and the caller blocked until its context expired.

**Bug B is not health-specific.** `increaseNumberOfClients` is called from `GetRpc`, so pool refill was broken for every `grpc(s)://` endpoint on the serving path. `nConns=1` — what `health` builds — only turns "pool never grows" into "every relay hangs", because the single client is retained for reflection.

## The fix

| # | Commit | Change |
|---|---|---|
| 1 | `660f031` | `SkipWebsocketVerification` moves onto the parser; `health` already builds one parser per endpoint, and both readers already hold one. No shared cell, so no mutex and no serialization |
| 2 | `53ef5c2` | `grpcDialAddress` becomes the single normalizer for every gRPC dial site |
| 3 | `572b97b` | `backfillLatestBlock` reports a real height on legs that passed |
| 4 | `7555c80` | Review follow-ups: stop backfilling failed legs; correct the Bug A narrative in code |

Commit 3 addresses the ticket's "known related quirk": `ValidateCollect` fetches the latest block only when a verification needs it for a `LatestDistance`, so specs without one reported `latestBlock: 0` on passing legs.

Commit 4 closes a gap review found in commit 3: the fetch routes through the router built over **all** of an endpoint's probed URLs, so a row for URL A could be filled with a height obtained via URL B — and it filled failed rows too, printing a plausible height beside a leg's own failures. Only passing rows are backfilled now, and the value's endpoint-level provenance is documented on both the function and the JSON struct field rather than left implied.

## Live acceptance

Three-point A/B against public Akash endpoints. `config/akash.yml` from the ticket does not exist — lava-specs PR #42 only landed `akash.json` — so the config below was written to reproduce its shape, with the tendermintrpc entry deliberately mixing `https` + `wss` in one entry.

| Leg | `main` | + ws fix | **this branch** |
|---|---|---|---|
| tmrpc `https://akash-rpc.publicnode.com` | ❌ `connector is closed` | ✅ | ✅ |
| tmrpc `wss://akash-rpc.publicnode.com/websocket` | ❌ `connector is closed` | ✅ | ✅ |
| tmrpc `https://rpc.lavenderfive.com:443/akash` | ✅ | ✅ | ✅ |
| rest `https://rest.lavenderfive.com:443/akash` | ✅ | ✅ | ✅ |
| grpc `grpcs://akash.lavenderfive.com:443` | ❌ `waiting for a free client` | ❌ same | ✅ |
| **top-level** | **`ok:false`** | **`ok:false`** | **`ok:true`** |

Every leg green including the WSS and `grpcs://` legs, and every `latestBlock` positive:

```
TOP-LEVEL ok: True
  akash-tmrpc-publicnode     tendermintrpc  https://akash-rpc.publicnode.com          ok=True  block=28237143
  akash-tmrpc-publicnode     tendermintrpc  wss://akash-rpc.publicnode.com/websocket  ok=True  block=28237144
  akash-tmrpc-lavenderfive   tendermintrpc  https://rpc.lavenderfive.com:443/akash    ok=True  block=28237143
  akash-rest-lavenderfive    rest           https://rest.lavenderfive.com:443/akash   ok=True  block=28237143
  akash-grpc-lavenderfive    grpc           grpcs://akash.lavenderfive.com:443        ok=True  block=28237144
```

The isolated inline-triplet repro from the ticket reproduces and clears the same way. On `grpcs://akash.lavenderfive.com:443`, before: `ok:false`, both checks failing `descriptorSource.FindSymbol ErrMsg: rpc error: code = DeadlineExceeded` — the ticket's Bug B string verbatim. After: `ok:true`, `latestBlock: 28226553`.

<details>
<summary>Config used (self-contained, not committed)</summary>

```yaml
direct-rpc:
  - name: "akash-tmrpc-publicnode"
    chain-id: "AKASH"
    api-interface: "tendermintrpc"
    node-urls:
      - url: "https://akash-rpc.publicnode.com"
        timeout: 15s
      - url: "wss://akash-rpc.publicnode.com/websocket"
        timeout: 15s
  - name: "akash-tmrpc-lavenderfive"
    chain-id: "AKASH"
    api-interface: "tendermintrpc"
    node-urls:
      - url: "https://rpc.lavenderfive.com:443/akash"
        timeout: 15s
  - name: "akash-rest-lavenderfive"
    chain-id: "AKASH"
    api-interface: "rest"
    node-urls:
      - url: "https://rest.lavenderfive.com:443/akash"
        timeout: 15s
  - name: "akash-grpc-lavenderfive"
    chain-id: "AKASH"
    api-interface: "grpc"
    node-urls:
      - url: "grpcs://akash.lavenderfive.com:443"
        timeout: 15s
```

Run with `cd <dir-with-config> && smartrouter health akash_health.yml --use-static-spec <lava-specs> --timeout 60s` — the config argument resolves through viper's search paths, so it must be a bare filename.
</details>

## Testing

- `go build ./...`, `go vet ./protocol/...` clean
- `go test -race ./protocol/chainlib/... ./protocol/rpcsmartrouter/... ./protocol/lavasession/...` — all pass
- `gofmt` clean on every file this PR touches. `chain_router.go` and `chain_router_test.go` are listed by `gofmt -l`, but they already are on `main` (import ordering); left alone rather than fold an unrelated reorder into this diff.

New regression tests, each verified to fail on the unfixed code:

- `TestSkipWebsocketVerificationIsPerParser` — builds two routers concurrently from parsers with opposite settings, against an http-only endpoint and a subscribe-capable spec. Note this pins the per-parser shape on the **serving** path; under `health` that gate is short-circuited, so it is not a reproduction of the reported symptom.
- `TestGRPCConnectorRefillsPoolForSchemePrefixedURL` / `...ForTLSSchemePrefixedURL` — build a one-connection pool, borrow its only client, and require the async refill to produce another. Covers plaintext `grpc://` and a TLS reflection server behind `grpcs://`; both fail in 10s unfixed.
- `TestGrpcDialAddress` — both schemes, bare `host:port`, and a hostname merely containing `grpc`.
- `TestBackfillLatestBlock_*` — fills only missing values on **passing** rows, fetches at most once, skips failed rows, costs no fetch when only failed rows lack a height, and leaves rows untouched on fetch failure.

### Known test gap

The mechanism that actually fixes Bug A — removing the mutex that serialized `ValidateCollect` while per-endpoint timeouts ran down — has **no regression test**. Every health test is a pure-function unit test, and a faithful timing test needs the full probe machinery (real specs, routers, and two endpoints whose verification phases can be observed overlapping). A cheap seam at the `runHealthProbes` fan-out level would pin concurrency that was never broken and would pass against the old code, so none was added. Worth its own ticket. The live A/B above is the current evidence.

## Not addressed

- **`GrpcConfig.ReflectionTimeout` is still declared-but-unread.** Defined, defaulted to 5s and validated, with zero production readers. Wiring it would make reflection stricter than today's inherited relay timeout and could turn currently-passing slow gateways red, so it wants its own ticket.
- **`IgnoreWsEnforcementForTestCommands` is the same anti-pattern**, left in place — a package global in the very same `if`, written by `health_cmd.go` and `testing.go`. No race today, since both writes land before any goroutine starts, but the argument in this PR applies to it too. Follow-up.
- **`increaseNumberOfClients` discards `impliesTLS`** and keeps a second dial loop without the TLS-upgrade retry. Verified safe today only because `NewGRPCConnector` always runs `createConnection` first. The durable version is for it to call `createConnection`. Follow-up.
- **`grpcs://akash-grpc.publicnode.com:443` still reports `ok:false`, for an unrelated upstream reason.** It now reaches the node (`latestBlock: 28226584`) and fails on the response: allnodes blocks `/cosmos.base.tendermint.v1beta1.Service/GetNodeInfo` on their free tier. AKASH's `chain-id` verification calls that method, so the leg reads red regardless of router behaviour. It was green when the ticket was filed on 2026-07-05, so this is a tightening on their side.
- Worth a follow-up: the router surfaces that rejection as `proto: bad wiretype`, which reads like a parsing bug rather than an access-policy response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
