### PR TITLE
feat(smart-router): back off a rate-limited provider instead of re-probing it

### DIFF
--- a/protocol/rpcsmartrouter/reverify_backoff.go
+++ b/protocol/rpcsmartrouter/reverify_backoff.go
@@ -1,0 +1,117 @@
+package rpcsmartrouter
+
+import (
+	"sync"
+	"time"
+)
+
+// Rate-limit backoff bounds for the re-verify pass.
+//
+// The first penalty is deliberately larger than a relay retry would use: this is a
+// capability probe, not a request a caller is waiting on, so there is no cost to waiting and
+// every reason not to add load to an upstream that just told us to slow down. The cap keeps a
+// provider from disappearing from verification indefinitely — at the ceiling it is still
+// re-probed regularly, just far less often than the interval.
+//
+// ExponentialBackoff applies its jitter AFTER capping, so an individual delay can exceed
+// ReVerifyRateLimitBackoffMax by up to WebSocketJitterFactor. That is deliberate rather than
+// tolerated: without it every provider held off by one vendor-wide limit would come back at
+// the same instant and rebuild the burst this is meant to damp.
+var (
+	ReVerifyRateLimitBackoffInitial = 5 * time.Minute
+	ReVerifyRateLimitBackoffMax     = time.Hour
+)
+
+const reVerifyRateLimitBackoffMultiplier = 2.0
+
+// reverifyBackoff decides when a rate-limited provider may be probed again.
+//
+// Keyed by provider NAME rather than node URL. A 429 is a vendor-level signal — the account
+// is over its limit, not that one endpoint is broken — so where a process serves several
+// chains through the same vendor, one chain's rate-limit should slow the others too. Keying
+// by URL would let a process keep hammering an account through its other chains.
+//
+// The zero value is not usable; call newReverifyBackoff.
+type reverifyBackoff struct {
+	mu    sync.Mutex
+	state map[string]*providerBackoff
+}
+
+type providerBackoff struct {
+	eb    *ExponentialBackoff
+	until time.Time
+}
+
+func newReverifyBackoff() *reverifyBackoff {
+	return &reverifyBackoff{state: map[string]*providerBackoff{}}
+}
+
+// ready reports whether this provider may be probed now. A provider that has never been
+// rate-limited is always ready, so the common path costs one map lookup.
+func (b *reverifyBackoff) ready(provider string, now time.Time) bool {
+	if b == nil {
+		return true
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	st, ok := b.state[provider]
+	if !ok {
+		return true
+	}
+	return !now.Before(st.until)
+}
+
+// penalise records a rate-limited probe and returns how long the provider is now held off
+// for. Consecutive rate-limits grow the interval; the ExponentialBackoff carries the attempt
+// count and applies its own jitter, so two providers hitting the same cap do not come back
+// in lockstep.
+func (b *reverifyBackoff) penalise(provider string, now time.Time) time.Duration {
+	if b == nil {
+		return 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	st, ok := b.state[provider]
+	if !ok {
+		st = &providerBackoff{eb: NewExponentialBackoff(
+			ReVerifyRateLimitBackoffInitial,
+			ReVerifyRateLimitBackoffMax,
+			reVerifyRateLimitBackoffMultiplier,
+			0, // unlimited: a rate-limit must never exhaust into "give up on this provider"
+		)}
+		b.state[provider] = st
+	}
+	delay, _ := st.eb.NextBackoff()
+	st.until = now.Add(delay)
+	return delay
+}
+
+// clear drops any penalty after a probe that was not rate-limited. Called on every
+// non-rate-limited outcome, not only success: once the upstream is answering us again --
+// even to report a genuine capability failure -- it is no longer refusing us for load, and
+// the demote logic should see that failure at the normal cadence rather than through a
+// backoff window.
+func (b *reverifyBackoff) clear(provider string) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.state, provider)
+}
+
+// heldOff reports how many providers are currently in backoff. Used for logging.
+func (b *reverifyBackoff) heldOff(now time.Time) int {
+	if b == nil {
+		return 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	n := 0
+	for _, st := range b.state {
+		if now.Before(st.until) {
+			n++
+		}
+	}
+	return n
+}

--- a/protocol/rpcsmartrouter/reverify_backoff_test.go
+++ b/protocol/rpcsmartrouter/reverify_backoff_test.go
@@ -1,0 +1,163 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReverifyBackoff(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Run("never-penalised provider is always ready", func(t *testing.T) {
+		b := newReverifyBackoff()
+		require.True(t, b.ready("tatum", base))
+	})
+
+	t.Run("a nil backoff is inert", func(t *testing.T) {
+		var b *reverifyBackoff
+		require.True(t, b.ready("tatum", base), "nil must never hold a provider off")
+		require.Zero(t, b.penalise("tatum", base))
+		b.clear("tatum") // must not panic
+		require.Zero(t, b.heldOff(base))
+	})
+
+	t.Run("penalty holds the provider off, then releases it", func(t *testing.T) {
+		b := newReverifyBackoff()
+		d := b.penalise("tatum", base)
+		require.Positive(t, d)
+		require.False(t, b.ready("tatum", base), "held off immediately after the penalty")
+		require.False(t, b.ready("tatum", base.Add(d-time.Second)), "still held off just before expiry")
+		require.True(t, b.ready("tatum", base.Add(d)), "ready once the window elapses")
+	})
+
+	t.Run("consecutive rate-limits grow the interval", func(t *testing.T) {
+		b := newReverifyBackoff()
+		first := b.penalise("tatum", base)
+		second := b.penalise("tatum", base)
+		third := b.penalise("tatum", base)
+		require.Greater(t, second, first, "second penalty must exceed the first")
+		require.Greater(t, third, second, "third penalty must exceed the second")
+	})
+
+	t.Run("growth is capped", func(t *testing.T) {
+		b := newReverifyBackoff()
+		var last time.Duration
+		for i := 0; i < 40; i++ {
+			last = b.penalise("tatum", base)
+		}
+		// The helper jitters after capping, so the bound is the cap plus the jitter factor --
+		// asserting a hard ceiling here is flaky, and the overshoot is wanted (it stops every
+		// held-off provider returning at once).
+		bound := time.Duration(float64(ReVerifyRateLimitBackoffMax) * (1 + WebSocketJitterFactor))
+		require.LessOrEqual(t, last, bound,
+			"growth must be bounded by the cap plus jitter, never unbounded")
+		require.GreaterOrEqual(t, last, time.Duration(float64(ReVerifyRateLimitBackoffMax)*(1-WebSocketJitterFactor)),
+			"and must actually reach the ceiling rather than stalling below it")
+	})
+
+	t.Run("clear returns the provider to the normal cadence", func(t *testing.T) {
+		b := newReverifyBackoff()
+		b.penalise("tatum", base)
+		require.False(t, b.ready("tatum", base))
+		b.clear("tatum")
+		require.True(t, b.ready("tatum", base), "a recovered provider must not serve out its penalty")
+
+		// and the next penalty starts from the bottom again
+		require.LessOrEqual(t, b.penalise("tatum", base), ReVerifyRateLimitBackoffInitial*2,
+			"clear must reset the growth, not just the deadline")
+	})
+
+	t.Run("providers are independent", func(t *testing.T) {
+		b := newReverifyBackoff()
+		b.penalise("tatum", base)
+		require.False(t, b.ready("tatum", base))
+		require.True(t, b.ready("chainstack", base), "one vendor's limit must not hold off another")
+		require.Equal(t, 1, b.heldOff(base))
+	})
+}
+
+// The backoff has to reach the same verdict a fresh 429 would: held-off providers stay in the
+// pairing and do not advance the demote streak. A skip that read as a failure would demote
+// exactly the providers this is meant to protect.
+func TestApplyReverification_BackoffSkipStaysInconclusive(t *testing.T) {
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "jsonrpc"}
+
+	probes := 0
+	active := map[uint64]*lavasession.ConsumerSessionsWithProvider{0: makeSession("tatum")}
+	inputs := &chainReverifyInputs{
+		rpcEndpoint:                rpc,
+		convertProvidersToSessions: fakeConvert,
+		configuredStatic:           []*lavasession.RPCStaticProviderEndpoint{makeProvider("tatum")},
+		validateFn: func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+			probes++
+			return common.StatusCodeError429
+		},
+	}
+
+	got := runCycles(t, inputs, active, 6)
+	require.Contains(t, got, "tatum", "a held-off provider must stay paired")
+	require.Empty(t, inputs.demoteFailStreak, "a held-off cycle must not advance the demote streak")
+	require.Equal(t, 1, probes,
+		"after the first rate-limit the provider must be skipped, not re-probed; got %d probes", probes)
+}
+
+// The guard must not swallow real failures: once the upstream answers again, a genuine
+// capability failure has to reach the demote logic at the normal cadence.
+func TestApplyReverification_BackoffClearsOnNonRateLimitedAnswer(t *testing.T) {
+	withImmediateDemote(t)
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "jsonrpc"}
+
+	rateLimited := true
+	inputs := &chainReverifyInputs{
+		rpcEndpoint:                rpc,
+		convertProvidersToSessions: fakeConvert,
+		configuredStatic:           []*lavasession.RPCStaticProviderEndpoint{makeProvider("tatum")},
+		validateFn: func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+			if rateLimited {
+				return common.StatusCodeError429
+			}
+			return errors.New("upstream does not serve archive")
+		},
+	}
+
+	active := map[uint64]*lavasession.ConsumerSessionsWithProvider{0: makeSession("tatum")}
+	active, _, _ = applyReverification(context.Background(), inputs, active, reverifyTierStatic, 1)
+	require.Contains(t, collectNames(active), "tatum", "rate-limited: still paired")
+
+	// The upstream starts answering, with a genuine capability failure. Clear the penalty the
+	// way a real recovery would -- the provider is answering us again -- and the failure must
+	// then demote at the normal cadence.
+	rateLimited = false
+	inputs.rateLimitBackoff.clear("tatum")
+	active, _, _ = applyReverification(context.Background(), inputs, active, reverifyTierStatic, 2)
+	require.NotContains(t, collectNames(active), "tatum",
+		"a genuine capability failure must still demote once the upstream answers")
+}
+
+// A healthy provider must never enter backoff, so the common path is untouched.
+func TestApplyReverification_HealthyProviderNeverHeldOff(t *testing.T) {
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "jsonrpc"}
+
+	probes := 0
+	inputs := &chainReverifyInputs{
+		rpcEndpoint:                rpc,
+		convertProvidersToSessions: fakeConvert,
+		configuredStatic:           []*lavasession.RPCStaticProviderEndpoint{makeProvider("chainstack")},
+		validateFn: func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+			probes++
+			return nil
+		},
+	}
+
+	active := map[uint64]*lavasession.ConsumerSessionsWithProvider{0: makeSession("chainstack")}
+	got := runCycles(t, inputs, active, 5)
+	require.Contains(t, got, "chainstack")
+	require.Equal(t, 5, probes, "a healthy provider must be probed every cycle")
+	require.Zero(t, inputs.rateLimitBackoff.heldOff(time.Now()))
+}

--- a/protocol/rpcsmartrouter/spec_reverifier.go
+++ b/protocol/rpcsmartrouter/spec_reverifier.go
@@ -87,6 +87,12 @@ type chainReverifyInputs struct {
 	// holds that lock across both tier calls. Lazily allocated so test fixtures that build
 	// chainReverifyInputs by hand need not.
 	demoteFailStreak map[string]int
+	// rateLimitBackoff holds off providers that answered a probe with a rate-limit, so the
+	// pass stops adding load to an upstream that just told us it is over its limit. Lazily
+	// allocated so test fixtures built by hand need not supply one; a nil backoff is
+	// always-ready and never penalises, which keeps existing tests exercising the
+	// no-backoff path unchanged.
+	rateLimitBackoff *reverifyBackoff
 }
 
 // applyReverification revalidates configured providers for one tier and
@@ -179,11 +185,42 @@ func applyReverification(
 	if len(configured) == 0 {
 		return fresh, nil, nil
 	}
-	validate := inputs.validateFn
-	if validate == nil {
-		validate = func(c context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
+	probe := inputs.validateFn
+	if probe == nil {
+		probe = func(c context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
 			return validateProvider(c, p, inputs.chainParser, SpecReVerifyAttemptTimeout)
 		}
+	}
+	if inputs.rateLimitBackoff == nil {
+		inputs.rateLimitBackoff = newReverifyBackoff()
+	}
+
+	// A provider that answered with a rate-limit is held off rather than re-probed. The
+	// skip returns the rate-limit error itself, so the reconciliation below reaches the same
+	// inconclusive verdict it would have from a fresh 429 -- membership unchanged, streak
+	// untouched -- without spending a request to learn it.
+	validate := func(c context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
+		now := time.Now()
+		if !inputs.rateLimitBackoff.ready(p.Name, now) {
+			utils.LavaFormatDebug("re-verify: provider held off after a rate-limit, skipping probe",
+				utils.LogAttr("chain", inputs.rpcEndpoint.ChainID),
+				utils.LogAttr("provider", p.Name),
+			)
+			return common.StatusCodeError429
+		}
+		err := probe(c, p)
+		if isRateLimitFailure(err) {
+			delay := inputs.rateLimitBackoff.penalise(p.Name, now)
+			utils.LavaFormatWarning("re-verify: provider rate-limited, backing off", err,
+				utils.LogAttr("chain", inputs.rpcEndpoint.ChainID),
+				utils.LogAttr("provider", p.Name),
+				utils.LogAttr("backoff", delay.String()),
+			)
+			return err
+		}
+		// Any other outcome means the upstream is answering us again.
+		inputs.rateLimitBackoff.clear(p.Name)
+		return err
 	}
 
 	// WaitGroup + buffered-channel semaphore. Replaces an earlier errgroup —


### PR DESCRIPTION
#Closes MAG-2911

Jira ticket: MAG-2911

> **Stacked on PR #304** (MAG-2910). Base branch is `mag-2910`, so the diff here is just this change. Merge #304 first.

## Why

#304 stopped the router *misreading* a 429. It did not stop the router *causing more of them*.

`IsRateLimited` gates not marking an endpoint unhealthy — the relay path, `recovery_probe.go` and now re-verification all honour that — but none of them wait any longer before the next request. A rate-limited provider was re-probed on exactly the same schedule, so a fleet that had hit a shared vendor cap kept hitting it.

`endpoints.go:457` says "callers back off". No caller did.

## What changed

A provider that answers a probe with a rate-limit is held off for a growing interval instead of probed.

The skip **returns the rate-limit error**, so the reconciliation reaches the same inconclusive verdict a fresh 429 would — membership unchanged, streak untouched — without spending a request to learn it. That equivalence is the load-bearing property: a skip that read as a failure would demote exactly the providers this is meant to protect.

Any other outcome **clears** the penalty. Not just success: once the upstream is answering us again, even to report a genuine capability failure, it is no longer refusing us for load, and that failure should reach the demote logic at the normal cadence rather than through a backoff window.

## Three design calls worth reviewing

**Keyed by provider name, not node URL.** A 429 is a vendor-level signal — the account is over its limit, not that one endpoint is broken. Where a process serves several chains through one vendor, one chain's rate-limit slows the others too. Keying by URL would let a process keep hammering an account through its other chains.

**Reuses `ExponentialBackoff`** rather than adding a second implementation. Worth knowing: it applies jitter *after* capping, so an individual delay can exceed `ReVerifyRateLimitBackoffMax` by up to `WebSocketJitterFactor` (0.3). That's wanted here — without it, every provider held off by one vendor-wide limit would return at the same instant and rebuild the burst. My first test asserted a hard ceiling and was flaky because of it; the assertion now states the real bound.

**Scope is re-verification only.** The relay path already has QoS and endpoint-health machinery deciding where traffic goes, and adding a second independent throttle there is a larger decision than this change should make.

## Deliberately not here

**Account-wide backoff across processes.** A 429 is usually the vendor rate-limiting an *account*, and on a deployment of one router per chain those processes share an account but no memory. A true account-wide penalty needs shared state (Redis or equivalent) between routers — materially different work. Provider-name keying is the closest approximation available locally, and on a multi-chain process it is exact.

**`Retry-After`.** Strictly better than guessing when the vendor sends it, and the header *is* reachable where the error is built (`rest.go` has the `http.Response` in hand). The blocker is that `ValidateStatusCodes(statusCode, strict)` — which mints the typed 429 — takes no headers, so honouring it means changing a shared helper's signature and threading a duration through a new typed error. Worth doing as its own change.

Both are recorded on the ticket rather than dropped.

## How to verify

```
go build ./... && go vet ./protocol/rpcsmartrouter/
go test ./protocol/rpcsmartrouter/ ./protocol/chainlib/ ./protocol/common/
go test -race ./protocol/rpcsmartrouter/ -run 'Backoff|RateLimit|Reverification'
go test ./protocol/rpcsmartrouter/ -run 'TestReverifyBackoff|TestApplyReverification_Backoff|TestApplyReverification_Healthy' -v
```

The behavioural tests are the ones to read: a held-off provider stays paired and is probed **once** across six cycles rather than six times; a healthy provider is probed every cycle and never enters backoff; and a genuine capability failure still demotes once the upstream starts answering. Unit tests cover growth, the cap, reset-on-clear, per-provider independence, and that a nil backoff is inert (so fixtures built by hand keep exercising the no-backoff path).
