### PR TITLE
fix(smart-router): stop the relay timeout from bounding gRPC descriptor lookups

### DIFF
--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -330,17 +330,40 @@ func (gc *GrpcConfig) Validate() error {
 	}
 
 	// Validate reflection timeout bounds
-	if gc.ReflectionTimeout > 0 {
-		if gc.ReflectionTimeout < 100*time.Millisecond {
-			return utils.LavaFormatError("reflection-timeout too short", nil,
-				utils.LogAttr("timeout", gc.ReflectionTimeout),
-				utils.LogAttr("min", "100ms"))
-		}
-		if gc.ReflectionTimeout > 30*time.Second {
-			return utils.LavaFormatError("reflection-timeout too long", nil,
-				utils.LogAttr("timeout", gc.ReflectionTimeout),
-				utils.LogAttr("max", "30s"))
-		}
+	if err := gc.ValidateReflectionTimeout(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ValidateReflectionTimeout checks the reflection-timeout bounds on their own.
+//
+// Split out of Validate because the request path needs exactly this check and
+// nothing else. GetReflectionTimeout is what budgets gRPC descriptor lookups, so
+// an out-of-bounds value there is not cosmetic: a nanosecond timeout fails every
+// lookup on the endpoint, and a multi-minute one holds a pooled client for that
+// long. Validate as a whole cannot stand in — it also requires a descriptor-set
+// path for "hybrid", which DescriptorSourceForNode deliberately tolerates by
+// degrading to reflection, so calling it from the connection path would reject
+// configurations that work today.
+func (gc *GrpcConfig) ValidateReflectionTimeout() error {
+	// Bound what GetReflectionTimeout will actually return, which is the 5s default
+	// for anything <= 0. Rejecting a value the getter never yields would make a
+	// config invalid and harmless at the same time.
+	if gc == nil || gc.ReflectionTimeout <= 0 {
+		return nil
+	}
+
+	if gc.ReflectionTimeout < 100*time.Millisecond {
+		return utils.LavaFormatError("reflection-timeout too short", nil,
+			utils.LogAttr("timeout", gc.ReflectionTimeout),
+			utils.LogAttr("min", "100ms"))
+	}
+	if gc.ReflectionTimeout > 30*time.Second {
+		return utils.LavaFormatError("reflection-timeout too long", nil,
+			utils.LogAttr("timeout", gc.ReflectionTimeout),
+			utils.LogAttr("max", "30s"))
 	}
 
 	return nil

--- a/protocol/lavasession/direct_rpc_close_race_test.go
+++ b/protocol/lavasession/direct_rpc_close_race_test.go
@@ -334,9 +334,16 @@ func TestSendRequest_ReturnsBorrowedClientExactlyOnce(t *testing.T) {
 	_, err := g.SendRequest(ctx, []byte("{}"), grpcTestHeaders())
 	require.Error(t, err)
 
+	// Two borrows, not one: the descriptor lookup takes a client of its own rather
+	// than riding on the relay's, because it outlives the relay by design and the
+	// relay hands its client back the moment it gives up (MAG-2860). The count is
+	// not racy — the lookup returns its client before it publishes its result, and
+	// the relay does not return its own until it has read that result.
 	returned := fake.returnedConns()
-	require.Len(t, returned, 1)
-	require.Same(t, conn, returned[0])
+	require.Len(t, returned, 2, "each borrowed client must be handed back exactly once")
+	for i, got := range returned {
+		require.Same(t, conn, got, "return %d", i)
+	}
 }
 
 // TestClose_DuringFirstInitialization_DoesNotPublishConnector closes the window

--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -83,6 +83,26 @@ type DirectRPCConnection interface {
 	GetNodeUrl() *common.NodeUrl
 }
 
+// DirectRPCPrewarmer is an optional interface for connections that have setup
+// work worth doing BEFORE the endpoint holding them is published.
+//
+// It exists for gRPC descriptor resolution (MAG-2860). Everything else about a
+// direct connection is either free at construction or bounded by the relay that
+// needs it; descriptor reflection is neither, and a relay that arrives before it
+// has happened is the one that pays — which for cross-validation, needing N
+// successes in one request, reads as an outage rather than a slow first call.
+//
+// The contract is a boundary, not a guarantee of success: Prewarm returns when
+// the connection is as ready as it is going to get, and a failure is a reason to
+// publish the endpoint anyway, not to withhold it. Boot must not become fatal on
+// upstream health.
+type DirectRPCPrewarmer interface {
+	// Prewarm establishes the connection and fills whatever caches the relay path
+	// would otherwise fill on demand. It is idempotent, safe to call concurrently,
+	// and bounded by ctx.
+	Prewarm(ctx context.Context) error
+}
+
 // GRPCDescriptorProvider is an optional interface that gRPC connections can implement
 // to provide access to method descriptors. This is used for parsing gRPC responses
 // to extract block heights for QoS sync tracking.
@@ -203,6 +223,15 @@ type GRPCDirectRPCConnection struct {
 	inflight  map[string]*descriptorResolution
 	resolveMu sync.Mutex
 
+	// The descriptor warm-up runs exactly once per connection, whichever path
+	// triggers it: Prewarm during endpoint setup, or initialize() on a connection
+	// that was never prewarmed. warmOnce is what makes it once; warmed is closed
+	// when the sweep has finished, and is what Prewarm waits on — a second caller
+	// must be able to WAIT for the sweep, which sync.Once alone cannot express
+	// without also blocking uninterruptibly.
+	warmOnce sync.Once
+	warmed   chan struct{}
+
 	// Initialization state. `initialized` latches on SUCCESS only: a failed
 	// initialize is retried by the next relay rather than replayed from a cached
 	// error, which would strand the connection for the life of the pairing.
@@ -248,6 +277,7 @@ func newGRPCDirectRPCConnection(nodeUrl common.NodeUrl) *GRPCDirectRPCConnection
 		nodeUrl:          nodeUrl,
 		descriptorsCache: &common.SafeSyncMap[string, *desc.MethodDescriptor]{},
 		inflight:         map[string]*descriptorResolution{},
+		warmed:           make(chan struct{}),
 		connectorCtx:     connectorCtx,
 		connectorCancel:  connectorCancel,
 	}
@@ -286,6 +316,90 @@ func newGRPCConnector(lifetimeCtx, dialCtx context.Context, nConns uint, nodeUrl
 // direct connection that has been closed. Callers should treat it as a normal
 // relay failure and fail over, not as a fatal condition.
 var ErrGRPCConnectionClosed = errors.New("gRPC connection is closed")
+
+// DirectRPCPrewarmBudget bounds the readiness step that endpoint setup runs
+// before publishing connections.
+//
+// It is a cap on how long setup WAITS, not on the work: a prewarm that overruns
+// keeps going in the background and the endpoint is published regardless. That
+// asymmetry is deliberate. Publishing an unwarmed endpoint costs at most one slow
+// relay, which the detached-lookup half of MAG-2860 already makes recoverable,
+// whereas letting an unreachable upstream hold up setup would make boot fatal on
+// upstream health — which it must never be.
+//
+// Prewarms run concurrently, so this is the budget for the slowest endpoint, not
+// the sum. It sits below the sweep's own 6x-reflection-timeout budget: setup
+// waits for the common case and declines to wait out the pathological one.
+const DirectRPCPrewarmBudget = 15 * time.Second
+
+// PrewarmDirectConnections runs the pre-relay readiness step on every connection
+// that has one, concurrently, and returns when they have all finished or the
+// budget runs out.
+//
+// This is the boundary that makes "no relay is ever cold" true rather than
+// merely likely (MAG-2860). Connections are constructed lazily — a gRPC one has
+// made no network call at all when NewDirectRPCConnection returns — so without a
+// step like this the first relay to an endpoint is the one that dials it and
+// resolves its descriptors, and for cross-validation, which needs N successes in
+// a single request, that first relay failing IS the reported bug. Call this
+// before the endpoints holding these connections are published.
+//
+// It never returns an error and never withholds anything: a connection that
+// fails or overruns is logged and left to the on-demand path.
+func PrewarmDirectConnections(ctx context.Context, connections []DirectRPCConnection, budget time.Duration) {
+	// Keep the connection next to its prewarmer rather than asserting back to it
+	// later: the two views are of the same object, but only this loop has proof of
+	// that.
+	type target struct {
+		connection DirectRPCConnection
+		prewarmer  DirectRPCPrewarmer
+	}
+	targets := make([]target, 0, len(connections))
+	for _, connection := range connections {
+		if prewarmer, ok := connection.(DirectRPCPrewarmer); ok {
+			targets = append(targets, target{connection: connection, prewarmer: prewarmer})
+		}
+	}
+	if len(targets) == 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, budget)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for _, t := range targets {
+		wg.Add(1)
+		go func(t target) {
+			defer wg.Done()
+			if err := t.prewarmer.Prewarm(ctx); err != nil {
+				// Warning, not error: an endpoint that could not be prewarmed is still
+				// a usable endpoint, and saying otherwise at boot would read as a
+				// failure the operator has to act on.
+				utils.LavaFormatWarning("direct RPC connection prewarm did not complete", err,
+					utils.LogAttr("url", t.connection.GetURL()))
+			}
+		}(t)
+	}
+
+	// Wait on a channel rather than wg.Wait() directly. Every Prewarm honours ctx,
+	// so this should be redundant — but "should" is not a bound, and setup blocking
+	// forever on a misbehaving transport is precisely the failure this budget exists
+	// to rule out.
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		utils.LavaFormatWarning("direct RPC prewarm budget elapsed, publishing endpoints anyway", ctx.Err(),
+			utils.LogAttr("connections", len(targets)),
+			utils.LogAttr("budget", budget))
+	}
+}
 
 // grpcConnectorInterface abstracts GRPCConnector for testing
 type grpcConnectorInterface interface {
@@ -862,6 +976,21 @@ func (g *GRPCDirectRPCConnection) initialize(ctx context.Context) error {
 		return err
 	}
 
+	// Bound reflection-timeout before anything derives a context from it. It budgets
+	// every descriptor lookup (lookupService) and, multiplied, the warm-up sweep, so
+	// an out-of-bounds value is not cosmetic: a nanosecond fails every lookup on the
+	// endpoint for as long as it is configured, and there is no later check to catch
+	// it — common.GrpcConfig.Validate defines these bounds but has no caller on any
+	// path that reaches here, and the static-provider validation only checks the URL.
+	//
+	// Only the timeout half of Validate is applied. The rest of it requires a
+	// descriptor-set path for "hybrid", which DescriptorSourceForNode deliberately
+	// tolerates by degrading to reflection, so running all of Validate here would
+	// reject configurations that work today.
+	if err := g.nodeUrl.GrpcConfig.ValidateReflectionTimeout(); err != nil {
+		return err
+	}
+
 	// Resolve the descriptor source before dialing. It needs no connection — it
 	// only reads config and the process-wide protoset cache — and failing here
 	// keeps a misconfigured endpoint from spending a dial budget it can never use.
@@ -936,16 +1065,62 @@ func (g *GRPCDirectRPCConnection) initialize(ctx context.Context) error {
 		utils.LogAttr("url", g.nodeUrl.Url),
 		utils.LogAttr("tls", parsedURL.Scheme == "grpcs"))
 
-	// Fill the descriptor cache behind this call, so no RELAY is the one that pays
-	// for it (MAG-2860). Detaching the lookup from the relay timeout is what stops a
-	// slow endpoint being permanently unusable; warming here is what stops the first
-	// request to it failing at all. Deliberately after the connector is published —
-	// the warm borrows from that pool — and deliberately a goroutine: initMu is held
-	// across initialize(), so doing this inline would make every relay queued behind
-	// wait out a reflection sweep.
-	go g.warmDescriptorCache()
+	// Start the descriptor sweep behind this call. On the prewarmed path Prewarm has
+	// already started it and is waiting on it; this is the fallback for a connection
+	// that reached its first relay without one — the lazily-initialized paths, and
+	// any endpoint whose prewarm ran out of budget at setup.
+	//
+	// Deliberately after the connector is published (the sweep borrows from that
+	// pool), and deliberately not awaited: initMu is held across initialize(), so
+	// waiting here would make every relay queued behind sit through a reflection
+	// sweep. The boundary that actually removes the cold relay is Prewarm.
+	g.startDescriptorWarmup()
 
 	return nil
+}
+
+// Prewarm implements DirectRPCPrewarmer: it dials the endpoint and resolves its
+// descriptors, so that by the time this connection is reachable by a relay the
+// work a relay would otherwise trigger is already done.
+//
+// This is the boundary MAG-2860 turns on. Detaching descriptor lookups from the
+// relay deadline stops a slow endpoint being permanently unusable, but it still
+// leaves the FIRST request paying — and cross-validation needs N successes in one
+// request, so a first request that fails is the reported bug, not a slow start.
+// Calling this before the endpoint is published is what removes the cold relay
+// rather than merely making it recoverable.
+//
+// Idempotent and concurrency-safe: the sweep runs once per connection whoever
+// asks, and later callers wait for the running one rather than starting another.
+// Bounded by ctx — an expired ctx abandons the WAIT, never the sweep, which
+// carries on against its own budget and caches what it finds.
+func (g *GRPCDirectRPCConnection) Prewarm(ctx context.Context) error {
+	if err := g.ensureInitialized(ctx); err != nil {
+		return err
+	}
+
+	select {
+	case <-g.startDescriptorWarmup():
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// startDescriptorWarmup starts the one descriptor sweep this connection will ever
+// run and returns the channel closed when it finishes.
+//
+// Once-ness is the point: Prewarm and initialize() both reach here, and a second
+// sweep would re-resolve, on a node likely chosen for this treatment because its
+// reflection is slow, everything the first one already cached.
+func (g *GRPCDirectRPCConnection) startDescriptorWarmup() <-chan struct{} {
+	g.warmOnce.Do(func() {
+		go func() {
+			defer close(g.warmed)
+			g.warmDescriptorCache()
+		}()
+	})
+	return g.warmed
 }
 
 // descriptorWarmupBudgetFactor scales grpc-config's per-lookup reflection-timeout
@@ -958,22 +1133,15 @@ func (g *GRPCDirectRPCConnection) initialize(ctx context.Context) error {
 // reflection stream keeps that client checked out until Close.
 const descriptorWarmupBudgetFactor = 6
 
-// warmDescriptorCache resolves every service the node serves, once, in the
-// background.
-//
-// This is the other half of MAG-2860. Detaching a lookup from the relay that
-// triggered it means a cold endpoint costs one failed relay instead of failing
-// forever — but cross-validation needs N successes in ONE request, so "the second
-// attempt works" still reads as an outage to the client that sent the first.
-// Warming at connect time is what removes the cold relay entirely.
+// warmDescriptorCache resolves every service the node serves. It runs at most
+// once per connection — see startDescriptorWarmup — and is what Prewarm waits on.
 //
 // It stays transport-only: the node's own reflection lists what it serves, so
 // nothing here has to know which chain it is or which methods a spec will call.
 //
-// Results go straight into descriptorsCache and NOT through the inflight map: a
-// relay that arrives mid-sweep must not end up waiting on a sweep that is busy
-// with an unrelated service. Worst case the two overlap on one service and the
-// cache absorbs the duplicate.
+// Each service is claimed through the same registry the on-demand path uses, so
+// the two never resolve the same service twice, and a relay that arrives mid-sweep
+// waits on the sweep's claim for ITS service rather than on the sweep as a whole.
 func (g *GRPCDirectRPCConnection) warmDescriptorCache() {
 	// Nothing to warm in "file" mode: it never touches the network, and
 	// initializeDescriptorSource has already loaded the protoset into the
@@ -1028,7 +1196,7 @@ func (g *GRPCDirectRPCConnection) warmDescriptorCache() {
 	}
 
 	started := time.Now()
-	warmed, methods := 0, 0
+	warmed, methods, skipped := 0, 0, 0
 	for _, service := range services {
 		if ctx.Err() != nil {
 			break
@@ -1038,31 +1206,61 @@ func (g *GRPCDirectRPCConnection) warmDescriptorCache() {
 			continue
 		}
 
-		descriptor, err := descriptorSource.FindSymbol(service)
-		if err != nil {
+		// Claim the service through the same registry the on-demand path uses. A
+		// relay that got here first already owns this one and is resolving it on its
+		// own client; resolving it again would be exactly the duplicate reflection
+		// this sweep exists to avoid, against a node whose reflection is the reason
+		// we are sweeping at all. Skip it and move on — the sweep has other services
+		// to reach, and waiting would only serialize the two.
+		resolution, claimed := g.claimServiceResolution(service)
+		if !claimed {
+			skipped++
+			continue
+		}
+
+		serviceDescriptor, err := resolveServiceFrom(descriptorSource, service)
+		if err == nil {
+			g.cacheServiceMethods(serviceDescriptor)
+			warmed++
+			methods += len(serviceDescriptor.GetMethods())
+		} else {
 			// One unresolvable service must not abandon the rest; it falls back to an
 			// on-demand lookup like any other cache miss.
 			utils.LavaFormatDebug("gRPC descriptor warm-up skipped a service",
 				utils.LogAttr("service", service),
 				utils.LogAttr("error", err.Error()),
 				utils.LogAttr("url", g.nodeUrl.Url))
-			continue
-		}
-		serviceDescriptor, ok := descriptor.(*desc.ServiceDescriptor)
-		if !ok {
-			continue
 		}
 
-		g.cacheServiceMethods(serviceDescriptor)
-		warmed++
-		methods += len(serviceDescriptor.GetMethods())
+		// Always publish: relays that joined this claim mid-sweep are waiting on it.
+		g.publishServiceResolution(service, resolution, serviceDescriptor, err)
 	}
 
 	utils.LavaFormatInfo("gRPC descriptor cache warmed",
 		utils.LogAttr("services", warmed),
 		utils.LogAttr("methods", methods),
+		utils.LogAttr("alreadyResolving", skipped),
 		utils.LogAttr("duration", time.Since(started)),
 		utils.LogAttr("url", g.nodeUrl.Url))
+}
+
+// resolveServiceFrom pulls one service descriptor out of an already-built
+// descriptor source. It is the half of lookupService that does not own a
+// connection, shared so the sweep and the on-demand path cannot drift on what
+// counts as a resolved service.
+func resolveServiceFrom(descriptorSource grpcurl.DescriptorSource, service string) (*desc.ServiceDescriptor, error) {
+	descriptor, err := descriptorSource.FindSymbol(service)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceDescriptor, ok := descriptor.(*desc.ServiceDescriptor)
+	if !ok {
+		return nil, utils.LavaFormatError("descriptor is not a ServiceDescriptor", nil,
+			utils.LogAttr("service", service))
+	}
+
+	return serviceDescriptor, nil
 }
 
 // cacheServiceMethods stores every method of a resolved service.
@@ -1158,45 +1356,71 @@ func (g *GRPCDirectRPCConnection) getMethodDescriptor(
 
 	resolution := g.resolveService(service)
 
+	var finished bool
 	select {
 	case <-resolution.done:
+		finished = true
 	case <-ctx.Done():
-		// A lookup that finished in the same instant is not thrown away just because
-		// select picked the other ready case.
-		if methodDesc, found, _ := g.descriptorsCache.Load(fullMethodName); found {
-			return methodDesc, nil
+		// Both cases can be ready at once, and select picks among ready cases at
+		// RANDOM — so landing here proves nothing about the lookup. Ask again before
+		// deciding anything, or roughly half of the races report whichever outcome
+		// the runtime happened to choose.
+		select {
+		case <-resolution.done:
+			finished = true
+		default:
 		}
+	}
 
-		// This relay is out of budget; the lookup it started is not. Failing here is
-		// still right — the caller has a deadline to honour and other endpoints to
-		// try — but the lookup keeps running and warms the cache behind us, so the
-		// next relay to this endpoint is not cold. Before this, the relay timeout
-		// killed the lookup before it could cache anything, and every subsequent
-		// relay repeated the same doomed cold lookup: a permanent stall for any
-		// endpoint whose reflection is slower than one relay timeout, which is what
-		// made cross-validation unable to reach quorum on gRPC (MAG-2860).
-		//
-		// ctx.Err() is passed through rather than flattened into a message so
-		// context.Canceled survives in the chain: a leg the router itself abandoned
-		// must not be scored as a node failure (same reasoning as handleGRPCError).
-		return nil, utils.LavaFormatWarning("gRPC descriptor lookup outlived the relay, continuing in background", ctx.Err(),
+	// A lookup that SUCCEEDED is used whatever the caller's context now says. The
+	// descriptor is in hand and costs nothing to return; discarding it would fail a
+	// relay we can still serve, and the cancellation will be noticed by the caller
+	// on its own terms anyway.
+	if finished && resolution.err == nil {
+		methodDescriptor := resolution.svc.FindMethodByName(methodName)
+		if methodDescriptor == nil {
+			return nil, utils.LavaFormatError("method not found in service", nil,
+				utils.LogAttr("service", service),
+				utils.LogAttr("method", methodName))
+		}
+		return methodDescriptor, nil
+	}
+
+	// Some other resolution — the warm-up sweep, or another relay's lookup — may
+	// have cached this method while we waited. A descriptor is a descriptor.
+	if methodDesc, found, _ := g.descriptorsCache.Load(fullMethodName); found {
+		return methodDesc, nil
+	}
+
+	// From here the lookup has given us nothing, so the question is only which
+	// error to report. The caller's own context wins over the lookup's error
+	// whenever both are available.
+	//
+	// This is not cosmetic. common.IsClientCancellation matches on the
+	// context.Canceled SENTINEL, and a relay the router itself abandoned — a loser
+	// of a stateful fan-out race, or a client that hung up — must not be scored
+	// against the endpoint. Reporting the lookup's generic failure instead drops
+	// that sentinel and hands endpoint health a node error that never happened.
+	// The risk is asymmetric in the same way handleGRPCError's cancellation branch
+	// is: over-reporting cancellation only skips scoring a relay whose result we
+	// were discarding, while under-reporting it penalises an endpoint that did
+	// nothing wrong.
+	//
+	// Passing ctx.Err() through rather than flattening it into a message is what
+	// keeps the sentinel reachable by errors.Is.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		// The lookup itself is NOT abandoned here — it runs on its own budget and
+		// caches what it finds, so the next relay to this endpoint is not cold. That
+		// is what stops one slow endpoint being permanently unusable (MAG-2860).
+		return nil, utils.LavaFormatWarning("gRPC descriptor lookup outlived the relay, continuing in background", ctxErr,
 			utils.LogAttr("service", service),
 			utils.LogAttr("method", methodName),
 			utils.LogAttr("url", g.nodeUrl.Url))
 	}
 
-	if resolution.err != nil {
-		return nil, resolution.err
-	}
-
-	methodDescriptor := resolution.svc.FindMethodByName(methodName)
-	if methodDescriptor == nil {
-		return nil, utils.LavaFormatError("method not found in service", nil,
-			utils.LogAttr("service", service),
-			utils.LogAttr("method", methodName))
-	}
-
-	return methodDescriptor, nil
+	// Unreachable unless the lookup finished: the select above only returns on one
+	// of the two channels, and a live ctx means it was resolution.done.
+	return nil, resolution.err
 }
 
 // resolveService starts — or joins — the one running lookup of `service` on this
@@ -1207,51 +1431,79 @@ func (g *GRPCDirectRPCConnection) getMethodDescriptor(
 // stream turns one slow lookup into N concurrent ones against a node that is
 // already too slow to answer inside a relay timeout.
 func (g *GRPCDirectRPCConnection) resolveService(service string) *descriptorResolution {
-	g.resolveMu.Lock()
-	defer g.resolveMu.Unlock()
-
-	if resolution, ok := g.inflight[service]; ok {
-		return resolution
+	resolution, claimed := g.claimServiceResolution(service)
+	if claimed {
+		go g.runServiceResolution(service, resolution)
 	}
-
-	resolution := &descriptorResolution{done: make(chan struct{})}
-	g.inflight[service] = resolution
-	go g.runServiceResolution(service, resolution)
-
 	return resolution
 }
 
-// runServiceResolution performs one service lookup and publishes its outcome.
+// claimServiceResolution registers the caller as the one resolving `service`, or
+// hands back the resolution already running for it.
+//
+// The claim is what keeps the warm-up sweep and the on-demand path from resolving
+// the same service twice: whichever reaches a service first owns it, and the
+// other either waits on it (a relay) or skips it (the sweep, which has other
+// services to get on with).
+func (g *GRPCDirectRPCConnection) claimServiceResolution(service string) (resolution *descriptorResolution, claimed bool) {
+	g.resolveMu.Lock()
+	defer g.resolveMu.Unlock()
+
+	if existing, ok := g.inflight[service]; ok {
+		return existing, false
+	}
+
+	resolution = &descriptorResolution{done: make(chan struct{})}
+	g.inflight[service] = resolution
+	return resolution, true
+}
+
+// publishServiceResolution ends a claimed resolution, waking every waiter.
+//
+// It must be reached on every path out of a claimed lookup, including failures:
+// a claim that is never published is a resolution every future waiter blocks on
+// until its own context expires.
+func (g *GRPCDirectRPCConnection) publishServiceResolution(
+	service string,
+	resolution *descriptorResolution,
+	serviceDescriptor *desc.ServiceDescriptor,
+	err error,
+) {
+	resolution.svc, resolution.err = serviceDescriptor, err
+
+	// Drop the entry BEFORE publishing, so a relay that arrives after a failed
+	// lookup starts a fresh one instead of joining a finished one and being handed
+	// its stale error. Waiters already holding this resolution still get the real
+	// answer. The cost is a short window in which a second lookup can start while
+	// this one is finishing; the cache check in getMethodDescriptor makes that a
+	// no-op as soon as one of them succeeds.
+	g.resolveMu.Lock()
+	if g.inflight[service] == resolution {
+		delete(g.inflight, service)
+	}
+	g.resolveMu.Unlock()
+
+	close(resolution.done)
+}
+
+// runServiceResolution performs one claimed service lookup and publishes it.
 func (g *GRPCDirectRPCConnection) runServiceResolution(service string, resolution *descriptorResolution) {
 	started := time.Now()
 
-	defer func() {
-		// Drop the entry BEFORE publishing, so a relay that arrives after a failed
-		// lookup starts a fresh one instead of joining a finished one and being
-		// handed its stale error. Waiters already holding this resolution still get
-		// the real answer. The cost is a short window in which a second lookup can
-		// start while this one is finishing; the cache check in getMethodDescriptor
-		// makes that a no-op as soon as one of them succeeds.
-		g.resolveMu.Lock()
-		if g.inflight[service] == resolution {
-			delete(g.inflight, service)
-		}
-		g.resolveMu.Unlock()
-		close(resolution.done)
-	}()
+	serviceDescriptor, err := g.lookupService(service)
+	if err == nil {
+		// Cache before publishing: a waiter woken by the close below re-checks the
+		// cache, and finding it already filled is one less way to race.
+		g.cacheServiceMethods(serviceDescriptor)
 
-	resolution.svc, resolution.err = g.lookupService(service)
-	if resolution.err != nil {
-		return
+		utils.LavaFormatDebug("gRPC service descriptor resolved",
+			utils.LogAttr("service", service),
+			utils.LogAttr("methods", len(serviceDescriptor.GetMethods())),
+			utils.LogAttr("duration", time.Since(started)),
+			utils.LogAttr("url", g.nodeUrl.Url))
 	}
 
-	g.cacheServiceMethods(resolution.svc)
-
-	utils.LavaFormatDebug("gRPC service descriptor resolved",
-		utils.LogAttr("service", service),
-		utils.LogAttr("methods", len(resolution.svc.GetMethods())),
-		utils.LogAttr("duration", time.Since(started)),
-		utils.LogAttr("url", g.nodeUrl.Url))
+	g.publishServiceResolution(service, resolution, serviceDescriptor, err)
 }
 
 // lookupService resolves one service descriptor on a budget of its own.
@@ -1301,18 +1553,12 @@ func (g *GRPCDirectRPCConnection) lookupService(service string) (*desc.ServiceDe
 		return nil, err
 	}
 
-	descriptor, err := descriptorSource.FindSymbol(service)
+	serviceDescriptor, err := resolveServiceFrom(descriptorSource, service)
 	if err != nil {
 		return nil, utils.LavaFormatError("failed to find service descriptor", err,
 			utils.LogAttr("service", service),
 			utils.LogAttr("descriptor-source", g.nodeUrl.GrpcConfig.GetDescriptorSource()),
 			utils.LogAttr("reflection-timeout", g.nodeUrl.GrpcConfig.GetReflectionTimeout()))
-	}
-
-	serviceDescriptor, ok := descriptor.(*desc.ServiceDescriptor)
-	if !ok {
-		return nil, utils.LavaFormatError("descriptor is not a ServiceDescriptor", nil,
-			utils.LogAttr("service", service))
 	}
 
 	return serviceDescriptor, nil

--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/fullstorydev/grpcurl"
 	"github.com/golang/protobuf/proto"
@@ -195,6 +196,13 @@ type GRPCDirectRPCConnection struct {
 	// Descriptor handling
 	descriptorsCache *common.SafeSyncMap[string, *desc.MethodDescriptor]
 
+	// inflight holds the one running descriptor lookup per service, so N concurrent
+	// relays for the same service share a single reflection round trip instead of
+	// each opening their own. Set at construction like descriptorsCache; resolveMu
+	// guards it and is a leaf lock — no other lock is taken while it is held.
+	inflight  map[string]*descriptorResolution
+	resolveMu sync.Mutex
+
 	// Initialization state. `initialized` latches on SUCCESS only: a failed
 	// initialize is retried by the next relay rather than replayed from a cached
 	// error, which would strand the connection for the life of the pairing.
@@ -239,9 +247,21 @@ func newGRPCDirectRPCConnection(nodeUrl common.NodeUrl) *GRPCDirectRPCConnection
 	return &GRPCDirectRPCConnection{
 		nodeUrl:          nodeUrl,
 		descriptorsCache: &common.SafeSyncMap[string, *desc.MethodDescriptor]{},
+		inflight:         map[string]*descriptorResolution{},
 		connectorCtx:     connectorCtx,
 		connectorCancel:  connectorCancel,
 	}
+}
+
+// descriptorResolution is a single in-flight service-descriptor lookup, shared by
+// every relay that asks for the same service while it runs.
+//
+// svc and err are written once, before done is closed, and read only after it —
+// the close is the happens-before edge, so no lock is needed on them.
+type descriptorResolution struct {
+	done chan struct{}
+	svc  *desc.ServiceDescriptor // nil unless err == nil
+	err  error
 }
 
 // grpcConnectorFactory mirrors chainproxy.NewGRPCConnector, including its two
@@ -728,7 +748,7 @@ func (g *GRPCDirectRPCConnection) SendRequest(
 	svc, methodName := rpcInterfaceMessages.ParseSymbol(methodPath)
 
 	// Get method descriptor (with caching)
-	methodDescriptor, err := g.getMethodDescriptor(ctx, conn, svc, methodName)
+	methodDescriptor, err := g.getMethodDescriptor(ctx, svc, methodName)
 	if err != nil {
 		return nil, utils.LavaFormatError("failed to get method descriptor", err,
 			utils.LogAttr("method", methodPath))
@@ -916,7 +936,145 @@ func (g *GRPCDirectRPCConnection) initialize(ctx context.Context) error {
 		utils.LogAttr("url", g.nodeUrl.Url),
 		utils.LogAttr("tls", parsedURL.Scheme == "grpcs"))
 
+	// Fill the descriptor cache behind this call, so no RELAY is the one that pays
+	// for it (MAG-2860). Detaching the lookup from the relay timeout is what stops a
+	// slow endpoint being permanently unusable; warming here is what stops the first
+	// request to it failing at all. Deliberately after the connector is published —
+	// the warm borrows from that pool — and deliberately a goroutine: initMu is held
+	// across initialize(), so doing this inline would make every relay queued behind
+	// wait out a reflection sweep.
+	go g.warmDescriptorCache()
+
 	return nil
+}
+
+// descriptorWarmupBudgetFactor scales grpc-config's per-lookup reflection-timeout
+// into a budget for the warm-up, which resolves the node's whole service list
+// rather than one symbol.
+//
+// It is a backstop, not a target: nobody waits on the warm, whatever it finishes
+// is cached, and anything it misses still resolves on demand. What the bound is
+// actually for is the pooled client the sweep holds — without it, one hung
+// reflection stream keeps that client checked out until Close.
+const descriptorWarmupBudgetFactor = 6
+
+// warmDescriptorCache resolves every service the node serves, once, in the
+// background.
+//
+// This is the other half of MAG-2860. Detaching a lookup from the relay that
+// triggered it means a cold endpoint costs one failed relay instead of failing
+// forever — but cross-validation needs N successes in ONE request, so "the second
+// attempt works" still reads as an outage to the client that sent the first.
+// Warming at connect time is what removes the cold relay entirely.
+//
+// It stays transport-only: the node's own reflection lists what it serves, so
+// nothing here has to know which chain it is or which methods a spec will call.
+//
+// Results go straight into descriptorsCache and NOT through the inflight map: a
+// relay that arrives mid-sweep must not end up waiting on a sweep that is busy
+// with an unrelated service. Worst case the two overlap on one service and the
+// cache absorbs the duplicate.
+func (g *GRPCDirectRPCConnection) warmDescriptorCache() {
+	// Nothing to warm in "file" mode: it never touches the network, and
+	// initializeDescriptorSource has already loaded the protoset into the
+	// process-wide cache that backs it. Hybrid still warms — reflection is the half
+	// it falls back to, and that half is the slow one.
+	if g.nodeUrl.GrpcConfig.GetDescriptorSource() == common.GrpcDescriptorSourceFile {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(g.connectorCtx,
+		descriptorWarmupBudgetFactor*g.nodeUrl.GrpcConfig.GetReflectionTimeout())
+	defer cancel()
+
+	g.connMu.RLock()
+	connector := g.connector
+	if connector == nil {
+		g.connMu.RUnlock()
+		return
+	}
+	conn, err := connector.GetRpc(ctx, true)
+	g.connMu.RUnlock()
+	if err != nil {
+		utils.LavaFormatDebug("gRPC descriptor warm-up skipped, no connection",
+			utils.LogAttr("error", err.Error()),
+			utils.LogAttr("url", g.nodeUrl.Url))
+		return
+	}
+	defer connector.ReturnRpc(conn)
+
+	// One reflection client for the whole sweep. grpcreflect caches the file
+	// descriptors it downloads per client, and services on a node share most of
+	// their imports, so resolving them together costs roughly one descriptor set
+	// rather than one per service — which matters on the gateways that throttle
+	// reflection in the first place.
+	cl := grpcreflect.NewClientAuto(ctx, conn)
+	defer cl.Reset()
+
+	services, err := cl.ListServices()
+	if err != nil {
+		// Not an error: a node that does not serve reflection is a supported
+		// configuration ("file"/"hybrid" with a protoset), and one that is merely
+		// slow or unreachable right now still resolves on demand later.
+		utils.LavaFormatDebug("gRPC descriptor warm-up could not list services",
+			utils.LogAttr("error", err.Error()),
+			utils.LogAttr("url", g.nodeUrl.Url))
+		return
+	}
+
+	descriptorSource, err := rpcInterfaceMessages.DescriptorSourceForGrpcConfig(&g.nodeUrl.GrpcConfig, rpcInterfaceMessages.DescriptorSourceFromServer(cl))
+	if err != nil {
+		return
+	}
+
+	started := time.Now()
+	warmed, methods := 0, 0
+	for _, service := range services {
+		if ctx.Err() != nil {
+			break
+		}
+		// Reflection's own service is never relayed, so resolving it is pure cost.
+		if strings.HasPrefix(service, "grpc.reflection.") {
+			continue
+		}
+
+		descriptor, err := descriptorSource.FindSymbol(service)
+		if err != nil {
+			// One unresolvable service must not abandon the rest; it falls back to an
+			// on-demand lookup like any other cache miss.
+			utils.LavaFormatDebug("gRPC descriptor warm-up skipped a service",
+				utils.LogAttr("service", service),
+				utils.LogAttr("error", err.Error()),
+				utils.LogAttr("url", g.nodeUrl.Url))
+			continue
+		}
+		serviceDescriptor, ok := descriptor.(*desc.ServiceDescriptor)
+		if !ok {
+			continue
+		}
+
+		g.cacheServiceMethods(serviceDescriptor)
+		warmed++
+		methods += len(serviceDescriptor.GetMethods())
+	}
+
+	utils.LavaFormatInfo("gRPC descriptor cache warmed",
+		utils.LogAttr("services", warmed),
+		utils.LogAttr("methods", methods),
+		utils.LogAttr("duration", time.Since(started)),
+		utils.LogAttr("url", g.nodeUrl.Url))
+}
+
+// cacheServiceMethods stores every method of a resolved service.
+//
+// Every method, not only the one that was asked for: resolving the service
+// resolved all of them, and the cache is keyed per method — so without this the
+// second method on a service pays the full cold cost again.
+func (g *GRPCDirectRPCConnection) cacheServiceMethods(serviceDescriptor *desc.ServiceDescriptor) {
+	service := serviceDescriptor.GetFullyQualifiedName()
+	for _, method := range serviceDescriptor.GetMethods() {
+		g.descriptorsCache.Store(service+"."+method.GetName(), method)
+	}
 }
 
 // validateURL checks if the gRPC URL is valid
@@ -979,11 +1137,16 @@ func (g *GRPCDirectRPCConnection) initializeDescriptorSource() error {
 	return nil
 }
 
-// getMethodDescriptor retrieves the method descriptor from cache, or resolves it
-// through the node's configured descriptor source (reflection, file, or hybrid).
+// getMethodDescriptor retrieves the method descriptor from cache, or waits on a
+// lookup against the node's configured descriptor source (reflection, file, or
+// hybrid).
+//
+// The WAIT is bounded by the caller's ctx. The LOOKUP is not (MAG-2860): it runs
+// on its own budget and caches what it finds even if this relay has already given
+// up, so the cost of a cold cache is paid once for the endpoint rather than once
+// per attempt. See resolveService.
 func (g *GRPCDirectRPCConnection) getMethodDescriptor(
 	ctx context.Context,
-	conn *grpc.ClientConn,
 	service, methodName string,
 ) (*desc.MethodDescriptor, error) {
 	fullMethodName := service + "." + methodName
@@ -992,6 +1155,140 @@ func (g *GRPCDirectRPCConnection) getMethodDescriptor(
 	if methodDesc, found, _ := g.descriptorsCache.Load(fullMethodName); found {
 		return methodDesc, nil
 	}
+
+	resolution := g.resolveService(service)
+
+	select {
+	case <-resolution.done:
+	case <-ctx.Done():
+		// A lookup that finished in the same instant is not thrown away just because
+		// select picked the other ready case.
+		if methodDesc, found, _ := g.descriptorsCache.Load(fullMethodName); found {
+			return methodDesc, nil
+		}
+
+		// This relay is out of budget; the lookup it started is not. Failing here is
+		// still right — the caller has a deadline to honour and other endpoints to
+		// try — but the lookup keeps running and warms the cache behind us, so the
+		// next relay to this endpoint is not cold. Before this, the relay timeout
+		// killed the lookup before it could cache anything, and every subsequent
+		// relay repeated the same doomed cold lookup: a permanent stall for any
+		// endpoint whose reflection is slower than one relay timeout, which is what
+		// made cross-validation unable to reach quorum on gRPC (MAG-2860).
+		//
+		// ctx.Err() is passed through rather than flattened into a message so
+		// context.Canceled survives in the chain: a leg the router itself abandoned
+		// must not be scored as a node failure (same reasoning as handleGRPCError).
+		return nil, utils.LavaFormatWarning("gRPC descriptor lookup outlived the relay, continuing in background", ctx.Err(),
+			utils.LogAttr("service", service),
+			utils.LogAttr("method", methodName),
+			utils.LogAttr("url", g.nodeUrl.Url))
+	}
+
+	if resolution.err != nil {
+		return nil, resolution.err
+	}
+
+	methodDescriptor := resolution.svc.FindMethodByName(methodName)
+	if methodDescriptor == nil {
+		return nil, utils.LavaFormatError("method not found in service", nil,
+			utils.LogAttr("service", service),
+			utils.LogAttr("method", methodName))
+	}
+
+	return methodDescriptor, nil
+}
+
+// resolveService starts — or joins — the one running lookup of `service` on this
+// endpoint, and returns the handle to wait on.
+//
+// Deduplicating matters here for the same reason detaching does: a cold service is
+// cold for every relay at once, and letting each of them open its own reflection
+// stream turns one slow lookup into N concurrent ones against a node that is
+// already too slow to answer inside a relay timeout.
+func (g *GRPCDirectRPCConnection) resolveService(service string) *descriptorResolution {
+	g.resolveMu.Lock()
+	defer g.resolveMu.Unlock()
+
+	if resolution, ok := g.inflight[service]; ok {
+		return resolution
+	}
+
+	resolution := &descriptorResolution{done: make(chan struct{})}
+	g.inflight[service] = resolution
+	go g.runServiceResolution(service, resolution)
+
+	return resolution
+}
+
+// runServiceResolution performs one service lookup and publishes its outcome.
+func (g *GRPCDirectRPCConnection) runServiceResolution(service string, resolution *descriptorResolution) {
+	started := time.Now()
+
+	defer func() {
+		// Drop the entry BEFORE publishing, so a relay that arrives after a failed
+		// lookup starts a fresh one instead of joining a finished one and being
+		// handed its stale error. Waiters already holding this resolution still get
+		// the real answer. The cost is a short window in which a second lookup can
+		// start while this one is finishing; the cache check in getMethodDescriptor
+		// makes that a no-op as soon as one of them succeeds.
+		g.resolveMu.Lock()
+		if g.inflight[service] == resolution {
+			delete(g.inflight, service)
+		}
+		g.resolveMu.Unlock()
+		close(resolution.done)
+	}()
+
+	resolution.svc, resolution.err = g.lookupService(service)
+	if resolution.err != nil {
+		return
+	}
+
+	g.cacheServiceMethods(resolution.svc)
+
+	utils.LavaFormatDebug("gRPC service descriptor resolved",
+		utils.LogAttr("service", service),
+		utils.LogAttr("methods", len(resolution.svc.GetMethods())),
+		utils.LogAttr("duration", time.Since(started)),
+		utils.LogAttr("url", g.nodeUrl.Url))
+}
+
+// lookupService resolves one service descriptor on a budget of its own.
+//
+// The context is rooted at connectorCtx, never at a relay's. A relay's deadline is
+// how long the CALLER waits, not how long the lookup may take; bounding the lookup
+// by it meant a node whose reflection is slower than one relay could never finish
+// one, and so could never cache one. Rooting it at the connection's lifetime keeps
+// Close prompt all the same — the cancellation in Close step 2 aborts this and
+// releases the pooled client below before the drain in step 5 waits on it.
+//
+// The budget itself is grpc-config's reflection-timeout (default 5s, validated to
+// 100ms..30s). That knob was defined and validated but never applied to anything;
+// this is the call it was written for.
+func (g *GRPCDirectRPCConnection) lookupService(service string) (*desc.ServiceDescriptor, error) {
+	ctx, cancel := context.WithTimeout(g.connectorCtx, g.nodeUrl.GrpcConfig.GetReflectionTimeout())
+	defer cancel()
+
+	// Borrow a client of our own rather than reusing the one the triggering relay
+	// holds: that relay hands its client back the moment it gives up on us, and a
+	// handed-back client can be closed outright (ReturnRpc closes it when the pool
+	// is over-full or being torn down). Borrowing keeps the connector's accounting
+	// true for exactly as long as we use it.
+	g.connMu.RLock()
+	connector := g.connector
+	if connector == nil {
+		g.connMu.RUnlock()
+		return nil, ErrGRPCConnectionClosed
+	}
+	conn, err := connector.GetRpc(ctx, true)
+	g.connMu.RUnlock()
+	if err != nil {
+		return nil, utils.LavaFormatError("gRPC get connection failed for descriptor lookup", err,
+			utils.LogAttr("service", service),
+			utils.LogAttr("url", g.nodeUrl.Url))
+	}
+	defer connector.ReturnRpc(conn)
 
 	// Resolve through the node's configured descriptor source. In "reflection" mode
 	// (the default) this is exactly the reflection client below; in "file" mode the
@@ -1008,7 +1305,8 @@ func (g *GRPCDirectRPCConnection) getMethodDescriptor(
 	if err != nil {
 		return nil, utils.LavaFormatError("failed to find service descriptor", err,
 			utils.LogAttr("service", service),
-			utils.LogAttr("descriptor-source", g.nodeUrl.GrpcConfig.GetDescriptorSource()))
+			utils.LogAttr("descriptor-source", g.nodeUrl.GrpcConfig.GetDescriptorSource()),
+			utils.LogAttr("reflection-timeout", g.nodeUrl.GrpcConfig.GetReflectionTimeout()))
 	}
 
 	serviceDescriptor, ok := descriptor.(*desc.ServiceDescriptor)
@@ -1017,17 +1315,7 @@ func (g *GRPCDirectRPCConnection) getMethodDescriptor(
 			utils.LogAttr("service", service))
 	}
 
-	methodDescriptor := serviceDescriptor.FindMethodByName(methodName)
-	if methodDescriptor == nil {
-		return nil, utils.LavaFormatError("method not found in service", nil,
-			utils.LogAttr("service", service),
-			utils.LogAttr("method", methodName))
-	}
-
-	// Cache the descriptor
-	g.descriptorsCache.Store(fullMethodName, methodDescriptor)
-
-	return methodDescriptor, nil
+	return serviceDescriptor, nil
 }
 
 // GetCachedMethodDescriptor returns a cached method descriptor for the given method path.

--- a/protocol/lavasession/direct_rpc_descriptor_lookup_test.go
+++ b/protocol/lavasession/direct_rpc_descriptor_lookup_test.go
@@ -1,0 +1,271 @@
+package lavasession
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// MAG-2860 cover: a gRPC endpoint whose descriptor reflection is slower than one
+// relay timeout used to be permanently unusable, because the relay's deadline
+// killed the lookup before it could cache anything and every later relay repeated
+// the same doomed cold lookup. Cross-validation is where that surfaces — it needs
+// N successes rather than one, so a single cold participant parks it one short of
+// the threshold forever.
+//
+// The health service is the fixture: it is a real registered service with two
+// methods (Check, Watch), which is also what the "one lookup caches the whole
+// service" assertion needs.
+const healthCheckMethod = "grpc.health.v1.Health/Check"
+
+// slowReflectionServer is an in-process gRPC server that serves health and
+// reflection, delays every reflection stream, and counts them.
+type slowReflectionServer struct {
+	conn             *grpc.ClientConn
+	reflectionStream atomic.Int32
+}
+
+// startSlowReflectionServer brings up the fixture over bufconn — no ports, no
+// dialing, no flakiness — with server reflection artificially slowed by delay.
+//
+// The delay is what reproduces the bug: it stands in for the real Sui testnet
+// endpoint whose reflection round trip took longer than the 2s relay timeout.
+func startSlowReflectionServer(t *testing.T, delay time.Duration) *slowReflectionServer {
+	t.Helper()
+
+	s := &slowReflectionServer{}
+
+	lis := bufconn.Listen(1024 * 1024)
+	srv := grpc.NewServer(
+		grpc.StreamInterceptor(func(sr any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+			if !strings.Contains(info.FullMethod, "ServerReflectionInfo") {
+				return handler(sr, ss)
+			}
+			s.reflectionStream.Add(1)
+			select {
+			case <-time.After(delay):
+			case <-ss.Context().Done():
+				return ss.Context().Err()
+			}
+			return handler(sr, ss)
+		}),
+	)
+	healthpb.RegisterHealthServer(srv, health.NewServer())
+	reflection.Register(srv)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	s.conn = conn
+	return s
+}
+
+// newGRPCConnOverServer wires a GRPCDirectRPCConnection to the fixture, standing in
+// for a connection whose lazy initialization already succeeded.
+func newGRPCConnOverServer(t *testing.T, s *slowReflectionServer) *GRPCDirectRPCConnection {
+	t.Helper()
+	fake := newFakeGRPCConnector()
+	fake.conn = s.conn
+	g := newInitializedGRPCConn(fake)
+	t.Cleanup(func() { _ = g.Close() })
+	return g
+}
+
+func healthCheckHeaders() map[string]string {
+	return map[string]string{GRPCMethodHeader: healthCheckMethod}
+}
+
+// TestMAG2860_ColdDescriptorLookupOutlivesTheRelay is the regression pin.
+//
+// The first relay is given far less budget than reflection needs, so it fails —
+// that part is correct and unchanged: the caller has a deadline to honour and
+// other endpoints to try. What must NOT happen is the lookup dying with it. The
+// lookup runs on grpc-config's reflection-timeout instead, caches what it finds,
+// and the next relay to the same endpoint is warm.
+//
+// Before the fix the cache stayed empty forever and every subsequent relay failed
+// identically — 12 attempts, every one at exactly the relay timeout, zero
+// successes — which is what made cross-validation unable to reach quorum.
+func TestMAG2860_ColdDescriptorLookupOutlivesTheRelay(t *testing.T) {
+	s := startSlowReflectionServer(t, 300*time.Millisecond)
+	g := newGRPCConnOverServer(t, s)
+
+	// A relay budget that cannot possibly cover the reflection round trip.
+	relayCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	resp, coldErr := g.SendRequest(relayCtx, []byte("{}"), healthCheckHeaders())
+	require.Error(t, coldErr, "a relay that runs out of budget mid-lookup still fails")
+	require.Nil(t, resp)
+
+	// The lookup it started is still running on its own budget.
+	require.Eventually(t, func() bool {
+		return g.GetCachedMethodDescriptor(healthCheckMethod) != nil
+	}, 5*time.Second, 10*time.Millisecond,
+		"the descriptor must be cached even though the relay that asked for it gave up")
+
+	// ...so the next relay is warm, and now succeeds inside a budget that could
+	// never have covered a cold lookup.
+	warmCtx, cancelWarm := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancelWarm()
+
+	resp, err := g.SendRequest(warmCtx, []byte("{}"), healthCheckHeaders())
+	require.NoError(t, err, "the second relay must not repeat the cold lookup")
+	require.NotNil(t, resp)
+	require.NotEmpty(t, resp.Data)
+
+	// The abandoned relay's own deadline survives in the error chain rather than
+	// being flattened into a message. It is what keeps a leg the router itself
+	// cancelled distinguishable from a node that answered badly — the same reason
+	// handleGRPCError re-attaches context.Canceled (MAG-2687).
+	require.ErrorIs(t, coldErr, context.DeadlineExceeded)
+}
+
+// TestMAG2860_ResolvingOneMethodCachesTheWholeService pins that the round trip is
+// paid once per service, not once per method.
+//
+// FindSymbol resolves the whole service, so the sibling methods are already in
+// hand; the cache is keyed per method, so without storing them the second method
+// on a service would pay the full cold cost again — and on a slow endpoint, fail
+// exactly the way the first one did.
+func TestMAG2860_ResolvingOneMethodCachesTheWholeService(t *testing.T) {
+	s := startSlowReflectionServer(t, 0)
+	g := newGRPCConnOverServer(t, s)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := g.SendRequest(ctx, []byte("{}"), healthCheckHeaders())
+	require.NoError(t, err)
+
+	require.NotNil(t, g.GetCachedMethodDescriptor(healthCheckMethod))
+	require.NotNil(t, g.GetCachedMethodDescriptor("grpc.health.v1.Health/Watch"),
+		"a sibling method must not need its own reflection round trip")
+
+	require.Equal(t, int32(1), s.reflectionStream.Load(),
+		"one service lookup is one reflection stream")
+}
+
+// TestMAG2860_ConcurrentRelaysShareOneLookup pins the deduplication.
+//
+// A cold service is cold for every relay at once. Without a single in-flight
+// lookup per service, a fan-out (cross-validation, hedging, a burst of traffic)
+// opens one reflection stream per relay against a node already too slow to answer
+// one inside a relay timeout.
+func TestMAG2860_ConcurrentRelaysShareOneLookup(t *testing.T) {
+	s := startSlowReflectionServer(t, 200*time.Millisecond)
+	g := newGRPCConnOverServer(t, s)
+
+	const relays = 8
+	var wg sync.WaitGroup
+	errs := make([]error, relays)
+	for i := range relays {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_, errs[i] = g.SendRequest(ctx, []byte("{}"), healthCheckHeaders())
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "relay %d", i)
+	}
+	require.Equal(t, int32(1), s.reflectionStream.Load(),
+		"%d concurrent relays for one service must share one reflection stream", relays)
+}
+
+// TestMAG2860_ConnectWarmsTheCacheSoNoRelayIsCold is the ticket's actual symptom.
+//
+// Detaching the lookup from the relay makes a cold endpoint cost one failed relay
+// instead of failing forever — but cross-validation needs N successes in ONE
+// request, so "the second attempt works" is still an outage to the client that
+// sent the first. Connecting warms the cache, so the first real relay is not the
+// one paying for it.
+//
+// The endpoint here is slow enough that a cold lookup could never fit inside the
+// relay budget used below: if the warm did not happen, this relay is the failing
+// one from the bug report.
+func TestMAG2860_ConnectWarmsTheCacheSoNoRelayIsCold(t *testing.T) {
+	s := startSlowReflectionServer(t, 300*time.Millisecond)
+
+	fake := newFakeGRPCConnector()
+	fake.conn = s.conn
+	g := newUninitializedGRPCConn(func(lifetimeCtx, dialCtx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
+		return fake, nil
+	})
+	t.Cleanup(func() { _ = g.Close() })
+
+	// Connecting is all that happens here — no relay has asked for anything.
+	require.NoError(t, g.ensureInitialized(context.Background()))
+
+	require.Eventually(t, func() bool {
+		return g.GetCachedMethodDescriptor(healthCheckMethod) != nil
+	}, 5*time.Second, 10*time.Millisecond,
+		"connecting must warm the descriptor cache, with no relay involved")
+
+	// A budget that a cold lookup could not possibly fit inside.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	resp, err := g.SendRequest(ctx, []byte("{}"), healthCheckHeaders())
+	require.NoError(t, err, "the FIRST relay must already be warm")
+	require.NotNil(t, resp)
+
+	require.Equal(t, int32(1), s.reflectionStream.Load(),
+		"the warm-up sweep is one reflection stream, and the relay adds none")
+}
+
+// TestMAG2860_CloseAbortsAnInFlightLookup is the lifecycle guard on detaching the
+// lookup from the relay.
+//
+// The lookup is rooted at the connection's own context rather than the relay's, so
+// the thing that must still stop it is Close. If it did not, Close would block
+// behind a pooled client held by a lookup nobody is waiting for — for as long as
+// the endpoint's reflection takes — and teardown would stall a chain at a time.
+func TestMAG2860_CloseAbortsAnInFlightLookup(t *testing.T) {
+	// Far longer than the Close budget asserted below, so a Close that waited it
+	// out would lose by the full margin rather than by a scheduling accident.
+	s := startSlowReflectionServer(t, 30*time.Second)
+	g := newGRPCConnOverServer(t, s)
+
+	relayCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := g.SendRequest(relayCtx, []byte("{}"), healthCheckHeaders())
+	require.Error(t, err)
+
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		require.NoError(t, g.Close())
+	}()
+
+	select {
+	case <-closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Close blocked on a background descriptor lookup instead of cancelling it")
+	}
+}

--- a/protocol/lavasession/direct_rpc_descriptor_lookup_test.go
+++ b/protocol/lavasession/direct_rpc_descriptor_lookup_test.go
@@ -2,6 +2,7 @@ package lavasession
 
 import (
 	"context"
+	"errors"
 	"net"
 	"strings"
 	"sync"
@@ -49,20 +50,7 @@ func startSlowReflectionServer(t *testing.T, delay time.Duration) *slowReflectio
 	s := &slowReflectionServer{}
 
 	lis := bufconn.Listen(1024 * 1024)
-	srv := grpc.NewServer(
-		grpc.StreamInterceptor(func(sr any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-			if !strings.Contains(info.FullMethod, "ServerReflectionInfo") {
-				return handler(sr, ss)
-			}
-			s.reflectionStream.Add(1)
-			select {
-			case <-time.After(delay):
-			case <-ss.Context().Done():
-				return ss.Context().Err()
-			}
-			return handler(sr, ss)
-		}),
-	)
+	srv := grpc.NewServer(grpc.StreamInterceptor(slowReflectionInterceptor(&s.reflectionStream, delay)))
 	healthpb.RegisterHealthServer(srv, health.NewServer())
 	reflection.Register(srv)
 	go func() { _ = srv.Serve(lis) }()
@@ -79,6 +67,47 @@ func startSlowReflectionServer(t *testing.T, delay time.Duration) *slowReflectio
 
 	s.conn = conn
 	return s
+}
+
+// startSlowReflectionListener is startSlowReflectionServer on a real loopback
+// port, returning host:port.
+//
+// bufconn is not usable for the lifecycle test: it goes through the PRODUCTION
+// connector, and chainproxy.NewGRPCConnector dials the node URL itself with no
+// dialer seam. A real listener is the point — the dial has to be real for the
+// test to be about the real lifecycle.
+func startSlowReflectionListener(t *testing.T, delay time.Duration) string {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := grpc.NewServer(grpc.StreamInterceptor(slowReflectionInterceptor(nil, delay)))
+	healthpb.RegisterHealthServer(srv, health.NewServer())
+	reflection.Register(srv)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	return lis.Addr().String()
+}
+
+// slowReflectionInterceptor delays every server-reflection stream by delay, and
+// counts them when counter is non-nil.
+func slowReflectionInterceptor(counter *atomic.Int32, delay time.Duration) grpc.StreamServerInterceptor {
+	return func(sr any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if !strings.Contains(info.FullMethod, "ServerReflectionInfo") {
+			return handler(sr, ss)
+		}
+		if counter != nil {
+			counter.Add(1)
+		}
+		select {
+		case <-time.After(delay):
+		case <-ss.Context().Done():
+			return ss.Context().Err()
+		}
+		return handler(sr, ss)
+	}
 }
 
 // newGRPCConnOverServer wires a GRPCDirectRPCConnection to the fixture, standing in
@@ -198,19 +227,15 @@ func TestMAG2860_ConcurrentRelaysShareOneLookup(t *testing.T) {
 		"%d concurrent relays for one service must share one reflection stream", relays)
 }
 
-// TestMAG2860_ConnectWarmsTheCacheSoNoRelayIsCold is the ticket's actual symptom.
+// TestMAG2860_InitializeWarmsInBackground covers the FALLBACK warm, on a
+// connection that reached initialize() without ever being prewarmed.
 //
-// Detaching the lookup from the relay makes a cold endpoint cost one failed relay
-// instead of failing forever — but cross-validation needs N successes in ONE
-// request, so "the second attempt works" is still an outage to the client that
-// sent the first. Connecting warms the cache, so the first real relay is not the
-// one paying for it.
-//
-// The endpoint here is slow enough that a cold lookup could never fit inside the
-// relay budget used below: if the warm did not happen, this relay is the failing
-// one from the bug report.
-func TestMAG2860_ConnectWarmsTheCacheSoNoRelayIsCold(t *testing.T) {
-	s := startSlowReflectionServer(t, 300*time.Millisecond)
+// This is a weaker guarantee than the readiness boundary below and is not what
+// closes the bug — a relay racing this warm can still be cold. It is pinned
+// separately because it is what a connection built outside endpoint setup gets,
+// and because it is what makes the sweep run exactly once either way.
+func TestMAG2860_InitializeWarmsInBackground(t *testing.T) {
+	s := startSlowReflectionServer(t, 100*time.Millisecond)
 
 	fake := newFakeGRPCConnector()
 	fake.conn = s.conn
@@ -219,24 +244,102 @@ func TestMAG2860_ConnectWarmsTheCacheSoNoRelayIsCold(t *testing.T) {
 	})
 	t.Cleanup(func() { _ = g.Close() })
 
-	// Connecting is all that happens here — no relay has asked for anything.
 	require.NoError(t, g.ensureInitialized(context.Background()))
 
 	require.Eventually(t, func() bool {
 		return g.GetCachedMethodDescriptor(healthCheckMethod) != nil
 	}, 5*time.Second, 10*time.Millisecond,
-		"connecting must warm the descriptor cache, with no relay involved")
+		"initialize must warm the descriptor cache behind itself, with no relay involved")
+}
 
-	// A budget that a cold lookup could not possibly fit inside.
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+// TestMAG2860_PrewarmedEndpointServesTheFirstRelay is the ticket's actual symptom,
+// through the real lifecycle.
+//
+// Nothing here reaches inside the connection: it is constructed by the production
+// constructor against a real listener, taken through the production readiness step
+// that endpoint setup runs before publishing it, and then relayed to. No
+// ensureInitialized, no waiting on the cache, no fake connector — the dial, the
+// reflection and the sweep are all real.
+//
+// That distinction is the point. Warming started from initialize() only RACES the
+// first relay, because production builds connections lazily: NewDirectRPCConnection
+// makes no network call, and SendRequest calls ensureInitialized and continues
+// straight on. So the first relay could still arrive mid-sweep and start its own
+// slow lookup, which is the failure in the bug report. The boundary has to be
+// crossed before the endpoint is reachable, not alongside the request that reaches
+// it.
+//
+// The relay budget below is a third of what one cold reflection round trip costs
+// against this server, so a regression cannot pass by being merely fast.
+func TestMAG2860_PrewarmedEndpointServesTheFirstRelay(t *testing.T) {
+	const reflectionDelay = 300 * time.Millisecond
+	addr := startSlowReflectionListener(t, reflectionDelay)
+
+	// Production construction: same call, same arguments as rpcsmartrouter's
+	// endpoint setup.
+	conn, err := NewDirectRPCConnection(
+		context.Background(),
+		common.NodeUrl{
+			Url:        "grpc://" + addr,
+			GrpcConfig: common.GrpcConfig{AllowInsecure: true},
+		},
+		uint(MaximumStreamsOverASingleConnection),
+		"grpc",
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	// Production readiness step: exactly what runs before these connections are
+	// handed to UpdateAllProviders and become selectable.
+	PrewarmDirectConnections(context.Background(), []DirectRPCConnection{conn}, DirectRPCPrewarmBudget)
+
+	// The first relay this endpoint ever sees, on a budget a cold lookup could not
+	// come close to fitting inside.
+	relayCtx, cancel := context.WithTimeout(context.Background(), reflectionDelay/3)
 	defer cancel()
 
-	resp, err := g.SendRequest(ctx, []byte("{}"), healthCheckHeaders())
-	require.NoError(t, err, "the FIRST relay must already be warm")
+	resp, err := conn.SendRequest(relayCtx, []byte("{}"), healthCheckHeaders())
+	require.NoError(t, err, "the FIRST relay to a published endpoint must never be cold")
 	require.NotNil(t, resp)
+	require.NotEmpty(t, resp.Data)
+}
+
+// TestMAG2860_PrewarmIsIdempotentAndSweepsOnce pins that the readiness step and
+// the initialize() fallback do not each run a sweep.
+//
+// A duplicate sweep would re-resolve every service on the node — against exactly
+// the slow-reflection endpoints this treatment is aimed at, and on gateways where
+// reflection is rate-limited.
+func TestMAG2860_PrewarmIsIdempotentAndSweepsOnce(t *testing.T) {
+	s := startSlowReflectionServer(t, 0)
+
+	fake := newFakeGRPCConnector()
+	fake.conn = s.conn
+	g := newUninitializedGRPCConn(func(lifetimeCtx, dialCtx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
+		return fake, nil
+	})
+	t.Cleanup(func() { _ = g.Close() })
+
+	// Concurrent prewarms, plus relays racing them, plus a repeat afterwards.
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			require.NoError(t, g.Prewarm(context.Background()))
+		}()
+	}
+	wg.Wait()
+
+	require.NoError(t, g.Prewarm(context.Background()))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := g.SendRequest(ctx, []byte("{}"), healthCheckHeaders())
+	require.NoError(t, err)
 
 	require.Equal(t, int32(1), s.reflectionStream.Load(),
-		"the warm-up sweep is one reflection stream, and the relay adds none")
+		"the descriptor sweep must run once per connection, however many callers ask")
 }
 
 // TestMAG2860_CloseAbortsAnInFlightLookup is the lifecycle guard on detaching the
@@ -268,4 +371,141 @@ func TestMAG2860_CloseAbortsAnInFlightLookup(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("Close blocked on a background descriptor lookup instead of cancelling it")
 	}
+}
+
+// TestMAG2860_LocalCancellationBeatsLookupFailure pins that a relay the router
+// itself abandoned is never reported as a node failure.
+//
+// getMethodDescriptor waits on two channels: the resolution finishing, and the
+// caller's context ending. Go picks among READY select cases at random, so when
+// both are ready the resolution case wins about half the time — and returning its
+// error there drops the context.Canceled sentinel that common.IsClientCancellation
+// matches on. Endpoint health then books a node error against an endpoint that did
+// nothing wrong, for a relay whose result was being discarded anyway.
+//
+// The barrier is construction, not timing: the resolution has already published a
+// generic failure and the context is already cancelled before the waiter reaches
+// the select, so BOTH cases are ready on every iteration and the randomisation is
+// fully exercised. No sleeps, and no dependence on goroutine scheduling.
+func TestMAG2860_LocalCancellationBeatsLookupFailure(t *testing.T) {
+	const service = "pkg.Service"
+
+	// One iteration would pass by luck half the time; a regression has to lose all
+	// of these to pass.
+	for i := range 200 {
+		g := newGRPCDirectRPCConnection(common.NodeUrl{Url: "grpc://127.0.0.1:1"})
+
+		// A waiter arriving on a resolution that is already in flight.
+		resolution := &descriptorResolution{done: make(chan struct{})}
+		g.inflight[service] = resolution
+
+		// ...whose context is cancelled...
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		// ...and which then publishes a generic error, with nothing cached.
+		resolution.err = errors.New("lookup failed")
+		close(resolution.done)
+
+		methodDesc, err := g.getMethodDescriptor(ctx, service, "Method")
+		require.Nil(t, methodDesc)
+		require.ErrorIs(t, err, context.Canceled,
+			"iteration %d lost local cancellation and reported the lookup's error instead", i)
+	}
+}
+
+// TestMAG2860_SuccessfulLookupSurvivesCancellation is the other half of the rule
+// above: cancellation is authoritative over a lookup FAILURE, not over a lookup
+// that produced the descriptor.
+//
+// Throwing away a descriptor already in hand would fail a relay that can still be
+// served, and would make the endpoint look worse than it is.
+func TestMAG2860_SuccessfulLookupSurvivesCancellation(t *testing.T) {
+	s := startSlowReflectionServer(t, 0)
+	g := newGRPCConnOverServer(t, s)
+
+	// Resolve once so the service descriptor is genuinely available.
+	warmCtx, cancelWarm := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelWarm()
+	require.NoError(t, g.Prewarm(warmCtx))
+
+	service, method := "grpc.health.v1.Health", "Check"
+	resolution, claimed := g.claimServiceResolution(service)
+	require.True(t, claimed)
+
+	descriptor, err := g.lookupService(service)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	g.publishServiceResolution(service, resolution, descriptor, nil)
+
+	// Both select cases ready, and the lookup succeeded.
+	methodDesc, err := g.getMethodDescriptor(ctx, service, method)
+	require.NoError(t, err, "a descriptor already in hand must not be discarded on cancellation")
+	require.NotNil(t, methodDesc)
+}
+
+// TestMAG2860_ReflectionTimeoutBoundsAreEnforced pins that grpc-config's
+// reflection-timeout is checked on the path that uses it.
+//
+// GetReflectionTimeout budgets every descriptor lookup and, multiplied, the
+// warm-up sweep. common.GrpcConfig.Validate has defined 100ms..30s bounds all
+// along but has no caller on any path reaching a connection, and static-provider
+// validation only checks the URL — so a nanosecond timeout reached
+// context.WithTimeout and failed every lookup on the endpoint, silently and
+// permanently.
+//
+// Production path: ensureInitialized, with the dial replaced so an accepted
+// config is not also a network test.
+func TestMAG2860_ReflectionTimeoutBoundsAreEnforced(t *testing.T) {
+	newConn := func(t *testing.T, timeout time.Duration) *GRPCDirectRPCConnection {
+		t.Helper()
+		g := newGRPCDirectRPCConnection(common.NodeUrl{
+			Url: "grpc://127.0.0.1:1",
+			GrpcConfig: common.GrpcConfig{
+				AllowInsecure:     true,
+				ReflectionTimeout: timeout,
+			},
+		})
+		g.newConnector = func(lifetimeCtx, dialCtx context.Context, nConns uint, nodeUrl common.NodeUrl) (grpcConnectorInterface, error) {
+			return newFakeGRPCConnector(), nil
+		}
+		t.Cleanup(func() { _ = g.Close() })
+		return g
+	}
+
+	t.Run("unset keeps the 5s default", func(t *testing.T) {
+		g := newConn(t, 0)
+		require.NoError(t, g.ensureInitialized(context.Background()))
+		require.Equal(t, 5*time.Second, g.nodeUrl.GrpcConfig.GetReflectionTimeout())
+	})
+
+	t.Run("below the minimum is rejected", func(t *testing.T) {
+		for _, timeout := range []time.Duration{time.Nanosecond, time.Millisecond, 99 * time.Millisecond} {
+			g := newConn(t, timeout)
+			err := g.ensureInitialized(context.Background())
+			require.Error(t, err, "reflection-timeout %s must not reach a context", timeout)
+			require.Contains(t, err.Error(), "reflection-timeout too short")
+			require.False(t, g.initialized.Load(), "a rejected config must not leave the connection initialized")
+		}
+	})
+
+	t.Run("above the maximum is rejected", func(t *testing.T) {
+		for _, timeout := range []time.Duration{31 * time.Second, time.Hour} {
+			g := newConn(t, timeout)
+			err := g.ensureInitialized(context.Background())
+			require.Error(t, err, "reflection-timeout %s must not reach a context", timeout)
+			require.Contains(t, err.Error(), "reflection-timeout too long")
+			require.False(t, g.initialized.Load())
+		}
+	})
+
+	t.Run("in-bounds values are accepted", func(t *testing.T) {
+		for _, timeout := range []time.Duration{100 * time.Millisecond, 2 * time.Second, 30 * time.Second} {
+			g := newConn(t, timeout)
+			require.NoError(t, g.ensureInitialized(context.Background()))
+			require.Equal(t, timeout, g.nodeUrl.GrpcConfig.GetReflectionTimeout())
+		}
+	})
 }

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -2159,6 +2159,9 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	// Helper function to convert provider endpoints to sessions
 	convertProvidersToSessions := func(providerList []*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
 		sessions := make(map[uint64]*lavasession.ConsumerSessionsWithProvider)
+		// Every connection built below, so the readiness step at the end of this
+		// function can run before any of them is reachable by a relay (MAG-2860).
+		createdConnections := []lavasession.DirectRPCConnection{}
 		for idx, provider := range providerList {
 			// Only process providers matching this endpoint's API interface
 			if provider.ApiInterface != rpcEndpoint.ApiInterface || provider.ChainID != rpcEndpoint.ChainID {
@@ -2194,6 +2197,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 					utils.LogAttr("protocol", directConn.GetProtocol()),
 					utils.LogAttr("provider", provider.Name),
 				)
+				createdConnections = append(createdConnections, directConn)
 
 				endpoint := &lavasession.Endpoint{
 					NetworkAddress:    url.Url,
@@ -2253,6 +2257,24 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 			providerEntry.GroupLabel = provider.GroupLabel // cross-validation group-diversity label (may be empty)
 			sessions[uint64(idx)] = providerEntry
 		}
+
+		// The readiness boundary (MAG-2860). Direct connections are lazy — a gRPC one
+		// has made no network call at all when NewDirectRPCConnection returns — so
+		// without this the first RELAY to an endpoint is what dials it and resolves
+		// its protobuf descriptors. Reflection on a slow node outlasts a relay
+		// timeout, and cross-validation needs N successes in one request, so that
+		// first relay failing is the whole defect rather than a slow start.
+		//
+		// Here is the one place that covers every lifecycle which produces a
+		// connection — boot, the failed-provider retry, epoch re-verification and
+		// /debug/reset-pairing all funnel through this closure — and it runs before
+		// the caller hands any of these sessions to UpdateAllProviders, which is what
+		// makes an endpoint selectable.
+		//
+		// Bounded and never fatal, in keeping with MAG-2525: a connection that does
+		// not finish is published anyway and falls back to on-demand resolution.
+		lavasession.PrewarmDirectConnections(ctx, createdConnections, lavasession.DirectRPCPrewarmBudget)
+
 		return sessions
 	}
 


### PR DESCRIPTION
# Description

Cross-validation over gRPC could never reach quorum against an endpoint whose
descriptor reflection is slower than the relay timeout. It parked one short of the
threshold with `nodeErrorCount: 0` — the second endpoint returned nothing at all
rather than something wrong.

Each `DirectRPCConnection` filled its protobuf descriptor cache by reflection on
first use, on the **relay's** context. When reflection outran that budget the
lookup was killed *before* the descriptor was cached, so the next relay did
another cold lookup and failed identically. Permanent for that provider, not a
slow start — 12 attempts against `sui-grpc-1`, every one at exactly 2.000s, zero
successes, while its warm sibling answered in ~140ms throughout.

Ordinary traffic hides this, because the warm provider answers. CV is where it
surfaces, because it needs N successes in one request rather than one.

## The lifecycle invariant

> A gRPC connection is dialed and its descriptor cache filled **before the endpoint
> holding it is published to the session manager.** Publication is what makes an
> endpoint selectable, so no relay can be the one paying for a cold lookup.

Bounded and never fatal: prewarms run concurrently under one budget, and a
connection that overruns is published anyway and falls back to on-demand
resolution. Gating selectability on upstream health would undo MAG-2525 — the
attempt is what's gated, not its success.

## What changed

**1. Descriptor lookups no longer die with the relay that triggered them.**
`lookupService` runs on grpc-config's `reflection-timeout`, rooted at the
connection's lifetime rather than any relay's, and caches what it finds after the
caller has given up. The relay still fails on its own deadline — it has failover to
do — but a cold cache now costs the endpoint once instead of once per attempt.
`reflection-timeout` was already defined, defaulted to 5s and validated to
100ms..30s; it had never been applied to anything.

**2. Warming is a readiness step, not a side effect.** This is the part the first
round of review corrected. Production builds connections lazily —
`NewDirectRPCConnection` makes no network call, `SendRequest` calls
`ensureInitialized` and continues — so warming from `initialize()` only *raced*
the first relay. `DirectRPCPrewarmer.Prewarm` + `PrewarmDirectConnections` now run
across every connection endpoint setup has just built, before those sessions reach
`UpdateAllProviders`. The creation closure in `rpcsmartrouter.go` is the one seam
all five lifecycles funnel through — boot, failed-provider retry, epoch
re-verification, `/debug/reset-pairing` — so the boundary holds for every
connection that exists. The `initialize()` sweep remains as the fallback, and both
paths share one `sync.Once`.

**3. Local cancellation is authoritative over lookup failure.** `select` picks
among ready cases at random, so when the caller's context and the resolution were
both ready the resolution won about half the time and its generic error replaced
`context.Canceled`. `common.IsClientCancellation` matches on that sentinel, so a
relay the router itself abandoned was booked against endpoint health as a node
error that never happened. A lookup that *succeeded* is still used — discarding a
descriptor already in hand would fail a relay we can serve.

**4. `reflection-timeout` bounds are enforced on the path that uses them.**
`GrpcConfig.Validate` defines them but has no caller reaching a connection, and
static-provider validation only checks the URL, so `ReflectionTimeout: 1ns` reached
`context.WithTimeout` and failed every lookup on the endpoint, silently and
permanently. Only the timeout half of `Validate` is applied: the rest requires a
descriptor-set path for `hybrid` that `DescriptorSourceForNode` deliberately
tolerates, so running all of it here would reject configurations that work today.
`Validate`'s own behaviour is unchanged.

**5. Smaller, same path.** Resolving a service caches every method on it rather
than only the one asked for; concurrent relays for one service share a single
lookup; and the warm-up sweep claims services through the same registry the
on-demand path uses, so the two never resolve the same service twice.

`Close` still stops all of it — it cancels the connector context before its drain
waits on the pooled client the sweep holds.

## Most critical to review

* `PrewarmDirectConnections` and its call site — the invariant above lives or dies
  on running before `UpdateAllProviders`, and on never being fatal.
* `lookupService` — the context is rooted at `connectorCtx`, never a relay's. That
  is the fix; it is also what would strand a pooled client if cancellation were
  wrong.
* `getMethodDescriptor`'s post-`select` ordering — success, then cache, then
  context, then lookup error. The order is the behaviour.
* `publishServiceResolution` must be reached on every path out of a claim, or
  waiters block until their own context expires.

## Behaviour change worth flagging

`TestSendRequest_ReturnsBorrowedClientExactlyOnce` now expects **two** handbacks.
The lookup borrows a client of its own instead of riding on the relay's, because
the relay hands its client back the moment it gives up and `ReturnRpc` can close it
outright. Not racy: the lookup returns its client before publishing its result, and
the relay does not return its own until it has read that result.

## Testing

Ten tests in `direct_rpc_descriptor_lookup_test.go`. The three that carry the
weight:

* `TestMAG2860_PrewarmedEndpointServesTheFirstRelay` — production constructor
  against a real listener, production readiness step, then a relay on a 100ms
  budget against 300ms reflection. No `ensureInitialized`, no cache wait, no fake
  connector.
* `TestMAG2860_LocalCancellationBeatsLookupFailure` — both `select` cases made
  ready **by construction**, 200 iterations, no sleeps.
* `TestMAG2860_ReflectionTimeoutBoundsAreEnforced` — 5s default, sub-100ms,
  over-30s, in-bounds, all through `ensureInitialized`.

Every test was confirmed to **fail with its own fix surgically removed**, so none
would pass unchanged on `main`.

```
go test -race ./protocol/lavasession -run '^(TestMAG2860_|TestSendRequest_ReturnsBorrowedClientExactlyOnce$)' -count=10   ok
go test -race ./protocol/lavasession ./protocol/rpcsmartrouter ./protocol/endpointstate ./protocol/chainlib -count=1      ok
go test -race ./protocol/common -count=1                                                                                 ok
git diff --check                                                                                                         clean
```

**These Go tests are not regression coverage.** No workflow in `.github/workflows/`
invokes `go test`, so they run once, on the author's machine, and never again. Real
coverage for this needs a nightly automation test in smart-router-automation —
happy to open a follow-up.

## Not done

Direction 3 from the ticket — sharing one descriptor cache across providers that
resolve to the same upstream — is an optimization rather than part of the defect,
and assumes two endpoints serve identical protos, which is not guaranteed.
Per-service dedup plus whole-service caching covers the cost concern within a
connection.

The ticket's open question (whether any production deployment runs CV on a gRPC
chain today) is unanswered and unchanged by this PR. Not re-run against Sui
testnet either: the MAG-2643 repro script is not on `main` yet, so the fixtures
reproduce the shape — reflection slower than the relay budget — not that endpoint.

## Jira ticket

Jira ticket: MAG-2860

---

## Author Checklist

I have...

* [x] read the contribution guide
* [x] included the correct type prefix in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change — n/a, no API or client breaking change
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests — unit tests added; see the note above on why they are not CI coverage
* [x] updated the relevant documentation or specification, including comments for documenting Go code
* [x] confirmed all CI checks have passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
