### PR TITLE
feat(smart-router): add --skip-all-verifications flag

### DIFF
--- a/protocol/chainlib/base_chain_parser.go
+++ b/protocol/chainlib/base_chain_parser.go
@@ -23,7 +23,12 @@ import (
 
 var (
 	SkipWebsocketVerification = false
-	DefaultApiName            = "Default-"
+	// SkipAllVerifications is the process-wide off switch behind --skip-all-verifications.
+	// Read through chainlib.skipVerification, so it suppresses the latest-block probe as well
+	// as the verifications themselves. Bound by the rpcsmartrouter command only — the health
+	// command deliberately does not expose it, since reporting verification results is its job.
+	SkipAllVerifications = false
+	DefaultApiName       = "Default-"
 )
 
 type PolicyInf interface {

--- a/protocol/chainlib/chain_fetcher.go
+++ b/protocol/chainlib/chain_fetcher.go
@@ -91,6 +91,15 @@ func (cf *ChainFetcher) getVerificationsKey(verification VerificationContainer, 
 	return key
 }
 
+// skipVerification is the single gate deciding whether a verification runs for a node-url.
+// Two independent sources can suppress it: the per-node-url skip-verifications config (with
+// its "*" wildcard), and the process-wide --skip-all-verifications flag. Everything that
+// acts on behalf of a verification must go through here — including needsLatestBlock, so a
+// suppressed verification cannot drag the latest-block probe out to the upstream anyway.
+func skipVerification(url common.NodeUrl, name string) bool {
+	return SkipAllVerifications || url.ShouldSkipVerification(name)
+}
+
 // needsLatestBlock reports whether any verification that will ACTUALLY RUN for this
 // node-url depends on the chain head, and therefore whether Validate has to spend a
 // FetchLatestBlockNum relay against the upstream before verifying.
@@ -102,7 +111,7 @@ func (cf *ChainFetcher) getVerificationsKey(verification VerificationContainer, 
 // the burst still got its provider demoted with every verification skipped.
 func needsLatestBlock(url common.NodeUrl, verifications []VerificationContainer) bool {
 	for _, v := range verifications {
-		if url.ShouldSkipVerification(v.Name) {
+		if skipVerification(url, v.Name) {
 			continue
 		}
 		if v.Value == "" && v.LatestDistance != 0 {
@@ -140,7 +149,7 @@ func (cf *ChainFetcher) Validate(ctx context.Context) error {
 		// invalidating cache as value might change
 		defer cf.invalidateVerificationsCache()
 		for _, verification := range verifications {
-			if url.ShouldSkipVerification(verification.Name) {
+			if skipVerification(url, verification.Name) {
 				utils.LavaFormatInfo("Skipping Verification due to provider configuration (skip-verifications setting)", utils.LogAttr("verification", verification.Name))
 				continue
 			}
@@ -221,7 +230,7 @@ func (cf *ChainFetcher) ValidateCollect(ctx context.Context) []NodeURLValidation
 		nodeResult.LatestBlock = latestBlock
 
 		for _, verification := range verifications {
-			if url.ShouldSkipVerification(verification.Name) {
+			if skipVerification(url, verification.Name) {
 				continue
 			}
 			var verifyErr error

--- a/protocol/chainlib/needs_latest_block_test.go
+++ b/protocol/chainlib/needs_latest_block_test.go
@@ -54,7 +54,7 @@ func TestNeedsLatestBlock(t *testing.T) {
 		},
 		{
 			name:          "wildcard drops the fetch",
-			skip:          []string{common.SkipAllVerifications},
+			skip:          []string{common.SkipVerificationsWildcard},
 			verifications: []VerificationContainer{headDependent("pruning"), headDependent("trace")},
 			want:          false,
 		},

--- a/protocol/chainlib/skip_all_verifications_test.go
+++ b/protocol/chainlib/skip_all_verifications_test.go
@@ -1,0 +1,65 @@
+package chainlib
+
+import (
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// withSkipAll flips the process-wide flag for one test and restores it, so a failure
+// cannot leak the "verification is off" state into every later test in the package.
+func withSkipAll(t *testing.T, v bool) {
+	t.Helper()
+	prev := SkipAllVerifications
+	SkipAllVerifications = v
+	t.Cleanup(func() { SkipAllVerifications = prev })
+}
+
+// skipVerification is the single gate every verification-driven probe consults. The flag
+// and the per-node-url config are independent sources of suppression; neither may mask a
+// bug in the other.
+func TestSkipVerification_FlagAndConfig(t *testing.T) {
+	plain := common.NodeUrl{Url: "https://example.invalid"}
+	named := common.NodeUrl{Url: "https://example.invalid", SkipVerifications: []string{"pruning"}}
+	wild := common.NodeUrl{Url: "https://example.invalid", SkipVerifications: []string{common.SkipVerificationsWildcard}}
+
+	t.Run("flag off: nothing is skipped without config", func(t *testing.T) {
+		withSkipAll(t, false)
+		require.False(t, skipVerification(plain, "pruning"))
+		require.False(t, skipVerification(plain, "chain-id"))
+	})
+
+	t.Run("flag off: config still governs", func(t *testing.T) {
+		withSkipAll(t, false)
+		require.True(t, skipVerification(named, "pruning"))
+		require.False(t, skipVerification(named, "chain-id"), "a named skip must not spill onto other verifications")
+		require.True(t, skipVerification(wild, "chain-id"), "the config wildcard still works with the flag off")
+	})
+
+	t.Run("flag on: every verification is skipped, config irrelevant", func(t *testing.T) {
+		withSkipAll(t, true)
+		require.True(t, skipVerification(plain, "pruning"))
+		require.True(t, skipVerification(plain, "chain-id"))
+		require.True(t, skipVerification(plain, "some-verification-nobody-enumerated"))
+		require.True(t, skipVerification(named, "chain-id"))
+	})
+
+	t.Run("flag defaults to off", func(t *testing.T) {
+		require.False(t, SkipAllVerifications, "the process-wide switch must be opt-in")
+	})
+}
+
+// The flag has to suppress the latest-block probe too, not just the verifications. That probe
+// is a real relay whose failure aborts Validate and demotes the provider, so a flag that left
+// it running would not actually stop the router touching the upstream.
+func TestSkipAllVerifications_SuppressesLatestBlockFetch(t *testing.T) {
+	url := common.NodeUrl{Url: "https://example.invalid"}
+	headDependent := []VerificationContainer{{Name: "pruning", LatestDistance: 100}}
+
+	withSkipAll(t, false)
+	require.True(t, needsLatestBlock(url, headDependent), "baseline: a live head-dependent verification needs the fetch")
+
+	withSkipAll(t, true)
+	require.False(t, needsLatestBlock(url, headDependent), "the flag must drop the latest-block probe as well")
+}

--- a/protocol/common/cobra_common.go
+++ b/protocol/common/cobra_common.go
@@ -105,6 +105,10 @@ const (
 	LimitParallelWebsocketConnectionsPerIpFlag   = "limit-parallel-websocket-connections-per-ip"
 	LimitWebsocketIdleTimeFlag                   = "limit-websocket-connection-idle-time"
 	SkipWebsocketVerificationFlag                = "skip-websocket-verification"
+	// SkipAllVerificationsFlag turns spec verification off process-wide. Broader than the
+	// per-node-url "*" wildcard in skip-verifications: it covers EVERY provider this process
+	// serves, healthy ones included. Prefer the wildcard for anything ongoing.
+	SkipAllVerificationsFlag = "skip-all-verifications"
 	// specification default flags
 	ProbeUpdateWeightFlagName = "probe-update-weight"
 	// ProbeLoopIntervalFlagName is the cadence of the MAG-2161 (Topic D) proactive health prober —

--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -125,22 +125,22 @@ type NodeUrl struct {
 	GrpcConfig GrpcConfig `yaml:"grpc-config,omitempty" json:"grpc-config,omitempty" mapstructure:"grpc-config"`
 }
 
-// SkipAllVerifications is the sentinel a node-url's skip-verifications list can carry
+// SkipVerificationsWildcard is the sentinel a node-url's skip-verifications list can carry
 // to suppress every verification the spec defines for that url, without enumerating
 // each name. Follows the wildcard idiom the cors-* flags already use.
 //
 // It must be quoted in YAML (`skip-verifications: ["*"]`) — a bare * opens an alias.
-const SkipAllVerifications = "*"
+const SkipVerificationsWildcard = "*"
 
 // ShouldSkipVerification reports whether this node-url's skip-verifications list
-// suppresses the named verification, honouring the SkipAllVerifications wildcard.
+// suppresses the named verification, honouring the SkipVerificationsWildcard wildcard.
 //
 // Callers must consult this before doing ANY work on behalf of a verification —
 // including the shared latest-block fetch that several verifications depend on.
 // Probing an upstream for a verification that is about to be skipped is what made
 // skip-verifications fail to actually skip.
 func (nurl NodeUrl) ShouldSkipVerification(name string) bool {
-	return slices.Contains(nurl.SkipVerifications, SkipAllVerifications) ||
+	return slices.Contains(nurl.SkipVerifications, SkipVerificationsWildcard) ||
 		slices.Contains(nurl.SkipVerifications, name)
 }
 

--- a/protocol/common/skip_verifications_test.go
+++ b/protocol/common/skip_verifications_test.go
@@ -21,13 +21,13 @@ func TestShouldSkipVerification(t *testing.T) {
 		{"exact name matches", []string{"pruning"}, "pruning", true},
 		{"unrelated name does not match", []string{"pruning"}, "chain-id", false},
 		{"one of several matches", []string{"pruning", "trace", "chain-id"}, "trace", true},
-		{"wildcard matches any name", []string{SkipAllVerifications}, "chain-id", true},
-		{"wildcard matches a name nobody enumerated", []string{SkipAllVerifications}, "tracking-shard-11", true},
-		{"wildcard alongside explicit names still matches", []string{"pruning", SkipAllVerifications}, "enabled", true},
+		{"wildcard matches any name", []string{SkipVerificationsWildcard}, "chain-id", true},
+		{"wildcard matches a name nobody enumerated", []string{SkipVerificationsWildcard}, "tracking-shard-11", true},
+		{"wildcard alongside explicit names still matches", []string{"pruning", SkipVerificationsWildcard}, "enabled", true},
 		{"wildcard is the literal star only", []string{"*pruning"}, "pruning", false},
 		{"match is case sensitive", []string{"Pruning"}, "pruning", false},
 		{"empty query is not matched by an explicit list", []string{"pruning"}, "", false},
-		{"empty query IS matched by the wildcard", []string{SkipAllVerifications}, "", true},
+		{"empty query IS matched by the wildcard", []string{SkipVerificationsWildcard}, "", true},
 	}
 
 	for _, tc := range playbook {
@@ -40,6 +40,6 @@ func TestShouldSkipVerification(t *testing.T) {
 
 // The wildcard is a config-surface constant; pinning it guards against a rename
 // silently invalidating every deployed values file that carries it.
-func TestSkipAllVerificationsToken(t *testing.T) {
-	require.Equal(t, "*", SkipAllVerifications)
+func TestSkipVerificationsWildcardToken(t *testing.T) {
+	require.Equal(t, "*", SkipVerificationsWildcard)
 }

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -3049,6 +3049,7 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	cmdRPCSmartRouter.Flags().DurationVar(&chainlib.WebSocketBanDuration, common.BanDurationForWebsocketRateLimitExceededFlag, chainlib.WebSocketBanDuration, "once websocket rate limit is reached, user will be banned Xfor a duration, default no ban")
 
 	cmdRPCSmartRouter.Flags().BoolVar(&chainlib.SkipWebsocketVerification, common.SkipWebsocketVerificationFlag, chainlib.SkipWebsocketVerification, "skip websocket verification for chains that require ws/wss endpoints")
+	cmdRPCSmartRouter.Flags().BoolVar(&chainlib.SkipAllVerifications, common.SkipAllVerificationsFlag, chainlib.SkipAllVerifications, "skip ALL spec verifications for every provider this process serves, healthy ones included. An escape hatch for bringing a router up against upstreams that cannot survive being probed; prefer the per-node-url skip-verifications config (which accepts \"*\") for anything ongoing")
 
 	cmdRPCSmartRouter.Flags().DurationVar(&lavasession.ProbeLoopInterval, common.ProbeLoopIntervalFlagName, lavasession.ProbeLoopInterval, "cadence of the proactive health prober (MAG-2161 Topic D); must be > 0, default 5s")
 	cmdRPCSmartRouter.Flags().Float64(common.ProbeUpdateWeightFlagName, scoreutils.DefaultProbeUpdateWeight, "weight multiplier for provider-optimizer probe updates (liveness/latency); must be > 0")


### PR DESCRIPTION
#Closes MAG-2883

Jira ticket: MAG-2883

> **Stacked on PR #296** ("fix(chainlib): make skip-verifications actually skip, and add a skip-all wildcard", MAG-2873). Base branch is `mag-2873`, so the diff here is just this change. Merge #296 first.

## Why

`--skip-websocket-verification` already exists as a process-wide switch over one verification family. This generalises the same shape to all of them.

PR #296 adds the per-node-url `"*"` wildcard, which is config-driven and targeted — the right tool for steady state. What it doesn't cover is the operational case: bringing a router up *now* against upstreams that can't survive being probed, without editing and redeploying config for every node.

## What changed

- `protocol/common/cobra_common.go` — `SkipAllVerificationsFlag = "skip-all-verifications"`, next to the websocket flag.
- `protocol/chainlib/base_chain_parser.go` — `SkipAllVerifications` package bool, default false, next to `SkipWebsocketVerification`.
- `protocol/rpcsmartrouter/rpcsmartrouter.go` — bound with `BoolVar`, exactly as the websocket flag is.
- `protocol/chainlib/chain_fetcher.go` — new `skipVerification(url, name)` gate where the config wildcard and the flag meet. The three existing call sites route through it.

**The gate placement is the load-bearing part.** `needsLatestBlock` consults it too, so the flag also suppresses the latest-block probe. A flag that skipped the verifications but left that probe running would still relay to the upstream — and that probe's failure is precisely what demotes a provider (the bug #296 fixes). Covered by a test.

**Not exposed on `smartrouter health`.** That command exists to report verification results; a switch turning them all off makes it report nothing. `--skip-websocket-verification` is on `health` because excluding one transport still leaves a meaningful probe. Asserted by the verification steps below.

## One rename

`common.SkipAllVerifications` (the `"*"` token, introduced in #296, never released) becomes `common.SkipVerificationsWildcard`. Without it, a string token and a bool would sit one package apart under the same name. The new name also just says what it is.

## Safety — please weigh this in review

This is a bigger hammer than the wildcard and the flag help text says so.

`skip_verifications: "*"` targets one vendor on one node. This flag disables verification for **every provider the process serves, healthy ones included**. On the production fleet each router process serves one chain with two providers, so it would also stop verifying the primary — and verification is exactly what caught dwellir on STRK mainnet being unable to serve `trace` at all. Prefer the per-node wildcard for anything ongoing.

## How to verify

```
go build ./... && go vet ./protocol/common/ ./protocol/chainlib/ ./protocol/rpcsmartrouter/
go test ./protocol/common/ ./protocol/chainlib/ ./protocol/rpcsmartrouter/
go test ./protocol/chainlib/ -run 'TestSkipVerification_FlagAndConfig|TestSkipAllVerifications_SuppressesLatestBlockFetch' -v

# registered on the router command, absent from health
go run ./cmd/smartrouter rpcsmartrouter --help | grep skip-all-verifications
go run ./cmd/smartrouter health --help | grep -c skip-all-verifications   # expect 0
```

The tests cover both suppression sources independently, so neither can mask a bug in the other: flag off + no config skips nothing; flag off + config still governs (including that a named skip does not spill onto other verifications); flag on skips everything regardless of config; and the flag defaults to off.