### PR TITLE
fix(smart-router): a rate-limited probe is inconclusive, not a capability failure

### DIFF
--- a/protocol/chainlib/chain_fetcher.go
+++ b/protocol/chainlib/chain_fetcher.go
@@ -499,7 +499,7 @@ func (cf *ChainFetcher) FetchLatestBlockNum(ctx context.Context) (int64, error) 
 	}
 	reply, _, _, proxyUrl, chainId, err := cf.chainRouter.SendNodeMsg(ctx, nil, chainMessage, nil)
 	if err != nil {
-		return spectypes.NOT_APPLICABLE, utils.LavaFormatDebug(tagName+" failed sending chainMessage", []utils.Attribute{{Key: "chainID", Value: cf.endpoint.ChainID}, {Key: "APIInterface", Value: cf.endpoint.ApiInterface}, {Key: "error", Value: err}}...)
+		return spectypes.NOT_APPLICABLE, utils.LavaFormatWarning(tagName+" failed sending chainMessage", err, []utils.Attribute{{Key: "chainID", Value: cf.endpoint.ChainID}, {Key: "APIInterface", Value: cf.endpoint.ApiInterface}}...)
 	}
 	parserInput, err := FormatResponseForParsing(reply.RelayReply, chainMessage)
 	if err != nil {
@@ -597,7 +597,7 @@ func (cf *ChainFetcher) fetchSingleBlockHashByNum(ctx context.Context, blockNum 
 	reply, _, _, proxyUrl, chainId, err := cf.chainRouter.SendNodeMsg(ctx, nil, chainMessage, nil)
 	if err != nil {
 		timeTaken := time.Since(start)
-		return "", nil, utils.LavaFormatDebug(tagName+" failed sending chainMessage", []utils.Attribute{{Key: "sendTime", Value: timeTaken}, {Key: "error", Value: err}, {Key: "chainID", Value: cf.endpoint.ChainID}, {Key: "APIInterface", Value: cf.endpoint.ApiInterface}}...)
+		return "", nil, utils.LavaFormatWarning(tagName+" failed sending chainMessage", err, []utils.Attribute{{Key: "sendTime", Value: timeTaken}, {Key: "chainID", Value: cf.endpoint.ChainID}, {Key: "APIInterface", Value: cf.endpoint.ApiInterface}}...)
 	}
 
 	responseData := reply.RelayReply.Data

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -535,7 +535,7 @@ func (rcp *RestChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{},
 
 	err = rcp.HandleStatusError(res.StatusCode, nodeMessage.GetDisableErrorHandling())
 	if err != nil {
-		return nil, "", nil, utils.LavaFormatWarning("Received invalid status code", nil, utils.Attribute{Key: "Status Code", Value: res.StatusCode}, utils.Attribute{Key: "chainID", Value: rcp.BaseChainProxy.ChainID}, utils.Attribute{Key: "apiName", Value: chainMessage.GetApi().Name})
+		return nil, "", nil, utils.LavaFormatWarning("Received invalid status code", err, utils.Attribute{Key: "Status Code", Value: res.StatusCode}, utils.Attribute{Key: "chainID", Value: rcp.BaseChainProxy.ChainID}, utils.Attribute{Key: "apiName", Value: chainMessage.GetApi().Name})
 	}
 
 	body, err := io.ReadAll(res.Body)

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -737,7 +737,7 @@ func (cp *tendermintRpcChainProxy) SendURI(ctx context.Context, nodeMessage *rpc
 
 	err = cp.HandleStatusError(res.StatusCode, nodeMessage.GetDisableErrorHandling())
 	if err != nil {
-		return nil, "", nil, utils.LavaFormatWarning("Received invalid status code", nil, utils.Attribute{Key: "Status Code", Value: res.StatusCode}, utils.Attribute{Key: "chainID", Value: cp.BaseChainProxy.ChainID}, utils.Attribute{Key: "apiName", Value: chainMessage.GetApi().Name})
+		return nil, "", nil, utils.LavaFormatWarning("Received invalid status code", err, utils.Attribute{Key: "Status Code", Value: res.StatusCode}, utils.Attribute{Key: "chainID", Value: cp.BaseChainProxy.ChainID}, utils.Attribute{Key: "apiName", Value: chainMessage.GetApi().Name})
 	}
 
 	// read the response body

--- a/protocol/rpcsmartrouter/rate_limit_inconclusive_test.go
+++ b/protocol/rpcsmartrouter/rate_limit_inconclusive_test.go
@@ -1,0 +1,91 @@
+package rpcsmartrouter
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/utils"
+	"github.com/stretchr/testify/require"
+)
+
+// Detection is structural wherever a status code exists: ValidateStatusCodes mints
+// common.StatusCodeError429 and every HTTP-family proxy propagates it as LavaFormat's cause,
+// so errors.Is finds it through the wrapping. The cases below drive each transport the way
+// production produces it, so a path that starts discarding its typed error fails here rather
+// than silently demoting a healthy provider.
+func TestIsRateLimitFailure_ProductionShapes(t *testing.T) {
+	rateLimited := []struct {
+		name string
+		err  error
+	}{
+		{
+			"the bare sentinel",
+			common.StatusCodeError429,
+		},
+		{
+			// jsonrpc over http: ValidateStatusCodes mints the sentinel, the proxy wraps it.
+			"jsonrpc over http, one wrap",
+			utils.LavaFormatWarning("Received invalid status code", common.StatusCodeError429),
+		},
+		{
+			// rest / tendermint: same sentinel, reached through HandleStatusError. These two
+			// proxies used to pass nil here and render the code into an attribute instead,
+			// which left nothing for errors.Is to find.
+			"rest, sentinel through the full verify stack",
+			utils.LavaFormatWarning("[-] verify failed sending chainMessage",
+				utils.LavaFormatWarning("Received invalid status code", common.StatusCodeError429)),
+		},
+		{
+			// The latest-block path, which used to drop the cause into an attribute.
+			"wrapped sentinel via the GET_BLOCKNUM path",
+			utils.LavaFormatWarning("GET_BLOCKNUM failed sending chainMessage", common.StatusCodeError429),
+		},
+		{
+			// grpc is the one transport with no status code to check: grpc-go reports
+			// codes.Unavailable and the 429 survives only inside the status description.
+			"grpc transport, no status code exists",
+			errors.New(`[-] verify failed sending chainMessage ErrMsg: rpc error: code = Unavailable desc = unexpected HTTP status code received from server: 429 (Too Many Requests); transport: received unexpected content-type "application/json"`),
+		},
+	}
+	for _, tc := range rateLimited {
+		t.Run(tc.name, func(t *testing.T) {
+			require.True(t, isRateLimitFailure(tc.err), "must be read as rate-limited: %v", tc.err)
+		})
+	}
+
+	notRateLimited := []struct {
+		name string
+		err  error
+	}{
+		{"nil", nil},
+		{
+			// A genuine capability gap. Must still demote — this is the dwellir/STRK case.
+			"upstream cannot serve the addon",
+			errors.New("[-] verify failed to parse result {chainId:BERAB,Method:eth_getBlockByNumber,Response:{\"error\":{\"code\":-16503,\"message\":\"No healthy upstream available\"}}}"),
+		},
+		{
+			"node error unrelated to rate limiting",
+			errors.New("[-] verify failed sending chainMessage ErrMsg: txIndex 2: nonce too high"),
+		},
+		{
+			// A block number that happens to contain 429 must not be mistaken for a status code.
+			"block number containing 429",
+			errors.New("[-] verify failed to parse result {block:4293102,Method:eth_getBlockByNumber}"),
+		},
+		{
+			"connection refused",
+			errors.New("dial tcp 1.2.3.4:443: connect: connection refused"),
+		},
+		{
+			// A different status code must not ride the same path.
+			"504 sentinel, wrapped the same way",
+			utils.LavaFormatWarning("Received invalid status code", common.StatusCodeError504),
+		},
+	}
+	for _, tc := range notRateLimited {
+		t.Run(tc.name, func(t *testing.T) {
+			require.False(t, isRateLimitFailure(tc.err), "must NOT be read as rate-limited: %v", tc.err)
+		})
+	}
+}

--- a/protocol/rpcsmartrouter/rate_limit_reverify_test.go
+++ b/protocol/rpcsmartrouter/rate_limit_reverify_test.go
@@ -1,0 +1,121 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/stretchr/testify/require"
+)
+
+// runCycles drives N consecutive re-verify cycles against the same inputs, threading the
+// surviving map forward exactly as updateEpoch does, and returns the final active set.
+func runCycles(t *testing.T, inputs *chainReverifyInputs, active map[uint64]*lavasession.ConsumerSessionsWithProvider, n int) map[string]struct{} {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		active, _, _ = applyReverification(context.Background(), inputs, active, reverifyTierStatic, uint64(100+i))
+	}
+	return collectNames(active)
+}
+
+// A rate-limited probe says the vendor refused us for asking too fast. It is not evidence the
+// provider cannot serve, so it must never demote — no matter how many cycles it persists for.
+// Before this, the fleet demoted providers that were serving traffic fine, because the
+// fleet's own synchronized verification burst blew a shared 200 rps vendor cap.
+func TestApplyReverification_RateLimitNeverDemotes(t *testing.T) {
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "jsonrpc"}
+
+	active := map[uint64]*lavasession.ConsumerSessionsWithProvider{0: makeSession("tatum")}
+	inputs := &chainReverifyInputs{
+		rpcEndpoint:                rpc,
+		convertProvidersToSessions: fakeConvert,
+		configuredStatic:           []*lavasession.RPCStaticProviderEndpoint{makeProvider("tatum")},
+		validateFn: func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+			return common.StatusCodeError429
+		},
+	}
+
+	// Ten cycles is five times the demote threshold; a counted failure would have demoted long ago.
+	got := runCycles(t, inputs, active, 10)
+	require.Contains(t, got, "tatum", "a rate-limited provider must stay paired")
+	require.Empty(t, inputs.demoteFailStreak, "a rate-limited cycle must not advance the demote streak")
+}
+
+// The guard must be narrow: a provider that genuinely cannot serve still has to go. This is the
+// dwellir-on-STRK case, where the upstream could not serve `trace` at all.
+func TestApplyReverification_RealFailureStillDemotes(t *testing.T) {
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "jsonrpc"}
+
+	active := map[uint64]*lavasession.ConsumerSessionsWithProvider{0: makeSession("dwellir")}
+	inputs := &chainReverifyInputs{
+		rpcEndpoint:                rpc,
+		convertProvidersToSessions: fakeConvert,
+		configuredStatic:           []*lavasession.RPCStaticProviderEndpoint{makeProvider("dwellir")},
+		validateFn: func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+			return errors.New("[-] verify failed to parse result: upstream does not serve trace")
+		},
+	}
+
+	got := runCycles(t, inputs, active, reverifyDemoteThreshold)
+	require.NotContains(t, got, "dwellir", "a genuine capability failure must still demote")
+}
+
+// A rate-limited probe on an inactive provider is not evidence of health either — it must not
+// promote one back into the pairing on no information.
+func TestApplyReverification_RateLimitDoesNotPromote(t *testing.T) {
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "jsonrpc"}
+
+	var converted []string
+	inputs := &chainReverifyInputs{
+		rpcEndpoint: rpc,
+		convertProvidersToSessions: func(p []*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+			for _, ep := range p {
+				converted = append(converted, ep.Name)
+			}
+			return fakeConvert(p)
+		},
+		configuredStatic: []*lavasession.RPCStaticProviderEndpoint{makeProvider("absent")},
+		validateFn: func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+			return common.StatusCodeError429
+		},
+	}
+
+	got := runCycles(t, inputs, map[uint64]*lavasession.ConsumerSessionsWithProvider{}, 3)
+	require.Empty(t, got, "a rate-limited probe is not evidence of health")
+	require.Empty(t, converted, "must not promote on an inconclusive result")
+}
+
+// Mixed set: the rate-limited one survives, the broken one goes, in the same cycle.
+func TestApplyReverification_MixedRateLimitAndFailure(t *testing.T) {
+	withImmediateDemote(t)
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "jsonrpc"}
+
+	active := map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: makeSession("busy"),
+		1: makeSession("broken"),
+		2: makeSession("healthy"),
+	}
+	inputs := &chainReverifyInputs{
+		rpcEndpoint:                rpc,
+		convertProvidersToSessions: fakeConvert,
+		configuredStatic: []*lavasession.RPCStaticProviderEndpoint{
+			makeProvider("busy"), makeProvider("broken"), makeProvider("healthy"),
+		},
+		validateFn: func(_ context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
+			switch p.Name {
+			case "busy":
+				return common.StatusCodeError429
+			case "broken":
+				return errors.New("upstream does not serve archive")
+			}
+			return nil
+		},
+	}
+
+	got := runCycles(t, inputs, active, 1)
+	require.Contains(t, got, "busy", "rate-limited stays")
+	require.Contains(t, got, "healthy", "healthy stays")
+	require.NotContains(t, got, "broken", "genuinely failing goes")
+}

--- a/protocol/rpcsmartrouter/spec_reverifier.go
+++ b/protocol/rpcsmartrouter/spec_reverifier.go
@@ -2,6 +2,8 @@ package rpcsmartrouter
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"sync"
 	"time"
 
@@ -121,6 +123,45 @@ type chainReverifyInputs struct {
 // The third return is the names promoted this cycle. updateEpoch needs them to drop
 // those providers from the failed lists — promoting here while leaving them pending
 // for retryFailedProviders produces two sessions for one provider.
+// rateLimitTextSignatures covers the one transport where no status code exists to check.
+//
+// Every HTTP-family transport now reaches us as common.StatusCodeError429 — ValidateStatusCodes
+// mints it, and each proxy propagates it as LavaFormat's cause, so Unwrap survives and errors.Is
+// below is the real check. gRPC is different in kind: there is no HTTP status in the error at
+// all. grpc-go reports codes.Unavailable and the vendor's 429 survives only inside the status
+// description, so there is nothing structural to match on.
+//
+// Verbatim from a production failure. Keep this list minimal — a new entry here is usually a
+// signal that some path is discarding a typed error, which is worth fixing at the source
+// instead.
+var rateLimitTextSignatures = []string{
+	"429 (Too Many Requests)", // grpc transport: no status code, only the status description
+}
+
+// isRateLimitFailure reports whether a failed validation was the upstream refusing us for
+// asking too fast, rather than the upstream being unable to serve what it declares.
+//
+// The distinction is already settled elsewhere in this codebase — see the IsRateLimited
+// comment on common.RelayResult: "the endpoint is healthy but busy. Callers back off but
+// must not mark it unhealthy, which is why the direct-RPC availability gate excludes it."
+// The relay path honours that; re-verification did not, and a rate-limited probe demoted
+// providers that were serving traffic perfectly well.
+func isRateLimitFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, common.StatusCodeError429) {
+		return true
+	}
+	msg := err.Error()
+	for _, sig := range rateLimitTextSignatures {
+		if strings.Contains(msg, sig) {
+			return true
+		}
+	}
+	return false
+}
+
 func applyReverification(
 	ctx context.Context,
 	inputs *chainReverifyInputs,
@@ -185,6 +226,22 @@ func applyReverification(
 					utils.LogAttr("provider", p.Name),
 				)
 			}
+			continue
+		}
+		if isRateLimitFailure(err) {
+			// Inconclusive, not failed: the upstream refused us for asking too fast and told
+			// us nothing about whether it can serve. Leave the streak untouched — advancing it
+			// would let a busy vendor demote a healthy provider — and leave membership as-is:
+			// an active provider stays paired, an inactive one is not promoted on no evidence.
+			if wasActive {
+				healthyNames[p.Name] = struct{}{}
+			}
+			utils.LavaFormatWarning("re-verify: "+tier.String()+" rate-limited, treating as inconclusive", err,
+				utils.LogAttr("chain", inputs.rpcEndpoint.ChainID),
+				utils.LogAttr("provider", p.Name),
+				utils.LogAttr("active", wasActive),
+				utils.LogAttr("consecutiveFailures", inputs.demoteFailStreak[streakKey]),
+			)
 			continue
 		}
 		if !wasActive {


### PR DESCRIPTION
#Closes MAG-2910

Jira ticket: MAG-2910

Split out of PR #301 so the rate-limit handling can land on its own and grow a backoff. #301 keeps the scheduling work (decoupling re-verification from the epoch tick, and jittering it).

## Why

`endpoints.go:457` states the rule, and the relay path follows it:

> `IsRateLimited` … the endpoint is healthy but busy. Callers back off but must not mark it unhealthy, which is why the direct-RPC availability gate excludes it.

`recovery_probe.go` follows it too — a rate-limited probe returns `relayProbeInconclusive`. Re-verification did not: a 429 made `Validate` return an error, which advanced the demote streak and dropped the provider out of the pairing.

That's a category error. A rate-limit says we asked too fast; it says nothing about whether the node serves what it declares. In production it demoted providers that were serving traffic fine, because the fleet's own synchronized verification burst blew a shared 200 rps vendor cap.

## What changed

A rate-limited re-verify is now **inconclusive**: streak untouched, membership unchanged, and an inactive provider is *not* promoted on no evidence. Genuine capability failures demote exactly as before — there's a test for the shape where an upstream can't serve a declared addon.

**Detection is structural, not textual.** `ValidateStatusCodes` already mints `common.StatusCodeError429`; the problem was four call sites discarding it, passing the cause as a `LavaFormat` **attribute** rather than its `err` parameter. That sends `err=nil` into `LavaFormatLog`, which returns a plain `fmt.Errorf` instead of a `wrappedLavaError` — dropping `Unwrap`, and with it `errors.Is`:

| site | was |
|---|---|
| `chain_fetcher.go` ×2 | why the latest-block failure surfaced as a bare `GET_BLOCKNUM failed sending chainMessage` with no 429 in it |
| `rest.go`, `tendermintRPC.go` | discarded the typed error `HandleStatusError` had just returned |

All four now propagate the cause — matching what `jsonRPC.go` and the sibling `tendermintRPC` site already did.

That leaves **one** text signature, for gRPC alone: `grpc-go` reports `codes.Unavailable` and the vendor's 429 survives only inside the status description, so there is no status code to check. The comment says to treat a new entry there as a signal that some path is discarding a typed error, and to fix it at the source instead.

## How to verify

```
go build ./... && go vet ./protocol/chainlib/ ./protocol/rpcsmartrouter/
go test ./protocol/chainlib/ ./protocol/rpcsmartrouter/ ./protocol/common/
go test ./protocol/rpcsmartrouter/ -run 'TestIsRateLimitFailure|TestApplyReverification_RateLimit|TestApplyReverification_RealFailure|TestApplyReverification_Mixed' -v
```

Tests drive each transport through the wrapping production actually builds, so a path that starts discarding its typed error fails here rather than silently demoting a healthy provider. Negative cases matter as much: a genuine capability gap, a 504 wrapped identically, and a block number that merely contains `429` must all stay unclassified.

## Still to come on this ticket — backoff

Classification is only half of it. **Nothing in the router actually backs off when told to slow down.** `IsRateLimited` gates *not marking unhealthy*; it does not change the cadence of the next request, so a rate-limited upstream is asked again on exactly the same schedule. `Retry-After` is not read anywhere in the codebase.

Open questions I'd want settled before implementing, noted on the ticket:

- **Where** — the background re-verify pass is the clear case; whether the relay path and recovery probe share the mechanism is a bigger call.
- **Shape** — per-provider exponential, capped, reset on success. `upstream_grpc_pool.go` already has an `ExponentialBackoff` worth reusing rather than writing a second one.
- **Retry-After** — cheap to honour and strictly better than guessing, but the header isn't surfaced through the proxy layer today.
- **Scope of the penalty** — a 429 is usually account-wide, not per-endpoint. Backing off only the probed URL may be too narrow when several chains share one vendor account.

## Relationship to #301

Independent, either order. They touch adjacent lines in `applyReverification`'s if-chain and both add an import, so whichever merges second takes a small conflict; the resolution is the union of both branches. I test-merged them locally and the combined result builds and passes all three suites — the two inconclusive branches (rate-limited, and not-yet-probed) sit side by side after the `err == nil` case and before the demote path.

#301 reduces the load that produces the 429s. This one stops the router misreading the result, and is where compounding it gets fixed.
