### PR TITLE
chore(smart-router): remove the customer identifier from a test comment

### DIFF
--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -3354,7 +3354,7 @@ func TestIsFinalizedForCacheWrite(t *testing.T) {
 // filtered. With one endpoint that means an all-failed result -> ConsistencyError ->
 // the "No pairings available" the customer saw.
 //
-// The numbers are the real incident values from the GK8 logs:
+// The numbers are the real values from the incident logs:
 // seenBlock=424549212, block-height tip=403165980, gap=21383232.
 func TestFilterEndpointsByConsistency_SolanaSlotVsBlockHeightUnitMismatch(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
#Closes MAG-2903

Jira ticket: MAG-2903

## Why

One line in a test comment attributed an incident to a named customer. The rest of the comment is fine — it's just the attribution.

## What changed

That one line, in `protocol/rpcsmartrouter/rpcsmartrouter_server_test.go`. The comment now reads "the real values from the incident logs".

**The figures stay.** They're what makes the regression test concrete, and the paragraph above them explains exactly how the slot-vs-block-height unit gap produces `No pairings available`. Only the attribution goes.

A sweep of the repository for the known customer identifiers plus the common custody and exchange vendors returns **zero** remaining hits after this, so nothing else here needs touching.

## How to verify

```
go test ./protocol/rpcsmartrouter/ -run TestFilterEndpointsByConsistency_SolanaSlotVsBlockHeightUnitMismatch
```

Then re-run the identifier sweep (pattern in MAG-2903) and confirm it returns nothing.

## Related

PR #117 in smart-router-helm-chart — the same cleanup for the chart README, which is the more exposed of the two since it's public-facing documentation that also carried internal hostnames. Independent of this one; either can merge first.