### PR TITLE
fix(smart-router): resolve a config argument that is a path as a path

### DIFF
--- a/protocol/rpcsmartrouter/config_source.go
+++ b/protocol/rpcsmartrouter/config_source.go
@@ -141,13 +141,17 @@ func configFilePathCandidates(arg string) []string {
 	return candidates
 }
 
-// resolveWithSupportedExt reports the file a single candidate resolves to, trying each
-// supported extension before the bare path. A candidate that already declares its format
-// has nothing to append and must exist as given.
+// resolveWithSupportedExt reports the file a single candidate resolves to, mirroring
+// searchInPath: every supported extension is appended and tried first, in viper's own
+// order, and only then the candidate as given.
+//
+// The appended forms are tried even when the candidate already ends in a supported
+// extension, because searchInPath appends to v.configName unconditionally — it never checks
+// whether the name already carries one. `sub/router.yml` has therefore always been able to
+// resolve to sub/router.yml.json, and short-circuiting on a recognized extension (which
+// looks obviously right) is the one remaining way the two branches could disagree. Pathological
+// as that layout is, "strictly additive" has to mean it.
 func resolveWithSupportedExt(candidate string) (resolved string, found bool) {
-	if ext := strings.TrimPrefix(filepath.Ext(candidate), "."); slices.Contains(viper.SupportedExts, ext) {
-		return candidate, isExistingFile(candidate)
-	}
 	for _, ext := range viper.SupportedExts {
 		if withExt := candidate + "." + ext; isExistingFile(withExt) {
 			return withExt, true
@@ -179,12 +183,18 @@ func isConfigNotFound(err error) bool {
 }
 
 // configNotFoundMessage explains where the config was looked for, in the terms the
-// operator used: the one path they named, or the search paths their bare name was
-// resolved against.
+// operator used — and, importantly, describes the search that actually happened. An
+// absolute path is resolved against nothing but itself, so naming search paths for it is
+// the MAG-2861 confusion; a relative path *is* probed across configSearchPaths, so claiming
+// otherwise is the same confusion pointed the other way.
 func configNotFoundMessage(target string, isFile bool) string {
 	if isFile {
 		if info, err := os.Stat(target); err == nil && info.IsDir() {
 			return "the given config path is a directory, not a config file: " + target
+		}
+		if !filepath.IsAbs(target) {
+			return "config file not found: " + target +
+				" — a relative path is resolved against each of the search paths"
 		}
 		return "config file not found at the given path: " + target
 	}
@@ -194,7 +204,9 @@ func configNotFoundMessage(target string, isFile bool) string {
 
 // configLocationAttributes describe where the config was looked for, for attachment to a
 // not-found error. A relative target is reported alongside the working directory it was
-// resolved against, since that is the piece an operator cannot see from the log line.
+// resolved against and the full list of paths actually probed, since neither is visible
+// from the log line — and reporting only the working directory would describe a narrower
+// search than the one that ran.
 func configLocationAttributes(target string, isFile bool) []utils.Attribute {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -205,11 +217,20 @@ func configLocationAttributes(target string, isFile bool) []utils.Attribute {
 		if abs, err := filepath.Abs(target); err == nil {
 			resolved = abs
 		}
-		return []utils.Attribute{
+		attributes := []utils.Attribute{
 			{Key: "config_file", Value: target},
 			{Key: "resolved_path", Value: resolved},
 			{Key: "working_directory", Value: cwd},
 		}
+		if !filepath.IsAbs(target) {
+			// The exact candidate list, not a restatement of configSearchPaths: it is what
+			// was probed, and it saves the operator from having to perform the join in
+			// their head to see where the file was expected.
+			attributes = append(attributes, utils.Attribute{
+				Key: "searched_paths", Value: strings.Join(configFilePathCandidates(target), " "),
+			})
+		}
+		return attributes
 	}
 	return []utils.Attribute{
 		{Key: "config_name", Value: target},

--- a/protocol/rpcsmartrouter/config_source.go
+++ b/protocol/rpcsmartrouter/config_source.go
@@ -1,0 +1,138 @@
+package rpcsmartrouter
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/magma-Devs/smart-router/utils"
+	"github.com/spf13/viper"
+)
+
+// Config resolution for the commands that take one — `smartrouter [config]` and
+// `smartrouter health [config]` — lives here so the two cannot drift apart.
+//
+// Viper locates a config in one of two mutually exclusive ways, and the argument used to
+// be handed to the wrong one for path-shaped values. SetConfigName treats its value as a
+// *name* joined onto every search path, and filepath.Join swallows the leading separator
+// of an absolute path — Join(".", "/etc/smartrouter/config.yml") is
+// "etc/smartrouter/config.yml". An absolute path was therefore looked for *inside* each
+// search directory, could never exist there, and failed against directories the operator
+// never named (MAG-2861). Relative paths worked only by accident, because "." happens to
+// be a search path.
+//
+// So a path-shaped argument now goes to SetConfigFile and is loaded verbatim, while a
+// bare name keeps the search-path lookup it has always had.
+
+// configSearchPaths are the directories a bare config *name* is resolved against, in
+// precedence order.
+var configSearchPaths = []string{".", "./config", lavaDefaultNodeHome}
+
+// defaultConfigType is the format assumed for a config whose extension does not declare
+// one — including the extension-less names the search-path lookup accepts. Every
+// smartrouter config is YAML.
+const defaultConfigType = "yml"
+
+// pointViperAtConfig aims the global viper at the config selected by the command's
+// arguments. Exactly one argument names the config; anything else (none, or inline
+// endpoint triplets) selects the default config name.
+//
+// It reports the target it settled on, for use in messages, and whether that target is an
+// exact file rather than a name searched for across configSearchPaths — which decides how
+// a failure to read it should be explained.
+func pointViperAtConfig(args []string) (target string, isFile bool) {
+	target = DefaultRPCSmartRouterFileName
+	if len(args) == 1 {
+		target = args[0]
+	}
+
+	if isConfigFilePath(target) {
+		viper.SetConfigFile(target)
+		// Let a recognized extension declare the format, and fall back to YAML for
+		// anything else. Set it either way: without an explicit type an extension-less
+		// path fails as UnsupportedConfigError instead of being read at all.
+		if ext := strings.TrimPrefix(filepath.Ext(target), "."); slices.Contains(viper.SupportedExts, ext) {
+			viper.SetConfigType(ext)
+		} else {
+			viper.SetConfigType(defaultConfigType)
+		}
+		return target, true
+	}
+
+	viper.SetConfigName(target)
+	viper.SetConfigType(defaultConfigType)
+	for _, path := range configSearchPaths {
+		viper.AddConfigPath(path)
+	}
+	return target, false
+}
+
+// isConfigFilePath reports whether the argument names a config file directly, rather than
+// a name to look up across the search paths.
+//
+// An absolute path always qualifies: the search-path lookup provably cannot resolve one.
+// A relative path qualifies once it actually resolves to a file from the working
+// directory — which is the very file the "." search path would have returned, so every
+// invocation that worked before still loads exactly what it loaded before. Anything that
+// does not resolve to a file stays on the search-path lookup, which is what lets a bare
+// `smartrouter myconfig` still find ./config/myconfig.yml.
+func isConfigFilePath(arg string) bool {
+	if arg == "" {
+		return false
+	}
+	if filepath.IsAbs(arg) {
+		return true
+	}
+	info, err := os.Stat(arg)
+	return err == nil && !info.IsDir()
+}
+
+// isConfigNotFound reports whether err means "no config file was there", which viper
+// phrases two different ways: ConfigFileNotFoundError when it searched and came up empty,
+// and a plain fs.ErrNotExist when it was pointed at an exact file. Both are operator
+// mistakes worth a clean message; anything else (malformed YAML, a permissions problem) is
+// not.
+func isConfigNotFound(err error) bool {
+	var notFound viper.ConfigFileNotFoundError
+	return errors.As(err, &notFound) || errors.Is(err, fs.ErrNotExist)
+}
+
+// configNotFoundMessage explains where the config was looked for, in the terms the
+// operator used: the one path they named, or the search paths their bare name was
+// resolved against.
+func configNotFoundMessage(target string, isFile bool) string {
+	if isFile {
+		return "config file not found at the given path: " + target
+	}
+	return "no config file found — pass a config file as an argument (e.g. `smartrouter <config-file>.yml`, " +
+		"absolute or relative), or place " + DefaultRPCSmartRouterFileName + " in one of the search paths"
+}
+
+// configLocationAttributes describe where the config was looked for, for attachment to a
+// not-found error. A relative target is reported alongside the working directory it was
+// resolved against, since that is the piece an operator cannot see from the log line.
+func configLocationAttributes(target string, isFile bool) []utils.Attribute {
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = "<unknown>"
+	}
+	if isFile {
+		resolved := target
+		if abs, err := filepath.Abs(target); err == nil {
+			resolved = abs
+		}
+		return []utils.Attribute{
+			{Key: "config_file", Value: target},
+			{Key: "resolved_path", Value: resolved},
+			{Key: "working_directory", Value: cwd},
+		}
+	}
+	return []utils.Attribute{
+		{Key: "config_name", Value: target},
+		{Key: "search_paths", Value: strings.Join(configSearchPaths, " ")},
+		{Key: "working_directory", Value: cwd},
+	}
+}

--- a/protocol/rpcsmartrouter/config_source.go
+++ b/protocol/rpcsmartrouter/config_source.go
@@ -50,6 +50,7 @@ func pointViperAtConfig(args []string) (target string, isFile bool) {
 	}
 
 	if isConfigFilePath(target) {
+		target = resolveConfigFilePath(target)
 		viper.SetConfigFile(target)
 		// Let a recognized extension declare the format, and fall back to YAML for
 		// anything else. Set it either way: without an explicit type an extension-less
@@ -73,20 +74,47 @@ func pointViperAtConfig(args []string) (target string, isFile bool) {
 // isConfigFilePath reports whether the argument names a config file directly, rather than
 // a name to look up across the search paths.
 //
-// An absolute path always qualifies: the search-path lookup provably cannot resolve one.
-// A relative path qualifies once it actually resolves to a file from the working
-// directory — which is the very file the "." search path would have returned, so every
-// invocation that worked before still loads exactly what it loaded before. Anything that
-// does not resolve to a file stays on the search-path lookup, which is what lets a bare
-// `smartrouter myconfig` still find ./config/myconfig.yml.
+// The test is lexical — does the value name a directory component? — and deliberately does
+// not consult the filesystem. What is being decided here is what the operator *meant*, and
+// that cannot depend on which files happen to sit in the working directory: an earlier cut
+// of this fix keyed on os.Stat, which made a bare `smartrouter router` load an
+// extension-less ./router in preference to the ./router.yml the search path has always
+// returned. A name with no separator is a name, always, and goes to the lookup that has
+// always handled it.
 func isConfigFilePath(arg string) bool {
 	if arg == "" {
 		return false
 	}
-	if filepath.IsAbs(arg) {
-		return true
+	return filepath.IsAbs(arg) || strings.ContainsRune(arg, '/') || strings.ContainsRune(arg, filepath.Separator)
+}
+
+// resolveConfigFilePath returns the file an explicit path refers to.
+//
+// A path carrying no recognized config extension is also tried with each supported
+// extension appended, in viper's own order, because that is what the search-path lookup
+// does inside a directory: `smartrouter config/akash` has always loaded config/akash.yml,
+// and a lexical split that skipped this would have broken it. Extensions are tried before
+// the bare path for the same reason — searchInPath does — so resolution is identical
+// whichever branch an argument takes.
+//
+// When nothing resolves, the path as given is returned, so viper fails against the file
+// the operator actually named and the error can say so.
+func resolveConfigFilePath(arg string) string {
+	if ext := strings.TrimPrefix(filepath.Ext(arg), "."); slices.Contains(viper.SupportedExts, ext) {
+		return arg // already declares its format; nothing to append
 	}
-	info, err := os.Stat(arg)
+	for _, ext := range viper.SupportedExts {
+		if candidate := arg + "." + ext; isExistingFile(candidate) {
+			return candidate
+		}
+	}
+	return arg
+}
+
+// isExistingFile reports whether path is a regular file that can be stat-ed. A directory is
+// not a config.
+func isExistingFile(path string) bool {
+	info, err := os.Stat(path)
 	return err == nil && !info.IsDir()
 }
 

--- a/protocol/rpcsmartrouter/config_source.go
+++ b/protocol/rpcsmartrouter/config_source.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"syscall"
 
 	"github.com/magma-Devs/smart-router/utils"
 	"github.com/spf13/viper"
@@ -24,11 +25,15 @@ import (
 // never named (MAG-2861). Relative paths worked only by accident, because "." happens to
 // be a search path.
 //
-// So a path-shaped argument now goes to SetConfigFile and is loaded verbatim, while a
-// bare name keeps the search-path lookup it has always had.
+// So a path-shaped argument now goes to SetConfigFile, while a bare name keeps the
+// search-path lookup it has always had. The branch decides how a failure is *explained* —
+// against the one path the operator named, or against the directories a name is searched
+// in — not where the file is found: a relative path is still resolved against every search
+// path, because that is what SetConfigName did for it and what operators rely on.
 
-// configSearchPaths are the directories a bare config *name* is resolved against, in
-// precedence order.
+// configSearchPaths are the directories a config argument is resolved against, in
+// precedence order — both a bare *name* and a *relative* path. An absolute path names its
+// file outright and is not resolved against them.
 var configSearchPaths = []string{".", "./config", lavaDefaultNodeHome}
 
 // defaultConfigType is the format assumed for a config whose extension does not declare
@@ -90,25 +95,65 @@ func isConfigFilePath(arg string) bool {
 
 // resolveConfigFilePath returns the file an explicit path refers to.
 //
-// A path carrying no recognized config extension is also tried with each supported
-// extension appended, in viper's own order, because that is what the search-path lookup
-// does inside a directory: `smartrouter config/akash` has always loaded config/akash.yml,
-// and a lexical split that skipped this would have broken it. Extensions are tried before
-// the bare path for the same reason — searchInPath does — so resolution is identical
-// whichever branch an argument takes.
+// A *relative* path is probed against configSearchPaths, in the same precedence order a
+// bare name is, because that is what SetConfigName + AddConfigPath already did for it.
+// filepath.Join only swallows a *leading* separator, so Join("./config",
+// "smartrouter_examples/eth.yml") resolved perfectly well — only absolute paths were
+// demoted (MAG-2861). Dropping the search paths for relative paths would have narrowed
+// resolution rather than fixed it: `smartrouter smartrouter_examples/smartrouter_eth.yml`
+// from the project root has always loaded config/smartrouter_examples/smartrouter_eth.yml.
+//
+// An absolute path is never joined onto a search path. That join is the demotion this
+// ticket removed, and a search path cannot contribute anything to an already-rooted path.
+//
+// Within each candidate a path carrying no recognized config extension is tried with each
+// supported extension appended, in viper's own order and before the bare path, exactly as
+// searchInPath does — which is why `smartrouter config/akash` loads config/akash.yml and
+// why an extension-less ./router must not shadow ./router.yml.
 //
 // When nothing resolves, the path as given is returned, so viper fails against the file
 // the operator actually named and the error can say so.
 func resolveConfigFilePath(arg string) string {
-	if ext := strings.TrimPrefix(filepath.Ext(arg), "."); slices.Contains(viper.SupportedExts, ext) {
-		return arg // already declares its format; nothing to append
-	}
-	for _, ext := range viper.SupportedExts {
-		if candidate := arg + "." + ext; isExistingFile(candidate) {
-			return candidate
+	for _, candidate := range configFilePathCandidates(arg) {
+		if resolved, found := resolveWithSupportedExt(candidate); found {
+			return resolved
 		}
 	}
 	return arg
+}
+
+// configFilePathCandidates lists the paths an explicit path argument may refer to, in
+// precedence order. A relative path is joined onto each search path — the first of which is
+// ".", so the working directory is tried first and unchanged. An absolute path refers only
+// to itself.
+func configFilePathCandidates(arg string) []string {
+	if filepath.IsAbs(arg) {
+		return []string{arg}
+	}
+	candidates := make([]string, 0, len(configSearchPaths))
+	for _, searchPath := range configSearchPaths {
+		// Viper runs a search path through absPathify, which expands the $HOME that the
+		// lavaDefaultNodeHome literal carries. filepath.Join would keep it verbatim, so the
+		// expansion has to happen here for $HOME/.lava to mean the same thing in both
+		// branches.
+		candidates = append(candidates, filepath.Join(os.ExpandEnv(searchPath), arg))
+	}
+	return candidates
+}
+
+// resolveWithSupportedExt reports the file a single candidate resolves to, trying each
+// supported extension before the bare path. A candidate that already declares its format
+// has nothing to append and must exist as given.
+func resolveWithSupportedExt(candidate string) (resolved string, found bool) {
+	if ext := strings.TrimPrefix(filepath.Ext(candidate), "."); slices.Contains(viper.SupportedExts, ext) {
+		return candidate, isExistingFile(candidate)
+	}
+	for _, ext := range viper.SupportedExts {
+		if withExt := candidate + "." + ext; isExistingFile(withExt) {
+			return withExt, true
+		}
+	}
+	return candidate, isExistingFile(candidate)
 }
 
 // isExistingFile reports whether path is a regular file that can be stat-ed. A directory is
@@ -119,13 +164,18 @@ func isExistingFile(path string) bool {
 }
 
 // isConfigNotFound reports whether err means "no config file was there", which viper
-// phrases two different ways: ConfigFileNotFoundError when it searched and came up empty,
-// and a plain fs.ErrNotExist when it was pointed at an exact file. Both are operator
-// mistakes worth a clean message; anything else (malformed YAML, a permissions problem) is
-// not.
+// phrases three different ways: ConfigFileNotFoundError when it searched and came up empty,
+// a plain fs.ErrNotExist when it was pointed at an exact file, and EISDIR when that exact
+// path turned out to be a directory. All three are operator mistakes worth a clean message;
+// anything else (malformed YAML, a permissions problem) is not, and must stay on the loud
+// path.
+//
+// The directory case only arises for an explicit path — a search of configSearchPaths
+// skips directories and reports ConfigFileNotFoundError — and without it `smartrouter
+// ./config` would take the LavaFormatFatal stack-dump path this fix exists to remove.
 func isConfigNotFound(err error) bool {
 	var notFound viper.ConfigFileNotFoundError
-	return errors.As(err, &notFound) || errors.Is(err, fs.ErrNotExist)
+	return errors.As(err, &notFound) || errors.Is(err, fs.ErrNotExist) || errors.Is(err, syscall.EISDIR)
 }
 
 // configNotFoundMessage explains where the config was looked for, in the terms the
@@ -133,6 +183,9 @@ func isConfigNotFound(err error) bool {
 // resolved against.
 func configNotFoundMessage(target string, isFile bool) string {
 	if isFile {
+		if info, err := os.Stat(target); err == nil && info.IsDir() {
+			return "the given config path is a directory, not a config file: " + target
+		}
 		return "config file not found at the given path: " + target
 	}
 	return "no config file found — pass a config file as an argument (e.g. `smartrouter <config-file>.yml`, " +

--- a/protocol/rpcsmartrouter/config_source_test.go
+++ b/protocol/rpcsmartrouter/config_source_test.go
@@ -100,6 +100,44 @@ func TestPointViperAtConfigResolution(t *testing.T) {
 				return []string{"myconfig.yml"}, "cwd"
 			},
 		},
+		{
+			// An extension-less file must not shadow the .yml a bare name has always
+			// resolved to. Keying the path/name split on os.Stat instead of on the shape
+			// of the argument got this wrong: `router` found ./router and stopped.
+			name: "bare name prefers the extension over an extensionless file",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				writeConfig(t, filepath.Join(dir, "router"), "extensionless-shadow")
+				writeConfig(t, filepath.Join(dir, "router.yml"), "yml-wins")
+				return []string{"router"}, "yml-wins"
+			},
+		},
+		{
+			// A path carrying no extension still resolves, the way it always has via the
+			// "." search path. This is the case that makes the lexical split safe.
+			name: "relative path without extension resolves to the yml file",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				writeConfig(t, filepath.Join(dir, "config", "akash.yml"), "path-ext-appended")
+				return []string{"config/akash"}, "path-ext-appended"
+			},
+		},
+		{
+			// The same precedence inside the explicit-path branch, so an argument resolves
+			// identically no matter which branch its shape sends it down.
+			name: "path prefers the extension over an extensionless file",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				writeConfig(t, filepath.Join(dir, "config", "router"), "extensionless-shadow")
+				writeConfig(t, filepath.Join(dir, "config", "router.yml"), "yml-wins")
+				return []string{"config/router"}, "yml-wins"
+			},
+		},
+		{
+			// An explicit "./" is intent, not decoration.
+			name: "dot-slash relative path",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				writeConfig(t, filepath.Join(dir, "router.yml"), "dot-slash")
+				return []string{"./router.yml"}, "dot-slash"
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
@@ -147,6 +185,29 @@ func TestPointViperAtConfigNotFound(t *testing.T) {
 			"an explicit path was never searched for — mentioning search paths is what sent MAG-2861 the wrong way")
 	})
 
+	t.Run("missing relative path is a clean not-found naming that path", func(t *testing.T) {
+		// The whole point of MAG-2861 is that a path the operator named must not come back
+		// as a complaint about directories they never mentioned. A relative path is no
+		// less explicit than an absolute one.
+		dir := t.TempDir()
+		t.Chdir(dir)
+		viper.Reset()
+		t.Cleanup(viper.Reset)
+
+		target, isFile := pointViperAtConfig([]string{"nested/missing.yml"})
+		require.True(t, isFile, "a value naming a directory component is a path, not a name")
+		require.Equal(t, "nested/missing.yml", target)
+
+		err := viper.ReadInConfig()
+		require.Error(t, err)
+		require.True(t, isConfigNotFound(err))
+
+		msg := configNotFoundMessage(target, isFile)
+		require.Contains(t, msg, "nested/missing.yml")
+		require.NotContains(t, msg, "search paths",
+			"the search paths were never consulted for an explicit path — naming them is the MAG-2861 confusion")
+	})
+
 	t.Run("missing bare name reports the search paths", func(t *testing.T) {
 		dir := t.TempDir()
 		t.Chdir(dir)
@@ -191,6 +252,9 @@ func TestPointViperAtConfigNotFound(t *testing.T) {
 // TestIsConfigFilePath pins the one judgement call in the resolution: which arguments are
 // treated as paths. Getting this wrong either resurrects MAG-2861 or breaks the bare-name
 // invocations that have always worked.
+//
+// The classification is deliberately lexical, so these cases hold regardless of what is on
+// disk — the working directory below is populated precisely to prove that.
 func TestIsConfigFilePath(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
@@ -204,10 +268,13 @@ func TestIsConfigFilePath(t *testing.T) {
 	}{
 		{"/etc/smartrouter/config.yml", true, "an absolute path can never be resolved by the search paths"},
 		{"/etc/smartrouter/missing.yml", true, "absolute stays a path even when absent, so the error can name it"},
-		{"here.yml", true, "it resolves to a real file from the working directory"},
-		{"there.yml", false, "only ./config/there.yml exists, which is the search path's job"},
+		{"config/router.yml", true, "it names a directory component, so it is a path"},
+		{"nested/missing.yml", true, "a path stays a path when absent, so the error can name it"},
+		{"./router.yml", true, "an explicit ./ is intent"},
+		{"here.yml", false, "no separator: a name, even though ./here.yml exists"},
+		{"there.yml", false, "no separator: the search path's job"},
 		{"myconfig", false, "a bare name is looked up, with the extension appended"},
-		{"config", false, "a directory is not a config file"},
+		{"config", false, "no separator, so a name — the directory on disk is irrelevant"},
 		{"", false, "no argument means the default name"},
 	} {
 		require.Equal(t, tc.want, isConfigFilePath(tc.arg), "%q: %s", tc.arg, tc.why)

--- a/protocol/rpcsmartrouter/config_source_test.go
+++ b/protocol/rpcsmartrouter/config_source_test.go
@@ -195,6 +195,33 @@ func TestPointViperAtConfigResolution(t *testing.T) {
 				return []string{abs}, "absolute-wins"
 			},
 		},
+		{
+			// searchInPath appends every supported extension to v.configName without ever
+			// checking whether it already ends in one, so `sub/router.yml` has always been
+			// able to resolve to sub/router.yml.json. A short-circuit on "already declares
+			// its format" looks obviously correct and silently drops that — the last way the
+			// two branches could disagree. Pathological layout, but "strictly additive"
+			// has to mean it.
+			name: "path with a supported extension still prefers an appended extension",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "sub", "router.yml.json"),
+					[]byte(`{"marker":"appended-wins"}`), 0o644))
+				writeConfig(t, filepath.Join(dir, "sub", "router.yml"), "bare-loses")
+				return []string{"sub/router.yml"}, "appended-wins"
+			},
+		},
+		{
+			// The same rule in the name branch, which never stopped doing it — this is the
+			// case that makes the one above an equivalence rather than a quirk.
+			name: "name with a supported extension still prefers an appended extension",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "router.yml.json"),
+					[]byte(`{"marker":"appended-wins-name"}`), 0o644))
+				writeConfig(t, filepath.Join(dir, "router.yml"), "bare-loses")
+				return []string{"router.yml"}, "appended-wins-name"
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
@@ -239,13 +266,20 @@ func TestPointViperAtConfigNotFound(t *testing.T) {
 		msg := configNotFoundMessage(target, isFile)
 		require.Contains(t, msg, missing, "the message must name the path the operator gave")
 		require.NotContains(t, msg, "search paths",
-			"an explicit path was never searched for — mentioning search paths is what sent MAG-2861 the wrong way")
+			"an absolute path is resolved against nothing but itself — mentioning search paths for one is what sent MAG-2861 the wrong way")
+
+		for _, attr := range configLocationAttributes(target, isFile) {
+			require.NotEqual(t, "searched_paths", attr.Key,
+				"an absolute path has exactly one candidate; listing it as a search would be noise")
+		}
 	})
 
-	t.Run("missing relative path is a clean not-found naming that path", func(t *testing.T) {
-		// The whole point of MAG-2861 is that a path the operator named must not come back
-		// as a complaint about directories they never mentioned. A relative path is no
-		// less explicit than an absolute one.
+	t.Run("missing relative path names the path and the roots it was searched under", func(t *testing.T) {
+		// The point of MAG-2861 is that the diagnostics must describe the search that
+		// actually ran. A relative path *is* probed across configSearchPaths, so the message
+		// has to say so and the attributes have to list the candidates — an earlier cut of
+		// this asserted the search paths "were never consulted", which stopped being true
+		// the moment relative paths were resolved against them again.
 		dir := t.TempDir()
 		t.Chdir(dir)
 		viper.Reset()
@@ -253,7 +287,8 @@ func TestPointViperAtConfigNotFound(t *testing.T) {
 
 		target, isFile := pointViperAtConfig([]string{"nested/missing.yml"})
 		require.True(t, isFile, "a value naming a directory component is a path, not a name")
-		require.Equal(t, "nested/missing.yml", target)
+		require.Equal(t, "nested/missing.yml", target,
+			"an unresolvable path is reported as the operator typed it")
 
 		err := viper.ReadInConfig()
 		require.Error(t, err)
@@ -261,8 +296,18 @@ func TestPointViperAtConfigNotFound(t *testing.T) {
 
 		msg := configNotFoundMessage(target, isFile)
 		require.Contains(t, msg, "nested/missing.yml")
-		require.NotContains(t, msg, "search paths",
-			"the search paths were never consulted for an explicit path — naming them is the MAG-2861 confusion")
+		require.Contains(t, msg, "search paths",
+			"a relative path is resolved against them, so a miss that hides that is misleading")
+
+		attrs := map[string]string{}
+		for _, attr := range configLocationAttributes(target, isFile) {
+			attrs[attr.Key] = attr.Value.(string)
+		}
+		require.Contains(t, attrs, "searched_paths")
+		require.Contains(t, attrs["searched_paths"], filepath.Join("config", "nested", "missing.yml"),
+			"the candidate list must name where the file was actually looked for")
+		require.Contains(t, attrs, "working_directory",
+			"a relative lookup is only decipherable alongside the directory it resolved against")
 	})
 
 	t.Run("missing bare name reports the search paths", func(t *testing.T) {

--- a/protocol/rpcsmartrouter/config_source_test.go
+++ b/protocol/rpcsmartrouter/config_source_test.go
@@ -138,6 +138,63 @@ func TestPointViperAtConfigResolution(t *testing.T) {
 				return []string{"./router.yml"}, "dot-slash"
 			},
 		},
+		{
+			// The regression review caught: SetConfigName joined a *relative* path onto
+			// every search path perfectly well — filepath.Join only swallows a leading
+			// separator — so `smartrouter smartrouter_examples/smartrouter_eth.yml` from the
+			// project root has always loaded it out of ./config. Sending path-shaped
+			// arguments to SetConfigFile without re-probing the search paths narrowed
+			// resolution instead of fixing it.
+			name: "relative path resolves through the config search path",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				writeConfig(t, filepath.Join(dir, "config", "smartrouter_examples", "eth.yml"), "via-config-dir")
+				return []string{"smartrouter_examples/eth.yml"}, "via-config-dir"
+			},
+		},
+		{
+			// The same, for the last search path. lavaDefaultNodeHome is the literal
+			// "$HOME/.lava"; viper expands it through absPathify, so the path branch has to
+			// expand it too or this resolves against a directory named "$HOME".
+			name: "relative path resolves through the lava home search path",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				home := t.TempDir()
+				t.Setenv("HOME", home)
+				writeConfig(t, filepath.Join(home, ".lava", "sub", "router.yml"), "via-lava-home")
+				return []string{"sub/router.yml"}, "via-lava-home"
+			},
+		},
+		{
+			// Precedence must not change with the branch: the working directory is the first
+			// search path, so it wins over the ./config shadow for a path exactly as it does
+			// for a name.
+			name: "relative path prefers the working directory over the config directory",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				writeConfig(t, filepath.Join(dir, "sub", "router.yml"), "cwd-wins")
+				writeConfig(t, filepath.Join(dir, "config", "sub", "router.yml"), "shadowed")
+				return []string{"sub/router.yml"}, "cwd-wins"
+			},
+		},
+		{
+			// Extension appending applies inside a search path too, since that is what
+			// searchInPath did for the whole joined name.
+			name: "extensionless relative path resolves through the config search path",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				writeConfig(t, filepath.Join(dir, "config", "smartrouter_examples", "eth.yml"), "via-config-dir-ext")
+				return []string{"smartrouter_examples/eth"}, "via-config-dir-ext"
+			},
+		},
+		{
+			// MAG-2861 itself, stated as an invariant rather than a symptom: an absolute path
+			// must never be joined onto a search path. Join("./config", "/abs/x.yml") is
+			// "config/abs/x.yml" — the demotion this ticket removed — so a file planted at
+			// exactly that shadow location must lose to the real one.
+			name: "absolute path is not resolved against the search paths",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				abs := writeConfig(t, filepath.Join(dir, "elsewhere", "router.yml"), "absolute-wins")
+				writeConfig(t, filepath.Join(dir, "config", abs), "demoted-shadow")
+				return []string{abs}, "absolute-wins"
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
@@ -232,6 +289,29 @@ func TestPointViperAtConfigNotFound(t *testing.T) {
 			"a relative lookup is only decipherable alongside the directory it resolved against")
 	})
 
+	t.Run("a path that is a directory is a clean not-found, not a stack dump", func(t *testing.T) {
+		// Pointing viper at a directory fails with EISDIR rather than fs.ErrNotExist, which
+		// classified as "not a not-found" and so took the LavaFormatFatal path — the exact
+		// failure mode MAG-2861 exists to remove, reintroduced in a narrow case. Searching
+		// for a *name* never hit this: searchInPath skips directories.
+		dir := t.TempDir()
+		t.Chdir(dir)
+		viper.Reset()
+		t.Cleanup(viper.Reset)
+
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "config"), 0o755))
+
+		target, isFile := pointViperAtConfig([]string{"./config"})
+		require.True(t, isFile)
+
+		err := viper.ReadInConfig()
+		require.Error(t, err)
+		require.True(t, isConfigNotFound(err),
+			"a directory holds no config, so it must stay on the clean path, got %v", err)
+		require.Contains(t, configNotFoundMessage(target, isFile), "is a directory",
+			"the message should say what is actually wrong rather than claim the path is absent")
+	})
+
 	t.Run("malformed config is not mistaken for a missing one", func(t *testing.T) {
 		dir := t.TempDir()
 		t.Chdir(dir)
@@ -281,16 +361,26 @@ func TestIsConfigFilePath(t *testing.T) {
 	}
 }
 
-// TestConfigSearchPathsMatchDocumentedHelp keeps the command help honest: the Long text
-// tells operators which directories a bare name is looked up in, and it is the only place
-// that claim is written down.
+// TestConfigSearchPathsMatchDocumentedHelp keeps the command help honest: the Long text is
+// the only place the search paths are written down, and both commands that take a config
+// resolve it identically, so both have to say so. Documenting only rpcsmartrouter's left
+// health's argument undescribed, and describing the paths as applying to a bare *name*
+// left relative paths — which are resolved against them too — unaccounted for.
 func TestConfigSearchPathsMatchDocumentedHelp(t *testing.T) {
-	long := CreateRPCSmartRouterCobraCommand().Long
-	for _, path := range configSearchPaths {
-		if path == "." {
-			continue // spelled "the local running directory" in prose
-		}
-		require.True(t, strings.Contains(long, path),
-			"search path %q is not mentioned in the command help", path)
+	for name, long := range map[string]string{
+		"rpcsmartrouter": CreateRPCSmartRouterCobraCommand().Long,
+		"health":         CreateHealthCobraCommand().Long,
+	} {
+		t.Run(name, func(t *testing.T) {
+			for _, path := range configSearchPaths {
+				if path == "." {
+					continue // spelled "the local running directory" in prose
+				}
+				require.True(t, strings.Contains(long, path),
+					"search path %q is not mentioned in the command help", path)
+			}
+			require.Contains(t, long, "relative path",
+				"the help must say a relative path is resolved against the search paths too")
+		})
 	}
 }

--- a/protocol/rpcsmartrouter/config_source_test.go
+++ b/protocol/rpcsmartrouter/config_source_test.go
@@ -1,0 +1,229 @@
+package rpcsmartrouter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+// writeConfig drops a config carrying a distinctive marker, so a test can assert *which*
+// of several same-named candidates viper actually loaded rather than merely that it loaded
+// something.
+func writeConfig(t *testing.T, path, marker string) string {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("marker: "+marker+"\n"), 0o644))
+	return path
+}
+
+// TestPointViperAtConfigResolution is the regression net for MAG-2861: an absolute config
+// path used to be handed to viper as a config *name* and joined onto each search path
+// (filepath.Join(".", "/abs/x.yml") == "abs/x.yml"), so it could never resolve. Each case
+// asserts both that the config loads and that the *expected* file loaded.
+func TestPointViperAtConfigResolution(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// setup lays out files under the temp working directory and returns the args to
+		// pass, plus the marker of the file that must end up loaded.
+		setup func(t *testing.T, dir string) (args []string, wantMarker string)
+	}{
+		{
+			// The bug: this failed with "Not Found in [. ./config $HOME/.lava]".
+			name: "absolute path",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				abs := writeConfig(t, filepath.Join(dir, "elsewhere", "router.yml"), "absolute")
+				return []string{abs}, "absolute"
+			},
+		},
+		{
+			// An absolute path is loaded verbatim, so nothing appends an extension —
+			// the format has to be assumed. Every smartrouter config is YAML.
+			name: "absolute path without extension",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				abs := writeConfig(t, filepath.Join(dir, "elsewhere", "router"), "extensionless")
+				return []string{abs}, "extensionless"
+			},
+		},
+		{
+			// The form every scripts/pre_setups/ launcher uses, after cd-ing to the
+			// project root. It worked before only because "." is a search path.
+			name: "relative path",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				writeConfig(t, filepath.Join(dir, "config", "smartrouter_examples", "eth.yml"), "relative")
+				return []string{"config/smartrouter_examples/eth.yml"}, "relative"
+			},
+		},
+		{
+			name: "bare name resolved from the config search path",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				writeConfig(t, filepath.Join(dir, "config", "myconfig.yml"), "searched")
+				return []string{"myconfig"}, "searched"
+			},
+		},
+		{
+			// A name that carries an extension is still a name: the search path has to
+			// find it, since it names no directory of its own.
+			name: "bare name with extension resolved from the config search path",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				writeConfig(t, filepath.Join(dir, "config", "myconfig.yml"), "searched-ext")
+				return []string{"myconfig.yml"}, "searched-ext"
+			},
+		},
+		{
+			name: "no argument falls back to the default config name",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				writeConfig(t, filepath.Join(dir, DefaultRPCSmartRouterFileName), "default")
+				return nil, "default"
+			},
+		},
+		{
+			// Inline "host:port chain api-interface" triplets are not a config name;
+			// the default config is selected exactly as when no argument is given.
+			name: "inline endpoint args fall back to the default config name",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				writeConfig(t, filepath.Join(dir, DefaultRPCSmartRouterFileName), "default-inline")
+				return []string{"127.0.0.1:3333", "ETH1", "jsonrpc"}, "default-inline"
+			},
+		},
+		{
+			// The working directory wins over the ./config shadow, matching the search
+			// path's own precedence order — resolution must not change with the branch
+			// taken.
+			name: "working directory wins over the config directory",
+			setup: func(t *testing.T, dir string) ([]string, string) {
+				writeConfig(t, filepath.Join(dir, "myconfig.yml"), "cwd")
+				writeConfig(t, filepath.Join(dir, "config", "myconfig.yml"), "shadowed")
+				return []string{"myconfig.yml"}, "cwd"
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			// t.TempDir can hand back a symlinked path on macOS (/var -> /private/var);
+			// resolve it so an absolute-path assertion compares like for like.
+			if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+				dir = resolved
+			}
+			t.Chdir(dir)
+			viper.Reset()
+			t.Cleanup(viper.Reset)
+
+			args, wantMarker := tc.setup(t, dir)
+
+			_, _ = pointViperAtConfig(args)
+			require.NoError(t, viper.ReadInConfig())
+			require.Equal(t, wantMarker, viper.GetString("marker"),
+				"loaded %q, which is not the config this case names", viper.ConfigFileUsed())
+		})
+	}
+}
+
+// TestPointViperAtConfigNotFound covers the other half of MAG-2861: the message. Pointing
+// viper at an exact file makes a miss an fs.ErrNotExist rather than a
+// viper.ConfigFileNotFoundError, and the router's clean-error branch keyed only on the
+// latter — so a typo'd path would have taken the LavaFormatFatal stack-dump path instead.
+func TestPointViperAtConfigNotFound(t *testing.T) {
+	t.Run("missing absolute path is a clean not-found naming that path", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		viper.Reset()
+		t.Cleanup(viper.Reset)
+
+		missing := filepath.Join(dir, "nope", "router.yml")
+		target, isFile := pointViperAtConfig([]string{missing})
+		require.True(t, isFile, "an absolute path must be loaded as a file, not searched for as a name")
+
+		err := viper.ReadInConfig()
+		require.Error(t, err)
+		require.True(t, isConfigNotFound(err), "a missing explicit file must classify as not-found, got %v", err)
+
+		msg := configNotFoundMessage(target, isFile)
+		require.Contains(t, msg, missing, "the message must name the path the operator gave")
+		require.NotContains(t, msg, "search paths",
+			"an explicit path was never searched for — mentioning search paths is what sent MAG-2861 the wrong way")
+	})
+
+	t.Run("missing bare name reports the search paths", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		viper.Reset()
+		t.Cleanup(viper.Reset)
+
+		target, isFile := pointViperAtConfig(nil)
+		require.False(t, isFile)
+
+		err := viper.ReadInConfig()
+		require.Error(t, err)
+		require.True(t, isConfigNotFound(err))
+
+		require.Contains(t, configNotFoundMessage(target, isFile), "search paths")
+		attrs := configLocationAttributes(target, isFile)
+		var keys []string
+		for _, attr := range attrs {
+			keys = append(keys, attr.Key)
+		}
+		require.Contains(t, keys, "search_paths")
+		require.Contains(t, keys, "working_directory",
+			"a relative lookup is only decipherable alongside the directory it resolved against")
+	})
+
+	t.Run("malformed config is not mistaken for a missing one", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		viper.Reset()
+		t.Cleanup(viper.Reset)
+
+		broken := filepath.Join(dir, "broken.yml")
+		require.NoError(t, os.WriteFile(broken, []byte("this: [is not: valid\n"), 0o644))
+
+		pointViperAtConfig([]string{broken})
+		err := viper.ReadInConfig()
+		require.Error(t, err)
+		require.False(t, isConfigNotFound(err),
+			"a parse failure must stay on the loud path — it is not an operator typo")
+	})
+}
+
+// TestIsConfigFilePath pins the one judgement call in the resolution: which arguments are
+// treated as paths. Getting this wrong either resurrects MAG-2861 or breaks the bare-name
+// invocations that have always worked.
+func TestIsConfigFilePath(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeConfig(t, filepath.Join(dir, "here.yml"), "x")
+	writeConfig(t, filepath.Join(dir, "config", "there.yml"), "x")
+
+	for _, tc := range []struct {
+		arg  string
+		want bool
+		why  string
+	}{
+		{"/etc/smartrouter/config.yml", true, "an absolute path can never be resolved by the search paths"},
+		{"/etc/smartrouter/missing.yml", true, "absolute stays a path even when absent, so the error can name it"},
+		{"here.yml", true, "it resolves to a real file from the working directory"},
+		{"there.yml", false, "only ./config/there.yml exists, which is the search path's job"},
+		{"myconfig", false, "a bare name is looked up, with the extension appended"},
+		{"config", false, "a directory is not a config file"},
+		{"", false, "no argument means the default name"},
+	} {
+		require.Equal(t, tc.want, isConfigFilePath(tc.arg), "%q: %s", tc.arg, tc.why)
+	}
+}
+
+// TestConfigSearchPathsMatchDocumentedHelp keeps the command help honest: the Long text
+// tells operators which directories a bare name is looked up in, and it is the only place
+// that claim is written down.
+func TestConfigSearchPathsMatchDocumentedHelp(t *testing.T) {
+	long := CreateRPCSmartRouterCobraCommand().Long
+	for _, path := range configSearchPaths {
+		if path == "." {
+			continue // spelled "the local running directory" in prose
+		}
+		require.True(t, strings.Contains(long, path),
+			"search path %q is not mentioned in the command help", path)
+	}
+}

--- a/protocol/rpcsmartrouter/health_cmd.go
+++ b/protocol/rpcsmartrouter/health_cmd.go
@@ -194,19 +194,18 @@ func collectHealthProviders(args []string, includeBackup bool) ([]healthProvider
 		return providers, nil
 	}
 
-	// Config-file mode.
-	configName := DefaultRPCSmartRouterFileName
-	if len(args) == 1 {
-		configName = args[0]
-	}
+	// Config-file mode. The argument is a config file path (absolute or relative) or a
+	// bare name resolved against the search paths; see config_source.go.
 	viper.Reset()
-	viper.SetConfigName(configName)
-	viper.SetConfigType("yml")
-	viper.AddConfigPath(".")
-	viper.AddConfigPath("./config")
-	viper.AddConfigPath(lavaDefaultNodeHome)
+	configTarget, configIsFile := pointViperAtConfig(args)
 	if err := viper.ReadInConfig(); err != nil {
-		return nil, utils.LavaFormatError("failed reading config file", err, utils.Attribute{Key: "config", Value: configName})
+		// This command is what an operator reaches for when a config will not boot, so a
+		// config it cannot even find has to say where it looked, in the terms they used.
+		if isConfigNotFound(err) {
+			return nil, utils.LavaFormatError(configNotFoundMessage(configTarget, configIsFile), err,
+				configLocationAttributes(configTarget, configIsFile)...)
+		}
+		return nil, utils.LavaFormatError("failed reading config file", err, utils.Attribute{Key: "config", Value: configTarget})
 	}
 
 	keys := []string{commonlib.DirectRPCConfigName}

--- a/protocol/rpcsmartrouter/health_cmd.go
+++ b/protocol/rpcsmartrouter/health_cmd.go
@@ -89,7 +89,11 @@ never as a non-zero exit. Only a fatal setup error (bad config, missing --use-st
 exits non-zero, and even then a JSON envelope with a populated "error" is printed first.
 
 Endpoints can come from a smartrouter config file (probes every node-url under direct-rpc),
-or from inline "address chain-id api-interface" triplets like the rpcsmartrouter command.`,
+or from inline "address chain-id api-interface" triplets like the rpcsmartrouter command.
+
+The config argument resolves exactly as the rpcsmartrouter command's does: an absolute path
+names the file outright, while a relative path or a bare name is looked up in the local
+running directory, ./config, then ` + lavaDefaultNodeHome + `.`,
 		Example: `  smartrouter health config/smartrouter_examples/smartrouter_eth.yml --use-static-spec specs/
   smartrouter health https://eth1.lava.build ETH1 jsonrpc --use-static-spec specs/`,
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -18,8 +18,6 @@ package rpcsmartrouter
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"math"
 	"net/http"
 	"os/signal"
@@ -2738,9 +2736,10 @@ func CreateRPCSmartRouterCobraCommand() *cobra.Command {
 		SilenceUsage: true,
 		Long: `rpcsmartrouter sets up a centralized server with static and backup providers to perform api requests through the lava protocol.
 		This is the smart router mode that uses pre-configured static providers instead of dynamically discovering providers on-chain.
-		all configs should be located in the local running directory /config or ` + lavaDefaultNodeHome + `
 		if no arguments are passed, assumes default config file: ` + DefaultRPCSmartRouterFileName + `
-		if one argument is passed, its assumed the config file name
+		if one argument is passed, it is the config to load — either a path to the file
+		(absolute or relative to the working directory), or a bare name looked up in the
+		local running directory, ./config, or ` + lavaDefaultNodeHome + `
 		`,
 		Example: `required: --direct-rpc ...
 rpcsmartrouter <flags>
@@ -2766,16 +2765,9 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 			defer cancel()
 
 			var err error
-			// set viper
-			config_name := DefaultRPCSmartRouterFileName
-			if len(args) == 1 {
-				config_name = args[0] // name of config file (without extension)
-			}
-			viper.SetConfigName(config_name)
-			viper.SetConfigType("yml")
-			viper.AddConfigPath(".")
-			viper.AddConfigPath("./config")
-			viper.AddConfigPath(lavaDefaultNodeHome)
+			// set viper — the argument is a config file path (absolute or relative) or a
+			// bare name resolved against the search paths; see config_source.go.
+			configTarget, configIsFile := pointViperAtConfig(args)
 
 			// Bind all cobra flags to viper so viper.GetString/GetBool works.
 			// Previously Cosmos SDK's AddTxFlagsToCmd did this automatically.
@@ -2821,12 +2813,11 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 				// it as a clean, actionable error instead of a fatal stack-trace
 				// dump — reserve the loud path for genuinely unexpected read
 				// failures like malformed YAML.
-				var notFound viper.ConfigFileNotFoundError
-				if errors.As(err, &notFound) {
+				if isConfigNotFound(err) {
 					return utils.LavaFormatError(
-						"no config file found — pass a config file as an argument (e.g. `smartrouter <config-file>.yml`), or place "+DefaultRPCSmartRouterFileName+" in one of the search paths",
+						configNotFoundMessage(configTarget, configIsFile),
 						err,
-						utils.Attribute{Key: "config_name", Value: DefaultRPCSmartRouterFileName},
+						configLocationAttributes(configTarget, configIsFile)...,
 					)
 				}
 				utils.LavaFormatFatal("could not load config file", err, utils.Attribute{Key: "expected_config_name", Value: viper.ConfigFileUsed()})

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -2738,15 +2738,17 @@ func CreateRPCSmartRouterCobraCommand() *cobra.Command {
 		Long: `rpcsmartrouter sets up a centralized server with static and backup providers to perform api requests through the lava protocol.
 		This is the smart router mode that uses pre-configured static providers instead of dynamically discovering providers on-chain.
 		if no arguments are passed, assumes default config file: ` + DefaultRPCSmartRouterFileName + `
-		if one argument is passed, it is the config to load — either a path to the file
-		(absolute or relative to the working directory), or a bare name looked up in the
-		local running directory, ./config, or ` + lavaDefaultNodeHome + `
+		if one argument is passed, it is the config to load. An absolute path names the file
+		outright; anything else — a relative path, or a bare name — is looked up in the
+		local running directory, ./config, then ` + lavaDefaultNodeHome + `.
+		An argument without a recognized extension has the supported ones appended, so
+		"akash" and "config/akash" both find config/akash.yml.
 		`,
 		Example: `required: --direct-rpc ...
 rpcsmartrouter <flags>
 rpcsmartrouter rpcsmartrouter_conf <flags>
 rpcsmartrouter 127.0.0.1:3333 OSMOSIS tendermintrpc 127.0.0.1:3334 OSMOSIS rest <flags>
-rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127.0.0.1:7778" [--debug-relays] --log_level <debug|warn|...>`,
+rpcsmartrouter smartrouter_examples/smartrouter_eth.yml --cache-be "127.0.0.1:7778" [--debug-relays] --log_level <debug|warn|...>`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			// Optionally run one of the validators provided by cobra
 			if err := cobra.RangeArgs(0, 1)(cmd, args); err == nil {

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -18,6 +18,7 @@ package rpcsmartrouter
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"math"
 	"net/http"
 	"os/signal"


### PR DESCRIPTION
# Description

`smartrouter /abs/path/config.yml` always failed, even with the file present and readable, and the error named search directories the operator never mentioned:

```
Config File "/abs/path/config.yml" Not Found in "[/repo /repo/config ~/.lava]"
```

The argument was handed to viper's `SetConfigName`, which treats its value as a **name** joined onto each search path — and `filepath.Join` swallows the leading separator, so `Join(".", "/abs/path/config.yml")` is `"abs/path/config.yml"`. Every absolute path was quietly demoted to a relative one and looked for *inside* each search directory, where it could never exist. I reproduced this against viper v1.21.0 in isolation before changing anything:

```
what viper actually looks for under ".": "var/folders/.../router.yml"
OLD -> Config File "/var/folders/.../router.yml" Not Found in "[. ./config ~/.lava]"
```

Relative paths worked only by coincidence, on two of them: `.` happens to be a search path, and `searchInPath` only falls back to the bare name — without appending an extension — because `SetConfigType("yml")` happens to be set. That is why every script under `scripts/pre_setups/` has to `cd` to the project root first, and why the one that did not (the Sui script, on MAG-2643) read as a broken router until the cause was traced.

## What changed

Resolution now lives in `protocol/rpcsmartrouter/config_source.go` (**the file to review**), shared by the two commands that take a config so they cannot drift:

- an argument that **names a directory component** — absolute, or containing a separator — is an explicit path and goes to `SetConfigFile`
- **anything else is a name** and keeps the name-plus-search-path lookup untouched, which is what lets a bare `smartrouter myconfig` still find `./config/myconfig.yml`

The classification is **lexical and does not consult the filesystem**. What is being decided is what the operator *meant*, and that must not vary with the contents of the working directory. An earlier revision of this PR keyed on `os.Stat`; review caught that it made a bare `smartrouter router` load an extension-less `./router` in preference to the `./router.yml` the search path has always returned, and it also sent a missing `nested/missing.yml` down the name branch, reproducing the very search-directory error this ticket exists to remove. Both are fixed in c28d095 and both have regression tests.

The lexical split is only safe because extension resolution moved with it. `smartrouter config/akash` has always resolved to `config/akash.yml` via `searchInPath`'s extension loop; `resolveConfigFilePath` now does the same for an explicit path, trying viper's `SupportedExts` in viper's own order and preferring an extension to the bare path exactly as `searchInPath` does. **The two branches resolve an argument identically** — the only thing the branch changes is which error message you get when nothing is there. (This was *not* true of `c28d095`, which dropped the search paths for relative paths; see the review fixes below.)

## Two consequences of `SetConfigFile` that had to be handled

Without these the fix would have traded a confusing message for a worse one.

**It changes the error type.** A missing searched name is `viper.ConfigFileNotFoundError`; a missing explicit file is a plain `fs.ErrNotExist` from the open. `rpcsmartrouter.go`'s clean-error branch keyed only on the former, so a typo'd path would have fallen through to `LavaFormatFatal` and dumped a stack trace instead of saying the file is not there. `isConfigNotFound` covers both.

**It disables extension-appending**, so an extension-less path needs an explicit `configType` or viper rejects it as `UnsupportedConfigError` before opening the file at all. A recognized extension now declares the format; everything else assumes YAML, which every smartrouter config is.

Messages report where the config was looked for in the terms the operator used — an exact path names that path, its resolved absolute form and the working directory; a bare name names the search paths:

```
ERR config file not found at the given path: /etc/smartrouter/typo.yml
    error="open /etc/smartrouter/typo.yml: no such file or directory"
    config_file=/etc/smartrouter/typo.yml resolved_path=/etc/smartrouter/typo.yml
    working_directory=/repo
```

`health_cmd.go` resolved its config the same way and had the same behaviour, as the ticket suspected — it now shares the helper, and reports a missing config inside its JSON envelope rather than as a generic read failure. Its `Long` now documents how its config argument resolves, which it never did.

The router's own `Long` claimed configs "should be located in the local running directory /config or `$HOME/.lava`"; it now documents that a path works, and that a relative path is still resolved against those directories.

## Review fixes (c28d095)

- **The first commit did not compile.** Dropping the now-unused `errors` import took `fmt` with it, and `fmt` is used at 22 sites in `rpcsmartrouter.go`. The build and test results quoted on `ab53600` were not run against its content. Restored, and the committed tree is now verified from a clean worktree checkout rather than from the working directory.
- **Path/name classification** reworked from `os.Stat` to lexical, as described above.

## Review fixes (062e9e6)

Review found that the lexical split fixed absolute paths but **narrowed** relative ones, and I reproduced both findings before changing anything.

**Relative paths lost two of the three search paths.** `filepath.Join` swallows only a *leading* separator, so it destroyed absolute paths while handling relative ones perfectly — `SetConfigName` + `AddConfigPath` already resolved `smartrouter_examples/smartrouter_eth.yml` to `config/smartrouter_examples/smartrouter_eth.yml`. Sending every path-shaped argument to `SetConfigFile` resolved it against the working directory alone, so that invocation stopped loading, as did anything under `$HOME/.lava`. Measured against binaries built from each commit, from the repo root:

| | `c28d095` | `062e9e6` |
|---|---|---|
| `smartrouter smartrouter_examples/smartrouter_eth.yml` | `config file not found at the given path` | loads |

`resolveConfigFilePath` now probes a relative path against `configSearchPaths` in the same precedence order a bare name uses, each candidate through the extension loop it already had. Absolute paths are still never joined onto a search path — that join *is* MAG-2861 — and a test now pins it as an invariant rather than as a symptom, by planting a decoy at the exact location the demotion would have found. `lavaDefaultNodeHome` is the literal `"$HOME/.lava"` and viper expands it via `absPathify`, so the path branch expands it too; without that it would resolve against a directory named `$HOME`.

This restores the "strictly additive" property the checklist claims. It was not true of `c28d095`.

**A path argument naming a directory took the fatal path.** Viper fails with `EISDIR`, not `fs.ErrNotExist`, so `smartrouter ./config` classified as "not a not-found" and fell through to `LavaFormatFatal` — the exact stack-dump failure mode this PR exists to remove, in a narrow case. `isConfigNotFound` covers `EISDIR`, and the message says what is actually wrong:

```
ERR the given config path is a directory, not a config file: ./config
    error="read ./config: is a directory"
```

Stack-dump lines for that invocation: **1** on `c28d095`, **0** on `062e9e6`.

**Help text.** Both commands now state that a relative path is resolved against the search paths too — the previous wording attached them to bare names only, which is the documentation gap the first finding hid behind. `TestConfigSearchPathsMatchDocumentedHelp` now checks both commands and asserts the relative-path claim is present. The router's `Example` named `smartrouter_examples/full_smartrouter_example.yml`, which does not exist in the repo; it now names one that does.


## Review fixes (88d3074)

Two compatibility gaps in `062e9e6`, both reproduced before changing anything.

**Supported-extension paths did not follow viper's suffix order.** `searchInPath` appends every supported extension to `v.configName` *unconditionally* — it never checks whether the name already ends in one — so `sub/router.yml` has always been able to resolve to `sub/router.yml.json`. `resolveWithSupportedExt` short-circuited on a recognized extension, which looks obviously right and was the last way the two branches could still disagree:

| arg | on disk | `062e9e6` | `88d3074` |
|---|---|---|---|
| `sub/router.yml` | `sub/router.yml.json` | `open sub/router.yml: no such file or directory` | loads `sub/router.yml.json` |

The layout is pathological, but "strictly additive" has to cover it. The short-circuit is gone and appended forms are tried first for every candidate. Two tests pin it: one on the path branch, one on the name branch — which never stopped doing this — so the pair asserts an equivalence rather than a quirk.

**The not-found diagnostics described a search that no longer matched the one that ran.** Once relative paths were probed across `configSearchPaths` again, naming only the path and the working directory understated it, and a test asserted the search paths "were never consulted" — true of an absolute path, false of a relative one. The message now says so, and the attributes carry the exact candidate list rather than a restatement of `configSearchPaths`:

```
ERR config file not found: nested/missing.yml — a relative path is resolved against each of the search paths
    error="open nested/missing.yml: no such file or directory"
    searched_paths="nested/missing.yml config/nested/missing.yml /Users/x/.lava/nested/missing.yml"
```

Absolute paths are unchanged — they still name nothing but themselves, and a test asserts no candidate list is attached to them, since that would re-introduce the MAG-2861 confusion from the other direction.


## Testing

28 subtests pin the resolution matrix (absolute, extension-less absolute, relative, `./`-prefixed, extension-less path, bare name with and without extension, default, inline endpoint args, cwd-beats-`./config` precedence, and extension-beats-extension-less in both branches), all three not-found shapes, and that a malformed config stays on the loud path rather than being mistaken for a missing one.

Each of the three review regressions was verified to **fail against a faithful replica of `ab53600`'s logic**. Worth noting for anyone reproducing: restoring the `os.Stat` classification alone is not enough to reproduce the `router`/`router.yml` shadowing, because the new extension resolution masks it — the replica also has to drop `resolveConfigFilePath`.

Verified end to end against a binary built from the committed tree in an isolated worktree:

| Case | Result |
|---|---|
| Absolute path, run from `/tmp` | loads (was the bug) |
| `config/smartrouter_examples/smartrouter_eth.yml` from repo root — every `pre_setups` launcher | still loads |
| Bare name via `./config` | still loads |
| Missing absolute path | clean error naming the path, no stack dump |
| Missing relative path `nested/missing.yml` | `config file not found at the given path: nested/missing.yml` |
| `smartrouter router` with both `router` and `router.yml` present | loads `router.yml` |
| `smartrouter config/akash` with only `config/akash.yml` present | loads `config/akash.yml` |
| No argument, no config | original search-path message preserved |
| `smartrouter_examples/smartrouter_eth.yml` from repo root | loads via `./config` (regressed by `c28d095`) |
| `smartrouter_examples/smartrouter_eth` (no extension) from repo root | loads via `./config` |
| Relative path present under `$HOME/.lava` | loads |
| Absolute path with a decoy at the demotion location | loads the real file, not the decoy |
| `smartrouter ./config` (a directory) | `the given config path is a directory, not a config file`, no stack dump |
| `sub/router.yml` with only `sub/router.yml.json` present | loads the `.json`, matching `searchInPath` |
| Missing relative path | names the path *and* the three candidates probed |
| Missing absolute path | names that path only, no candidate list |
| `health <abs path>` | resolves, probes ran |
| `health <missing abs path>` | clean error inside the JSON envelope, exit 0 contract intact |

`go build ./...`, `go vet` and the full `protocol/rpcsmartrouter` suite pass; `gofmt` clean.

**CI note, so the green checks are not read for more than they are:** this repo has no unit-test lane. The workflows run lint, `govulncheck`, cross-platform builds, the Docker image, GoReleaser config, Jira validation and the labeler — but nothing invokes `go test`. Every subtest cited above is local evidence only, reproducible with:

```
go test ./protocol/rpcsmartrouter/ -run 'TestPointViperAtConfig|TestIsConfigFilePath|TestConfigSearchPaths' -v
```

Out of scope: the `scripts/pre_setups/` launchers still `cd` and pass relative paths. They work and changing them is churn this fix does not need.

## Jira ticket

Jira ticket: MAG-2861

---

## Author Checklist

I have...

* [x] read the [contribution guide](https://github.com/magma-Devs/smart-router/blob/main/CONTRIBUTING.md)
* [x] included the correct type prefix in the PR title (`fix`)
* [x] confirmed `!` in the type prefix if API or client breaking change — not applicable, strictly additive: every argument form that resolved before resolves to the same file
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification — MAG-2861
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests
* [x] updated the relevant documentation or specification, including comments for documenting Go code — command `Long` help and package comments in `config_source.go`
* [x] confirmed all CI checks have passed — all green on `88d3074` (see the CI note under Testing: none of them is a unit-test lane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)




