### PR TITLE
fix(smart-router): dial the upstream that serves the api's internal path, root included

### DIFF
--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -620,7 +620,9 @@ func (csm *ConsumerSessionManager) probeProvider(ctx context.Context, consumerSe
 		return csm.probeDirectRPCEndpoints(ctx, consumerSessionsWithProvider, consumerSessionsWithProvider.PublicLavaAddress)
 	}
 
-	connected, endpoints, providerAddress, err := consumerSessionsWithProvider.fetchEndpointConnectionFromConsumerSessionWithProvider(ctx, tryReconnectToDisabledEndpoints, true, "", nil)
+	// A probe measures reachability of the provider, not of one api collection —
+	// no internal path to match on, so every endpoint stays eligible.
+	connected, endpoints, providerAddress, err := consumerSessionsWithProvider.fetchEndpointConnectionFromConsumerSessionWithProvider(ctx, tryReconnectToDisabledEndpoints, true, "", nil, "")
 	if err != nil || !connected {
 		if errors.Is(err, AllProviderEndpointsDisabledError) {
 			csm.blockProvider(ctx, providerAddress, true, epoch, MaxConsecutiveConnectionAttempts, 0, false, csm.GenerateReconnectCallback(consumerSessionsWithProvider)) // reporting and blocking provider this epoch
@@ -976,6 +978,15 @@ type GetSessionsOptions struct {
 	// agreement threshold so each group can independently reach its internal quorum; default 0/1 keeps the
 	// one-provider-per-group behavior (group-blind fill).
 	PerGroupTarget int
+	// InternalPath is the internal path of the api collection this relay
+	// resolved to ("/v2", "/P", "" for the root). Endpoint selection matches on
+	// it, because in direct mode the path lives in the upstream URL: a chain
+	// serving two API versions over two node-urls (TON's toncenter v2 +
+	// tonindex v3) has one endpoint per version, and dialing the wrong one
+	// returns that vendor's 404 as if it were an answer. Empty for every caller
+	// that doesn't resolve an api collection (probes, tests) — selection is
+	// then unfiltered, exactly as before.
+	InternalPath string
 }
 
 func (csm *ConsumerSessionManager) GetSessions(ctx context.Context, wantedProviderNumber int, cuNeededForSession uint64, usedProviders UsedProvidersInf, requestedBlock int64, addon string, extensions []*spectypes.Extension, stateful uint32, virtualEpoch uint64, stickiness string, selectedProvider string, opts ...GetSessionsOptions) (
@@ -985,6 +996,7 @@ func (csm *ConsumerSessionManager) GetSessions(ctx context.Context, wantedProvid
 	// groups. Variadic so the many existing non-cross-validation callers are unchanged.
 	minGroups := groupBlindMinGroups
 	perGroupTarget := groupBlindPerGroupTarget
+	internalPath := ""
 	if len(opts) > 0 {
 		if opts[0].MinGroups > 1 {
 			minGroups = opts[0].MinGroups
@@ -992,6 +1004,7 @@ func (csm *ConsumerSessionManager) GetSessions(ctx context.Context, wantedProvid
 		if opts[0].PerGroupTarget > 1 {
 			perGroupTarget = opts[0].PerGroupTarget
 		}
+		internalPath = opts[0].InternalPath
 	}
 	// set usedProviders if they were chosen for this relay
 	timeoutCtx, cancel := context.WithTimeout(ctx, time.Second)
@@ -1040,7 +1053,7 @@ func (csm *ConsumerSessionManager) GetSessions(ctx context.Context, wantedProvid
 			sessionEpoch := sessionWithProvider.CurrentEpoch
 
 			// Get a valid Endpoint from the provider chosen
-			connected, endpoints, _, err := consumerSessionsWithProvider.fetchEndpointConnectionFromConsumerSessionWithProvider(ctx, false, false, addon, extensionNames)
+			connected, endpoints, _, err := consumerSessionsWithProvider.fetchEndpointConnectionFromConsumerSessionWithProvider(ctx, false, false, addon, extensionNames, internalPath)
 			if err != nil {
 				// verify err is AllProviderEndpointsDisabled and report.
 				if errors.Is(err, AllProviderEndpointsDisabledError) {

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -622,7 +622,7 @@ func (csm *ConsumerSessionManager) probeProvider(ctx context.Context, consumerSe
 
 	// A probe measures reachability of the provider, not of one api collection —
 	// no internal path to match on, so every endpoint stays eligible.
-	connected, endpoints, providerAddress, err := consumerSessionsWithProvider.fetchEndpointConnectionFromConsumerSessionWithProvider(ctx, tryReconnectToDisabledEndpoints, true, "", nil, "")
+	connected, endpoints, providerAddress, err := consumerSessionsWithProvider.fetchEndpointConnectionFromConsumerSessionWithProvider(ctx, tryReconnectToDisabledEndpoints, true, "", nil, nil)
 	if err != nil || !connected {
 		if errors.Is(err, AllProviderEndpointsDisabledError) {
 			csm.blockProvider(ctx, providerAddress, true, epoch, MaxConsecutiveConnectionAttempts, 0, false, csm.GenerateReconnectCallback(consumerSessionsWithProvider)) // reporting and blocking provider this epoch
@@ -979,14 +979,17 @@ type GetSessionsOptions struct {
 	// one-provider-per-group behavior (group-blind fill).
 	PerGroupTarget int
 	// InternalPath is the internal path of the api collection this relay
-	// resolved to ("/v2", "/P", "" for the root). Endpoint selection matches on
-	// it, because in direct mode the path lives in the upstream URL: a chain
-	// serving two API versions over two node-urls (TON's toncenter v2 +
-	// tonindex v3) has one endpoint per version, and dialing the wrong one
-	// returns that vendor's 404 as if it were an answer. Empty for every caller
-	// that doesn't resolve an api collection (probes, tests) — selection is
-	// then unfiltered, exactly as before.
-	InternalPath string
+	// resolved to ("/v2", "/P", or "" for a spec's root collection). Endpoint
+	// selection matches on it EXACTLY, because in direct mode the path lives in
+	// the upstream URL: a chain serving two API versions over two node-urls
+	// (TON's toncenter v2 + tonindex v3) has one endpoint per version, and
+	// dialing the wrong one returns that vendor's 404 as if it were an answer.
+	//
+	// nil — not "" — is the "no collection to match on" case (probes, tests),
+	// which leaves selection unfiltered. "" is a real path: a chain that
+	// enables a root collection alongside versioned ones (STRK) must keep its
+	// root traffic on the root url.
+	InternalPath *string
 }
 
 func (csm *ConsumerSessionManager) GetSessions(ctx context.Context, wantedProviderNumber int, cuNeededForSession uint64, usedProviders UsedProvidersInf, requestedBlock int64, addon string, extensions []*spectypes.Extension, stateful uint32, virtualEpoch uint64, stickiness string, selectedProvider string, opts ...GetSessionsOptions) (
@@ -996,7 +999,7 @@ func (csm *ConsumerSessionManager) GetSessions(ctx context.Context, wantedProvid
 	// groups. Variadic so the many existing non-cross-validation callers are unchanged.
 	minGroups := groupBlindMinGroups
 	perGroupTarget := groupBlindPerGroupTarget
-	internalPath := ""
+	var internalPath *string
 	if len(opts) > 0 {
 		if opts[0].MinGroups > 1 {
 			minGroups = opts[0].MinGroups

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -1803,6 +1803,7 @@ func TestDeadConnectionCleanup(t *testing.T) {
 		false, // getAllEndpoints
 		"",    // addon
 		nil,   // extensionNames
+		"",    // internalPath
 	)
 
 	// Should successfully connect (we have one valid connection)
@@ -2264,6 +2265,7 @@ func TestCanceledContextDoesNotPenalizeEndpoint(t *testing.T) {
 		false, // getAllEndpoints
 		"",    // addon
 		nil,   // extensionNames
+		"",    // internalPath
 	)
 
 	// Connection should fail (context canceled), but the endpoint must not be penalized.

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -1803,7 +1803,7 @@ func TestDeadConnectionCleanup(t *testing.T) {
 		false, // getAllEndpoints
 		"",    // addon
 		nil,   // extensionNames
-		"",    // internalPath
+		nil,   // internalPath
 	)
 
 	// Should successfully connect (we have one valid connection)
@@ -2265,7 +2265,7 @@ func TestCanceledContextDoesNotPenalizeEndpoint(t *testing.T) {
 		false, // getAllEndpoints
 		"",    // addon
 		nil,   // extensionNames
-		"",    // internalPath
+		nil,   // internalPath
 	)
 
 	// Connection should fail (context canceled), but the endpoint must not be penalized.

--- a/protocol/lavasession/consumer_types.go
+++ b/protocol/lavasession/consumer_types.go
@@ -1105,30 +1105,43 @@ func (cswp *ConsumerSessionsWithProvider) sortEndpointsByLatency(endpointInfos [
 
 // fetching an endpoint from a ConsumerSessionWithProvider and establishing a connection,
 // can fail without an error if trying to connect once to each endpoint but none of them are active.
-func (cswp *ConsumerSessionsWithProvider) fetchEndpointConnectionFromConsumerSessionWithProvider(ctx context.Context, retryDisabledEndpoints bool, getAllEndpoints bool, addon string, extensionNames []string, internalPath string) (connected bool, endpointsList []*EndpointAndChosenConnection, providerAddress string, err error) {
+//
+// internalPath is the collection the relay resolved to, or nil when the caller
+// has no collection to match on (probes). "" is a REAL path — the spec's root
+// collection — and matches only the endpoint serving the root, so a chain that
+// enables both a root and versioned collections (STRK) keeps its root traffic
+// on the root url.
+func (cswp *ConsumerSessionsWithProvider) fetchEndpointConnectionFromConsumerSessionWithProvider(ctx context.Context, retryDisabledEndpoints bool, getAllEndpoints bool, addon string, extensionNames []string, internalPath *string) (connected bool, endpointsList []*EndpointAndChosenConnection, providerAddress string, err error) {
 	getConnectionFromConsumerSessionsWithProvider := func(ctx context.Context) (connected bool, endpointPtr []*EndpointAndChosenConnection, allDisabled bool) {
 		endpoints := make([]*EndpointAndChosenConnection, 0)
 		cswp.Lock.Lock()
 		defer cswp.Lock.Unlock()
 		// Restrict to the endpoints serving the api's internal path — but only
-		// when this provider has any. Every non-empty path is expanded at
-		// construction (rpcsmartrouter.go), so a provider that CAN serve the
-		// path has a matching endpoint and the filter bites. A provider that
-		// has none — a provider-relay pool, where the path lives on the
-		// provider's side and not in our url, or an endpoint list built some
-		// way we haven't modelled — keeps every endpoint it had, rather than
-		// losing the whole pool to a filter that was never populated for it.
+		// when this provider has any. Every path is expanded at construction
+		// (rpcsmartrouter.go), so a provider that CAN serve the path has a
+		// matching endpoint and the filter bites. A provider that has none — a
+		// provider-relay pool, where the path lives on the provider's side and
+		// not in our url, or an endpoint list built some way we haven't
+		// modelled — keeps every endpoint it had, rather than losing the whole
+		// pool to a filter that was never populated for it.
+		//
+		// Matching is exact in both directions. On a chain with no internal
+		// paths every endpoint is "" and every relay asks for "", so this is a
+		// no-op. On a chain that enables a root collection ALONGSIDE versioned
+		// ones (STRK: "" carries the whole method set, /rpc/v0_8 … carry it
+		// again per version), a root relay must stay on the root url rather
+		// than drift onto a versioned door the expansion generated.
 		restrictToPath := false
-		if internalPath != "" {
+		if internalPath != nil {
 			for _, endpoint := range cswp.Endpoints {
-				if endpoint.ServesInternalPath(internalPath) {
+				if endpoint.ServesInternalPath(*internalPath) {
 					restrictToPath = true
 					break
 				}
 			}
 		}
 		for idx, endpoint := range cswp.Endpoints {
-			if restrictToPath && !endpoint.ServesInternalPath(internalPath) {
+			if restrictToPath && !endpoint.ServesInternalPath(*internalPath) {
 				continue
 			}
 			// retryDisabledEndpoints will attempt to reconnect to the provider even though we have disabled the endpoint

--- a/protocol/lavasession/consumer_types.go
+++ b/protocol/lavasession/consumer_types.go
@@ -227,6 +227,17 @@ type Endpoint struct {
 	relayProbeAttempts uint64
 	Addons             map[string]struct{}
 	Extensions         map[string]struct{}
+	// InternalPath is the spec collection this endpoint's url serves — "/v2",
+	// "/P", or "" for the root. It mirrors the chain router's own per-path
+	// proxies (chainlib/chain_router.go): a node-url declaring `internal-path`
+	// IS that path's root, and a node-url declaring none is expanded into one
+	// endpoint per path at construction, with the path appended to its url.
+	//
+	// Session selection has to match on it, because the url is where the path
+	// lives: dialing the /v2 upstream for a /v3 api asks the vendor for a route
+	// it does not serve, and the vendor's 404 then reads as a verdict on the
+	// request.
+	InternalPath string
 	mu                 sync.RWMutex // Protects Connections, ConnectionRefusals, Enabled, consecutiveHealthyProbes, disabledAt, lastRecoveryPoll, probeReenabled, reenableProbeFlaps, relayProbeMethod, relayProbePayload, relayProbeTimeout, relayProbeAttempts
 
 	// Per-endpoint observed tip lives in the shared endpointtip store (single source of
@@ -238,6 +249,12 @@ type Endpoint struct {
 // IsDirectRPC returns true if this endpoint uses direct RPC connections (smart router mode)
 func (e *Endpoint) IsDirectRPC() bool {
 	return len(e.DirectConnections) > 0
+}
+
+// ServesInternalPath reports whether this endpoint's url is the one to dial for
+// an api served under `internalPath`.
+func (e *Endpoint) ServesInternalPath(internalPath string) bool {
+	return e.InternalPath == internalPath
 }
 
 // IsEnabled returns the endpoint's enable bit under the endpoint mutex. Enabled is written under
@@ -1088,12 +1105,32 @@ func (cswp *ConsumerSessionsWithProvider) sortEndpointsByLatency(endpointInfos [
 
 // fetching an endpoint from a ConsumerSessionWithProvider and establishing a connection,
 // can fail without an error if trying to connect once to each endpoint but none of them are active.
-func (cswp *ConsumerSessionsWithProvider) fetchEndpointConnectionFromConsumerSessionWithProvider(ctx context.Context, retryDisabledEndpoints bool, getAllEndpoints bool, addon string, extensionNames []string) (connected bool, endpointsList []*EndpointAndChosenConnection, providerAddress string, err error) {
+func (cswp *ConsumerSessionsWithProvider) fetchEndpointConnectionFromConsumerSessionWithProvider(ctx context.Context, retryDisabledEndpoints bool, getAllEndpoints bool, addon string, extensionNames []string, internalPath string) (connected bool, endpointsList []*EndpointAndChosenConnection, providerAddress string, err error) {
 	getConnectionFromConsumerSessionsWithProvider := func(ctx context.Context) (connected bool, endpointPtr []*EndpointAndChosenConnection, allDisabled bool) {
 		endpoints := make([]*EndpointAndChosenConnection, 0)
 		cswp.Lock.Lock()
 		defer cswp.Lock.Unlock()
+		// Restrict to the endpoints serving the api's internal path — but only
+		// when this provider has any. Every non-empty path is expanded at
+		// construction (rpcsmartrouter.go), so a provider that CAN serve the
+		// path has a matching endpoint and the filter bites. A provider that
+		// has none — a provider-relay pool, where the path lives on the
+		// provider's side and not in our url, or an endpoint list built some
+		// way we haven't modelled — keeps every endpoint it had, rather than
+		// losing the whole pool to a filter that was never populated for it.
+		restrictToPath := false
+		if internalPath != "" {
+			for _, endpoint := range cswp.Endpoints {
+				if endpoint.ServesInternalPath(internalPath) {
+					restrictToPath = true
+					break
+				}
+			}
+		}
 		for idx, endpoint := range cswp.Endpoints {
+			if restrictToPath && !endpoint.ServesInternalPath(internalPath) {
+				continue
+			}
 			// retryDisabledEndpoints will attempt to reconnect to the provider even though we have disabled the endpoint
 			// this is used on a routine that tries to reconnect to a provider that has been disabled due to being unable to connect to it.
 			endpoint.mu.RLock()

--- a/protocol/lavasession/direct_rpc_session_selection_test.go
+++ b/protocol/lavasession/direct_rpc_session_selection_test.go
@@ -169,6 +169,7 @@ func TestFetchEndpointConnection_DirectRPC(t *testing.T) {
 		false, // getAllEndpoints (get one endpoint)
 		"",    // addon
 		nil,   // extensionNames
+		"",    // internalPath
 	)
 
 	// Verify connection succeeded
@@ -222,7 +223,7 @@ func TestFetchEndpointConnection_DirectRPC_BackoffAndSelfHeal(t *testing.T) {
 	}
 
 	fetch := func() (bool, []*EndpointAndChosenConnection, error) {
-		connected, endpoints, _, err := cswp.fetchEndpointConnectionFromConsumerSessionWithProvider(ctx, false, false, "", nil)
+		connected, endpoints, _, err := cswp.fetchEndpointConnectionFromConsumerSessionWithProvider(ctx, false, false, "", nil, "")
 		return connected, endpoints, err
 	}
 
@@ -253,4 +254,71 @@ func TestFetchEndpointConnection_DirectRPC_BackoffAndSelfHeal(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, connected, "the endpoint must be selectable again after self-heal")
 	require.Len(t, endpoints, 1)
+}
+
+// TestFetchEndpointConnection_InternalPath is the regression guard for the TON
+// v2/v3 misroute: a chain serving two API versions over two node-urls had one
+// endpoint per version, but selection never looked at which. Whichever endpoint
+// the session picked answered every api, so v3 calls came back as the v2
+// upstream's 404 — indistinguishable from the chain not supporting them.
+func TestFetchEndpointConnection_InternalPath(t *testing.T) {
+	rand.InitRandomSeed()
+	ctx := context.Background()
+
+	newEndpoint := func(t *testing.T, url, internalPath string) *Endpoint {
+		t.Helper()
+		nodeUrl := common.NodeUrl{Url: url, InternalPath: internalPath}
+		directConn, err := NewDirectRPCConnection(ctx, nodeUrl, 5, "")
+		require.NoError(t, err)
+		return &Endpoint{
+			NetworkAddress:    url,
+			Enabled:           true,
+			InternalPath:      internalPath,
+			DirectConnections: []DirectRPCConnection{directConn},
+		}
+	}
+	newProvider := func(endpoints ...*Endpoint) *ConsumerSessionsWithProvider {
+		return &ConsumerSessionsWithProvider{
+			Sessions:          make(map[int64]*SingleConsumerSession),
+			PairingEpoch:      100,
+			StaticProvider:    true,
+			PublicLavaAddress: "ton-provider",
+			Endpoints:         endpoints,
+		}
+	}
+	fetchAll := func(cswp *ConsumerSessionsWithProvider, internalPath string) []*EndpointAndChosenConnection {
+		connected, endpoints, _, err := cswp.fetchEndpointConnectionFromConsumerSessionWithProvider(
+			ctx, false, true, "", nil, internalPath)
+		require.NoError(t, err)
+		require.True(t, connected)
+		return endpoints
+	}
+
+	root := newEndpoint(t, "https://ton.example/api", "")
+	v2 := newEndpoint(t, "https://ton.example/api/v2", "/v2")
+	v3 := newEndpoint(t, "https://ton.example/api/v3", "/v3")
+	cswp := newProvider(root, v2, v3)
+
+	t.Run("a versioned api reaches only its own upstream", func(t *testing.T) {
+		got := fetchAll(cswp, "/v3")
+		require.Len(t, got, 1)
+		assert.Equal(t, "https://ton.example/api/v3", got[0].endpoint.NetworkAddress)
+
+		got = fetchAll(cswp, "/v2")
+		require.Len(t, got, 1)
+		assert.Equal(t, "https://ton.example/api/v2", got[0].endpoint.NetworkAddress)
+	})
+
+	t.Run("no internal path keeps every endpoint eligible", func(t *testing.T) {
+		// Probes and every chain that declares no internal path at all.
+		assert.Len(t, fetchAll(cswp, ""), 3)
+	})
+
+	t.Run("a provider with no matching endpoint is not filtered to nothing", func(t *testing.T) {
+		// Provider-relay pools carry the path on the provider's side, not in
+		// our url. Dropping the whole pool would turn a routing refinement into
+		// an outage.
+		plain := newProvider(newEndpoint(t, "https://eth.example", ""))
+		assert.Len(t, fetchAll(plain, "/v2"), 1)
+	})
 }

--- a/protocol/lavasession/direct_rpc_session_selection_test.go
+++ b/protocol/lavasession/direct_rpc_session_selection_test.go
@@ -169,7 +169,7 @@ func TestFetchEndpointConnection_DirectRPC(t *testing.T) {
 		false, // getAllEndpoints (get one endpoint)
 		"",    // addon
 		nil,   // extensionNames
-		"",    // internalPath
+		nil,   // internalPath
 	)
 
 	// Verify connection succeeded
@@ -223,7 +223,7 @@ func TestFetchEndpointConnection_DirectRPC_BackoffAndSelfHeal(t *testing.T) {
 	}
 
 	fetch := func() (bool, []*EndpointAndChosenConnection, error) {
-		connected, endpoints, _, err := cswp.fetchEndpointConnectionFromConsumerSessionWithProvider(ctx, false, false, "", nil, "")
+		connected, endpoints, _, err := cswp.fetchEndpointConnectionFromConsumerSessionWithProvider(ctx, false, false, "", nil, nil)
 		return connected, endpoints, err
 	}
 
@@ -286,13 +286,14 @@ func TestFetchEndpointConnection_InternalPath(t *testing.T) {
 			Endpoints:         endpoints,
 		}
 	}
-	fetchAll := func(cswp *ConsumerSessionsWithProvider, internalPath string) []*EndpointAndChosenConnection {
+	fetchAll := func(cswp *ConsumerSessionsWithProvider, internalPath *string) []*EndpointAndChosenConnection {
 		connected, endpoints, _, err := cswp.fetchEndpointConnectionFromConsumerSessionWithProvider(
 			ctx, false, true, "", nil, internalPath)
 		require.NoError(t, err)
 		require.True(t, connected)
 		return endpoints
 	}
+	path := func(p string) *string { return &p }
 
 	root := newEndpoint(t, "https://ton.example/api", "")
 	v2 := newEndpoint(t, "https://ton.example/api/v2", "/v2")
@@ -300,18 +301,38 @@ func TestFetchEndpointConnection_InternalPath(t *testing.T) {
 	cswp := newProvider(root, v2, v3)
 
 	t.Run("a versioned api reaches only its own upstream", func(t *testing.T) {
-		got := fetchAll(cswp, "/v3")
+		got := fetchAll(cswp, path("/v3"))
 		require.Len(t, got, 1)
 		assert.Equal(t, "https://ton.example/api/v3", got[0].endpoint.NetworkAddress)
 
-		got = fetchAll(cswp, "/v2")
+		got = fetchAll(cswp, path("/v2"))
 		require.Len(t, got, 1)
 		assert.Equal(t, "https://ton.example/api/v2", got[0].endpoint.NetworkAddress)
 	})
 
-	t.Run("no internal path keeps every endpoint eligible", func(t *testing.T) {
-		// Probes and every chain that declares no internal path at all.
-		assert.Len(t, fetchAll(cswp, ""), 3)
+	t.Run("a root-collection api stays on the root url", func(t *testing.T) {
+		// STRK enables a root collection carrying the whole method set AND
+		// versioned collections carrying it again. Expansion generates a url
+		// per version, and a root relay must not drift onto one of them —
+		// least of all onto a /ws/... door generated over an http url.
+		got := fetchAll(cswp, path(""))
+		require.Len(t, got, 1)
+		assert.Equal(t, "https://ton.example/api", got[0].endpoint.NetworkAddress)
+	})
+
+	t.Run("no collection to match on keeps every endpoint eligible", func(t *testing.T) {
+		// Probes measure the provider, not one api collection.
+		assert.Len(t, fetchAll(cswp, nil), 3)
+	})
+
+	t.Run("a chain with no internal paths is unaffected", func(t *testing.T) {
+		// Every endpoint is "" and every relay asks for "" — the filter matches
+		// everything, which is the same list as before it existed.
+		plain := newProvider(
+			newEndpoint(t, "https://eth.example", ""),
+			newEndpoint(t, "https://eth-2.example", ""),
+		)
+		assert.Len(t, fetchAll(plain, path("")), 2)
 	})
 
 	t.Run("a provider with no matching endpoint is not filtered to nothing", func(t *testing.T) {
@@ -319,6 +340,21 @@ func TestFetchEndpointConnection_InternalPath(t *testing.T) {
 		// our url. Dropping the whole pool would turn a routing refinement into
 		// an outage.
 		plain := newProvider(newEndpoint(t, "https://eth.example", ""))
-		assert.Len(t, fetchAll(plain, "/v2"), 1)
+		assert.Len(t, fetchAll(plain, path("/v2")), 1)
+	})
+
+	t.Run("AVAX shape: no root collection, so the root url is never chosen", func(t *testing.T) {
+		// AVAX disables its root collections and serves from /C/rpc, /P, /X.
+		// Every relay carries a path, so the unpinned url the expansion kept
+		// stays unused rather than swallowing platform.* calls.
+		avax := newProvider(
+			newEndpoint(t, "https://avax.example/ext/bc", ""),
+			newEndpoint(t, "https://avax.example/ext/bc/C/rpc", "/C/rpc"),
+			newEndpoint(t, "https://avax.example/ext/bc/P", "/P"),
+			newEndpoint(t, "https://avax.example/ext/bc/X", "/X"),
+		)
+		got := fetchAll(avax, path("/P"))
+		require.Len(t, got, 1)
+		assert.Equal(t, "https://avax.example/ext/bc/P", got[0].endpoint.NetworkAddress)
 	})
 }

--- a/protocol/rpcsmartrouter/internal_paths_test.go
+++ b/protocol/rpcsmartrouter/internal_paths_test.go
@@ -71,6 +71,38 @@ func TestExpandInternalPaths(t *testing.T) {
 		require.Equal(t, "/P", got[1].InternalPath)
 	})
 
+	t.Run("a collection LABEL is not appended to a url", func(t *testing.T) {
+		// STRK carries its shared api set in "HTTP-ONLY" / "WS-ONLY"
+		// collections that exist only to be inherited. They are disabled, so
+		// the parser never reports them — but the idiom is in the spec repo,
+		// and an enabled one must not produce `https://host` + `HTTP-ONLY`.
+		got := expandInternalPaths(
+			[]common.NodeUrl{{Url: "https://strk.example"}},
+			[]string{"", "HTTP-ONLY", "WS-ONLY", "/rpc/v0_9"},
+		)
+		require.Equal(t, []common.NodeUrl{
+			{Url: "https://strk.example"},
+			{Url: "https://strk.example/rpc/v0_9", InternalPath: "/rpc/v0_9"},
+		}, got)
+	})
+
+	t.Run("a pinned url equal to base+path is not emitted twice", func(t *testing.T) {
+		// Legitimate config, and the generated twin would just be probed and
+		// registered in the metrics a second time.
+		got := expandInternalPaths(
+			[]common.NodeUrl{
+				{Url: "https://ton.example/api"},
+				{Url: "https://ton.example/api/v2", InternalPath: "/v2"},
+			},
+			[]string{"", "/v2", "/v3"},
+		)
+		require.Equal(t, []common.NodeUrl{
+			{Url: "https://ton.example/api"},
+			{Url: "https://ton.example/api/v2", InternalPath: "/v2"},
+			{Url: "https://ton.example/api/v3", InternalPath: "/v3"},
+		}, got)
+	})
+
 	t.Run("output order is stable whatever order the paths arrive in", func(t *testing.T) {
 		urls := []common.NodeUrl{{Url: "https://ton.example/api"}}
 		first := expandInternalPaths(urls, []string{"/v3", "/v2", ""})

--- a/protocol/rpcsmartrouter/internal_paths_test.go
+++ b/protocol/rpcsmartrouter/internal_paths_test.go
@@ -1,11 +1,16 @@
 package rpcsmartrouter
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/stretchr/testify/require"
 )
+
+// httpOnlyCollections is the probe for a spec whose every internal path is an
+// http collection — the shape of all six internal-path families but STRK.
+func httpOnlyCollections(string, []string) bool { return false }
 
 // The direct-RPC endpoint list has to name the same urls the chain router's
 // per-path proxies do, because both answer the same api collections — one for
@@ -14,8 +19,8 @@ import (
 func TestExpandInternalPaths(t *testing.T) {
 	t.Run("a spec with no internal paths is left alone", func(t *testing.T) {
 		urls := []common.NodeUrl{{Url: "https://eth.example"}}
-		require.Equal(t, urls, expandInternalPaths(urls, []string{""}))
-		require.Equal(t, urls, expandInternalPaths(urls, nil))
+		require.Equal(t, urls, expandInternalPaths(urls, []string{""}, httpOnlyCollections))
+		require.Equal(t, urls, expandInternalPaths(urls, nil, httpOnlyCollections))
 	})
 
 	t.Run("a shared root yields one url per path, with the path appended", func(t *testing.T) {
@@ -24,6 +29,7 @@ func TestExpandInternalPaths(t *testing.T) {
 		got := expandInternalPaths(
 			[]common.NodeUrl{{Url: "https://ton.example/api"}},
 			[]string{"/v3", "", "/v2"},
+			httpOnlyCollections,
 		)
 		require.Equal(t, []common.NodeUrl{
 			{Url: "https://ton.example/api"},
@@ -39,7 +45,7 @@ func TestExpandInternalPaths(t *testing.T) {
 			{Url: "https://ton.tatum.example", InternalPath: "/v2"},
 			{Url: "https://ton.tatum.example/api/v3", InternalPath: "/v3"},
 		}
-		require.Equal(t, urls, expandInternalPaths(urls, []string{"", "/v2", "/v3"}))
+		require.Equal(t, urls, expandInternalPaths(urls, []string{"", "/v2", "/v3"}, httpOnlyCollections))
 	})
 
 	t.Run("a mixed provider expands only the unpinned urls", func(t *testing.T) {
@@ -49,6 +55,7 @@ func TestExpandInternalPaths(t *testing.T) {
 				{Url: "https://ton.tatum.example", InternalPath: "/v2"},
 			},
 			[]string{"", "/v2", "/v3"},
+			httpOnlyCollections,
 		)
 		require.Equal(t, []common.NodeUrl{
 			{Url: "https://ton.example/api"},
@@ -65,6 +72,7 @@ func TestExpandInternalPaths(t *testing.T) {
 		got := expandInternalPaths(
 			[]common.NodeUrl{{Url: "https://avax.example", Addons: []string{"archive"}}},
 			[]string{"", "/P"},
+			httpOnlyCollections,
 		)
 		require.Len(t, got, 2)
 		require.Equal(t, []string{"archive"}, got[1].Addons)
@@ -79,6 +87,7 @@ func TestExpandInternalPaths(t *testing.T) {
 		got := expandInternalPaths(
 			[]common.NodeUrl{{Url: "https://strk.example"}},
 			[]string{"", "HTTP-ONLY", "WS-ONLY", "/rpc/v0_9"},
+			httpOnlyCollections,
 		)
 		require.Equal(t, []common.NodeUrl{
 			{Url: "https://strk.example"},
@@ -95,6 +104,7 @@ func TestExpandInternalPaths(t *testing.T) {
 				{Url: "https://ton.example/api/v2", InternalPath: "/v2"},
 			},
 			[]string{"", "/v2", "/v3"},
+			httpOnlyCollections,
 		)
 		require.Equal(t, []common.NodeUrl{
 			{Url: "https://ton.example/api"},
@@ -111,6 +121,7 @@ func TestExpandInternalPaths(t *testing.T) {
 		got := expandInternalPaths(
 			[]common.NodeUrl{{Url: "https://vendor.example/rpc/v0_8"}},
 			[]string{"", "/rpc/v0_8", "/rpc/v0_9"},
+			httpOnlyCollections,
 		)
 		require.Equal(t, []common.NodeUrl{
 			{Url: "https://vendor.example/rpc/v0_8"},
@@ -119,10 +130,63 @@ func TestExpandInternalPaths(t *testing.T) {
 		}, got)
 	})
 
+	t.Run("a path is generated only on the transport that serves it", func(t *testing.T) {
+		// STRK's real enabled path set. Its `/ws/rpc/v0_x` collections inherit
+		// WS-ONLY, which carries SUBSCRIBE; the `/rpc/v0_x` ones inherit
+		// HTTP-ONLY, which does not. A config carrying both schemes must yield
+		// the http paths on https and the ws paths on wss, and neither the
+		// other way round — `https://host/ws/rpc/v0_8` and
+		// `wss://host/rpc/v0_9` are urls chain_router.go refuses to build and
+		// no upstream answers.
+		strkPaths := []string{
+			"", "/rpc/v0_8", "/rpc/v0_9", "/rpc/v0_10", "/rpc/pathfinder/v0.1",
+			"/ws/rpc/v0_8", "/ws/rpc/v0_9", "/ws/rpc/v0_10",
+		}
+		subscriptionCollections := func(internalPath string, _ []string) bool {
+			return strings.HasPrefix(internalPath, "/ws/")
+		}
+
+		got := expandInternalPaths(
+			[]common.NodeUrl{
+				{Url: "https://strk.example"},
+				{Url: "wss://strk.example"},
+			},
+			strkPaths,
+			subscriptionCollections,
+		)
+
+		// Nine urls — the same nine chain_router.go builds proxies for.
+		require.Equal(t, []common.NodeUrl{
+			{Url: "https://strk.example"},
+			{Url: "https://strk.example/rpc/pathfinder/v0.1", InternalPath: "/rpc/pathfinder/v0.1"},
+			{Url: "https://strk.example/rpc/v0_10", InternalPath: "/rpc/v0_10"},
+			{Url: "https://strk.example/rpc/v0_8", InternalPath: "/rpc/v0_8"},
+			{Url: "https://strk.example/rpc/v0_9", InternalPath: "/rpc/v0_9"},
+			{Url: "wss://strk.example"},
+			{Url: "wss://strk.example/ws/rpc/v0_10", InternalPath: "/ws/rpc/v0_10"},
+			{Url: "wss://strk.example/ws/rpc/v0_8", InternalPath: "/ws/rpc/v0_8"},
+			{Url: "wss://strk.example/ws/rpc/v0_9", InternalPath: "/ws/rpc/v0_9"},
+		}, got)
+	})
+
+	t.Run("a url with no parseable scheme expands its http paths", func(t *testing.T) {
+		// gRPC node-urls are a bare host:port. They are not ws, so they carry
+		// the spec's non-subscription collections like any http url does.
+		got := expandInternalPaths(
+			[]common.NodeUrl{{Url: "avax.example:9090"}},
+			[]string{"", "/P"},
+			httpOnlyCollections,
+		)
+		require.Equal(t, []common.NodeUrl{
+			{Url: "avax.example:9090"},
+			{Url: "avax.example:9090/P", InternalPath: "/P"},
+		}, got)
+	})
+
 	t.Run("output order is stable whatever order the paths arrive in", func(t *testing.T) {
 		urls := []common.NodeUrl{{Url: "https://ton.example/api"}}
-		first := expandInternalPaths(urls, []string{"/v3", "/v2", ""})
-		second := expandInternalPaths(urls, []string{"", "/v2", "/v3"})
+		first := expandInternalPaths(urls, []string{"/v3", "/v2", ""}, httpOnlyCollections)
+		second := expandInternalPaths(urls, []string{"", "/v2", "/v3"}, httpOnlyCollections)
 		require.Equal(t, first, second)
 	})
 }

--- a/protocol/rpcsmartrouter/internal_paths_test.go
+++ b/protocol/rpcsmartrouter/internal_paths_test.go
@@ -103,6 +103,22 @@ func TestExpandInternalPaths(t *testing.T) {
 		}, got)
 	})
 
+	t.Run("a url that already ends in the path is that path's endpoint, not a parent", func(t *testing.T) {
+		// An operator who baked the version into the url instead of declaring
+		// `internal-path` — a config that works today, because before the
+		// endpoint list carried paths at all every relay went to that one url.
+		// Appending would ask the vendor for /rpc/v0_8/rpc/v0_8.
+		got := expandInternalPaths(
+			[]common.NodeUrl{{Url: "https://vendor.example/rpc/v0_8"}},
+			[]string{"", "/rpc/v0_8", "/rpc/v0_9"},
+		)
+		require.Equal(t, []common.NodeUrl{
+			{Url: "https://vendor.example/rpc/v0_8"},
+			{Url: "https://vendor.example/rpc/v0_8", InternalPath: "/rpc/v0_8"},
+			{Url: "https://vendor.example/rpc/v0_8/rpc/v0_9", InternalPath: "/rpc/v0_9"},
+		}, got)
+	})
+
 	t.Run("output order is stable whatever order the paths arrive in", func(t *testing.T) {
 		urls := []common.NodeUrl{{Url: "https://ton.example/api"}}
 		first := expandInternalPaths(urls, []string{"/v3", "/v2", ""})

--- a/protocol/rpcsmartrouter/internal_paths_test.go
+++ b/protocol/rpcsmartrouter/internal_paths_test.go
@@ -1,0 +1,80 @@
+package rpcsmartrouter
+
+import (
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// The direct-RPC endpoint list has to name the same urls the chain router's
+// per-path proxies do, because both answer the same api collections — one for
+// the tracker and the verifications, the other for relays. They diverged once,
+// and TON answered v3 apis out of the v2 upstream.
+func TestExpandInternalPaths(t *testing.T) {
+	t.Run("a spec with no internal paths is left alone", func(t *testing.T) {
+		urls := []common.NodeUrl{{Url: "https://eth.example"}}
+		require.Equal(t, urls, expandInternalPaths(urls, []string{""}))
+		require.Equal(t, urls, expandInternalPaths(urls, nil))
+	})
+
+	t.Run("a shared root yields one url per path, with the path appended", func(t *testing.T) {
+		// chainstack serves both TON versions under one base, exactly like the
+		// chain router's autoGenerateMissingInternalPaths.
+		got := expandInternalPaths(
+			[]common.NodeUrl{{Url: "https://ton.example/api"}},
+			[]string{"/v3", "", "/v2"},
+		)
+		require.Equal(t, []common.NodeUrl{
+			{Url: "https://ton.example/api"},
+			{Url: "https://ton.example/api/v2", InternalPath: "/v2"},
+			{Url: "https://ton.example/api/v3", InternalPath: "/v3"},
+		}, got)
+	})
+
+	t.Run("a pinned url is taken as it stands", func(t *testing.T) {
+		// tatum serves TON v2 at the host root and v3 under /api/v3, each
+		// pinned. Appending the path again would ask for /v2/v2/…
+		urls := []common.NodeUrl{
+			{Url: "https://ton.tatum.example", InternalPath: "/v2"},
+			{Url: "https://ton.tatum.example/api/v3", InternalPath: "/v3"},
+		}
+		require.Equal(t, urls, expandInternalPaths(urls, []string{"", "/v2", "/v3"}))
+	})
+
+	t.Run("a mixed provider expands only the unpinned urls", func(t *testing.T) {
+		got := expandInternalPaths(
+			[]common.NodeUrl{
+				{Url: "https://ton.example/api"},
+				{Url: "https://ton.tatum.example", InternalPath: "/v2"},
+			},
+			[]string{"", "/v2", "/v3"},
+		)
+		require.Equal(t, []common.NodeUrl{
+			{Url: "https://ton.example/api"},
+			{Url: "https://ton.example/api/v2", InternalPath: "/v2"},
+			{Url: "https://ton.example/api/v3", InternalPath: "/v3"},
+			{Url: "https://ton.tatum.example", InternalPath: "/v2"},
+		}, got)
+	})
+
+	t.Run("expansion carries the url's addons", func(t *testing.T) {
+		// The generated urls are the same upstream, so they serve whatever it
+		// serves — dropping the addons would make the archive leg unreachable
+		// on every internal path but the root.
+		got := expandInternalPaths(
+			[]common.NodeUrl{{Url: "https://avax.example", Addons: []string{"archive"}}},
+			[]string{"", "/P"},
+		)
+		require.Len(t, got, 2)
+		require.Equal(t, []string{"archive"}, got[1].Addons)
+		require.Equal(t, "/P", got[1].InternalPath)
+	})
+
+	t.Run("output order is stable whatever order the paths arrive in", func(t *testing.T) {
+		urls := []common.NodeUrl{{Url: "https://ton.example/api"}}
+		first := expandInternalPaths(urls, []string{"/v3", "/v2", ""})
+		second := expandInternalPaths(urls, []string{"", "/v2", "/v3"})
+		require.Equal(t, first, second)
+	})
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -1975,6 +1975,40 @@ func writeDebugRows(w http.ResponseWriter, rows []map[string]any) {
 	}
 }
 
+// subscriptionCollectionProbe reports whether the collection at `internalPath`
+// carries a SUBSCRIBE api, for the addons a node-url declares. It is the
+// transport half of the chain router's rule for generating per-path urls
+// (chainlib/chain_router.go): a subscription collection is served over ws, and
+// everything else over http.
+func subscriptionCollectionProbe(chainParser chainlib.ChainParser) func(internalPath string, declaredAddons []string) bool {
+	return func(internalPath string, declaredAddons []string) bool {
+		addons, _, err := chainParser.SeparateAddonsExtensions(context.Background(), declaredAddons)
+		if err != nil {
+			// The chain router surfaces this as a construction error. Here the
+			// endpoint list is being built for relays, so an unreadable addon
+			// set falls back to "http collection" — the shape all but STRK's
+			// three ws paths have.
+			return false
+		}
+		if len(addons) == 0 {
+			addons = append(addons, "")
+		}
+		for _, connectionType := range []string{"POST", ""} {
+			for _, addon := range addons {
+				collectionKey := chainlib.CollectionKey{
+					InternalPath:   internalPath,
+					Addon:          addon,
+					ConnectionType: connectionType,
+				}
+				if chainParser.IsTagInCollection(spectypes.FUNCTION_TAG_SUBSCRIBE, collectionKey) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+}
+
 // expandInternalPaths resolves each configured node-url into the set of urls
 // the router will actually dial, one per internal path the spec serves.
 //
@@ -1992,11 +2026,15 @@ func writeDebugRows(w http.ResponseWriter, rows []map[string]any) {
 //   - a url declaring none is the shared root: it stays (for the spec's own
 //     root collection, if it has one) and additionally yields one url per
 //     other internal path, with the path appended — the same
-//     `nodeUrl.Url = baseUrl + internalPath` the chain router does.
+//     `nodeUrl.Url = baseUrl + internalPath` the chain router does;
+//   - a path is generated only on the transport that serves it. A ws url
+//     yields the spec's subscription collections and an http url yields the
+//     rest, so STRK's `/ws/rpc/v0_8` is a wss endpoint and its `/rpc/v0_8` an
+//     https one — never the crossed pair, which no upstream answers.
 //
 // A spec with no internal paths at all (almost every chain) returns the input
 // unchanged.
-func expandInternalPaths(nodeUrls []common.NodeUrl, internalPaths []string) []common.NodeUrl {
+func expandInternalPaths(nodeUrls []common.NodeUrl, internalPaths []string, servesSubscriptions func(internalPath string, declaredAddons []string) bool) []common.NodeUrl {
 	nonRoot := make([]string, 0, len(internalPaths))
 	for _, internalPath := range internalPaths {
 		// A path is appended to a url, so only a url path can be expanded.
@@ -2036,7 +2074,27 @@ func expandInternalPaths(nodeUrls []common.NodeUrl, internalPaths []string) []co
 		if nodeUrl.InternalPath != "" {
 			continue
 		}
+		// gRPC node-urls are a bare host:port and do not parse as a url; the
+		// chain router reads those as non-ws too.
+		isWs, err := chainlib.IsUrlWebSocket(nodeUrl.Url)
+		if err != nil {
+			isWs = false
+		}
 		for _, internalPath := range nonRoot {
+			// The transport has to serve the collection. A ws url answers the
+			// spec's subscription collections and an http url answers the rest
+			// — chain_router.go's autoGenerateMissingInternalPaths applies the
+			// same rule to the proxies the tracker and the verifications run
+			// on, and the two lists have to name the same urls. Generating
+			// every path on every scheme would give a STRK config carrying both
+			// `https://` and `wss://` the crossed pair as well
+			// (`https://host/ws/rpc/v0_8`, `wss://host/rpc/v0_9`): urls no
+			// upstream serves, probed on every sweep and registered in the
+			// metrics, and now — with the filter below preferring an exact path
+			// match — half of what a relay for that path can be routed onto.
+			if isWs != servesSubscriptions(internalPath, nodeUrl.Addons) {
+				continue
+			}
 			generated := nodeUrl
 			if strings.HasSuffix(nodeUrl.Url, internalPath) {
 				// The url already ENDS in this path — an operator who baked the
@@ -2251,7 +2309,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 			}
 
 			endpoints := []*lavasession.Endpoint{}
-			for _, url := range expandInternalPaths(provider.NodeUrls, chainParser.GetAllInternalPaths()) {
+			for _, url := range expandInternalPaths(provider.NodeUrls, chainParser.GetAllInternalPaths(), subscriptionCollectionProbe(chainParser)) {
 				extensions := map[string]struct{}{}
 				for _, extension := range url.Addons {
 					extensions[extension] = struct{}{}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -1975,6 +1975,57 @@ func writeDebugRows(w http.ResponseWriter, rows []map[string]any) {
 	}
 }
 
+// expandInternalPaths resolves each configured node-url into the set of urls
+// the router will actually dial, one per internal path the spec serves.
+//
+// It mirrors chainRouterImpl.BatchNodeUrlsByServices exactly, because the two
+// have to agree on which url answers a given api collection: the chain router
+// builds the proxies the tracker and the verifications run on, and this builds
+// the direct-RPC endpoints relays run on. They diverged, and the relay path —
+// having no internal path anywhere in its endpoint list — dialed whichever url
+// session selection happened to hand it. A chain serving two API versions over
+// two urls (TON: toncenter v2 and tonindex v3) answered v3 apis out of the v2
+// upstream, which shows up as that vendor's 404 rather than as a routing fault.
+//
+//   - a url declaring `internal-path` IS that path's root and is taken as it
+//     stands;
+//   - a url declaring none is the shared root: it stays (for the spec's own
+//     root collection, if it has one) and additionally yields one url per
+//     other internal path, with the path appended — the same
+//     `nodeUrl.Url = baseUrl + internalPath` the chain router does.
+//
+// A spec with no internal paths at all (almost every chain) returns the input
+// unchanged.
+func expandInternalPaths(nodeUrls []common.NodeUrl, internalPaths []string) []common.NodeUrl {
+	nonRoot := make([]string, 0, len(internalPaths))
+	for _, internalPath := range internalPaths {
+		if internalPath != "" {
+			nonRoot = append(nonRoot, internalPath)
+		}
+	}
+	if len(nonRoot) == 0 {
+		return nodeUrls
+	}
+	// Deterministic: the endpoint list feeds session selection, and a map's
+	// iteration order would reshuffle it every boot.
+	sort.Strings(nonRoot)
+
+	expanded := make([]common.NodeUrl, 0, len(nodeUrls))
+	for _, nodeUrl := range nodeUrls {
+		expanded = append(expanded, nodeUrl)
+		if nodeUrl.InternalPath != "" {
+			continue
+		}
+		for _, internalPath := range nonRoot {
+			generated := nodeUrl
+			generated.Url = nodeUrl.Url + internalPath
+			generated.InternalPath = internalPath
+			expanded = append(expanded, generated)
+		}
+	}
+	return expanded
+}
+
 func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	ctx context.Context,
 	rpcEndpoint *lavasession.RPCEndpoint,
@@ -2169,7 +2220,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 			}
 
 			endpoints := []*lavasession.Endpoint{}
-			for _, url := range provider.NodeUrls {
+			for _, url := range expandInternalPaths(provider.NodeUrls, chainParser.GetAllInternalPaths()) {
 				extensions := map[string]struct{}{}
 				for _, extension := range url.Addons {
 					extensions[extension] = struct{}{}
@@ -2204,6 +2255,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 					Enabled:           true,
 					Addons:            extensions,
 					Extensions:        extensions,
+					InternalPath:      url.InternalPath,
 					Connections:       nil,
 					DirectConnections: []lavasession.DirectRPCConnection{directConn}, // Smart router uses direct RPC
 				}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -2038,6 +2038,17 @@ func expandInternalPaths(nodeUrls []common.NodeUrl, internalPaths []string) []co
 		}
 		for _, internalPath := range nonRoot {
 			generated := nodeUrl
+			if strings.HasSuffix(nodeUrl.Url, internalPath) {
+				// The url already ENDS in this path — an operator who baked the
+				// version into the url instead of declaring `internal-path`
+				// (`https://vendor/rpc/v0_8`, no field). It is the endpoint for
+				// that path as it stands; appending would ask the vendor for
+				// `/rpc/v0_8/rpc/v0_8`. It also stays the root endpoint, added
+				// above, which is what that config serves today.
+				generated.InternalPath = internalPath
+				add(generated)
+				continue
+			}
 			generated.Url = nodeUrl.Url + internalPath
 			generated.InternalPath = internalPath
 			add(generated)

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -1999,7 +1999,15 @@ func writeDebugRows(w http.ResponseWriter, rows []map[string]any) {
 func expandInternalPaths(nodeUrls []common.NodeUrl, internalPaths []string) []common.NodeUrl {
 	nonRoot := make([]string, 0, len(internalPaths))
 	for _, internalPath := range internalPaths {
-		if internalPath != "" {
+		// A path is appended to a url, so only a url path can be expanded.
+		// Specs also use the internal-path field as a plain collection LABEL
+		// for inheritance ingredients — STRK's "HTTP-ONLY" / "WS-ONLY". Those
+		// are disabled today, so the parser never reports them, but the idiom
+		// is in the spec repo and an enabled one would otherwise generate
+		// `https://host` + `HTTP-ONLY`. Skipping it leaves the provider with no
+		// endpoint for that path, which the selection filter reads as "not
+		// populated for this provider" and falls back to today's behaviour.
+		if strings.HasPrefix(internalPath, "/") {
 			nonRoot = append(nonRoot, internalPath)
 		}
 	}
@@ -2011,8 +2019,20 @@ func expandInternalPaths(nodeUrls []common.NodeUrl, internalPaths []string) []co
 	sort.Strings(nonRoot)
 
 	expanded := make([]common.NodeUrl, 0, len(nodeUrls))
-	for _, nodeUrl := range nodeUrls {
+	// An operator can declare the base url AND a pinned url that happens to
+	// equal base+path. Both are legitimate; emitting the same (url, path) twice
+	// would just probe it twice and register it twice in the metrics.
+	seen := make(map[string]struct{}, len(nodeUrls))
+	add := func(nodeUrl common.NodeUrl) {
+		key := nodeUrl.Url + "\x00" + nodeUrl.InternalPath
+		if _, dup := seen[key]; dup {
+			return
+		}
+		seen[key] = struct{}{}
 		expanded = append(expanded, nodeUrl)
+	}
+	for _, nodeUrl := range nodeUrls {
+		add(nodeUrl)
 		if nodeUrl.InternalPath != "" {
 			continue
 		}
@@ -2020,7 +2040,7 @@ func expandInternalPaths(nodeUrls []common.NodeUrl, internalPaths []string) []co
 			generated := nodeUrl
 			generated.Url = nodeUrl.Url + internalPath
 			generated.InternalPath = internalPath
-			expanded = append(expanded, generated)
+			add(generated)
 		}
 	}
 	return expanded

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -3655,6 +3655,13 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 	// per-group quorum (2.3), also front-load AgreementThreshold providers per group so each group can
 	// independently reach its internal quorum — otherwise QoS-skewed selection starves the smaller groups.
 	sessionOpts := lavasession.GetSessionsOptions{MinGroups: 1, PerGroupTarget: 1}
+	// Which internal path this api is served under, so selection can pick the
+	// endpoint whose URL is that path's root. In direct mode the path lives in
+	// the upstream url — one node-url per API version — and dialing the wrong
+	// one returns the vendor's 404 as if it were the chain's answer.
+	if apiCollection := protocolMessage.GetApiCollection(); apiCollection != nil {
+		sessionOpts.InternalPath = apiCollection.CollectionData.InternalPath
+	}
 	if cvp := relayProcessor.GetCrossValidationParams(); cvp != nil && cvp.MinGroups > 1 {
 		sessionOpts.MinGroups = cvp.MinGroups
 		if cvp.PerGroupQuorum {

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -3660,7 +3660,8 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 	// the upstream url — one node-url per API version — and dialing the wrong
 	// one returns the vendor's 404 as if it were the chain's answer.
 	if apiCollection := protocolMessage.GetApiCollection(); apiCollection != nil {
-		sessionOpts.InternalPath = apiCollection.CollectionData.InternalPath
+		resolvedInternalPath := apiCollection.CollectionData.InternalPath
+		sessionOpts.InternalPath = &resolvedInternalPath
 	}
 	if cvp := relayProcessor.GetCrossValidationParams(); cvp != nil && cvp.MinGroups > 1 {
 		sessionOpts.MinGroups = cvp.MinGroups


### PR DESCRIPTION
Jira ticket: MAG-2881

#Closes MAG-2881

## Summary

A chain serving two API versions over two node-urls gets one direct-RPC endpoint per version, and session selection never looked at which. Whichever endpoint it picked answered every api — so on TON a `/v3` call was dialed at the `/v2` upstream and came back as that vendor's 404, indistinguishable from the chain not supporting it.

Two code paths turn node-urls into dialable things, and they disagreed:

- **`chainRouterImpl.BatchNodeUrlsByServices`** builds one chain proxy per internal path, appending the path to an unpinned url (`autoGenerateMissingInternalPaths`: `nodeUrl.Url = baseUrl + internalPath`). The tracker and the verifications run on these, and they are correct.
- **`convertProvidersToSessions`** builds the direct-RPC endpoints relays run on. It recorded url, addons and extensions — and dropped the internal path.

`GetSessions` takes addon + extensions, so there was nothing left to match on.

## Reproduction

Local `smartrouter` on the TON spec, one shared-root node-url (`https://toncenter.com/api`), so the chain router auto-generates `/api/v2` and `/api/v3` correctly:

```console
$ curl -s 'localhost:3460/addressBook?address=EQAAFhjXz…'
{"ok":false,"error":"Not Found","code":404,"@extra":"_"}
```

`/addressBook` is a v3-only api. That is toncenter **v2**'s error shape — `@extra`, and `X-Api-Version: v2.1.13` on the response. The debug log shows the chain router holding the right proxies (`||internal-path:/v2| → …/api/v2`, `||internal-path:/v3| → …/api/v3`) while the relay dialed a different connection entirely.

## Change

- **`expandInternalPaths`** mirrors `autoGenerateMissingInternalPaths`: a pinned url is taken as it stands, an unpinned one additionally yields one url per internal path with the path appended.
- **A path is generated only on the transport that serves it.** The chain router generates a path url only on a transport matching the collection's subscription-ness (`chain_router.go:145-152`); `subscriptionCollectionProbe` reads the same `SUBSCRIBE` tag out of the parser (addons separated, `POST` and `""` connection types) and the expansion applies the same rule. Without it a STRK config carrying both schemes also yields the crossed pair — `https://host/ws/rpc/v0_8`, `wss://host/rpc/v0_9` — urls the chain router refuses to build and no upstream answers.
- **`lavasession.Endpoint`** carries `InternalPath`.
- **`GetSessionsOptions.InternalPath`** carries the resolved collection's path from `rpcsmartrouter_server.go` to the endpoint filter. Variadic, so the 38 existing test call sites are unchanged.
- **The filter matches exactly, in both directions**, and restricts **only when the provider has a matching endpoint**. A provider with none — a provider-relay pool, where the path lives on the provider's side rather than in our url — keeps every endpoint it had. A routing refinement must not become an outage.
- `internalPath` is a `*string`: **`nil`** means "no collection to match on" (probes), **`""`** is a real path meaning the spec's root collection.
- **A url that already ends in the path is that path's endpoint**, not a parent to append to. An operator can bake the version into the url instead of declaring `internal-path` (`https://vendor/rpc/v0_8`, no field) — a config that serves fine today, because before the endpoint list carried paths at all every relay went to that one url. Expanding it blindly would generate `…/rpc/v0_8/rpc/v0_8` and, with the filter now preferring an exact match, aim every `/rpc/v0_8` relay at that 404. It is registered as that path's endpoint as it stands, and stays the root endpoint too.

That last distinction is the one that matters for Starknet — see below.

## Every internal path in the spec repo

Swept all 247 enabled specs, resolving `imports` with child-overrides-parent (which is how a spec disables an inherited collection — AVAX declares `""` `enabled: false` to kill ETH1's root). **12 spec × interface pairs across 6 chain families** declare any internal path; every other chain has none and is untouched by every line of this PR.

| Spec | Interface | Shape | Paths |
|---|---|---|---|
| AVAX / AVAXT | jsonrpc | paths only | `/C/avax` `/C/rpc` `/P` `/X` |
| AVALANCHEC / CT | jsonrpc | paths only | `/C/avax` `/C/rpc` |
| AVALANCHEP / PT | jsonrpc | paths only | `/P` |
| MONERO / MONEROT | jsonrpc | paths only | `/json_rpc` |
| TON / TONT | rest | paths only | `/v2` `/v3` |
| STRK / STRKS | jsonrpc | **root + paths** | `/rpc/v0_8` `/rpc/v0_9` `/rpc/v0_10`, the three `/ws/...` twins, `/rpc/pathfinder/v0.1` |

Two shapes, and they behave differently:

**paths only** (10 of 12) — no enabled root collection, so every relay carries a path, the filter is always active and always has a matching endpoint, and the unpinned root url the expansion keeps is simply never chosen. Strictly a fix: AVAX's `platform.*` used to be dialed at the C-chain url, and MONERO's whole api used to be dialed at the base rather than `/json_rpc`.

**root + paths** (STRK only) — this is where the first cut of this PR **would have regressed**. STRK's `""` collection carries the whole 26-method set and each `/rpc/v0_x` carries it again, so most STRK relays resolve to `""`:

```
""                    ← HTTP-ONLY + WS-ONLY   (enabled, the whole method set)
/rpc/v0_8             ← HTTP-ONLY
/ws/rpc/v0_8          ← /rpc/v0_8 + WS-ONLY
/rpc/v0_9  /v0_10     …same
/rpc/pathfinder/v0.1  3 apis of its own
```

Treating `""` as "don't filter" would have left root traffic eligible for all **eight** endpoints the expansion generates from one unpinned url, and latency sorting could promote `https://host/rpc/v0_9` — or `https://host/ws/rpc/v0_8`, a ws door generated over an http url — ahead of the real root. Hence the `nil` / `""` distinction. Root traffic now stays on the root url, and a caller that asks for `/rpc/v0_9` gets that version at dial time too, where before its choice was honoured at parse time and then discarded.

| Relay's collection | Eligible endpoints |
|---|---|
| `""` — STRK root, and every chain with no internal paths | the root url only; on a chain with no paths that IS every endpoint, so no change |
| `/rpc/v0_9` | that version's url |
| `/P` — AVAX | `/P` |
| `nil` — probes | all, unchanged |

## Future-proofing

The sweep also produced two guards for specs that do not exist yet:

- **A collection label is not a url path.** Specs use the internal-path field as a plain label for inheritance ingredients — STRK's `HTTP-ONLY` / `WS-ONLY`. They are disabled today so the parser never reports them, but the idiom is in the spec repo, and an enabled one would generate `https://host` + `HTTP-ONLY`. Only a path starting with `/` is appended; anything else yields no endpoint, which the filter reads as "not populated for this provider" and falls back to today's behaviour. (Confirmed: no enabled path in the repo today fails that check.)
- **No duplicate emission.** An operator can declare the base url AND a pinned url equal to base+path. Both are legitimate; the generated twin would be probed and registered in the metrics twice. Emission is deduped on (url, internal path).

A brand-new chain that adds internal paths needs no code change: the path set is read from `chainParser.GetAllInternalPaths()` at construction, which is also what the chain router reads.

## Verified live

One router serving TON **and** ETH1 off the same build — ETH1 is the control, a chain with no internal paths going through the same selection code:

```
ETH1  eth_blockNumber          -> {"jsonrpc":"2.0","result":"0x18980c9","id":1}
TON   /getMasterchainInfo      -> {"ok":true,"result":{"@type":"blocks.masterchainInfo"…   (toncenter v2)
TON   /addressBook?address=…   -> {"EQAAFhjXz…":{"user_friendly":"UQAAFhjXz…","domain":null…  (tonindex v3)
```

Trackers green on both: `chainID=TON failed=0 success=3`, `chainID=ETH1 failed=0 success=1`. TON was also verified on both config shapes DFNS uses — one shared-root url, and one url pinned per version — with the same results; before this PR `/addressBook` returned the v2 404 under both. The shared-root boot log shows the expansion:

```
created direct RPC connection url=https://toncenter.com/api
created direct RPC connection url=https://toncenter.com/api/v2
created direct RPC connection url=https://toncenter.com/api/v3
```

**Every other internal-path family, live, all on shared-root urls so the expansion has to do the work:**

```
AVAX   eth_blockNumber    (/C/rpc)   -> {"result":"0x58dca22"}                     C-chain
AVAX   platform.getHeight (/P)       -> {"result":{"height":"25385361"}}           P-chain
AVAX   avm.getHeight      (/X)       -> {"result":{"height":"526970"}}             X-chain
MONERO get_block_count    (/json_rpc)-> {"result":{"count":3743520,"status":"OK"}}
```

Three Avalanche sub-chains, three upstream urls, each answering its own height. Trackers `failed=0 success=5` (AVAX: base + 4 paths) and `failed=0 success=2` (MONERO).

**STRK** — verified against both a real endpoint (`rpc.starknet.lava.build`) and the Lava gateway.

STRK's spec has subscriptions, so a valid config carries both schemes, and each scheme carries the collections it serves — `/ws/rpc/v0_x` inherits `WS-ONLY` (which holds `SUBSCRIBE`), `/rpc/v0_x` inherits `HTTP-ONLY` (which does not):

```
https://<host>                      ← root collection
  …/rpc/v0_8   …/rpc/v0_9   …/rpc/v0_10   …/rpc/pathfinder/v0.1

wss://<host>                        ← root collection
  …/ws/rpc/v0_8   …/ws/rpc/v0_9   …/ws/rpc/v0_10
```

Nine urls — the same nine the chain router builds proxies for, asserted exactly in `TestExpandInternalPaths`.

> ⚠ The live STRK run below predates the transport guard, which was added in `1f87a35` in response to review. Its endpoint enumeration and `failed=0 success=8` tracker line describe the pre-guard expansion off a single url. The per-url dial table that follows is unaffected — every path in it is an http collection — but the boot-time endpoint list wants a re-run before merge.

**Which url each client call lands on** is the thing this PR changes, and nothing in the router's logs or metrics records it — the per-endpoint metrics label by provider, not url. So the STRK run used a local upstream that answers well enough to boot and appends every request path to a file. `starknet_chainId` is never polled by the tracker, so a post-boot occurrence is always a client relay:

| client sends to | **unpatched** dials | **patched** dials |
|---|---|---|
| `<root>` | `/base` | `/base` |
| `/rpc/v0_9` | `/base` ❌ | `/base/rpc/v0_9` ✅ |
| `/rpc/v0_10` | `/base` ❌ | `/base/rpc/v0_10` ✅ |
| `/rpc/pathfinder/v0.1` | `/base` ❌ | `/base/rpc/pathfinder/v0.1` ✅ |

On the unpatched build all four calls returned the **same** answer, so a caller asking for a specific version had no way to tell the choice was discarded. That is the shape of the bug on a chain with a root collection: not an error, a silently wrong door. Root traffic stays on root in both — the property the `nil` / `""` distinction protects.

## Test plan

- `go build ./...`, `go vet ./protocol/...` — clean
- `go test ./protocol/lavasession/... ./protocol/rpcsmartrouter/... ./protocol/chainlib/...` — pass
- `TestExpandInternalPaths` — 10 cases: no-paths passthrough, shared-root expansion, pinned untouched, mixed provider, addons carried, label not appended, no duplicate emission, stable ordering, **transport guard (STRK's real path set over both schemes, asserting the exact 9-url output)**, **unparseable scheme (bare gRPC `host:port`) still expands its http paths**
- `TestFetchEndpointConnection_InternalPath` — 6 cases: versioned api reaches only its own upstream, **root-collection api stays on the root url (STRK)**, **AVAX shape where no root collection exists**, a chain with no internal paths is unaffected, probes unfiltered, provider with no matching endpoint not filtered to nothing

**Pre-existing flake, not from this PR:** `TestCheckAndUnblock_BackupUnblockedWhenHealthy` fails intermittently on the precondition at `consumer_session_manager_test.go:2521`. Reproduced on clean `main` with the same 20-run stress (`-count=20`), so it is not introduced here.

## Side effects worth knowing

- **Metrics cardinality.** Each generated url registers with the metrics manager, so a chain with N internal paths registers up to N+1 urls per unpinned node-url instead of 1. Bounded by the spec's path count, and only for the 6 families above.
- **Probe traffic.** `probeDirectRPCEndpoints` iterates endpoints, so those chains get one probe per path — matching what the chain router already does for trackers.
- Connections are cheap: HTTP shares one transport singleton, WS is dialed lazily on first send. The expansion opens no idle sockets.

## The tracker-retry double-prefix, also fixed here

A pinned url was being re-expanded into `…/api/v2/v2` — first seen when toncenter rate-limited a tracker attempt. I originally filed this as a separate defect on the theory that the retry path re-runs expansion. **That theory was wrong**, and the A/B says this PR fixes it.

Reproduction: TON with both urls pinned per version, `/v3` pointed at a refused port so its tracker fails and retries. Three runs of each binary, same config:

| build | run | chain routers | `…/vN/vN` urls | tracker retries |
|---|---|---|---|---|
| patched | 1 | 1 | **0** | 6 |
| patched | 2 | 1 | **0** | 7 |
| patched | 3 | **2** | **0** | 6 |
| unpatched | 1 | 2 | **4** | 9 |
| unpatched | 2 | 2 | **4** | 10 |
| unpatched | 3 | 1 | 0 | 0 |

What the table says, read carefully:

- The **second chain router is triggered by tracker-startup retries** — it appears in every run that retried and in neither run that did not (unpatched run 3 retried zero times and built one router).
- The second construction is not itself the bug. Patched run 3 built a second router and still produced **zero** double-prefixed urls.
- The bug is that on the unpatched build that second construction reads an endpoint list where the internal path has been flattened into the url, so it treats a pinned `…/api/v2` as a root and re-expands it. With `Endpoint.InternalPath` carried through, it no longer can.

Zero doubled urls across all three patched runs, including the one that exercised the second construction.

## Related

MAG-2880 / smart-router-dashboard#146 — the dashboard half of the same TON internal-path work.

