### PR TITLE
fix(chainlib): make skip-verifications actually skip, plus a skip-all wildcard and flag

### DIFF
--- a/protocol/chainlib/base_chain_parser.go
+++ b/protocol/chainlib/base_chain_parser.go
@@ -35,6 +35,12 @@ var (
 	// state removes the shared cell entirely.
 	SkipWebsocketVerificationDefault = false
 
+	// SkipAllVerifications is the process-wide off switch behind --skip-all-verifications.
+	// Read through chainlib.skipVerification, so it suppresses the latest-block probe as well
+	// as the verifications themselves. Bound by the rpcsmartrouter command only — the health
+	// command deliberately does not expose it, since reporting verification results is its job.
+	SkipAllVerifications = false
+
 	DefaultApiName = "Default-"
 )
 

--- a/protocol/chainlib/chain_fetcher.go
+++ b/protocol/chainlib/chain_fetcher.go
@@ -8,8 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"slices"
-
 	"github.com/magma-Devs/smart-router/protocol/chainlib/cacheformat"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy"
 	"github.com/magma-Devs/smart-router/protocol/common"
@@ -93,6 +91,27 @@ func (cf *ChainFetcher) getVerificationsKey(verification VerificationContainer, 
 	return key
 }
 
+// needsLatestBlock reports whether any verification that will ACTUALLY RUN for this
+// node-url depends on the chain head, and therefore whether Validate has to spend a
+// FetchLatestBlockNum relay against the upstream before verifying.
+//
+// Skipped verifications are excluded deliberately. The latest-block fetch is a real
+// relay: it retries 3x back-to-back and, in Validate, a failure aborts the whole
+// provider. Letting a configured-away verification pull it in meant skip-verifications
+// did not actually stop the router from probing the node — an upstream that rate-limits
+// the burst still got its provider demoted with every verification skipped.
+func needsLatestBlock(url common.NodeUrl, verifications []VerificationContainer) bool {
+	for _, v := range verifications {
+		if url.ShouldSkipVerification(v.Name) {
+			continue
+		}
+		if v.Value == "" && v.LatestDistance != 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func (cf *ChainFetcher) Validate(ctx context.Context) error {
 	for _, url := range cf.endpoint.NodeUrls {
 		utils.LavaFormatInfo("starting validation for url", utils.LogAttr("url", url.String()))
@@ -106,13 +125,7 @@ func (cf *ChainFetcher) Validate(ctx context.Context) error {
 		}
 
 		var latestBlock int64
-		needToFetchLatestBlock := false
-		for _, v := range verifications {
-			if v.Value == "" && v.LatestDistance != 0 {
-				needToFetchLatestBlock = true
-			}
-		}
-		if needToFetchLatestBlock {
+		if needsLatestBlock(url, verifications) {
 			for attempts := 0; attempts < 3; attempts++ {
 				latestBlock, err = cf.FetchLatestBlockNum(ctx)
 				if err == nil {
@@ -127,7 +140,7 @@ func (cf *ChainFetcher) Validate(ctx context.Context) error {
 		// invalidating cache as value might change
 		defer cf.invalidateVerificationsCache()
 		for _, verification := range verifications {
-			if slices.Contains(url.SkipVerifications, verification.Name) {
+			if url.ShouldSkipVerification(verification.Name) {
 				utils.LavaFormatInfo("Skipping Verification due to provider configuration (skip-verifications setting)", utils.LogAttr("verification", verification.Name))
 				continue
 			}
@@ -197,13 +210,7 @@ func (cf *ChainFetcher) ValidateCollect(ctx context.Context) []NodeURLValidation
 		}
 
 		var latestBlock int64
-		needToFetchLatestBlock := false
-		for _, v := range verifications {
-			if v.Value == "" && v.LatestDistance != 0 {
-				needToFetchLatestBlock = true
-			}
-		}
-		if needToFetchLatestBlock {
+		if needsLatestBlock(url, verifications) {
 			for attempts := 0; attempts < 3; attempts++ {
 				latestBlock, err = cf.FetchLatestBlockNum(ctx)
 				if err == nil {
@@ -214,7 +221,7 @@ func (cf *ChainFetcher) ValidateCollect(ctx context.Context) []NodeURLValidation
 		nodeResult.LatestBlock = latestBlock
 
 		for _, verification := range verifications {
-			if slices.Contains(url.SkipVerifications, verification.Name) {
+			if url.ShouldSkipVerification(verification.Name) {
 				continue
 			}
 			var verifyErr error

--- a/protocol/chainlib/chain_fetcher.go
+++ b/protocol/chainlib/chain_fetcher.go
@@ -91,6 +91,15 @@ func (cf *ChainFetcher) getVerificationsKey(verification VerificationContainer, 
 	return key
 }
 
+// skipVerification is the single gate deciding whether a verification runs for a node-url.
+// Two independent sources can suppress it: the per-node-url skip-verifications config (with
+// its "*" wildcard), and the process-wide --skip-all-verifications flag. Everything that
+// acts on behalf of a verification must go through here — including needsLatestBlock, so a
+// suppressed verification cannot drag the latest-block probe out to the upstream anyway.
+func skipVerification(url common.NodeUrl, name string) bool {
+	return SkipAllVerifications || url.ShouldSkipVerification(name)
+}
+
 // needsLatestBlock reports whether any verification that will ACTUALLY RUN for this
 // node-url depends on the chain head, and therefore whether Validate has to spend a
 // FetchLatestBlockNum relay against the upstream before verifying.
@@ -102,7 +111,7 @@ func (cf *ChainFetcher) getVerificationsKey(verification VerificationContainer, 
 // the burst still got its provider demoted with every verification skipped.
 func needsLatestBlock(url common.NodeUrl, verifications []VerificationContainer) bool {
 	for _, v := range verifications {
-		if url.ShouldSkipVerification(v.Name) {
+		if skipVerification(url, v.Name) {
 			continue
 		}
 		if v.Value == "" && v.LatestDistance != 0 {
@@ -140,7 +149,7 @@ func (cf *ChainFetcher) Validate(ctx context.Context) error {
 		// invalidating cache as value might change
 		defer cf.invalidateVerificationsCache()
 		for _, verification := range verifications {
-			if url.ShouldSkipVerification(verification.Name) {
+			if skipVerification(url, verification.Name) {
 				utils.LavaFormatInfo("Skipping Verification due to provider configuration (skip-verifications setting)", utils.LogAttr("verification", verification.Name))
 				continue
 			}
@@ -221,7 +230,7 @@ func (cf *ChainFetcher) ValidateCollect(ctx context.Context) []NodeURLValidation
 		nodeResult.LatestBlock = latestBlock
 
 		for _, verification := range verifications {
-			if url.ShouldSkipVerification(verification.Name) {
+			if skipVerification(url, verification.Name) {
 				continue
 			}
 			var verifyErr error

--- a/protocol/chainlib/needs_latest_block_test.go
+++ b/protocol/chainlib/needs_latest_block_test.go
@@ -1,0 +1,89 @@
+package chainlib
+
+import (
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// headDependent is a verification that needs the chain head resolved before it can run
+// (no fixed Value, non-zero LatestDistance) — the kind that pulls in FetchLatestBlockNum.
+func headDependent(name string) VerificationContainer {
+	return VerificationContainer{Name: name, LatestDistance: 100}
+}
+
+// selfContained carries its own expected Value, so it never needs the chain head.
+func selfContained(name string) VerificationContainer {
+	return VerificationContainer{Name: name, Value: "0x1"}
+}
+
+// Regression for the skip-verifications bypass: the latest-block probe is a real relay
+// to the upstream, and in Validate a failure aborts the provider outright. It used to be
+// decided over ALL verifications — including skipped ones — so an operator who skipped
+// every verification still had the node probed, and a rate-limited upstream still got
+// its provider demoted. Skipped verifications must not pull the fetch in.
+func TestNeedsLatestBlock(t *testing.T) {
+	playbook := []struct {
+		name          string
+		skip          []string
+		verifications []VerificationContainer
+		want          bool
+	}{
+		{
+			name:          "head-dependent verification needs the fetch",
+			verifications: []VerificationContainer{headDependent("pruning")},
+			want:          true,
+		},
+		{
+			name:          "self-contained verification does not",
+			verifications: []VerificationContainer{selfContained("chain-id")},
+			want:          false,
+		},
+		{
+			name:          "no verifications at all",
+			verifications: nil,
+			want:          false,
+		},
+		{
+			// The bug: skipping the only head-dependent verification still fetched.
+			name:          "skipping the only head-dependent verification drops the fetch",
+			skip:          []string{"pruning"},
+			verifications: []VerificationContainer{headDependent("pruning")},
+			want:          false,
+		},
+		{
+			name:          "wildcard drops the fetch",
+			skip:          []string{common.SkipAllVerifications},
+			verifications: []VerificationContainer{headDependent("pruning"), headDependent("trace")},
+			want:          false,
+		},
+		{
+			// Partial skips must NOT over-reach: a surviving head-dependent
+			// verification still needs the chain head resolved.
+			name:          "an unskipped head-dependent verification still forces the fetch",
+			skip:          []string{"pruning"},
+			verifications: []VerificationContainer{headDependent("pruning"), headDependent("trace")},
+			want:          true,
+		},
+		{
+			name:          "skipping a self-contained verification changes nothing",
+			skip:          []string{"chain-id"},
+			verifications: []VerificationContainer{selfContained("chain-id"), headDependent("pruning")},
+			want:          true,
+		},
+		{
+			name:          "skipping every head-dependent one but leaving a self-contained one",
+			skip:          []string{"pruning"},
+			verifications: []VerificationContainer{selfContained("chain-id"), headDependent("pruning")},
+			want:          false,
+		},
+	}
+
+	for _, tc := range playbook {
+		t.Run(tc.name, func(t *testing.T) {
+			nurl := common.NodeUrl{Url: "https://example.invalid", SkipVerifications: tc.skip}
+			require.Equal(t, tc.want, needsLatestBlock(nurl, tc.verifications))
+		})
+	}
+}

--- a/protocol/chainlib/needs_latest_block_test.go
+++ b/protocol/chainlib/needs_latest_block_test.go
@@ -54,7 +54,7 @@ func TestNeedsLatestBlock(t *testing.T) {
 		},
 		{
 			name:          "wildcard drops the fetch",
-			skip:          []string{common.SkipAllVerifications},
+			skip:          []string{common.SkipVerificationsWildcard},
 			verifications: []VerificationContainer{headDependent("pruning"), headDependent("trace")},
 			want:          false,
 		},

--- a/protocol/chainlib/skip_all_verifications_test.go
+++ b/protocol/chainlib/skip_all_verifications_test.go
@@ -1,0 +1,65 @@
+package chainlib
+
+import (
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// withSkipAll flips the process-wide flag for one test and restores it, so a failure
+// cannot leak the "verification is off" state into every later test in the package.
+func withSkipAll(t *testing.T, v bool) {
+	t.Helper()
+	prev := SkipAllVerifications
+	SkipAllVerifications = v
+	t.Cleanup(func() { SkipAllVerifications = prev })
+}
+
+// skipVerification is the single gate every verification-driven probe consults. The flag
+// and the per-node-url config are independent sources of suppression; neither may mask a
+// bug in the other.
+func TestSkipVerification_FlagAndConfig(t *testing.T) {
+	plain := common.NodeUrl{Url: "https://example.invalid"}
+	named := common.NodeUrl{Url: "https://example.invalid", SkipVerifications: []string{"pruning"}}
+	wild := common.NodeUrl{Url: "https://example.invalid", SkipVerifications: []string{common.SkipVerificationsWildcard}}
+
+	t.Run("flag off: nothing is skipped without config", func(t *testing.T) {
+		withSkipAll(t, false)
+		require.False(t, skipVerification(plain, "pruning"))
+		require.False(t, skipVerification(plain, "chain-id"))
+	})
+
+	t.Run("flag off: config still governs", func(t *testing.T) {
+		withSkipAll(t, false)
+		require.True(t, skipVerification(named, "pruning"))
+		require.False(t, skipVerification(named, "chain-id"), "a named skip must not spill onto other verifications")
+		require.True(t, skipVerification(wild, "chain-id"), "the config wildcard still works with the flag off")
+	})
+
+	t.Run("flag on: every verification is skipped, config irrelevant", func(t *testing.T) {
+		withSkipAll(t, true)
+		require.True(t, skipVerification(plain, "pruning"))
+		require.True(t, skipVerification(plain, "chain-id"))
+		require.True(t, skipVerification(plain, "some-verification-nobody-enumerated"))
+		require.True(t, skipVerification(named, "chain-id"))
+	})
+
+	t.Run("flag defaults to off", func(t *testing.T) {
+		require.False(t, SkipAllVerifications, "the process-wide switch must be opt-in")
+	})
+}
+
+// The flag has to suppress the latest-block probe too, not just the verifications. That probe
+// is a real relay whose failure aborts Validate and demotes the provider, so a flag that left
+// it running would not actually stop the router touching the upstream.
+func TestSkipAllVerifications_SuppressesLatestBlockFetch(t *testing.T) {
+	url := common.NodeUrl{Url: "https://example.invalid"}
+	headDependent := []VerificationContainer{{Name: "pruning", LatestDistance: 100}}
+
+	withSkipAll(t, false)
+	require.True(t, needsLatestBlock(url, headDependent), "baseline: a live head-dependent verification needs the fetch")
+
+	withSkipAll(t, true)
+	require.False(t, needsLatestBlock(url, headDependent), "the flag must drop the latest-block probe as well")
+}

--- a/protocol/common/cobra_common.go
+++ b/protocol/common/cobra_common.go
@@ -105,6 +105,10 @@ const (
 	LimitParallelWebsocketConnectionsPerIpFlag   = "limit-parallel-websocket-connections-per-ip"
 	LimitWebsocketIdleTimeFlag                   = "limit-websocket-connection-idle-time"
 	SkipWebsocketVerificationFlag                = "skip-websocket-verification"
+	// SkipAllVerificationsFlag turns spec verification off process-wide. Broader than the
+	// per-node-url "*" wildcard in skip-verifications: it covers EVERY provider this process
+	// serves, healthy ones included. Prefer the wildcard for anything ongoing.
+	SkipAllVerificationsFlag = "skip-all-verifications"
 	// specification default flags
 	ProbeUpdateWeightFlagName = "probe-update-weight"
 	// ProbeLoopIntervalFlagName is the cadence of the MAG-2161 (Topic D) proactive health prober —

--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -122,6 +123,25 @@ type NodeUrl struct {
 	Methods           []string      `yaml:"methods,omitempty" json:"methods,omitempty" mapstructure:"methods"`
 	// GrpcConfig holds gRPC-specific configuration for direct gRPC connections (smart router)
 	GrpcConfig GrpcConfig `yaml:"grpc-config,omitempty" json:"grpc-config,omitempty" mapstructure:"grpc-config"`
+}
+
+// SkipAllVerifications is the sentinel a node-url's skip-verifications list can carry
+// to suppress every verification the spec defines for that url, without enumerating
+// each name. Follows the wildcard idiom the cors-* flags already use.
+//
+// It must be quoted in YAML (`skip-verifications: ["*"]`) — a bare * opens an alias.
+const SkipAllVerifications = "*"
+
+// ShouldSkipVerification reports whether this node-url's skip-verifications list
+// suppresses the named verification, honouring the SkipAllVerifications wildcard.
+//
+// Callers must consult this before doing ANY work on behalf of a verification —
+// including the shared latest-block fetch that several verifications depend on.
+// Probing an upstream for a verification that is about to be skipped is what made
+// skip-verifications fail to actually skip.
+func (nurl NodeUrl) ShouldSkipVerification(name string) bool {
+	return slices.Contains(nurl.SkipVerifications, SkipAllVerifications) ||
+		slices.Contains(nurl.SkipVerifications, name)
 }
 
 type ChainMessageGetApiInterface interface {

--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -125,22 +125,22 @@ type NodeUrl struct {
 	GrpcConfig GrpcConfig `yaml:"grpc-config,omitempty" json:"grpc-config,omitempty" mapstructure:"grpc-config"`
 }
 
-// SkipAllVerifications is the sentinel a node-url's skip-verifications list can carry
+// SkipVerificationsWildcard is the sentinel a node-url's skip-verifications list can carry
 // to suppress every verification the spec defines for that url, without enumerating
 // each name. Follows the wildcard idiom the cors-* flags already use.
 //
 // It must be quoted in YAML (`skip-verifications: ["*"]`) — a bare * opens an alias.
-const SkipAllVerifications = "*"
+const SkipVerificationsWildcard = "*"
 
 // ShouldSkipVerification reports whether this node-url's skip-verifications list
-// suppresses the named verification, honouring the SkipAllVerifications wildcard.
+// suppresses the named verification, honouring the SkipVerificationsWildcard wildcard.
 //
 // Callers must consult this before doing ANY work on behalf of a verification —
 // including the shared latest-block fetch that several verifications depend on.
 // Probing an upstream for a verification that is about to be skipped is what made
 // skip-verifications fail to actually skip.
 func (nurl NodeUrl) ShouldSkipVerification(name string) bool {
-	return slices.Contains(nurl.SkipVerifications, SkipAllVerifications) ||
+	return slices.Contains(nurl.SkipVerifications, SkipVerificationsWildcard) ||
 		slices.Contains(nurl.SkipVerifications, name)
 }
 

--- a/protocol/common/skip_verifications_test.go
+++ b/protocol/common/skip_verifications_test.go
@@ -21,13 +21,13 @@ func TestShouldSkipVerification(t *testing.T) {
 		{"exact name matches", []string{"pruning"}, "pruning", true},
 		{"unrelated name does not match", []string{"pruning"}, "chain-id", false},
 		{"one of several matches", []string{"pruning", "trace", "chain-id"}, "trace", true},
-		{"wildcard matches any name", []string{SkipAllVerifications}, "chain-id", true},
-		{"wildcard matches a name nobody enumerated", []string{SkipAllVerifications}, "tracking-shard-11", true},
-		{"wildcard alongside explicit names still matches", []string{"pruning", SkipAllVerifications}, "enabled", true},
+		{"wildcard matches any name", []string{SkipVerificationsWildcard}, "chain-id", true},
+		{"wildcard matches a name nobody enumerated", []string{SkipVerificationsWildcard}, "tracking-shard-11", true},
+		{"wildcard alongside explicit names still matches", []string{"pruning", SkipVerificationsWildcard}, "enabled", true},
 		{"wildcard is the literal star only", []string{"*pruning"}, "pruning", false},
 		{"match is case sensitive", []string{"Pruning"}, "pruning", false},
 		{"empty query is not matched by an explicit list", []string{"pruning"}, "", false},
-		{"empty query IS matched by the wildcard", []string{SkipAllVerifications}, "", true},
+		{"empty query IS matched by the wildcard", []string{SkipVerificationsWildcard}, "", true},
 	}
 
 	for _, tc := range playbook {
@@ -40,6 +40,6 @@ func TestShouldSkipVerification(t *testing.T) {
 
 // The wildcard is a config-surface constant; pinning it guards against a rename
 // silently invalidating every deployed values file that carries it.
-func TestSkipAllVerificationsToken(t *testing.T) {
-	require.Equal(t, "*", SkipAllVerifications)
+func TestSkipVerificationsWildcardToken(t *testing.T) {
+	require.Equal(t, "*", SkipVerificationsWildcard)
 }

--- a/protocol/common/skip_verifications_test.go
+++ b/protocol/common/skip_verifications_test.go
@@ -1,0 +1,45 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ShouldSkipVerification is the single gate every verification-driven probe consults,
+// so both the exact-name and wildcard paths need to hold — a false negative silently
+// re-enables probing an upstream the operator configured away.
+func TestShouldSkipVerification(t *testing.T) {
+	playbook := []struct {
+		name  string
+		skip  []string
+		query string
+		want  bool
+	}{
+		{"nil list skips nothing", nil, "pruning", false},
+		{"empty list skips nothing", []string{}, "pruning", false},
+		{"exact name matches", []string{"pruning"}, "pruning", true},
+		{"unrelated name does not match", []string{"pruning"}, "chain-id", false},
+		{"one of several matches", []string{"pruning", "trace", "chain-id"}, "trace", true},
+		{"wildcard matches any name", []string{SkipAllVerifications}, "chain-id", true},
+		{"wildcard matches a name nobody enumerated", []string{SkipAllVerifications}, "tracking-shard-11", true},
+		{"wildcard alongside explicit names still matches", []string{"pruning", SkipAllVerifications}, "enabled", true},
+		{"wildcard is the literal star only", []string{"*pruning"}, "pruning", false},
+		{"match is case sensitive", []string{"Pruning"}, "pruning", false},
+		{"empty query is not matched by an explicit list", []string{"pruning"}, "", false},
+		{"empty query IS matched by the wildcard", []string{SkipAllVerifications}, "", true},
+	}
+
+	for _, tc := range playbook {
+		t.Run(tc.name, func(t *testing.T) {
+			nurl := NodeUrl{Url: "https://example.invalid", SkipVerifications: tc.skip}
+			require.Equal(t, tc.want, nurl.ShouldSkipVerification(tc.query))
+		})
+	}
+}
+
+// The wildcard is a config-surface constant; pinning it guards against a rename
+// silently invalidating every deployed values file that carries it.
+func TestSkipAllVerificationsToken(t *testing.T) {
+	require.Equal(t, "*", SkipAllVerifications)
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -3088,6 +3088,7 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	cmdRPCSmartRouter.Flags().DurationVar(&chainlib.WebSocketBanDuration, common.BanDurationForWebsocketRateLimitExceededFlag, chainlib.WebSocketBanDuration, "once websocket rate limit is reached, user will be banned Xfor a duration, default no ban")
 
 	cmdRPCSmartRouter.Flags().BoolVar(&chainlib.SkipWebsocketVerificationDefault, common.SkipWebsocketVerificationFlag, chainlib.SkipWebsocketVerificationDefault, "skip websocket verification for chains that require ws/wss endpoints")
+	cmdRPCSmartRouter.Flags().BoolVar(&chainlib.SkipAllVerifications, common.SkipAllVerificationsFlag, chainlib.SkipAllVerifications, "skip ALL spec verifications for every provider this process serves, healthy ones included. An escape hatch for bringing a router up against upstreams that cannot survive being probed; prefer the per-node-url skip-verifications config (which accepts \"*\") for anything ongoing")
 
 	cmdRPCSmartRouter.Flags().DurationVar(&lavasession.ProbeLoopInterval, common.ProbeLoopIntervalFlagName, lavasession.ProbeLoopInterval, "cadence of the proactive health prober (MAG-2161 Topic D); must be > 0, default 5s")
 	cmdRPCSmartRouter.Flags().Float64(common.ProbeUpdateWeightFlagName, scoreutils.DefaultProbeUpdateWeight, "weight multiplier for provider-optimizer probe updates (liveness/latency); must be > 0")


### PR DESCRIPTION
#Closes MAG-2873
#Closes MAG-2883

Jira ticket: MAG-2873

Two related changes to how `skip-verifications` works: a bug fix that makes it actually skip, and two ways to say "skip everything" — a per-node-url wildcard and a process-wide flag.

## Why

**1. Skipping did not stop the probing.** `Validate` decided whether it needed the chain head by looping over **all** verifications for a node-url and firing `FetchLatestBlockNum` if any of them wanted it. The skip check ran in the *next* loop, so a verification the operator had configured away still pulled in the latest-block relay on its behalf:

```
needToFetchLatestBlock  <- computed over ALL verifications   (skips not yet applied)
    GET_BLOCKNUM x3 -> 429 -> return err                     (Validate fails outright)
    (never reached)
for each verification: if skipped -> continue                (skips applied here)
```

That fetch is a real relay — 3 retries back-to-back, no delay — and in `Validate` a failure returns an error, which demotes the provider. One un-skippable call per node-url per epoch was enough to demote a node with every verification skipped.

Seen on one production fleet: all 33 tatum-backed chains were configured with the full 31-name list skipped, and on the first epoch after rollout CELO and SONIC still tripped re-verify.

```
{"level":"info","verification":"pruning","message":"Skipping Verification due to provider configuration (skip-verifications setting)"}
{"level":"error","error":"GET_BLOCKNUM failed sending chainMessage","message":"failed to fetch latest block number"}
{"level":"warn","error":"GET_BLOCKNUM failed sending chainMessage","chain":"CELO","provider":"tatum","consecutiveFailures":"1","demoteAfter":"2","message":"re-verify: active static failed but kept — under demote threshold"}
```

**2. There was no way to say "skip everything."** Enumerating meant a 31-entry list per node that goes stale whenever a spec adds a verification. `--skip-websocket-verification` was the only verification flag and it covers one family.

## What changed

**The fix (MAG-2873)**

- `protocol/chainlib/chain_fetcher.go` — new `needsLatestBlock(url, verifications)` skips over configured-away verifications when deciding whether to fetch the chain head. The decision loop was duplicated verbatim in `Validate` and `ValidateCollect` (the latter backs `smartrouter health`), so it moves into the helper and both call it.

**Per-node-url wildcard (MAG-2873)**

- `protocol/common/endpoints.go` — `SkipVerificationsWildcard = "*"` plus `NodeUrl.ShouldSkipVerification`. Putting it on the type means every current and future consumer honours the wildcard rather than each re-implementing `slices.Contains`.

**Process-wide flag (MAG-2883)**

- `protocol/common/cobra_common.go` — `SkipAllVerificationsFlag = "skip-all-verifications"`, next to the websocket flag.
- `protocol/chainlib/base_chain_parser.go` — `SkipAllVerifications` package bool, default false, next to `SkipWebsocketVerification`.
- `protocol/rpcsmartrouter/rpcsmartrouter.go` — bound with `BoolVar`, exactly as the websocket flag is.
- `protocol/chainlib/chain_fetcher.go` — `skipVerification(url, name)`, the single gate where the config wildcard and the flag meet. All three call sites route through it.

**The gate placement is load-bearing.** `needsLatestBlock` consults it too, so the flag also suppresses the latest-block probe. A flag that skipped the verifications but left that probe running would still relay to the upstream and reproduce the very bug above. Covered by a test.

**Not exposed on `smartrouter health`.** That command's job is reporting verification results; a switch turning them all off makes it report nothing. The websocket flag is on `health` because excluding one transport still leaves a meaningful probe.

## Notes for review

`"*"` follows the wildcard idiom the `cors-*` flags already document. It must be quoted in YAML — a bare `*` opens an alias. Expressing it through Helm needs the paired chart change: **PR #114 in smart-router-helm-chart**, "fix(routers): quote skip-verifications entries so the skip-all wildcard is usable" (MAG-2878). **Merge that first.** This PR is safe in either order on its own — an unquoted `*` never reaches the router, and an older router treats `"*"` as a name matching nothing.

**Two escape hatches, deliberately different in blast radius.** `skip_verifications: "*"` targets one vendor on one node. The flag disables verification for **every provider the process serves, healthy ones included** — on one production fleet each router process serves one chain with two providers, so it would also stop verifying the primary. Verification is exactly what caught dwellir on STRK mainnet being unable to serve `trace` at all. Prefer the wildcard for anything ongoing; the flag is for getting a router up now. The flag's help text says so.

## How to verify

```
go build ./... && go vet ./protocol/common/ ./protocol/chainlib/ ./protocol/rpcsmartrouter/
go test ./protocol/common/ ./protocol/chainlib/ ./protocol/rpcsmartrouter/
go test ./protocol/chainlib/ -run 'TestNeedsLatestBlock|TestSkipVerification_FlagAndConfig|TestSkipAllVerifications_SuppressesLatestBlockFetch' -v
go test ./protocol/common/ -run TestShouldSkipVerification -v

# registered on the router command, absent from health
go run ./cmd/smartrouter rpcsmartrouter --help | grep skip-all-verifications
go run ./cmd/smartrouter health --help | grep -c skip-all-verifications   # expect 0
```

To confirm the regression test is load-bearing, drop the `ShouldSkipVerification` guard from `needsLatestBlock` and re-run — three subtests fail (`skipping the only head-dependent verification drops the fetch`, `wildcard drops the fetch`, `skipping every head-dependent one but leaving a self-contained one`) and pass again once restored. The remaining subtests pass either way, which shows the guard has not over-reached: a partial skip that leaves a head-dependent verification alive still forces the fetch.

The flag tests cover both suppression sources independently, so neither can mask a bug in the other: flag off + no config skips nothing; flag off + config still governs (including that a named skip does not spill onto other verifications); flag on skips everything regardless of config; and the flag defaults to off.

## Not in scope

The reason the probe fails at all is a synchronized burst: 93% of the fleet's 429s (382 of 412 over 3h) land on the epoch-boundary minutes :00/:15/:30/:45, because ~80 router pods tick together (drift ~1.0s) against one shared vendor account capped at 200 rps. Jittering the re-verify tick across pods is the root-cause fix and deserves its own ticket.

Related: MAG-2865 records tatum absent from `validProviders` on 18 chains with cause not established. The demotion path described here is a strong candidate, but that link is **not proven** and this PR does not claim to close it.