### PR TITLE
feat(smart-router): capture Retry-After from a rate-limited upstream

### DIFF
--- a/protocol/chainlib/chainproxy/rpcclient/http.go
+++ b/protocol/chainlib/chainproxy/rpcclient/http.go
@@ -241,7 +241,9 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}, isJsonRPC bo
 
 	err = ValidateStatusCodes(resp.StatusCode, strict)
 	if err != nil {
-		return nil, err
+		// Attach the upstream's Retry-After while the response is still in scope. Passes
+		// through untouched for anything that is not a rate-limit.
+		return nil, common.WithRetryAfter(err, resp.Header, time.Now())
 	}
 
 	if isJsonRPC && (resp.StatusCode < 200 || resp.StatusCode >= 300) {

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -537,7 +537,8 @@ func (rcp *RestChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{},
 
 	err = rcp.HandleStatusError(res.StatusCode, nodeMessage.GetDisableErrorHandling())
 	if err != nil {
-		return nil, "", nil, utils.LavaFormatWarning("Received invalid status code", nil, utils.Attribute{Key: "Status Code", Value: res.StatusCode}, utils.Attribute{Key: "chainID", Value: rcp.BaseChainProxy.ChainID}, utils.Attribute{Key: "apiName", Value: chainMessage.GetApi().Name})
+		err = common.WithRetryAfter(err, res.Header, time.Now())
+		return nil, "", nil, utils.LavaFormatWarning("Received invalid status code", err, utils.Attribute{Key: "Status Code", Value: res.StatusCode}, utils.Attribute{Key: "chainID", Value: rcp.BaseChainProxy.ChainID}, utils.Attribute{Key: "apiName", Value: chainMessage.GetApi().Name})
 	}
 
 	body, err := io.ReadAll(res.Body)

--- a/protocol/chainlib/retry_after_propagation_test.go
+++ b/protocol/chainlib/retry_after_propagation_test.go
@@ -1,0 +1,85 @@
+package chainlib
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/chainlib/extensionslib"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// Capturing Retry-After is only worth anything if it survives the trip out of the chain proxy.
+// Each of the three status-code call sites hands its error to LavaFormatWarning, where passing
+// it as an attribute instead of the cause severs the chain silently — the error still reads
+// right in the log and no longer unwraps. These pin the whole path per interface.
+func TestRetryAfterPropagatesOutOfChainProxies(t *testing.T) {
+	rateLimitHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "120")
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+
+	requireRateLimited := func(t *testing.T, err error) {
+		t.Helper()
+		require.Error(t, err)
+		require.ErrorIs(t, err, common.StatusCodeError429, "the sentinel must survive the proxy's error wrapping")
+		d, ok := common.RetryAfterFrom(err)
+		require.True(t, ok, "the upstream's Retry-After must reach the caller")
+		require.Equal(t, 2*time.Minute, d)
+	}
+
+	t.Run("rest", func(t *testing.T) {
+		ctx := context.Background()
+		chainParser, chainRouter, _, closeServer, _, err := CreateChainLibMocks(ctx, "LAVA", spectypes.APIInterfaceRest, rateLimitHandler, nil, "../../", nil)
+		require.NoError(t, err)
+		if closeServer != nil {
+			defer closeServer()
+		}
+
+		parsing, apiCollection, ok := chainParser.GetParsingByTag(spectypes.FUNCTION_TAG_GET_BLOCKNUM)
+		require.True(t, ok)
+		chainMessage, err := chainParser.ParseMsg(parsing.ApiName, []byte{}, apiCollection.CollectionData.Type, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+		require.NoError(t, err)
+
+		_, _, _, _, _, err = chainRouter.SendNodeMsg(ctx, nil, chainMessage, nil)
+		requireRateLimited(t, err)
+	})
+
+	t.Run("jsonrpc", func(t *testing.T) {
+		ctx := context.Background()
+		wsHandler := createWebSocketHandler(func(message string) string {
+			return `{"jsonrpc":"2.0","id":1,"result":"0x10a7a08"}`
+		})
+		chainParser, chainRouter, _, closeServer, _, err := CreateChainLibMocks(ctx, "ETH1", spectypes.APIInterfaceJsonRPC, rateLimitHandler, wsHandler, "../../", nil)
+		require.NoError(t, err)
+		if closeServer != nil {
+			defer closeServer()
+		}
+
+		chainMessage, err := chainParser.ParseMsg("", []byte(`{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}`), http.MethodPost, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+		require.NoError(t, err)
+
+		_, _, _, _, _, err = chainRouter.SendNodeMsg(ctx, nil, chainMessage, nil)
+		requireRateLimited(t, err)
+	})
+
+	t.Run("tendermint uri", func(t *testing.T) {
+		ctx := context.Background()
+		chainParser, chainRouter, _, closeServer, _, err := CreateChainLibMocks(ctx, "LAVA", spectypes.APIInterfaceTendermintRPC, rateLimitHandler, nil, "../../", nil)
+		require.NoError(t, err)
+		if closeServer != nil {
+			defer closeServer()
+		}
+
+		// Empty data routes the parser down the URI branch, which is the SendURI call site —
+		// the JSON-RPC branch of the same proxy goes through the shared rpcclient instead.
+		chainMessage, err := chainParser.ParseMsg("status", nil, "", nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+		require.NoError(t, err)
+
+		_, _, _, _, _, err = chainRouter.SendNodeMsg(ctx, nil, chainMessage, nil)
+		requireRateLimited(t, err)
+	})
+}

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -739,7 +739,8 @@ func (cp *tendermintRpcChainProxy) SendURI(ctx context.Context, nodeMessage *rpc
 
 	err = cp.HandleStatusError(res.StatusCode, nodeMessage.GetDisableErrorHandling())
 	if err != nil {
-		return nil, "", nil, utils.LavaFormatWarning("Received invalid status code", nil, utils.Attribute{Key: "Status Code", Value: res.StatusCode}, utils.Attribute{Key: "chainID", Value: cp.BaseChainProxy.ChainID}, utils.Attribute{Key: "apiName", Value: chainMessage.GetApi().Name})
+		err = common.WithRetryAfter(err, res.Header, time.Now())
+		return nil, "", nil, utils.LavaFormatWarning("Received invalid status code", err, utils.Attribute{Key: "Status Code", Value: res.StatusCode}, utils.Attribute{Key: "chainID", Value: cp.BaseChainProxy.ChainID}, utils.Attribute{Key: "apiName", Value: chainMessage.GetApi().Name})
 	}
 
 	// read the response body

--- a/protocol/common/retry_after.go
+++ b/protocol/common/retry_after.go
@@ -7,6 +7,14 @@ import (
 	"time"
 )
 
+// MaxRetryAfter is the longest delay an upstream can ask for. RFC 9110 puts no ceiling on
+// the header, so an upstream — or a proxy in front of it — can name one measured in years,
+// and a caller honouring it verbatim parks a provider for that long. Anything above this
+// clamps to it, which also keeps delta-seconds well clear of int64 nanosecond overflow.
+const MaxRetryAfter = time.Hour
+
+const maxRetryAfterSeconds = int(MaxRetryAfter / time.Second)
+
 // RateLimitedError carries what the upstream told us about when to come back.
 //
 // It wraps StatusCodeError429 rather than replacing it, so every existing
@@ -16,16 +24,29 @@ type RateLimitedError struct {
 	// RetryAfter is what the upstream asked for, or 0 when it said nothing. Zero means
 	// "no opinion", never "retry immediately" — callers fall back to their own backoff.
 	RetryAfter time.Duration
+
+	// cause is the rate-limit error being enriched. Whatever context was already wrapped
+	// around the sentinel stays reachable; nil means the bare sentinel.
+	cause error
+}
+
+// underlying is what this error stands in for: the enriched error, or the sentinel when it
+// was built directly from a duration.
+func (e *RateLimitedError) underlying() error {
+	if e.cause != nil {
+		return e.cause
+	}
+	return StatusCodeError429
 }
 
 func (e *RateLimitedError) Error() string {
 	if e.RetryAfter > 0 {
-		return StatusCodeError429.Error() + ", retry after " + e.RetryAfter.String()
+		return e.underlying().Error() + ", retry after " + e.RetryAfter.String()
 	}
-	return StatusCodeError429.Error()
+	return e.underlying().Error()
 }
 
-func (e *RateLimitedError) Unwrap() error { return StatusCodeError429 }
+func (e *RateLimitedError) Unwrap() error { return e.underlying() }
 
 // RetryAfterFrom extracts an upstream-requested delay from an error chain. ok is false when
 // the error is not a rate-limit, or is one that carried no usable Retry-After.
@@ -38,9 +59,10 @@ func RetryAfterFrom(err error) (d time.Duration, ok bool) {
 }
 
 // ParseRetryAfter reads the header in either wire form RFC 9110 permits: delta-seconds
-// ("120") or an HTTP-date ("Wed, 21 Oct 2015 07:28:00 GMT"). Anything unparseable, negative,
-// or already in the past is treated as absent — a malformed header must leave the caller on
-// its own backoff, not push it to retry immediately.
+// ("120") or an HTTP-date ("Wed, 21 Oct 2015 07:28:00 GMT"). Anything unparseable, zero,
+// negative, or already in the past is treated as absent — a malformed header must leave the
+// caller on its own backoff, not push it to retry immediately. A delay longer than
+// MaxRetryAfter clamps to it.
 func ParseRetryAfter(h http.Header, now time.Time) (time.Duration, bool) {
 	if h == nil {
 		return 0, false
@@ -53,14 +75,31 @@ func ParseRetryAfter(h http.Header, now time.Time) (time.Duration, bool) {
 		if secs <= 0 {
 			return 0, false
 		}
+		if secs > maxRetryAfterSeconds {
+			return MaxRetryAfter, true
+		}
 		return time.Duration(secs) * time.Second, true
 	}
 	if t, err := http.ParseTime(raw); err == nil {
-		if d := t.Sub(now); d > 0 {
+		if d := t.Sub(retryAfterReferenceTime(h, now)); d > 0 {
+			if d > MaxRetryAfter {
+				return MaxRetryAfter, true
+			}
 			return d, true
 		}
 	}
 	return 0, false
+}
+
+// retryAfterReferenceTime picks the clock an HTTP-date is measured against. The date is
+// absolute, so a skewed upstream clock either inflates the wait or backdates the header into
+// "already past"; its own Date header states the same clock that wrote the deadline, which
+// cancels the skew. Local time is the fallback when it sends none.
+func retryAfterReferenceTime(h http.Header, now time.Time) time.Time {
+	if date, err := http.ParseTime(h.Get("Date")); err == nil {
+		return date
+	}
+	return now
 }
 
 // WithRetryAfter enriches a rate-limit error with the upstream's Retry-After, if it sent one.
@@ -75,5 +114,5 @@ func WithRetryAfter(err error, h http.Header, now time.Time) error {
 	if !ok {
 		return err
 	}
-	return &RateLimitedError{RetryAfter: d}
+	return &RateLimitedError{RetryAfter: d, cause: err}
 }

--- a/protocol/common/retry_after.go
+++ b/protocol/common/retry_after.go
@@ -1,0 +1,79 @@
+package common
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// RateLimitedError carries what the upstream told us about when to come back.
+//
+// It wraps StatusCodeError429 rather than replacing it, so every existing
+// errors.Is(err, StatusCodeError429) check keeps matching and only callers that want the
+// duration need to know this type exists.
+type RateLimitedError struct {
+	// RetryAfter is what the upstream asked for, or 0 when it said nothing. Zero means
+	// "no opinion", never "retry immediately" — callers fall back to their own backoff.
+	RetryAfter time.Duration
+}
+
+func (e *RateLimitedError) Error() string {
+	if e.RetryAfter > 0 {
+		return StatusCodeError429.Error() + ", retry after " + e.RetryAfter.String()
+	}
+	return StatusCodeError429.Error()
+}
+
+func (e *RateLimitedError) Unwrap() error { return StatusCodeError429 }
+
+// RetryAfterFrom extracts an upstream-requested delay from an error chain. ok is false when
+// the error is not a rate-limit, or is one that carried no usable Retry-After.
+func RetryAfterFrom(err error) (d time.Duration, ok bool) {
+	var rle *RateLimitedError
+	if errors.As(err, &rle) && rle.RetryAfter > 0 {
+		return rle.RetryAfter, true
+	}
+	return 0, false
+}
+
+// ParseRetryAfter reads the header in either wire form RFC 9110 permits: delta-seconds
+// ("120") or an HTTP-date ("Wed, 21 Oct 2015 07:28:00 GMT"). Anything unparseable, negative,
+// or already in the past is treated as absent — a malformed header must leave the caller on
+// its own backoff, not push it to retry immediately.
+func ParseRetryAfter(h http.Header, now time.Time) (time.Duration, bool) {
+	if h == nil {
+		return 0, false
+	}
+	raw := h.Get("Retry-After")
+	if raw == "" {
+		return 0, false
+	}
+	if secs, err := strconv.Atoi(raw); err == nil {
+		if secs <= 0 {
+			return 0, false
+		}
+		return time.Duration(secs) * time.Second, true
+	}
+	if t, err := http.ParseTime(raw); err == nil {
+		if d := t.Sub(now); d > 0 {
+			return d, true
+		}
+	}
+	return 0, false
+}
+
+// WithRetryAfter enriches a rate-limit error with the upstream's Retry-After, if it sent one.
+//
+// Any other error passes through untouched, so call sites can apply it unconditionally to
+// whatever ValidateStatusCodes returned without first checking which error they have.
+func WithRetryAfter(err error, h http.Header, now time.Time) error {
+	if err == nil || !errors.Is(err, StatusCodeError429) {
+		return err
+	}
+	d, ok := ParseRetryAfter(h, now)
+	if !ok {
+		return err
+	}
+	return &RateLimitedError{RetryAfter: d}
+}

--- a/protocol/common/retry_after_test.go
+++ b/protocol/common/retry_after_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -57,6 +58,55 @@ func TestParseRetryAfter(t *testing.T) {
 		_, ok := ParseRetryAfter(nil, now)
 		require.False(t, ok)
 	})
+
+	// RFC 9110 sets no ceiling, so both wire forms can name a delay long enough to park a
+	// provider indefinitely — and a large enough delta-seconds overflows int64 nanoseconds
+	// into a negative duration. Both clamp.
+	t.Run("clamped to MaxRetryAfter", func(t *testing.T) {
+		for _, tc := range []struct{ name, value string }{
+			{"delta-seconds over the cap", strconv.Itoa(int(MaxRetryAfter/time.Second) + 1)},
+			{"delta-seconds that would overflow", "10000000000"},
+			{"delta-seconds at max int64", "9223372036854775807"},
+			{"http-date beyond the cap", now.Add(365 * 24 * time.Hour).Format(http.TimeFormat)},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				d, ok := ParseRetryAfter(hdr(tc.value), now)
+				require.True(t, ok, "%q is a usable delay, just an excessive one", tc.value)
+				require.Equal(t, MaxRetryAfter, d)
+			})
+		}
+	})
+
+	// An HTTP-date is absolute, so it is only as good as the two clocks agreeing. The
+	// upstream's Date header states the clock that wrote the deadline, so the gap between
+	// them is skew-free; without it the local clock is all there is.
+	t.Run("http-date measured against the upstream Date header", func(t *testing.T) {
+		skewed := func(skew time.Duration) http.Header {
+			h := hdr(now.Add(skew + 90*time.Second).Format(http.TimeFormat))
+			h.Set("Date", now.Add(skew).Format(http.TimeFormat))
+			return h
+		}
+
+		t.Run("upstream clock ahead", func(t *testing.T) {
+			d, ok := ParseRetryAfter(skewed(10*time.Minute), now)
+			require.True(t, ok)
+			require.InDelta(t, float64(90*time.Second), float64(d), float64(time.Second))
+		})
+
+		t.Run("upstream clock behind", func(t *testing.T) {
+			d, ok := ParseRetryAfter(skewed(-10*time.Minute), now)
+			require.True(t, ok, "a backdated header must not read as already past")
+			require.InDelta(t, float64(90*time.Second), float64(d), float64(time.Second))
+		})
+
+		t.Run("unparseable Date falls back to the local clock", func(t *testing.T) {
+			h := hdr(now.Add(90 * time.Second).Format(http.TimeFormat))
+			h.Set("Date", "not a date")
+			d, ok := ParseRetryAfter(h, now)
+			require.True(t, ok)
+			require.InDelta(t, float64(90*time.Second), float64(d), float64(time.Second))
+		})
+	})
 }
 
 // The enriched error must stay a 429 to everything that already recognises one — the
@@ -97,5 +147,17 @@ func TestWithRetryAfter_PreservesTheSentinel(t *testing.T) {
 	t.Run("RetryAfterFrom is false for a plain rate-limit", func(t *testing.T) {
 		_, ok := RetryAfterFrom(StatusCodeError429)
 		require.False(t, ok)
+	})
+
+	// Enrichment is additive: whatever context was already wrapped around the sentinel has to
+	// survive, since the call sites apply it to whatever error they were handed.
+	t.Run("keeps the context wrapped around the sentinel", func(t *testing.T) {
+		inner := fmt.Errorf("upstream %s: %w", "eth-mainnet", StatusCodeError429)
+		enriched := WithRetryAfter(inner, hdr("60"), now)
+
+		require.ErrorIs(t, enriched, StatusCodeError429)
+		require.ErrorIs(t, enriched, inner)
+		require.Contains(t, enriched.Error(), "upstream eth-mainnet")
+		require.Contains(t, enriched.Error(), "retry after 1m0s")
 	})
 }

--- a/protocol/common/retry_after_test.go
+++ b/protocol/common/retry_after_test.go
@@ -1,0 +1,101 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func hdr(v string) http.Header {
+	h := http.Header{}
+	if v != "" {
+		h.Set("Retry-After", v)
+	}
+	return h
+}
+
+// RFC 9110 permits two wire forms and both are in use. Anything else must read as absent —
+// a malformed header pushing a caller to retry immediately is the one outcome worse than
+// having no header at all.
+func TestParseRetryAfter(t *testing.T) {
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+
+	t.Run("delta-seconds", func(t *testing.T) {
+		d, ok := ParseRetryAfter(hdr("120"), now)
+		require.True(t, ok)
+		require.Equal(t, 2*time.Minute, d)
+	})
+
+	t.Run("http-date in the future", func(t *testing.T) {
+		d, ok := ParseRetryAfter(hdr(now.Add(90*time.Second).Format(http.TimeFormat)), now)
+		require.True(t, ok)
+		require.InDelta(t, float64(90*time.Second), float64(d), float64(time.Second))
+	})
+
+	t.Run("treated as absent", func(t *testing.T) {
+		for _, tc := range []struct{ name, value string }{
+			{"no header", ""},
+			{"not a number or date", "soon"},
+			{"zero seconds", "0"},
+			{"negative seconds", "-30"},
+			{"float seconds", "1.5"},
+			{"http-date already past", now.Add(-time.Minute).Format(http.TimeFormat)},
+			{"http-date exactly now", now.Format(http.TimeFormat)},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				_, ok := ParseRetryAfter(hdr(tc.value), now)
+				require.False(t, ok, "%q must read as absent", tc.value)
+			})
+		}
+	})
+
+	t.Run("nil header", func(t *testing.T) {
+		_, ok := ParseRetryAfter(nil, now)
+		require.False(t, ok)
+	})
+}
+
+// The enriched error must stay a 429 to everything that already recognises one — the
+// classification in the parent PRs matches on the sentinel and must not care that a duration
+// rode along.
+func TestWithRetryAfter_PreservesTheSentinel(t *testing.T) {
+	now := time.Now()
+
+	enriched := WithRetryAfter(StatusCodeError429, hdr("60"), now)
+	require.ErrorIs(t, enriched, StatusCodeError429, "must still satisfy errors.Is on the sentinel")
+
+	d, ok := RetryAfterFrom(enriched)
+	require.True(t, ok)
+	require.Equal(t, time.Minute, d)
+
+	t.Run("survives further wrapping", func(t *testing.T) {
+		wrapped := fmt.Errorf("verify failed: %w", enriched)
+		require.ErrorIs(t, wrapped, StatusCodeError429)
+		d, ok := RetryAfterFrom(wrapped)
+		require.True(t, ok)
+		require.Equal(t, time.Minute, d)
+	})
+
+	t.Run("no header leaves the error alone", func(t *testing.T) {
+		same := WithRetryAfter(StatusCodeError429, hdr(""), now)
+		require.Equal(t, StatusCodeError429, same)
+		_, ok := RetryAfterFrom(same)
+		require.False(t, ok, "no header means no opinion, not zero delay")
+	})
+
+	t.Run("passes non-rate-limit errors through untouched", func(t *testing.T) {
+		other := errors.New("connection refused")
+		require.Equal(t, other, WithRetryAfter(other, hdr("60"), now))
+		require.Equal(t, StatusCodeError504, WithRetryAfter(StatusCodeError504, hdr("60"), now))
+		require.Nil(t, WithRetryAfter(nil, hdr("60"), now))
+	})
+
+	t.Run("RetryAfterFrom is false for a plain rate-limit", func(t *testing.T) {
+		_, ok := RetryAfterFrom(StatusCodeError429)
+		require.False(t, ok)
+	})
+}

--- a/protocol/endpointstate/endpoint_poller.go
+++ b/protocol/endpointstate/endpoint_poller.go
@@ -3,6 +3,7 @@ package endpointstate
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync/atomic"
 	"time"
 
@@ -456,10 +457,12 @@ func (ecf *EndpointPoller) doRESTRequest(ctx context.Context, method, path strin
 		return nil, err
 	}
 	if resp.StatusCode >= 400 {
+		retryAfter, _ := common.ParseRetryAfter(http.Header(resp.Headers), time.Now())
 		return nil, &lavasession.HTTPStatusError{
 			StatusCode: resp.StatusCode,
 			Status:     fmt.Sprintf("%d", resp.StatusCode),
 			Body:       resp.Body,
+			RetryAfter: retryAfter,
 		}
 	}
 	return resp.Body, nil

--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/fullstorydev/grpcurl"
 	"github.com/golang/protobuf/proto"
@@ -438,10 +439,12 @@ func (h *HTTPDirectRPCConnection) SendRequest(
 	// We return the response in both cases - the caller will check for RPC errors
 	if resp.StatusCode >= 400 {
 		// For 4xx/5xx errors, include status code in error but also return the response
+		retryAfter, _ := common.ParseRetryAfter(resp.Header, time.Now())
 		return response, &HTTPStatusError{
 			StatusCode: resp.StatusCode,
 			Status:     resp.Status,
 			Body:       body,
+			RetryAfter: retryAfter,
 		}
 	}
 
@@ -453,10 +456,24 @@ type HTTPStatusError struct {
 	StatusCode int
 	Status     string
 	Body       []byte
+	// RetryAfter is what a rate-limiting upstream asked for, or 0 when it sent no usable
+	// Retry-After. Read it through common.RetryAfterFrom rather than the field, so a caller
+	// works the same whichever path produced the error.
+	RetryAfter time.Duration
 }
 
 func (e *HTTPStatusError) Error() string {
 	return fmt.Sprintf("HTTP %d %s", e.StatusCode, e.Status)
+}
+
+// Unwrap presents a 429 as the shared rate-limit error, so errors.Is(err,
+// common.StatusCodeError429) and common.RetryAfterFrom read the same on the direct path as
+// on the chainlib proxies. Any other status has nothing to unwrap to.
+func (e *HTTPStatusError) Unwrap() error {
+	if e.StatusCode != http.StatusTooManyRequests {
+		return nil
+	}
+	return &common.RateLimitedError{RetryAfter: e.RetryAfter}
 }
 
 func (h *HTTPDirectRPCConnection) GetProtocol() DirectRPCProtocol {

--- a/protocol/lavasession/direct_rpc_connection_test.go
+++ b/protocol/lavasession/direct_rpc_connection_test.go
@@ -816,3 +816,49 @@ func TestGRPCDirectRPCConnection_DescriptorSourceFailureIsFatal(t *testing.T) {
 		}
 	})
 }
+
+// TestHTTPDirectRPCConnection_SendRequest_CapturesRetryAfter covers the direct path's own
+// rate-limit surface: it mints its HTTPStatusError with the response in scope, so a caller
+// deciding when to come back reads the upstream's answer through the same
+// common.RetryAfterFrom the chainlib proxies feed. The existing type assertion on
+// *HTTPStatusError (recovery_probe) must keep working alongside it.
+func TestHTTPDirectRPCConnection_SendRequest_CapturesRetryAfter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "90")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"rate limited"}`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	conn, err := NewDirectRPCConnection(ctx, common.NodeUrl{Url: server.URL}, 5, "")
+	require.NoError(t, err)
+
+	_, sendErr := conn.SendRequest(ctx, []byte(`{"jsonrpc":"2.0"}`), nil)
+	require.Error(t, sendErr)
+
+	httpErr, ok := sendErr.(*HTTPStatusError)
+	require.True(t, ok, "callers type-asserting the concrete error must be unaffected")
+	require.Equal(t, http.StatusTooManyRequests, httpErr.StatusCode)
+
+	require.ErrorIs(t, sendErr, common.StatusCodeError429, "a direct-path 429 is a 429")
+	d, ok := common.RetryAfterFrom(sendErr)
+	require.True(t, ok)
+	require.Equal(t, 90*time.Second, d)
+}
+
+// A non-429 must not read as a rate-limit just because it unwraps, and a 429 without the
+// header carries no opinion — the caller stays on its own backoff.
+func TestHTTPStatusError_UnwrapIsScopedToRateLimits(t *testing.T) {
+	notRateLimited := &HTTPStatusError{StatusCode: http.StatusInternalServerError, Status: "500"}
+	require.NotErrorIs(t, notRateLimited, common.StatusCodeError429)
+	_, ok := common.RetryAfterFrom(notRateLimited)
+	require.False(t, ok)
+
+	noHeader := &HTTPStatusError{StatusCode: http.StatusTooManyRequests, Status: "429"}
+	require.ErrorIs(t, noHeader, common.StatusCodeError429)
+	_, ok = common.RetryAfterFrom(noHeader)
+	require.False(t, ok, "no header means no opinion, not zero delay")
+}


### PR DESCRIPTION
#Closes MAG-2912

Jira ticket: MAG-2912

**Independent of the other rate-limit PRs.** Branches off `main`, merges in any order.

## Why

When an upstream sends `Retry-After` it is telling us when to come back, and the router throws it away — the header is not read anywhere in the codebase. Any caller wanting to slow down has to guess, and a guess fails both ways: too eager and it takes another 429, too cautious and a provider sits unverified far longer than the vendor asked.

## The part that looked expensive, and wasn't

`ValidateStatusCodes(statusCode int, strict bool)` mints the typed 429 and takes no headers — which reads like honouring `Retry-After` means changing a shared helper's signature and rippling through its callers.

It's avoidable. Every site that calls it already has the response in scope:

| site | response |
|---|---|
| `chainproxy/rpcclient/http.go:242` | `resp` |
| `chainlib/rest.go:536` | `res` |
| `chainlib/tendermintRPC.go:738` | `res` |

The header is attached at the call site; `ValidateStatusCodes` is untouched.

## What changed

**`common.RateLimitedError`** carries the duration and **wraps** the error it enriches, so it keeps unwrapping to the existing sentinel:

```go
func (e *RateLimitedError) Unwrap() error { return e.underlying() } // the enriched error, or StatusCodeError429
```

So every existing `errors.Is(err, StatusCodeError429)` keeps matching, whatever context was already wrapped around the sentinel stays reachable, and only callers that want the duration need to know the type exists.

**Both wire forms** RFC 9110 permits are parsed: delta-seconds (`120`) and HTTP-date (`Wed, 21 Oct 2015 07:28:00 GMT`). Anything unparseable, zero, negative, or already past reads as **absent** — a malformed header pushing a caller to retry immediately is the one outcome worse than having no header at all.

**A delay is clamped to `MaxRetryAfter` (1h).** RFC 9110 sets no ceiling, so an upstream — or a proxy in front of it — can name one measured in years, and a caller honouring it parks a provider for that long. The same clamp keeps delta-seconds clear of int64 nanosecond overflow, where a large enough value wrapped to a *negative* duration and reported itself as usable. The ceiling lives at the capture rather than in each backoff, since `RetryAfterFrom` is what every consumer reads.

**The HTTP-date form is measured against the upstream's `Date` header** when it sends one. The date is absolute, so a skewed upstream clock otherwise inflates the wait or backdates its own header into "already past"; `Date` states the clock that wrote the deadline, so the gap between the two is skew-free. Local time stays the fallback.

**The direct-RPC path captures it too.** `HTTPDirectRPCConnection` mints its own 429 from a response it holds, and `recovery_probe.go` branches on that status to call a provider merely busy — a second "come back later" decision made with no upstream input. `HTTPStatusError` now carries the duration and unwraps to the shared rate-limit error, which leaves the existing type assertions working and makes `common.RetryAfterFrom` read the same on both paths.

**A one-line propagation fix** in `rest.go` and `tendermintRPC.go`: both passed the status error as a LavaFormat *attribute* rather than its `err` parameter, which severs the chain and makes the enriched error impossible to unwrap. The same fix appears in PR #304; where they overlap the resolution is identical, so whichever merges second takes a trivial conflict.

## Tests

Unit coverage for both wire forms, every malformed shape, the clamp (including the overflow value), clock skew in both directions, and sentinel survival through further wrapping.

Beyond that, `protocol/chainlib/retry_after_propagation_test.go` drives all three status-code call sites end to end (REST, JSON-RPC, Tendermint URI) against a 429 test server. That is what pins the propagation fix — with the status error passed as an attribute instead of the cause, the log line still reads correctly and nothing unwraps, and each of the three subtests fails.

## Scope

This **captures** the value. Acting on it belongs to whichever backoff wants it, via `common.RetryAfterFrom(err)`.

PR #305 adds an exponential backoff for re-verification; wiring it to prefer `Retry-After` where it is longer is a small follow-up once both are in. I have that change written and tested (a longer request wins, a 1-second one does not shorten a minutes-long interval, an absurd one clamps to the cap) — it is held back only because it cannot compile until both this and #305 exist.

`Retry-After` is also defined on 503, which the router maps to `StatusCodeErrorStrict` and disables endpoints on. Left alone deliberately: a 503 is not a rate limit, so carrying it would mean a second error type with no consumer yet.

## How to verify

```
go build ./... && go vet ./protocol/common/ ./protocol/chainlib/ ./protocol/lavasession/ ./protocol/endpointstate/
go test ./protocol/common/ ./protocol/chainlib/... ./protocol/lavasession/ ./protocol/endpointstate/
go test ./protocol/common/ -run RetryAfter -v
go test ./protocol/chainlib/ -run RetryAfterPropagates -v
```
