### PR TITLE
perf(smart-router): decouple re-verification from the epoch tick and jitter it

### DIFF
--- a/protocol/common/cobra_common.go
+++ b/protocol/common/cobra_common.go
@@ -105,6 +105,12 @@ const (
 	LimitParallelWebsocketConnectionsPerIpFlag   = "limit-parallel-websocket-connections-per-ip"
 	LimitWebsocketIdleTimeFlag                   = "limit-websocket-connection-idle-time"
 	SkipWebsocketVerificationFlag                = "skip-websocket-verification"
+	// VerificationsIntervalFlag / VerificationsJitterFlag pace the background re-verify
+	// pass. The interval is how stale a capability answer may get; the jitter is how far
+	// apart instances sharing an upstream are spread, so a fleet does not probe in unison
+	// and rate-limit itself.
+	VerificationsIntervalFlag = "verifications-interval"
+	VerificationsJitterFlag   = "verifications-jitter"
 	// specification default flags
 	ProbeUpdateWeightFlagName = "probe-update-weight"
 	// ProbeLoopIntervalFlagName is the cadence of the MAG-2161 (Topic D) proactive health prober —

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -382,6 +382,11 @@ func (rpsr *RPCSmartRouter) Start(ctx context.Context, options *rpcSmartRouterSt
 	// Start the epoch timer
 	rpsr.epochTimer.Start(ctx)
 
+	// Re-verification runs on its own jittered schedule rather than on the epoch tick.
+	// Epoch boundaries are identical fleet-wide by construction, so probing on them made
+	// every pod hit the same upstreams at the same instant; see reverifyStartOffset.
+	rpsr.startReVerifyRefresher(ctx)
+
 	relaysMonitorAggregator.StartMonitoring(ctx)
 
 	// Start optional debug HTTP server for integration tests.
@@ -2321,6 +2326,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	// callback, bounded by SpecReVerifyConcurrency.
 	rpsr.mu.Lock()
 	rpsr.reverifyInputs[sessionManagerKey] = &chainReverifyInputs{
+		results:                    newReverifyResults(),
 		chainParser:                chainParser,
 		rpcEndpoint:                rpcEndpoint,
 		convertProvidersToSessions: convertProvidersToSessions,
@@ -3049,6 +3055,8 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	cmdRPCSmartRouter.Flags().DurationVar(&chainlib.WebSocketBanDuration, common.BanDurationForWebsocketRateLimitExceededFlag, chainlib.WebSocketBanDuration, "once websocket rate limit is reached, user will be banned Xfor a duration, default no ban")
 
 	cmdRPCSmartRouter.Flags().BoolVar(&chainlib.SkipWebsocketVerification, common.SkipWebsocketVerificationFlag, chainlib.SkipWebsocketVerification, "skip websocket verification for chains that require ws/wss endpoints")
+	cmdRPCSmartRouter.Flags().DurationVar(&SpecReVerifyInterval, common.VerificationsIntervalFlag, SpecReVerifyInterval, "how often the background pass re-verifies configured providers. Capability answers change when a vendor changes config, not by the minute, so this is deliberately slower than the epoch tick")
+	cmdRPCSmartRouter.Flags().DurationVar(&SpecReVerifyJitter, common.VerificationsJitterFlag, SpecReVerifyJitter, "window each re-verify pass is spread over. Every instance picks a pseudo-random point inside it from a seed unique to that process, so instances sharing an upstream account do not probe in unison. 0 disables jitter")
 
 	cmdRPCSmartRouter.Flags().DurationVar(&lavasession.ProbeLoopInterval, common.ProbeLoopIntervalFlagName, lavasession.ProbeLoopInterval, "cadence of the proactive health prober (MAG-2161 Topic D); must be > 0, default 5s")
 	cmdRPCSmartRouter.Flags().Float64(common.ProbeUpdateWeightFlagName, scoreutils.DefaultProbeUpdateWeight, "weight multiplier for provider-optimizer probe updates (liveness/latency); must be > 0")

--- a/protocol/rpcsmartrouter/spec_reverifier.go
+++ b/protocol/rpcsmartrouter/spec_reverifier.go
@@ -2,6 +2,7 @@ package rpcsmartrouter
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -85,6 +86,11 @@ type chainReverifyInputs struct {
 	// holds that lock across both tier calls. Lazily allocated so test fixtures that build
 	// chainReverifyInputs by hand need not.
 	demoteFailStreak map[string]int
+	// results is the last completed validation outcome per provider, written by the
+	// background refresher and read here. It is what decouples verification load from the
+	// epoch tick: the boundary reconciles from cached evidence instead of probing inline.
+	// Nil in test fixtures that inject validateFn, which bypasses the cache entirely.
+	results *reverifyResults
 }
 
 // applyReverification revalidates configured providers for one tier and
@@ -138,10 +144,13 @@ func applyReverification(
 	if len(configured) == 0 {
 		return fresh, nil, nil
 	}
+	// Production reads the background refresher's last completed result; it does NO network
+	// work on the epoch boundary. Tests inject validateFn to drive the reconciliation
+	// directly without standing up a refresher.
 	validate := inputs.validateFn
 	if validate == nil {
-		validate = func(c context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
-			return validateProvider(c, p, inputs.chainParser, SpecReVerifyAttemptTimeout)
+		validate = func(_ context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
+			return inputs.results.get(p.Name)
 		}
 	}
 
@@ -185,6 +194,20 @@ func applyReverification(
 					utils.LogAttr("provider", p.Name),
 				)
 			}
+			continue
+		}
+		if errors.Is(err, errNoReVerifyResultYet) {
+			// The background pass has not reached this provider yet — most often the first
+			// boundary after start-up. No evidence either way, so change nothing: start-up
+			// validation already gated what is in the pairing.
+			if wasActive {
+				healthyNames[p.Name] = struct{}{}
+			}
+			utils.LavaFormatDebug("re-verify: no completed result yet, leaving membership unchanged",
+				utils.LogAttr("chain", inputs.rpcEndpoint.ChainID),
+				utils.LogAttr("provider", p.Name),
+				utils.LogAttr("active", wasActive),
+			)
 			continue
 		}
 		if !wasActive {

--- a/protocol/rpcsmartrouter/spec_reverify_refresher.go
+++ b/protocol/rpcsmartrouter/spec_reverify_refresher.go
@@ -1,0 +1,252 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"hash/fnv"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/utils"
+)
+
+// SpecReVerifyInterval is how often the background pass re-probes configured providers.
+//
+// Re-verification used to ride the epoch tick, so it ran every epoch — 15 minutes. That
+// cadence was inherited from the hook, not chosen: a verification answers "does this
+// upstream still serve what it declares", and that changes when a vendor changes their
+// config, not every quarter hour. An hour keeps the answer fresh at a fraction of the
+// request volume.
+//
+// Note this stretches demote latency. reverifyDemoteThreshold consecutive failures now
+// span 2 × this interval rather than 2 epochs. Demotion was always the coarse cleanup —
+// endpoint health disables a dead endpoint within seconds and QoS stops routing to it —
+// so trading demote latency for a fleet that stops rate-limiting itself is the right way
+// round. Exported for tests; not flag-bound.
+var SpecReVerifyInterval = time.Hour
+
+// SpecReVerifyJitter is the window each refresh is spread over. Every instance picks a
+// pseudo-random point inside it, so the fleet's probes land scattered rather than together.
+//
+// It is deliberately separate from, and much smaller than, the interval. The interval says
+// how fresh the answer has to be; the jitter says how tightly the fleet is allowed to bunch
+// up. A couple of minutes is already ample: spreading ~80 instances over 2 minutes puts the
+// fleet in the single-digit rps range against a cap of hundreds, while keeping "verification
+// happens shortly after the interval elapses" true enough to reason about in logs.
+//
+// Bound to --verifications-jitter. Zero disables jitter entirely (every instance probes as
+// soon as its interval elapses), which is almost never what you want with more than one
+// instance sharing an upstream account.
+var SpecReVerifyJitter = 2 * time.Minute
+
+// errNoReVerifyResultYet marks a provider the background pass has not probed yet. It is
+// deliberately distinct from both nil (healthy) and a validation failure: at the first
+// epoch boundary after start-up there is no evidence either way, and the reconciliation
+// must not read absence as either health or failure.
+var errNoReVerifyResultYet = errors.New("re-verify: no completed result yet")
+
+// reverifyResults is the hand-off between the background prober and the epoch boundary.
+//
+// The boundary reads the last completed set and returns immediately; the prober refreshes
+// it on its own jittered schedule. This is what decouples verification load from the epoch
+// tick — see reverifyStartOffset for why that matters.
+type reverifyResults struct {
+	mu      sync.RWMutex
+	results map[string]error // provider name -> last validation outcome (nil = healthy)
+}
+
+func newReverifyResults() *reverifyResults {
+	return &reverifyResults{results: map[string]error{}}
+}
+
+// get returns the last completed outcome for a provider, or errNoReVerifyResultYet.
+func (r *reverifyResults) get(name string) error {
+	if r == nil {
+		return errNoReVerifyResultYet
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	err, ok := r.results[name]
+	if !ok {
+		return errNoReVerifyResultYet
+	}
+	return err
+}
+
+func (r *reverifyResults) set(name string, err error) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.results[name] = err
+}
+
+// reverifyJitter returns this instance's offset into the jitter window for a given tick.
+//
+// Deterministic in (seed, tick) rather than drawn from rand: the sequence is reproducible,
+// so an operator reading logs can work out when an instance probed and when it will next.
+// Re-derived per tick rather than fixed once, so two instances whose seeds happen to land
+// close together drift apart on the following cycle instead of colliding forever.
+func reverifyJitter(window time.Duration, seed string, tick uint64) time.Duration {
+	if window <= 0 {
+		return 0
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(seed))
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], tick)
+	_, _ = h.Write(buf[:])
+	return time.Duration(h.Sum64() % uint64(window))
+}
+
+// reverifySeed identifies this router instance for jitter purposes. It is the hostname
+// combined with a checksum over the routing configuration, and it needs both halves.
+//
+// A config checksum alone does not work. Replicas of one chain run byte-identical config --
+// same chains, same providers, same listen port inside each container -- so every replica
+// would hash to the same offset and probe together. On a fleet of N chains x 2 replicas that
+// throws away half the spread.
+//
+// A hostname alone does not work either. It is unique per pod under Kubernetes and nowhere
+// else: run several routers on one host -- compose, bare metal, one process per chain on a VM
+// -- and every one of them hashes to the same offset, exactly as synchronized as having no
+// jitter at all. That was the bug in the first revision of this file.
+//
+// Together they cover both: the hostname separates replicas of one config, the checksum
+// separates co-located processes running different configs. Both halves are config- or
+// environment-derived rather than random, so the seed survives a restart and a crashlooping
+// instance keeps its slot instead of re-rolling.
+//
+// Falls back to hostname + PID when no endpoint is known yet -- unique, but it re-rolls on
+// restart, which is why it is only the fallback.
+func (rpsr *RPCSmartRouter) reverifySeed() string {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		host = "smart-router"
+	}
+
+	rpsr.mu.Lock()
+	parts := make([]string, 0, len(rpsr.reverifyInputs))
+	for key, in := range rpsr.reverifyInputs {
+		if in == nil {
+			continue
+		}
+		entry := key
+		if in.rpcEndpoint != nil {
+			entry += "@" + in.rpcEndpoint.NetworkAddress
+		}
+		for _, tier := range [][]*lavasession.RPCStaticProviderEndpoint{in.configuredStatic, in.configuredBackup} {
+			for _, prov := range tier {
+				if prov == nil {
+					continue
+				}
+				entry += "|" + prov.Name
+				for _, u := range prov.NodeUrls {
+					entry += ">" + u.UrlStr() + "(" + strings.Join(u.Addons, "+") + ")"
+				}
+			}
+		}
+		parts = append(parts, entry)
+	}
+	rpsr.mu.Unlock()
+
+	if len(parts) == 0 {
+		return host + "/pid:" + strconv.Itoa(os.Getpid())
+	}
+	sort.Strings(parts) // map iteration order must not change the seed
+	sum := sha256.Sum256([]byte(strings.Join(parts, ";")))
+	return host + "/cfg:" + hex.EncodeToString(sum[:8])
+}
+
+// startReVerifyRefresher runs the background probe loop: wait out this pod's offset, then
+// refresh every SpecReVerifyInterval. Results land in each chain's reverifyResults, which
+// the epoch boundary consumes without doing any network work of its own.
+func (rpsr *RPCSmartRouter) startReVerifyRefresher(ctx context.Context) {
+	seed := rpsr.reverifySeed()
+	first := reverifyJitter(SpecReVerifyJitter, seed, 0)
+	utils.LavaFormatInfo("re-verify: background refresher scheduled",
+		utils.LogAttr("interval", SpecReVerifyInterval.String()),
+		utils.LogAttr("jitterWindow", SpecReVerifyJitter.String()),
+		utils.LogAttr("firstRunIn", first.String()),
+		utils.LogAttr("seed", seed),
+	)
+
+	go func() {
+		timer := time.NewTimer(first)
+		defer timer.Stop()
+		for tick := uint64(1); ; tick++ {
+			select {
+			case <-ctx.Done():
+				return
+			case <-timer.C:
+			}
+			rpsr.refreshReVerifyResults(ctx)
+			// Each cycle lands somewhere in [interval, interval+jitter).
+			timer.Reset(SpecReVerifyInterval + reverifyJitter(SpecReVerifyJitter, seed, tick))
+		}
+	}()
+}
+
+// refreshReVerifyResults probes every configured provider on every chain once and stores
+// the outcome. It performs no pairing mutation — the epoch boundary owns that.
+func (rpsr *RPCSmartRouter) refreshReVerifyResults(ctx context.Context) {
+	rpsr.mu.Lock()
+	type job struct {
+		chainKey string
+		inputs   *chainReverifyInputs
+	}
+	jobs := make([]job, 0, len(rpsr.reverifyInputs))
+	for k, in := range rpsr.reverifyInputs {
+		if in != nil {
+			jobs = append(jobs, job{chainKey: k, inputs: in})
+		}
+	}
+	rpsr.mu.Unlock()
+
+	started := time.Now()
+	probed := 0
+	for _, j := range jobs {
+		validate := j.inputs.validateFn
+		if validate == nil {
+			validate = func(c context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
+				return validateProvider(c, p, j.inputs.chainParser, SpecReVerifyAttemptTimeout)
+			}
+		}
+		configured := append(append([]*lavasession.RPCStaticProviderEndpoint{},
+			j.inputs.configuredStatic...), j.inputs.configuredBackup...)
+
+		var wg sync.WaitGroup
+		sem := make(chan struct{}, SpecReVerifyConcurrency)
+		for _, p := range configured {
+			p := p
+			select {
+			case <-ctx.Done():
+				return
+			case sem <- struct{}{}:
+			}
+			wg.Add(1)
+			probed++
+			go func() {
+				defer wg.Done()
+				defer func() { <-sem }()
+				j.inputs.results.set(p.Name, validate(ctx, p))
+			}()
+		}
+		wg.Wait()
+	}
+
+	utils.LavaFormatDebug("re-verify: background refresh complete",
+		utils.LogAttr("chains", len(jobs)),
+		utils.LogAttr("providersProbed", probed),
+		utils.LogAttr("elapsed", time.Since(started).String()),
+	)
+}

--- a/protocol/rpcsmartrouter/spec_reverify_refresher_test.go
+++ b/protocol/rpcsmartrouter/spec_reverify_refresher_test.go
@@ -1,0 +1,235 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"strings"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/stretchr/testify/require"
+)
+
+// runRefreshCycles drives N consecutive re-verify cycles against the same inputs, threading
+// the surviving map forward exactly as updateEpoch does, and returns the final active set.
+func runRefreshCycles(t *testing.T, inputs *chainReverifyInputs, active map[uint64]*lavasession.ConsumerSessionsWithProvider, n int) map[string]struct{} {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		active, _, _ = applyReverification(context.Background(), inputs, active, reverifyTierStatic, uint64(100+i))
+	}
+	return collectNames(active)
+}
+
+// Jitter is the whole point of the change: without it every instance probes the moment its
+// interval elapses, and a fleet that started together stays in lockstep forever.
+func TestReverifyJitter(t *testing.T) {
+	const window = 2 * time.Minute
+
+	t.Run("deterministic in seed and tick", func(t *testing.T) {
+		a := reverifyJitter(window, "router-a", 7)
+		b := reverifyJitter(window, "router-a", 7)
+		require.Equal(t, a, b, "the schedule must be reproducible from the seed")
+	})
+
+	t.Run("always inside the window", func(t *testing.T) {
+		for i := 0; i < 500; i++ {
+			off := reverifyJitter(window, fmt.Sprintf("router-%d", i), uint64(i))
+			require.GreaterOrEqual(t, off, time.Duration(0))
+			require.Less(t, off, window)
+		}
+	})
+
+	t.Run("zero window disables jitter", func(t *testing.T) {
+		require.Zero(t, reverifyJitter(0, "router-a", 3))
+		require.Zero(t, reverifyJitter(-time.Second, "router-a", 3))
+	})
+
+	t.Run("same instance moves between ticks", func(t *testing.T) {
+		// Two seeds landing close together must not stay collided forever.
+		seen := map[time.Duration]struct{}{}
+		for tick := uint64(0); tick < 20; tick++ {
+			seen[reverifyJitter(window, "router-a", tick)] = struct{}{}
+		}
+		require.Greater(t, len(seen), 10, "offsets must vary across ticks, got %d distinct", len(seen))
+	})
+
+	t.Run("a fleet spreads across the window", func(t *testing.T) {
+		buckets := map[int]int{}
+		for i := 0; i < 40; i++ {
+			for r := 0; r < 2; r++ {
+				seed := fmt.Sprintf("host-%02d-%d/CHAIN%02djsonrpc@0.0.0.0:%d", i, r, i, 3000+r)
+				buckets[int(reverifyJitter(window, seed, 0)/(10*time.Second))]++ // twelve 10s buckets
+			}
+		}
+		require.GreaterOrEqual(t, len(buckets), 10,
+			"80 instances must spread across the window; got %d buckets (%v)", len(buckets), buckets)
+		for b, n := range buckets {
+			require.LessOrEqual(t, n, 20, "bucket %d holds %d of 80 — too clustered", b, n)
+		}
+	})
+}
+
+// The seed needs both of its halves, and each covers a case the other misses. These are the
+// two real deployment shapes: replicas of one config on different hosts, and different
+// configs co-located on one host.
+func TestReverifySeed_CoversBothDeploymentShapes(t *testing.T) {
+	mk := func(chainKey, addr, provider, url string) *RPCSmartRouter {
+		return &RPCSmartRouter{reverifyInputs: map[string]*chainReverifyInputs{
+			chainKey: {
+				rpcEndpoint: &lavasession.RPCEndpoint{
+					ChainID: "ETH1", ApiInterface: "jsonrpc", NetworkAddress: addr,
+				},
+				configuredStatic: []*lavasession.RPCStaticProviderEndpoint{
+					{Name: provider, NodeUrls: []common.NodeUrl{{Url: url}}},
+				},
+			},
+		}}
+	}
+
+	t.Run("co-located processes: different config, same host", func(t *testing.T) {
+		// The hostname is identical for both; only the checksum can separate them.
+		a := mk("ETH1jsonrpc", "0.0.0.0:3000", "chainstack", "https://a.example").reverifySeed()
+		b := mk("SOLANAjsonrpc", "0.0.0.0:3001", "chainstack", "https://b.example").reverifySeed()
+		require.NotEqual(t, a, b, "co-located processes must not share a seed")
+		require.NotEqual(t, reverifyJitter(2*time.Minute, a, 0), reverifyJitter(2*time.Minute, b, 0),
+			"co-located processes must not land on the same offset")
+	})
+
+	t.Run("replicas: identical config, different hosts", func(t *testing.T) {
+		// Byte-identical config, so the checksum halves MATCH by construction. Only the
+		// hostname can separate them -- which is why a config checksum alone is not enough.
+		cfg := mk("ETH1jsonrpc", "0.0.0.0:3000", "chainstack", "https://a.example")
+		seed := cfg.reverifySeed()
+		_, digest, found := strings.Cut(seed, "/cfg:")
+		require.True(t, found, "seed must carry a config digest, got %q", seed)
+
+		replicaA := "router-abc123/cfg:" + digest
+		replicaB := "router-def456/cfg:" + digest
+		require.NotEqual(t, reverifyJitter(2*time.Minute, replicaA, 0), reverifyJitter(2*time.Minute, replicaB, 0),
+			"replicas of one config must not land on the same offset")
+	})
+
+	t.Run("stable across calls", func(t *testing.T) {
+		a := mk("ETH1jsonrpc", "0.0.0.0:3000", "chainstack", "https://a.example").reverifySeed()
+		b := mk("ETH1jsonrpc", "0.0.0.0:3000", "chainstack", "https://a.example").reverifySeed()
+		require.Equal(t, a, b, "a restart must keep the same slot")
+	})
+
+	t.Run("config changes move the seed", func(t *testing.T) {
+		base := mk("ETH1jsonrpc", "0.0.0.0:3000", "chainstack", "https://a.example").reverifySeed()
+		require.NotEqual(t, base, mk("ETH1jsonrpc", "0.0.0.0:3000", "tatum", "https://a.example").reverifySeed(),
+			"a different provider must change the checksum")
+		require.NotEqual(t, base, mk("ETH1jsonrpc", "0.0.0.0:3000", "chainstack", "https://z.example").reverifySeed(),
+			"a different node url must change the checksum")
+	})
+
+	t.Run("map iteration order must not leak in", func(t *testing.T) {
+		multi := func() string {
+			return (&RPCSmartRouter{reverifyInputs: map[string]*chainReverifyInputs{
+				"ETH1jsonrpc":   {rpcEndpoint: &lavasession.RPCEndpoint{NetworkAddress: "0.0.0.0:3000"}},
+				"SOLANAjsonrpc": {rpcEndpoint: &lavasession.RPCEndpoint{NetworkAddress: "0.0.0.0:3001"}},
+				"BASEjsonrpc":   {rpcEndpoint: &lavasession.RPCEndpoint{NetworkAddress: "0.0.0.0:3002"}},
+			}}).reverifySeed()
+		}
+		for i := 0; i < 20; i++ {
+			require.Equal(t, multi(), multi())
+		}
+	})
+
+	t.Run("no endpoints yet still yields a seed", func(t *testing.T) {
+		require.NotEmpty(t, (&RPCSmartRouter{reverifyInputs: map[string]*chainReverifyInputs{}}).reverifySeed())
+	})
+}
+
+func TestReverifyResults_Semantics(t *testing.T) {
+	r := newReverifyResults()
+
+	require.ErrorIs(t, r.get("never-probed"), errNoReVerifyResultYet,
+		"an unprobed provider must be distinguishable from a healthy one")
+
+	r.set("healthy", nil)
+	require.NoError(t, r.get("healthy"))
+
+	boom := errors.New("cannot serve archive")
+	r.set("broken", boom)
+	require.ErrorIs(t, r.get("broken"), boom)
+
+	// refreshes overwrite
+	r.set("broken", nil)
+	require.NoError(t, r.get("broken"))
+
+	var nilResults *reverifyResults
+	require.ErrorIs(t, nilResults.get("anything"), errNoReVerifyResultYet,
+		"a nil cache must read as no-evidence, never as healthy")
+}
+
+// Until the background pass has produced a result, the boundary must change nothing. Reading
+// absence as health would promote providers that failed start-up validation; reading it as
+// failure would demote the entire pairing on the first boundary after a restart.
+func TestApplyReverification_NoResultYetLeavesMembershipUnchanged(t *testing.T) {
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "jsonrpc"}
+
+	active := map[uint64]*lavasession.ConsumerSessionsWithProvider{0: makeSession("active")}
+	var converted []string
+	inputs := &chainReverifyInputs{
+		rpcEndpoint: rpc,
+		convertProvidersToSessions: func(p []*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+			for _, ep := range p {
+				converted = append(converted, ep.Name)
+			}
+			return fakeConvert(p)
+		},
+		configuredStatic: []*lavasession.RPCStaticProviderEndpoint{
+			makeProvider("active"), makeProvider("inactive"),
+		},
+		results: newReverifyResults(), // empty: nothing probed yet
+	}
+
+	got := runRefreshCycles(t, inputs, active, 3)
+	require.Contains(t, got, "active", "an active provider must survive an unprobed cycle")
+	require.NotContains(t, got, "inactive", "an unprobed provider must not be promoted")
+	require.Empty(t, converted, "no promotion may happen on absent evidence")
+	require.Empty(t, inputs.demoteFailStreak, "an unprobed cycle must not advance the demote streak")
+}
+
+// End to end through the refresher: it probes, stores, and the boundary then acts on what it
+// stored -- with no network work on the boundary itself.
+func TestRefreshReVerifyResults_FeedsTheBoundary(t *testing.T) {
+	withImmediateDemote(t)
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "jsonrpc"}
+
+	inputs := &chainReverifyInputs{
+		rpcEndpoint:                rpc,
+		convertProvidersToSessions: fakeConvert,
+		configuredStatic: []*lavasession.RPCStaticProviderEndpoint{
+			makeProvider("good"), makeProvider("bad"),
+		},
+		results: newReverifyResults(),
+		validateFn: func(_ context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
+			if p.Name == "bad" {
+				return errors.New("cannot serve archive")
+			}
+			return nil
+		},
+	}
+
+	rpsr := &RPCSmartRouter{reverifyInputs: map[string]*chainReverifyInputs{"TESTjsonrpc": inputs}}
+	rpsr.refreshReVerifyResults(context.Background())
+
+	require.NoError(t, inputs.results.get("good"))
+	require.Error(t, inputs.results.get("bad"))
+
+	// Now reconcile from the cache alone — validateFn cleared so any probing would surface
+	// as errNoReVerifyResultYet and leave membership untouched, failing the assertions below.
+	inputs.validateFn = nil
+	active := map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: makeSession("good"), 1: makeSession("bad"),
+	}
+	got := runRefreshCycles(t, inputs, active, 1)
+	require.Contains(t, got, "good")
+	require.NotContains(t, got, "bad", "the boundary must act on the cached failure")
+}


### PR DESCRIPTION
#Closes MAG-2887

Jira ticket: MAG-2887

Every router pod re-verified its providers at the same instant, against the same shared vendor account. The burst exceeded the vendor's rate limit, the resulting 429s were counted as verification failures, and healthy providers were demoted out of the pairing. The router caused the failure it then acted on.

Two defects in how re-verification is scheduled.

> The third defect originally in this PR — a rate-limit being counted as a capability failure — is now **PR #304** (MAG-2910), split out so it can grow a backoff. Independent of this one, either order.

## The evidence

93% of the fleet's 429s — 382 of 412 over three hours on production — land on the epoch-boundary minutes:

| minute | 429s |
| --- | --- |
| :00 | 106 |
| :15 | 90 |
| :30 | 85 |
| :45 | 101 |
| all other 56 minutes | 30 |

Between boundaries the vendor is fine. ~80 pods tick within ~1.0s of each other against an account capped at 200 rps.

## 1. Re-verification ran every epoch

Fifteen minutes was inherited from the hook, not chosen. `SpecReVerifyInterval` now defaults to an hour.

This stretches demote latency to 2 × the interval. That's the right trade: demotion was always the coarse cleanup — endpoint health disables a dead endpoint within seconds and QoS stops routing to it.

## 2. No jitter across instances

`epoch_timer.go` derives boundaries from wall clock against a fixed origin (2024-01-01 UTC) because epochs must agree fleet-wide for pairing rotation. **The tick can't be jittered without breaking epoch semantics**, so this moves the verification instead.

A background pass probes on its own schedule and stores the outcome; the epoch boundary reconciles from the last completed set and does no network work at all. That split follows a seam `applyReverification` already had — it ran validations, then reconciled them — so the reconciliation logic is unchanged.

Two knobs, deliberately separate:

```
--verifications-interval   how stale a capability answer may get   (default 1h)
--verifications-jitter     how tightly the fleet may bunch up      (default 2m, 0 disables)
```

Conflating them would mean the only way to spread probes further is to verify less often. Two minutes is ample — spreading ~80 instances over it puts the fleet in the single-digit rps range against a cap of hundreds — while keeping "verification happens shortly after the interval elapses" true enough to reason about in logs.

**The seed is hostname + a checksum over the routing configuration, and it needs both halves.**

An earlier revision used `os.Hostname()` alone, which is unique per pod under Kubernetes and nowhere else — several routers on one host would all hash to the same offset. But a config checksum alone doesn't work either: replicas of one chain run byte-identical config, so every replica would collide, throwing away half the spread on an N-chains × 2-replicas fleet.

| | separates replicas | separates co-located processes |
| --- | --- | --- |
| hostname only | yes | **no** |
| config checksum only | **no** | yes |
| both | yes | yes |

The checksum covers chains, listen addresses, provider names, node URLs and their addons. Both halves are config- or environment-derived rather than random, so the seed survives a restart and a crashlooping instance keeps its slot.

The offset is re-derived each tick rather than fixed once, so instances whose seeds land close together drift apart on the next cycle instead of colliding permanently.

An unprobed provider is tracked distinctly from a healthy one. Reading absence as health would promote providers that failed start-up validation; reading it as failure would demote the whole pairing on the first boundary after a restart.

## Expected effect

The same work spread across the interval instead of ~1 second — the fleet lands well under 1 rps against the 200 rps cap — and a rate-limit can no longer demote a healthy provider even if a burst does occur.

## How to verify

```
go build ./... && go vet ./protocol/rpcsmartrouter/ ./protocol/chainlib/
go test ./protocol/...
go test -race ./protocol/rpcsmartrouter/ -run 'Reverify|ReVerify|Reverification'
go test ./protocol/rpcsmartrouter/ -run 'TestIsRateLimitFailure_ProductionShapes|TestApplyReverification_RateLimit|TestApplyReverification_RealFailure|TestReverifyStartOffset' -v
```

`TestReverifyJitter` asserts a fleet of 80 instances spreads across the window with no bucket holding more than a quarter, that an instance's offset moves between ticks, and that a zero window disables jitter. `TestReverifySeed_DistinguishesCoLocatedInstances` pins the case review caught: two processes on one host must not share a seed or an offset, the seed must be stable across calls, and map iteration order must not leak into it.

## Notes for review

- Commits are separable. If you'd rather land the classification fix alone first — it stops the harm on its own, independent of load — the first commit stands by itself.
- `SpecReVerifyConcurrency` and `SpecReVerifyAttemptTimeout` remain vars, matching their existing treatment. The interval and jitter are flag-bound because they are the two an operator actually needs to tune per deployment.
- Related: MAG-2873 makes `skip-verifications` actually skip, which is the operator-side opt-out for this problem. This removes the need for it.
- MAG-2865 records tatum absent from `validProviders` on 18 chains, cause not established. The demotion path here is a strong candidate — **not proven**, and this PR does not claim to close it.