### PR TITLE
feat(chaintracker): make fork detection opt-in behind a flag (MAG-2920)

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -20,6 +20,7 @@ metrics manager.
 | --- | --- | --- |
 | `--metrics-listen-address` | `disabled` | Address to expose Prometheus metrics on, e.g. `:7779` or `localhost:7779`. The literal `disabled` turns the metrics server off entirely. |
 | `--optimizer-qos-sampling-interval` | `1s` | How often the optimizer-QoS sampler refreshes the `rpc_optimizer_selection_score` gauge and — when `--usage-otel-enabled` is set — emits `optimizer_qos` events to the OTel usage pipeline. |
+| `--enable-fork-detection` | `false` | Turns per-endpoint block-hash polling on. Off by default, which pins `rpc_endpoint_tracker_requests_total{kind="block_hash"}` at zero and is the single largest term in tracker request volume. Process-wide: it applies to every chain the process serves, and cannot be scoped to one of them. |
 
 ```bash
 # enable, then scrape
@@ -51,6 +52,8 @@ name and the `disabled` sentinel live in
   - `endpoint_id` — the configured upstream RPC endpoint.
   - `provider_address` — provider the relay was routed to.
   - `method` — RPC method name.
+  - `kind` — closed-set request classifier (`rpc_endpoint_tracker_requests_total` only):
+    `latest_block` or `block_hash`. Never a raw method name — that would be unbounded.
   - `function` — relay function class; the `function` label lets one metric serve both
     the per-function breakdown and (via `sum by (...)`) the aggregate.
 - **Boolean gauges** encode `1 = true / healthy / present`, `0 = false / unhealthy / absent`.
@@ -81,10 +84,35 @@ They split into **endpoint-scoped** (`rpc_endpoint_*`) and **router-scoped**
 | `rpc_endpoint_overall_health_breakdown` | Gauge | `spec`, `apiInterface` | Aggregate health per chain/interface. |
 | `rpc_endpoint_selection_score` | Gauge | `spec`, `apiInterface`, `endpoint_id`, `score_type` | Selection scores by `score_type` (availability / latency / sync / stake / composite). |
 | `rpc_endpoint_latest_block` | Gauge | `spec`, `apiInterface`, `endpoint_id` | Latest block reported by the endpoint. |
-| `rpc_endpoint_fetch_latest_fails` | Counter | `spec`, `apiInterface`, `endpoint_id` | Failed latest-block fetches. |
+| `rpc_endpoint_fetch_latest_fails` | Counter | `spec`, `apiInterface`, `endpoint_id` | Latest-block fetch failures. An **event** counter, not a request counter — see the note below. |
 | `rpc_endpoint_fetch_block_fails` | Counter | `spec`, `apiInterface`, `endpoint_id` | Failed specific-block fetches. |
-| `rpc_endpoint_fetch_latest_success` | Counter | `spec`, `apiInterface`, `endpoint_id` | Successful latest-block fetches. |
+| `rpc_endpoint_fetch_latest_success` | Counter | `spec`, `apiInterface`, `endpoint_id` | New-block **detections** by the chain tracker, not successful requests — see the note below. |
 | `rpc_endpoint_fetch_block_success` | Counter | `spec`, `apiInterface`, `endpoint_id` | Successful specific-block fetches. |
+| `rpc_endpoint_tracker_requests_total` | Counter | `spec`, `apiInterface`, `endpoint_id`, `kind` | Upstream requests the per-endpoint chain tracker actually sent, by `kind` (`latest_block`, `block_hash`). The only metric that measures tracker **request volume** — see the note below. |
+
+> **Tracker requests vs. fetch events.** `rpc_endpoint_fetch_latest_success` counts NEW BLOCK
+> detections and `rpc_endpoint_fetch_latest_fails` counts latest-block fetch failures. Neither
+> counts requests, and neither sits on the block-hash path at all — so a change in how much the
+> chain tracker asks of an upstream node moves neither of them. `rpc_endpoint_tracker_requests_total`
+> is the one that does: it increments at the transport chokepoint, once per request the node
+> actually received.
+>
+> `kind` is a closed set of two. `latest_block` is the "what is your latest block?" poll
+> (`eth_blockNumber`, `getLatestBlockhash`, ...), sent on every poll tick the relay traffic gate
+> does not suppress. `block_hash` is a block-hash fetch (`eth_getBlockByNumber`, `getBlock`),
+> which only fork detection asks for — so that series is **exactly zero** unless the router runs
+> with `--enable-fork-detection`, and the drop to zero is what makes the traffic reduction
+> provable. `/debug/endpoint-state` reports the matching `HashPolling` reason per endpoint
+> (`on`, `off-operator-choice`, or `off-spec-no-block-by-num`).
+>
+> Turning fork detection off can make `rpc_endpoint_fetch_latest_success` **increase** on
+> endpoints with flaky hash fetches. With it on, a failed hash fetch aborts the poll cycle before
+> the new-block callback fires, so new blocks stop being counted at all; without the hash step
+> they are recorded again.
+>
+> Like `rpc_endpoint_fetch_*`, this counter fans out across every provider configured on a shared
+> URL, so `endpoint_id` carries a provider name. Group by `endpoint_id` when reading it — a bare
+> `sum()` counts one physical request once per provider sharing that URL.
 
 > **Reading cancelled relays.** A stateful method (`stateful: 1` in the spec — e.g.
 > `eth_sendRawTransaction`, Solana `sendTransaction`) is broadcast to *every* endpoint; the

--- a/protocol/chaintracker/chain_tracker.go
+++ b/protocol/chaintracker/chain_tracker.go
@@ -874,6 +874,15 @@ func (cs *ChainTracker) fetchInitDataWithRetry(ctx context.Context) (err error) 
 	// error" below — which start() propagates, leaving startTrackerWithRetry looping forever on a
 	// chain that is in fact healthy. Publish the head we just fetched and finish init.
 	if cs.headOnly {
+		// A reply can parse cleanly and still carry no usable height: an SVM result object with
+		// no context.slot unmarshals to slot 0 with a nil error. Nothing below this branch would
+		// catch it, so reject it here — publishing head 0 and reporting the tracker started
+		// leaves an endpoint whose tip reads as "unknown" to consistency pre-validation.
+		if newLatestBlock <= 0 {
+			return utils.LavaFormatError("critical -- node reported no usable latest block, chain tracker creation error", nil,
+				utils.Attribute{Key: "latestBlock", Value: newLatestBlock},
+				utils.Attribute{Key: "endpoint", Value: cs.endpoint})
+		}
 		cs.advanceHeadOnly(newLatestBlock)
 		cs.setLatestChangeTime(time.Now())
 		return nil
@@ -1020,21 +1029,28 @@ func newCustomChainTracker(chainFetcher ChainFetcher, config ChainTrackerConfig)
 	// TODO: we can do it better by creating a spec fields for custom trackers.
 	// By applying a name SVM for example
 	case "SOLANA", "SOLANAT", "KOII", "KOIIT":
-		utils.LavaFormatInfo("using SVMChainTracker", utils.Attribute{Key: "chainID", Value: config.ChainId})
-		slotCache, err := ristretto.NewCache(&ristretto.Config[int64, int64]{NumCounters: CacheNumCounters, MaxCost: CacheMaxCost, BufferItems: 64, IgnoreInternalCost: true})
-		if err != nil {
-			utils.LavaFormatFatal("could not create cache", err)
-		}
-		hashCache, err := ristretto.NewCache(&ristretto.Config[int64, string]{NumCounters: CacheNumCounters, MaxCost: CacheMaxCost, BufferItems: 64, IgnoreInternalCost: true})
-		if err != nil {
-			utils.LavaFormatFatal("could not create cache", err)
-		}
-		chainTracker.iChainFetcherWrapper = &SVMChainTracker{
-			slotCache:    slotCache,
-			hashCache:    hashCache,
+		utils.LavaFormatInfo("using SVMChainTracker", utils.Attribute{Key: "chainID", Value: config.ChainId}, utils.Attribute{Key: "headOnly", Value: config.HeadOnlyTracking})
+		svm := &SVMChainTracker{
 			dataFetcher:  chainTracker,
 			chainFetcher: chainFetcher,
+			headOnly:     config.HeadOnlyTracking,
 		}
+		// Both caches serve FetchBlockHashByNum only, which head-only never calls. Skip the
+		// allocation entirely in that mode — each is sized for 100k entries and there is one
+		// pair PER ENDPOINT.
+		if !config.HeadOnlyTracking {
+			slotCache, err := ristretto.NewCache(&ristretto.Config[int64, int64]{NumCounters: CacheNumCounters, MaxCost: CacheMaxCost, BufferItems: 64, IgnoreInternalCost: true})
+			if err != nil {
+				utils.LavaFormatFatal("could not create cache", err)
+			}
+			hashCache, err := ristretto.NewCache(&ristretto.Config[int64, string]{NumCounters: CacheNumCounters, MaxCost: CacheMaxCost, BufferItems: 64, IgnoreInternalCost: true})
+			if err != nil {
+				utils.LavaFormatFatal("could not create cache", err)
+			}
+			svm.slotCache = slotCache
+			svm.hashCache = hashCache
+		}
+		chainTracker.iChainFetcherWrapper = svm
 	default:
 		chainTracker.iChainFetcherWrapper = &DefaultChainTrackerFetcher{
 			dataFetcher:  chainTracker,

--- a/protocol/chaintracker/head_only_svm_test.go
+++ b/protocol/chaintracker/head_only_svm_test.go
@@ -1,0 +1,258 @@
+package chaintracker_test
+
+// Head-only on the SOLANA/SVM path.
+//
+// The MAG-2218 head-only tests only ever exercised the generic (EVM) fetcher — they set no
+// chain id, so newCustomChainTracker gave them DefaultChainTrackerFetcher. Making fork
+// detection operator-switchable puts Solana into head-only on day one, which means the
+// SVMChainTracker wrapper is now the FIRST thing that runs in this mode. These tests cover
+// that combination.
+//
+// What must hold: the tracker publishes and advances the head, records a poll observation
+// for every poll (the signal that feeds the endpointtip store / ChainState / consistency
+// pre-validation), and never fetches a block hash — so it never reaches waitForSlotVisible,
+// which in head-only has no cache to wait on.
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	chaintracker "github.com/magma-Devs/smart-router/protocol/chaintracker"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/magma-Devs/smart-router/utils"
+	"github.com/stretchr/testify/require"
+)
+
+// svmHeadOnlyFetcher models a Solana node. getLatestBlockhash (CustomMessage) returns an
+// advancing slot plus its blockhash; getBlock (FetchBlockHashByNum) counts calls and must
+// never be reached in head-only. It also implements chaintracker.PollObserver, which is the
+// ONLY way a Solana endpoint records a poll observation.
+type svmHeadOnlyFetcher struct {
+	slot        atomic.Int64
+	customCalls atomic.Int64
+	hashCalls   atomic.Int64
+
+	observedCalls  atomic.Int64
+	observedBlock  atomic.Int64
+	observedErrors atomic.Int64
+}
+
+func (f *svmHeadOnlyFetcher) FetchEndpoint() lavasession.RPCProviderEndpoint {
+	return lavasession.RPCProviderEndpoint{ChainID: "SOLANA", ApiInterface: "jsonrpc"}
+}
+
+func (f *svmHeadOnlyFetcher) CustomMessage(ctx context.Context, path string, data []byte, connectionType, apiName string) ([]byte, error) {
+	f.customCalls.Add(1)
+	slot := f.slot.Load()
+	return []byte(fmt.Sprintf(
+		`{"jsonrpc":"2.0","result":{"context":{"slot":%d},"value":{"blockhash":"hash-%d"}},"id":1}`,
+		slot, slot)), nil
+}
+
+func (f *svmHeadOnlyFetcher) FetchBlockHashByNum(ctx context.Context, blockNum int64) (string, error) {
+	f.hashCalls.Add(1)
+	return "", fmt.Errorf("head-only must never fetch a block hash (slot %d)", blockNum)
+}
+
+// Unused on the SVM path (the wrapper polls via CustomMessage) but required by ChainFetcher.
+func (f *svmHeadOnlyFetcher) FetchLatestBlockNum(ctx context.Context) (int64, error) {
+	return f.slot.Load(), nil
+}
+
+func (f *svmHeadOnlyFetcher) FetchChainID(ctx context.Context) (string, string, error) {
+	return "", "", utils.LavaFormatError("FetchChainID not supported", nil)
+}
+
+// ObserveLatestBlockPoll makes this fetcher a chaintracker.PollObserver.
+func (f *svmHeadOnlyFetcher) ObserveLatestBlockPoll(block int64, transportLatency time.Duration, err error) {
+	f.observedCalls.Add(1)
+	f.observedBlock.Store(block)
+	if err != nil {
+		f.observedErrors.Add(1)
+	}
+}
+
+func svmHeadOnlyConfig(headOnly bool) chaintracker.ChainTrackerConfig {
+	return chaintracker.ChainTrackerConfig{
+		ChainId:               "SOLANA", // selects SVMChainTracker
+		BlocksToSave:          1,        // what the monitor forces for the Solana family
+		AverageBlockTime:      TimeForPollingMock,
+		ServerBlockMemory:     100,
+		ParseDirectiveEnabled: true,
+		HeadOnlyTracking:      headOnly,
+		FlatPollInterval:      TimeForPollingMock,
+	}
+}
+
+// TestHeadOnlySVM_NeverFetchesBlockHashes is the core guarantee: with fork detection off, a
+// Solana tracker makes exactly one upstream call per poll — getLatestBlockhash — and never
+// getBlock.
+func TestHeadOnlySVM_NeverFetchesBlockHashes(t *testing.T) {
+	fetcher := &svmHeadOnlyFetcher{}
+	fetcher.slot.Store(300_000_000)
+
+	tracker, err := chaintracker.NewChainTracker(context.Background(), fetcher, svmHeadOnlyConfig(true))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, tracker.StartAndServe(ctx), "head-only must start without any hash fetch")
+
+	for i := 0; i < 4; i++ {
+		fetcher.slot.Add(1)
+		time.Sleep(TimeForPollingMock * 2)
+	}
+	cancel()
+
+	require.Zero(t, fetcher.hashCalls.Load(), "head-only must never call getBlock on the SVM path")
+	require.Greater(t, fetcher.customCalls.Load(), int64(1), "the latest-slot poll must keep running")
+}
+
+// TestHeadOnlySVM_HeadAdvancesAndIsPublished proves the endpoint latest-block mechanism still
+// works: the tracker's published head follows the node, which is what consistency
+// pre-validation falls back to and what advanceHeadOnly writes.
+func TestHeadOnlySVM_HeadAdvancesAndIsPublished(t *testing.T) {
+	fetcher := &svmHeadOnlyFetcher{}
+	fetcher.slot.Store(300_000_000)
+
+	tracker, err := chaintracker.NewChainTracker(context.Background(), fetcher, svmHeadOnlyConfig(true))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, tracker.StartAndServe(ctx))
+
+	require.Equal(t, int64(300_000_000), tracker.GetAtomicLatestBlockNum(), "init must publish the head")
+
+	fetcher.slot.Store(300_000_007)
+	require.Eventually(t, func() bool {
+		return tracker.GetAtomicLatestBlockNum() == 300_000_007
+	}, time.Second*3, TimeForPollingMock, "the published head must follow the node")
+
+	block, changeTime := tracker.GetLatestBlockNum()
+	require.Equal(t, int64(300_000_007), block)
+	require.False(t, changeTime.IsZero(), "a head advance must stamp the change time")
+	require.Zero(t, fetcher.hashCalls.Load())
+}
+
+// TestHeadOnlySVM_RecordsPollObservations is the one that guards the tip pipeline. On Solana
+// the PollObserver hook is the ONLY place a poll observation is recorded, and that observation
+// is what feeds the endpointtip store, ChainState consensus and consistency pre-validation.
+// If head-only ever short-circuited before it, the tip would silently die.
+func TestHeadOnlySVM_RecordsPollObservations(t *testing.T) {
+	fetcher := &svmHeadOnlyFetcher{}
+	fetcher.slot.Store(300_000_000)
+
+	tracker, err := chaintracker.NewChainTracker(context.Background(), fetcher, svmHeadOnlyConfig(true))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, tracker.StartAndServe(ctx))
+
+	before := fetcher.observedCalls.Load()
+	require.Positive(t, before, "init's poll must already have been observed")
+
+	fetcher.slot.Add(3)
+	require.Eventually(t, func() bool {
+		return fetcher.observedCalls.Load() > before
+	}, time.Second*3, TimeForPollingMock, "every poll must record an observation in head-only")
+
+	require.Equal(t, fetcher.slot.Load(), fetcher.observedBlock.Load(), "the observed block must be the polled slot")
+	require.Zero(t, fetcher.observedErrors.Load(), "a healthy head-only poll must not be recorded as failed")
+}
+
+// TestHeadOnlySVM_LatestBlockDataHasNoHashes mirrors the generic head-only contract on the SVM
+// path: answer with the head and an empty hash slice rather than erroring.
+func TestHeadOnlySVM_LatestBlockDataHasNoHashes(t *testing.T) {
+	fetcher := &svmHeadOnlyFetcher{}
+	fetcher.slot.Store(300_000_000)
+
+	tracker, err := chaintracker.NewChainTracker(context.Background(), fetcher, svmHeadOnlyConfig(true))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, tracker.StartAndServe(ctx))
+
+	latest, hashes, _, err := tracker.GetLatestBlockData(spectypes.NOT_APPLICABLE, spectypes.NOT_APPLICABLE, spectypes.NOT_APPLICABLE)
+	require.NoError(t, err, "head-only must not treat an empty queue as a fault")
+	require.Equal(t, int64(300_000_000), latest)
+	require.Empty(t, hashes)
+}
+
+// TestHeadOnlySVM_MalformedReplyIsAFailedPoll guards the parse itself: head-only returns before
+// the hash work, but it must still read context.slot out of the getLatestBlockhash reply. A
+// malformed reply must be a failed poll, not a silent zero head.
+func TestHeadOnlySVM_MalformedReplyIsAFailedPoll(t *testing.T) {
+	fetcher := &svmBadReplyFetcher{body: []byte("<html>502 bad gateway</html>")}
+
+	tracker, err := chaintracker.NewChainTracker(context.Background(), fetcher, svmHeadOnlyConfig(true))
+	require.NoError(t, err)
+	// Init fetches the head; a reply that cannot be parsed must fail the tracker's start
+	// rather than publish a zero head.
+	err = tracker.StartAndServe(context.Background())
+	require.Error(t, err, "an unparseable latest-slot reply must fail start, not publish head 0")
+	require.Zero(t, fetcher.hashCalls.Load(), "still no hash fetch on the failure path")
+}
+
+// TestHeadOnlySVM_ParseableReplyWithNoSlotIsAFailedPoll is the case the malformed-reply test
+// above does NOT cover. These bodies are valid JSON and unmarshal without error — they simply
+// carry no usable context.slot, so the poll yields slot 0 with a nil error. Head-only returns
+// straight after publishing the head, so nothing downstream would reject it: without the init
+// guard the tracker would publish head 0 and report itself started.
+func TestHeadOnlySVM_ParseableReplyWithNoSlotIsAFailedPoll(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{name: "result object with no context", body: `{"jsonrpc":"2.0","result":{},"id":1}`},
+		{name: "context with no slot", body: `{"jsonrpc":"2.0","result":{"context":{}},"id":1}`},
+		{name: "slot explicitly zero", body: `{"jsonrpc":"2.0","result":{"context":{"slot":0}},"id":1}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fetcher := &svmBadReplyFetcher{body: []byte(tc.body)}
+
+			tracker, err := chaintracker.NewChainTracker(context.Background(), fetcher, svmHeadOnlyConfig(true))
+			require.NoError(t, err)
+
+			err = tracker.StartAndServe(context.Background())
+			require.Error(t, err, "a reply carrying no usable slot must fail start, not publish head 0")
+			require.Zero(t, tracker.GetAtomicLatestBlockNum(), "no head may be published from a slotless reply")
+			require.Zero(t, fetcher.hashCalls.Load(), "still no hash fetch on the failure path")
+		})
+	}
+}
+
+// svmBadReplyFetcher returns a fixed body for every latest-slot poll, so one type covers both
+// the unparseable and the parses-but-slotless cases.
+type svmBadReplyFetcher struct {
+	body      []byte
+	hashCalls atomic.Int64
+}
+
+func (f *svmBadReplyFetcher) FetchEndpoint() lavasession.RPCProviderEndpoint {
+	return lavasession.RPCProviderEndpoint{ChainID: "SOLANA", ApiInterface: "jsonrpc"}
+}
+
+func (f *svmBadReplyFetcher) CustomMessage(ctx context.Context, path string, data []byte, connectionType, apiName string) ([]byte, error) {
+	return f.body, nil
+}
+
+func (f *svmBadReplyFetcher) FetchBlockHashByNum(ctx context.Context, blockNum int64) (string, error) {
+	f.hashCalls.Add(1)
+	return "", fmt.Errorf("must not be called")
+}
+
+func (f *svmBadReplyFetcher) FetchLatestBlockNum(ctx context.Context) (int64, error) { return 0, nil }
+
+func (f *svmBadReplyFetcher) FetchChainID(ctx context.Context) (string, string, error) {
+	return "", "", utils.LavaFormatError("FetchChainID not supported", nil)
+}
+
+// compile-time proof the fetcher really is the observer hook the SVM path looks for.
+var _ chaintracker.PollObserver = (*svmHeadOnlyFetcher)(nil)

--- a/protocol/chaintracker/svm_chain_tracker.go
+++ b/protocol/chaintracker/svm_chain_tracker.go
@@ -55,6 +55,12 @@ type SVMChainTracker struct {
 	slotCache    *ristretto.Cache[int64, int64]  // cache for block to slot. (a few slots can point the same block, but we don't really care about that so overwrite is ok)
 	hashCache    *ristretto.Cache[int64, string] // cache for block to hash.
 	seenBlock    int64
+	// headOnly mirrors the tracker's mode. Both caches exist ONLY to serve
+	// FetchBlockHashByNum, which head-only never calls (the tracker returns right after
+	// publishing the head), so in that mode they are left nil: no allocation, and no
+	// write on every poll into a store nothing reads. Each cache is sized for 100k
+	// entries PER ENDPOINT, so this is real memory, not just cycles.
+	headOnly bool
 }
 
 type SVMLatestBlockResponse struct {
@@ -92,8 +98,10 @@ func (cs *SVMChainTracker) fetchLatestBlockNumInner(ctx context.Context) (int64,
 	blockHash := response.Result.Value.BlockHash
 
 	atomic.StoreInt64(&cs.seenBlock, slot)
-	cs.slotCache.SetWithTTL(slot, slot, 1, slotCacheTTL)
-	cs.hashCache.SetWithTTL(slot, blockHash, 1, hashCacheTTL)
+	if !cs.headOnly {
+		cs.slotCache.SetWithTTL(slot, slot, 1, slotCacheTTL)
+		cs.hashCache.SetWithTTL(slot, blockHash, 1, hashCacheTTL)
+	}
 
 	utils.LavaFormatTrace("[SVMChainTracker] fetching latest slot",
 		utils.LogAttr("slot", slot),
@@ -128,6 +136,12 @@ func (cs *SVMChainTracker) FetchLatestBlockNum(ctx context.Context) (int64, erro
 
 // On Solana the interface's `blockNum` parameter is a slot.
 func (cs *SVMChainTracker) FetchBlockHashByNum(ctx context.Context, slot int64) (string, error) {
+	// Defensive: head-only keeps no caches, and the tracker never reaches a hash fetch in
+	// that mode. Reaching here would mean the mode and the call path disagree, so say so
+	// instead of dereferencing a nil cache.
+	if cs.headOnly {
+		return "", fmt.Errorf("[SVMChainTracker] block hash requested for slot %d while head-only (fork detection off) — no hash cache exists in this mode", slot)
+	}
 	if slot < cs.dataFetcher.GetAtomicLatestBlockNum()-int64(cs.dataFetcher.GetServerBlockMemory()) {
 		return "", fmt.Errorf("requested slot: %d, latest slot: %d, server memory %d: %w", slot, cs.dataFetcher.GetAtomicLatestBlockNum(), cs.dataFetcher.GetServerBlockMemory(), ErrorFailedToFetchTooEarlyBlock)
 	}

--- a/protocol/endpointstate/endpoint_monitor.go
+++ b/protocol/endpointstate/endpoint_monitor.go
@@ -110,6 +110,11 @@ type EndpointMonitor struct {
 	retryMinDelay time.Duration
 	retryMaxDelay time.Duration
 
+	// hashPolling is resolved ONCE at construction (it depends only on the chain spec and
+	// the operator flag, both fixed by then) and reused for every tracker this monitor
+	// creates, so all endpoints of a chain agree and /debug can report a stable reason.
+	hashPolling HashPollingReason
+
 	// relayGateFreshness is the maximum age of a relay-harvested tip that still suppresses
 	// a dedicated poll (MAG-2159 Topic B / Pass 2 — the "gate freshness threshold"). A
 	// relay observation younger than this means served traffic kept the tip at most ~one
@@ -129,6 +134,10 @@ type EndpointMonitor struct {
 	// per-chain ChainState tip (SetLatestBlock). Fired AFTER obsMu is released so the tip lock
 	// is never taken while holding the observation lock. Set once at construction; immutable.
 	onTipObservation func(block int64)
+	// onTrackerRequest counts upstream tracker requests. Deliberately NOT generation-gated
+	// the way observations are: a late request from a replaced tracker still reached the
+	// node, so dropping it would under-report real load.
+	onTrackerRequest func(endpointURL, kind string)
 
 	// Context for managing goroutines (parent context for all trackers)
 	ctx    context.Context
@@ -143,6 +152,12 @@ type EndpointChainTrackerConfig struct {
 	AverageBlockTime time.Duration
 	BlocksToSave     uint64
 
+	// EnableForkDetection turns block-hash polling on. Off by default: the tracker then
+	// asks each endpoint only "what is your latest block?" and never fetches a hash. See
+	// EnableForkDetectionFlagName for why that is the default, and resolveHashPolling for
+	// how this combines with a spec that cannot serve hashes at all.
+	EnableForkDetection bool
+
 	// Optional callbacks
 	OnFork        func(endpointURL string, blockNum int64)
 	OnNewBlock    func(endpointURL string, fromBlock, toBlock int64)
@@ -151,6 +166,11 @@ type EndpointChainTrackerConfig struct {
 	// OnTipObservation, if set, feeds every positive poll/relay block into the per-chain
 	// ChainState tip (MAG-2160). See EndpointMonitor.onTipObservation.
 	OnTipObservation func(block int64)
+
+	// OnTrackerRequest, if set, is invoked once per upstream request a tracker actually sends,
+	// with the endpoint URL and the request kind (metrics.TrackerRequestKind*). It backs the
+	// only metric that measures tracker REQUEST VOLUME — see RecordTrackerRequest.
+	OnTrackerRequest func(endpointURL, kind string)
 }
 
 // NewEndpointMonitor creates a new manager for per-endpoint ChainTrackers.
@@ -206,9 +226,25 @@ func NewEndpointMonitor(ctx context.Context, config EndpointChainTrackerConfig) 
 		onConsistency:      config.OnConsistency,
 		onFetchError:       config.OnFetchError,
 		onTipObservation:   config.OnTipObservation,
+		onTrackerRequest:   config.OnTrackerRequest,
 		ctx:                ctxWithCancel,
 		cancel:             cancel,
 	}
+
+	// Resolved after the struct exists because it reads manager.chainParser. Both inputs are
+	// immutable from here on, so one resolution serves every tracker this monitor creates.
+	manager.hashPolling = manager.resolveHashPolling(config.EnableForkDetection)
+	// Logged in BOTH directions. An operator who passes --enable-fork-detection needs to be
+	// able to confirm from the log that it took effect on this chain — a line that only ever
+	// appears when the answer is "off" leaves them with nothing to read when it is "on", and
+	// the spec reason can override the flag on some chains of a multichain process but not
+	// others. The reason attribute distinguishes the two ways it can be off.
+	utils.LavaFormatInfo("block-hash polling (fork detection) resolved",
+		utils.LogAttr("chainID", config.ChainID),
+		utils.LogAttr("apiInterface", config.ApiInterface),
+		utils.LogAttr("enabled", !manager.hashPolling.HeadOnly()),
+		utils.LogAttr("reason", manager.hashPolling.String()),
+	)
 
 	return manager
 }
@@ -267,6 +303,14 @@ func (m *EndpointMonitor) GetOrCreateTracker(
 		m.recordPollObservation(endpointURL, gen, block, latency, pollErr, at)
 	}
 
+	// Count every upstream request this tracker sends. Set only when a consumer is wired, so
+	// the transport pays nothing (a nil check) otherwise.
+	if m.onTrackerRequest != nil {
+		fetcher.onTrackerRequest = func(kind string) {
+			m.onTrackerRequest(endpointURL, kind)
+		}
+	}
+
 	// Configure the ChainTracker
 	config := chaintracker.ChainTrackerConfig{
 		BlocksToSave:             m.blocksToSave,
@@ -275,10 +319,12 @@ func (m *EndpointMonitor) GetOrCreateTracker(
 		BlocksCheckpointDistance: chaintracker.DefaultBlockCheckpointDistance,
 		ChainId:                  m.chainID,
 		ParseDirectiveEnabled:    true, // Always enabled for direct RPC
-		// MAG-2218: a spec with a head but no usable GET_BLOCK_BY_NUM runs head-only rather
-		// than failing every hash fetch forever. ParseDirectiveEnabled stays true — turning it
-		// off would swap in a DummyChainTracker, which polls nothing at all.
-		HeadOnlyTracking: m.headOnlyTracking(),
+		// Head-only drops every block-hash fetch, so the tracker asks only for the latest
+		// block. Two reasons lead here (see resolveHashPolling): the operator left fork
+		// detection off (the default), or the spec has a head but no usable GET_BLOCK_BY_NUM
+		// and hashes are impossible anyway (MAG-2218). ParseDirectiveEnabled stays true —
+		// turning it off would swap in a DummyChainTracker, which polls nothing at all.
+		HeadOnlyTracking: m.hashPolling.HeadOnly(),
 		// MAG-2159 (Topic B): per-endpoint trackers use a FIXED flat cadence — the
 		// dedicated poll runs at exactly avgBlockTime/2 (slowed only by failure backoff),
 		// because relay harvest is the primary block signal and the poll is a sparse
@@ -408,16 +454,40 @@ func (m *EndpointMonitor) startTrackerWithRetry(tracker chaintracker.IChainTrack
 	}
 }
 
-// headOnlyTracking reports whether this chain can be tracked by head alone: it exposes a
+// resolveHashPolling decides whether this monitor's trackers do block-hash work, and records
+// WHY. Two independent causes disable it and they must stay distinguishable (see
+// HashPollingReason): a spec that cannot serve hashes at all, and the operator's flag.
+//
+// The spec reason wins when both apply. It is the immutable one — turning the flag on would
+// not give a Canton-shaped chain hashes — so reporting it is what stops an operator chasing
+// a flag that cannot help.
+func (m *EndpointMonitor) resolveHashPolling(enableForkDetection bool) HashPollingReason {
+	if m.specRequiresHeadOnly() {
+		return HashPollingOffSpecUnsupported
+	}
+	if !enableForkDetection {
+		return HashPollingOffOperatorChoice
+	}
+	return HashPollingOn
+}
+
+// HashPollingMode reports why block-hash polling is or is not running for this chain. Read
+// by /debug/endpoint-state; the value is fixed at construction.
+func (m *EndpointMonitor) HashPollingMode() HashPollingReason {
+	return m.hashPolling
+}
+
+// specRequiresHeadOnly reports whether this chain can ONLY be tracked by head: it exposes a
 // current block/offset (GET_BLOCKNUM) but has no usable "fetch block N" (GET_BLOCK_BY_NUM).
 // Canton is the case that forced this (MAG-2218) — its Ledger API reads are party-scoped and
 // not addressable by block number, so a generic per-block fetch cannot be expressed.
 //
 // Deliberately keyed on the directives the spec actually declares rather than on a chain
 // allowlist, and it mirrors the graceful degradation resolveTipApiNames already does for the
-// same tag. A chain declaring both tags is unaffected — as of MAG-2218 every shipped spec
-// declares both, so this returns false for all of them.
-func (m *EndpointMonitor) headOnlyTracking() bool {
+// same tag. A chain declaring both tags returns false here — as of MAG-2218 every shipped spec
+// declares both — which is why this is only HALF the decision: such a chain still ends up
+// head-only unless the operator turns fork detection on. See resolveHashPolling.
+func (m *EndpointMonitor) specRequiresHeadOnly() bool {
 	if m.chainParser == nil {
 		return false
 	}

--- a/protocol/endpointstate/endpoint_poller.go
+++ b/protocol/endpointstate/endpoint_poller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/chainlib"
 	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/protocol/metrics"
 	"github.com/magma-Devs/smart-router/protocol/parser"
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
 	spectypes "github.com/magma-Devs/smart-router/types/spec"
@@ -33,6 +34,14 @@ type EndpointPoller struct {
 	// poll error (nil on success), and the completion time. The EndpointMonitor sets it
 	// to record the per-endpoint observation (Topic A). Nil in standalone/test use.
 	onPollObservation func(block int64, latency time.Duration, err error, at time.Time)
+
+	// onTrackerRequest, if set, is invoked ONCE for every upstream request this poller
+	// actually sends, with the request's kind (metrics.TrackerRequestKind*). The
+	// EndpointMonitor wires it to the tracker request counter. Called from sendRawRequest —
+	// the single transport chokepoint all three request paths funnel through — so it counts
+	// requests the node received, never poll ticks that returned early or were gated away.
+	// Nil in standalone/test use.
+	onTrackerRequest func(kind string)
 }
 
 // NewEndpointPoller creates a new ChainFetcher for a direct RPC endpoint.
@@ -130,7 +139,7 @@ func (ecf *EndpointPoller) FetchLatestBlockNum(ctx context.Context) (blockNum in
 
 	// Send request via direct RPC connection (measure the transport round-trip)
 	reqStart := time.Now()
-	responseData, err := ecf.sendRawRequest(ctx, requestData, collectionData.Type, parsing.ApiName)
+	responseData, err := ecf.sendRawRequest(ctx, requestData, collectionData.Type, parsing.ApiName, metrics.TrackerRequestKindLatestBlock)
 	pollLatency = time.Since(reqStart)
 	if err != nil {
 		return spectypes.NOT_APPLICABLE, utils.LavaFormatDebug(tagName+" failed sending request",
@@ -265,7 +274,7 @@ func (ecf *EndpointPoller) fetchSingleBlockHash(
 	requestData := []byte(fmt.Sprintf(parsing.FunctionTemplate, blockNum))
 
 	start := time.Now()
-	responseData, err := ecf.sendRawRequest(ctx, requestData, connectionType, parsing.ApiName)
+	responseData, err := ecf.sendRawRequest(ctx, requestData, connectionType, parsing.ApiName, metrics.TrackerRequestKindBlockHash)
 	if err != nil {
 		timeTaken := time.Since(start)
 		return "", nil, utils.LavaFormatDebug(tagName+" failed sending request",
@@ -348,7 +357,10 @@ func (ecf *EndpointPoller) CustomMessage(ctx context.Context, path string, data 
 	if path != "" && connectionType != "GET" && ecf.apiInterface == spectypes.APIInterfaceRest {
 		apiName = path
 	}
-	return ecf.sendRawRequest(ctx, data, connectionType, apiName)
+	// CustomMessage has exactly one production caller: SVMChainTracker's getLatestBlockhash
+	// poll (the Solana latest-slot read). Counting it as a latest-block request is therefore
+	// accurate today; a second caller with different semantics would need its own kind.
+	return ecf.sendRawRequest(ctx, data, connectionType, apiName, metrics.TrackerRequestKindLatestBlock)
 }
 
 // ObserveLatestBlockPoll records a single latest-block poll observation for this
@@ -372,9 +384,16 @@ func (ecf *EndpointPoller) ObserveLatestBlockPoll(block int64, transportLatency 
 // For REST/GET requests, requestData is a URL path that must be appended to the base URL.
 // For REST/POST requests, requestData is the JSON body and apiName is the URL path.
 // For JSON-RPC/POST requests, requestData is the JSON body.
-func (ecf *EndpointPoller) sendRawRequest(ctx context.Context, requestData []byte, connectionType string, apiName string) ([]byte, error) {
+func (ecf *EndpointPoller) sendRawRequest(ctx context.Context, requestData []byte, connectionType string, apiName string, kind string) ([]byte, error) {
 	if ecf.directConnection == nil {
 		return nil, fmt.Errorf("no direct connection for endpoint %s", ecf.endpointURL)
+	}
+	// Counted once the request is about to go out, so the number matches what the upstream
+	// node was actually asked for. Deliberately AFTER the no-connection guard above (nothing
+	// was sent, so nothing is counted) and BEFORE the send itself (a request that fails or
+	// times out still reached the node and still cost it work).
+	if ecf.onTrackerRequest != nil {
+		ecf.onTrackerRequest(kind)
 	}
 
 	// REST GET: requestData is a URL path (e.g. "/cosmos/base/tendermint/v1beta1/blocks/latest")

--- a/protocol/endpointstate/endpoint_poller_test.go
+++ b/protocol/endpointstate/endpoint_poller_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/protocol/metrics"
 	spectypes "github.com/magma-Devs/smart-router/types/spec"
 	"github.com/stretchr/testify/require"
 )
@@ -254,7 +255,7 @@ func TestEndpointPoller_SendRawRequestRouting(t *testing.T) {
 				tc.apiInterface,
 			)
 
-			got, err := poller.sendRawRequest(context.Background(), []byte(tc.requestData), tc.connectionType, tc.apiName)
+			got, err := poller.sendRawRequest(context.Background(), []byte(tc.requestData), tc.connectionType, tc.apiName, metrics.TrackerRequestKindLatestBlock)
 			require.NoError(t, err)
 			require.Equal(t, `{"ok":true}`, string(got), "the upstream body must be returned verbatim")
 
@@ -366,7 +367,7 @@ func TestEndpointPoller_RESTRejectionSurfacesHTTPStatus(t *testing.T) {
 		spectypes.APIInterfaceRest,
 	)
 
-	_, err := poller.sendRawRequest(context.Background(), []byte(`{}`), "POST", "/wallet/getnowblock")
+	_, err := poller.sendRawRequest(context.Background(), []byte(`{}`), "POST", "/wallet/getnowblock", metrics.TrackerRequestKindLatestBlock)
 	require.Error(t, err)
 
 	var statusErr *lavasession.HTTPStatusError

--- a/protocol/endpointstate/fork_detection.go
+++ b/protocol/endpointstate/fork_detection.go
@@ -1,0 +1,48 @@
+package endpointstate
+
+// EnableForkDetectionFlagName is the operator switch for block-hash polling.
+//
+// The per-endpoint ChainTracker's only use for block hashes is fork detection: on every
+// poll it fetches the head's hash to compare against the one it stored, and on a new head
+// it walks backwards filling a block queue. Measured, that is roughly a third of all
+// upstream requests on Solana and two thirds on EVM chains — and nothing in this router
+// consumes the result. The fork callback writes a log line, and the hash-returning
+// GetLatestBlockData has no caller (finalization proofs / data reliability are not wired
+// in this fork).
+//
+// So the work is off by default and this flag turns it back on. The latest-block poll is
+// unaffected either way: it is what feeds the endpointtip store, ChainState consensus and
+// consistency pre-validation, and it runs before any hash work is even considered.
+const EnableForkDetectionFlagName = "enable-fork-detection"
+
+// HashPollingReason explains, for one tracker, whether block-hash polling is running and
+// why. It exists because two different causes produce the same behaviour and an operator
+// debugging a live endpoint has to be able to tell them apart:
+//
+//   - the chain CANNOT do hashes (no GET_BLOCK_BY_NUM in its spec — Canton, MAG-2218).
+//     Turning the flag on would not change anything.
+//   - the operator CHOSE not to do hashes (this flag). Turning the flag on WOULD change it.
+//
+// Surfaced as HashPolling on /debug/endpoint-state.
+type HashPollingReason string
+
+const (
+	// HashPollingOn — fork detection is running for this tracker.
+	HashPollingOn HashPollingReason = "on"
+
+	// HashPollingOffSpecUnsupported — the chain spec declares no usable GET_BLOCK_BY_NUM,
+	// so hashes are impossible regardless of the flag. Takes precedence over the operator
+	// reason: it is the immutable one, and reporting it is what tells an operator that
+	// turning the flag on would not help.
+	HashPollingOffSpecUnsupported HashPollingReason = "off-spec-no-block-by-num"
+
+	// HashPollingOffOperatorChoice — the chain could do hashes; fork detection is off
+	// because --enable-fork-detection was not set.
+	HashPollingOffOperatorChoice HashPollingReason = "off-operator-choice"
+)
+
+// HeadOnly reports whether this reason means the tracker skips all block-hash work.
+func (r HashPollingReason) HeadOnly() bool { return r != HashPollingOn }
+
+// String makes the reason printable in logs and debug rows.
+func (r HashPollingReason) String() string { return string(r) }

--- a/protocol/endpointstate/head_only_selector_test.go
+++ b/protocol/endpointstate/head_only_selector_test.go
@@ -1,7 +1,9 @@
 package endpointstate
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/magma-Devs/smart-router/protocol/chainlib"
@@ -9,10 +11,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// headOnlyTracking is the production selector for MAG-2218's head-only mode: the tracker
-// tests set the config flag directly, so without this the mode could be entirely dead in
-// production and every one of them would still pass.
-func TestHeadOnlyTracking_Selector(t *testing.T) {
+// specRequiresHeadOnly is the spec half of the production selector for MAG-2218's head-only
+// mode: the tracker tests set the config flag directly, so without this the mode could be
+// entirely dead in production and every one of them would still pass. The operator half
+// (--enable-fork-detection) is covered by TestResolveHashPolling below.
+func TestSpecRequiresHeadOnly_Selector(t *testing.T) {
 	directive := &spectypes.ParseDirective{}
 
 	for _, tc := range []struct {
@@ -74,12 +77,114 @@ func TestHeadOnlyTracking_Selector(t *testing.T) {
 				Return(tc.byNum, nil, tc.byNumPresent).AnyTimes()
 
 			m := &EndpointMonitor{chainParser: parser}
-			require.Equal(t, tc.want, m.headOnlyTracking())
+			require.Equal(t, tc.want, m.specRequiresHeadOnly())
 		})
 	}
 }
 
-func TestHeadOnlyTracking_NilParserIsSafe(t *testing.T) {
+func TestSpecRequiresHeadOnly_NilParserIsSafe(t *testing.T) {
 	m := &EndpointMonitor{}
-	require.False(t, m.headOnlyTracking(), "a nil parser must not panic or enable head-only")
+	require.False(t, m.specRequiresHeadOnly(), "a nil parser must not panic or enable head-only")
+}
+
+// TestResolveHashPolling covers the operator flag and, critically, the PRECEDENCE between the
+// two reasons. They both produce head-only, so only the reported reason distinguishes them —
+// and an operator who sees "off-operator-choice" on a Canton-shaped chain would turn the flag
+// on and watch nothing change.
+func TestResolveHashPolling(t *testing.T) {
+	directive := &spectypes.ParseDirective{}
+
+	for _, tc := range []struct {
+		name                string
+		specCanHash         bool
+		enableForkDetection bool
+		want                HashPollingReason
+		wantHeadOnly        bool
+	}{
+		{
+			name:        "flag off, spec can hash: the new default",
+			specCanHash: true, enableForkDetection: false,
+			want: HashPollingOffOperatorChoice, wantHeadOnly: true,
+		},
+		{
+			name:        "flag on, spec can hash: fork detection runs",
+			specCanHash: true, enableForkDetection: true,
+			want: HashPollingOn, wantHeadOnly: false,
+		},
+		{
+			name:        "flag off, spec cannot hash: spec reason wins",
+			specCanHash: false, enableForkDetection: false,
+			want: HashPollingOffSpecUnsupported, wantHeadOnly: true,
+		},
+		{
+			// The precedence case that matters: turning the flag ON must NOT claim fork
+			// detection is running on a chain that physically cannot serve hashes.
+			name:        "flag on, spec cannot hash: still off, and says why",
+			specCanHash: false, enableForkDetection: true,
+			want: HashPollingOffSpecUnsupported, wantHeadOnly: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			parser := chainlib.NewMockChainParser(ctrl)
+			parser.EXPECT().GetParsingByTag(spectypes.FUNCTION_TAG_GET_BLOCKNUM).
+				Return(directive, nil, true).AnyTimes()
+			// Absent GET_BLOCK_BY_NUM is what makes a chain unable to hash.
+			byNum := directive
+			if !tc.specCanHash {
+				byNum = nil
+			}
+			parser.EXPECT().GetParsingByTag(spectypes.FUNCTION_TAG_GET_BLOCK_BY_NUM).
+				Return(byNum, nil, tc.specCanHash).AnyTimes()
+
+			m := &EndpointMonitor{chainParser: parser}
+			got := m.resolveHashPolling(tc.enableForkDetection)
+			require.Equal(t, tc.want, got)
+			require.Equal(t, tc.wantHeadOnly, got.HeadOnly())
+		})
+	}
+}
+
+// TestNewEndpointMonitor_ForkDetectionFlagReachesTrackers closes the wiring gap the two tests
+// above cannot see: they call the resolver directly, so the config field could fail to reach
+// it and both would still pass. This asserts the value a real NewEndpointMonitor settles on.
+func TestNewEndpointMonitor_ForkDetectionFlagReachesTrackers(t *testing.T) {
+	newMonitor := func(t *testing.T, enable bool) *EndpointMonitor {
+		t.Helper()
+		ctrl := gomock.NewController(t)
+		t.Cleanup(ctrl.Finish)
+
+		directive := &spectypes.ParseDirective{}
+		parser := chainlib.NewMockChainParser(ctrl)
+		// A normal chain: both tags present, so the spec never forces head-only and the flag
+		// is the only thing deciding.
+		parser.EXPECT().GetParsingByTag(spectypes.FUNCTION_TAG_GET_BLOCKNUM).
+			Return(directive, nil, true).AnyTimes()
+		parser.EXPECT().GetParsingByTag(spectypes.FUNCTION_TAG_GET_BLOCK_BY_NUM).
+			Return(directive, nil, true).AnyTimes()
+
+		m := NewEndpointMonitor(context.Background(), EndpointChainTrackerConfig{
+			ChainParser:         parser,
+			ChainID:             "ETH1",
+			ApiInterface:        "jsonrpc",
+			AverageBlockTime:    time.Second,
+			EnableForkDetection: enable,
+		})
+		t.Cleanup(m.Stop)
+		return m
+	}
+
+	t.Run("default (flag off): hash polling is off by operator choice", func(t *testing.T) {
+		m := newMonitor(t, false)
+		require.Equal(t, HashPollingOffOperatorChoice, m.HashPollingMode())
+		require.True(t, m.HashPollingMode().HeadOnly(), "trackers must be built head-only")
+	})
+
+	t.Run("flag on: hash polling runs", func(t *testing.T) {
+		m := newMonitor(t, true)
+		require.Equal(t, HashPollingOn, m.HashPollingMode())
+		require.False(t, m.HashPollingMode().HeadOnly(), "trackers must do fork detection")
+	})
 }

--- a/protocol/endpointstate/tracker_request_metric_test.go
+++ b/protocol/endpointstate/tracker_request_metric_test.go
@@ -1,0 +1,178 @@
+package endpointstate
+
+// The tracker request counter (rpc_endpoint_tracker_requests_total).
+//
+// It exists because rpc_endpoint_fetch_latest_{success,fails} count EVENTS — a new block was
+// detected, a latest-block fetch failed — not REQUESTS. Neither moves when the tracker's
+// request volume changes, which is why its block-hash traffic was invisible until it was
+// measured by hand. These tests pin the property that makes the new counter useful: it is
+// incremented once per upstream request actually sent, at the transport chokepoint.
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/protocol/metrics"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingPoller captures what the transport hook reports.
+type requestRecorder struct {
+	mu    sync.Mutex
+	kinds []string
+	urls  []string
+}
+
+func (r *requestRecorder) record(url, kind string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.urls = append(r.urls, url)
+	r.kinds = append(r.kinds, kind)
+}
+
+func (r *requestRecorder) count(kind string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := 0
+	for _, k := range r.kinds {
+		if k == kind {
+			n++
+		}
+	}
+	return n
+}
+
+// TestSendRawRequest_CountsRequestsThatReachTheTransport pins what the counter means: one
+// increment per request actually sent, tagged with its kind.
+func TestSendRawRequest_CountsRequestsThatReachTheTransport(t *testing.T) {
+	rec := &requestRecorder{}
+	conn := &recordingConnection{url: "http://node.example", respBody: []byte(`{"ok":true}`)}
+	poller := NewEndpointPoller(
+		&lavasession.Endpoint{NetworkAddress: "http://node.example", Enabled: true},
+		conn, nil, "ETH1", spectypes.APIInterfaceJsonRPC,
+	)
+	poller.onTrackerRequest = func(kind string) { rec.record("http://node.example", kind) }
+
+	for i := 0; i < 3; i++ {
+		_, err := poller.sendRawRequest(context.Background(), []byte("{}"), "POST", "eth_blockNumber", metrics.TrackerRequestKindLatestBlock)
+		require.NoError(t, err)
+	}
+	_, err := poller.sendRawRequest(context.Background(), []byte("{}"), "POST", "eth_getBlockByNumber", metrics.TrackerRequestKindBlockHash)
+	require.NoError(t, err)
+
+	require.Equal(t, 3, rec.count(metrics.TrackerRequestKindLatestBlock))
+	require.Equal(t, 1, rec.count(metrics.TrackerRequestKindBlockHash),
+		"block-hash requests must be counted separately — this is the series that goes to zero when fork detection is off")
+}
+
+// TestSendRawRequest_NotCountedWhenNothingIsSent: with no connection the request never
+// leaves, so counting it would over-report load the customer's node never saw.
+func TestSendRawRequest_NotCountedWhenNothingIsSent(t *testing.T) {
+	rec := &requestRecorder{}
+	poller := &EndpointPoller{endpointURL: "http://node.example"}
+	poller.onTrackerRequest = func(kind string) { rec.record("http://node.example", kind) }
+
+	_, err := poller.sendRawRequest(context.Background(), []byte("{}"), "POST", "eth_blockNumber", metrics.TrackerRequestKindLatestBlock)
+	require.Error(t, err, "no direct connection is wired")
+	require.Zero(t, rec.count(metrics.TrackerRequestKindLatestBlock),
+		"a request that never left must not be counted as upstream load")
+}
+
+// TestSendRawRequest_NoHookIsSafe: the hook is only set when a consumer is wired.
+func TestSendRawRequest_NoHookIsSafe(t *testing.T) {
+	poller := &EndpointPoller{endpointURL: "http://node.example"}
+	require.NotPanics(t, func() {
+		_, _ = poller.sendRawRequest(context.Background(), []byte("{}"), "POST", "eth_blockNumber", metrics.TrackerRequestKindLatestBlock)
+	})
+}
+
+// TestTrackerRequestKindsAreClosedSet guards the Prometheus label. A raw method name here
+// would blow up cardinality on a chain with many parse directives.
+func TestTrackerRequestKindsAreClosedSet(t *testing.T) {
+	require.Equal(t, "latest_block", metrics.TrackerRequestKindLatestBlock)
+	require.Equal(t, "block_hash", metrics.TrackerRequestKindBlockHash)
+}
+
+// TestRecordTrackerRequest_NilManagerIsSafe mirrors every other metrics helper: the manager is
+// nil whenever metrics are disabled, and the tracker must not care.
+func TestRecordTrackerRequest_NilManagerIsSafe(t *testing.T) {
+	var m *metrics.SmartRouterMetricsManager
+	require.NotPanics(t, func() {
+		m.RecordTrackerRequest("ETH1", "jsonrpc", "http://node.example", metrics.TrackerRequestKindLatestBlock)
+	})
+}
+
+// TestTrackerRequestCounter_ByKind_EndToEnd drives a REAL EndpointMonitor + ChainTracker over a
+// mock connection and reports what the counter would show, in both modes. It is the end-to-end
+// proof of the counter's purpose: block_hash is the series that collapses when fork detection is
+// off, and latest_block keeps running.
+//
+// Read the logged numbers as SHAPE, not as rates. The mock does not serve real block hashes, so
+// the fork-detection-ON run dies during init retries and stops polling — which is itself a fair
+// illustration of the row-3 effect measured in the research doc (a failing hash fetch aborts the
+// whole cycle), but it means the two totals are not a like-for-like rate comparison. The
+// assertions below deliberately test presence and absence, not magnitude.
+func TestTrackerRequestCounter_ByKind_EndToEnd(t *testing.T) {
+	ensureRandSeeded()
+
+	run := func(t *testing.T, enableForkDetection bool) map[string]int {
+		t.Helper()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var mu sync.Mutex
+		counts := map[string]int{}
+
+		m := NewEndpointMonitor(ctx, EndpointChainTrackerConfig{
+			ChainParser:         newRealChainParser(t, "ETH1", spectypes.APIInterfaceJsonRPC),
+			ChainID:             "ETH1",
+			ApiInterface:        spectypes.APIInterfaceJsonRPC,
+			AverageBlockTime:    100 * time.Millisecond,
+			BlocksToSave:        1,
+			EnableForkDetection: enableForkDetection,
+			OnTrackerRequest: func(endpointURL, kind string) {
+				mu.Lock()
+				defer mu.Unlock()
+				counts[kind]++
+			},
+		})
+		require.NotNil(t, m)
+		defer m.Stop()
+
+		url := "http://eth-ep:8545"
+		_, err := m.GetOrCreateTracker(&lavasession.Endpoint{NetworkAddress: url, Enabled: true}, &mockDirectRPCConnection{url: url})
+		require.NoError(t, err)
+
+		// Let the poll loop run a few cycles at the 50ms flat cadence (avgBlockTime/2).
+		time.Sleep(600 * time.Millisecond)
+
+		mu.Lock()
+		defer mu.Unlock()
+		out := map[string]int{}
+		for k, v := range counts {
+			out[k] = v
+		}
+		return out
+	}
+
+	on := run(t, true)
+	off := run(t, false)
+
+	t.Logf("fork detection ON  -> latest_block=%d  block_hash=%d  (total %d)",
+		on[metrics.TrackerRequestKindLatestBlock], on[metrics.TrackerRequestKindBlockHash],
+		on[metrics.TrackerRequestKindLatestBlock]+on[metrics.TrackerRequestKindBlockHash])
+	t.Logf("fork detection OFF -> latest_block=%d  block_hash=%d  (total %d)",
+		off[metrics.TrackerRequestKindLatestBlock], off[metrics.TrackerRequestKindBlockHash],
+		off[metrics.TrackerRequestKindLatestBlock]+off[metrics.TrackerRequestKindBlockHash])
+
+	require.Positive(t, on[metrics.TrackerRequestKindBlockHash],
+		"with fork detection ON the tracker must send block-hash requests")
+	require.Zero(t, off[metrics.TrackerRequestKindBlockHash],
+		"with fork detection OFF the block_hash series must be exactly zero — this is the whole point")
+	require.Positive(t, off[metrics.TrackerRequestKindLatestBlock],
+		"the latest-block poll must keep running either way")
+}

--- a/protocol/metrics/smartrouter_metrics_manager.go
+++ b/protocol/metrics/smartrouter_metrics_manager.go
@@ -60,6 +60,7 @@ type SmartRouterMetricsManager struct {
 	endpointFetchBlockFails        *MappedLabelsCounterVec // rpc_endpoint_fetch_block_fails
 	endpointFetchLatestSuccess     *MappedLabelsCounterVec // rpc_endpoint_fetch_latest_success
 	endpointFetchBlockSuccess      *MappedLabelsCounterVec // rpc_endpoint_fetch_block_success
+	endpointTrackerRequests        *MappedLabelsCounterVec // rpc_endpoint_tracker_requests_total
 
 	// Router-scoped metrics (labels: spec, apiInterface, function)
 	routerTotalRelaysServiced *prometheus.CounterVec   // smartrouter_total_relays_serviced
@@ -257,6 +258,21 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 		Name:       "rpc_endpoint_fetch_block_success",
 		Help:       "Total successful specific-block fetch operations for this RPC endpoint.",
 		Labels:     endpointLabels,
+		Registerer: prometheus.DefaultRegisterer,
+	})
+
+	// Counts the actual upstream requests the per-endpoint ChainTracker sends, split by what
+	// the request was for. This is the ONLY metric that tracks tracker REQUEST VOLUME:
+	// rpc_endpoint_fetch_latest_{success,fails} count EVENTS (a new block was detected / the
+	// latest-block fetch failed), so neither moves when the number of requests changes — which
+	// is why the tracker's block-hash traffic was invisible until it was measured by hand.
+	//
+	// kind is bounded to trackerRequestKind* below. Watch kind="block_hash" go to zero when
+	// fork detection is off (--enable-fork-detection), and kind="latest_block" stay flat.
+	endpointTrackerRequests := NewMappedLabelsCounterVec(MappedLabelsMetricOpts{
+		Name:       "rpc_endpoint_tracker_requests_total",
+		Help:       "Total upstream requests sent by the per-endpoint chain tracker, by kind (latest_block, block_hash).",
+		Labels:     []string{"spec", "apiInterface", "endpoint_id", "kind"},
 		Registerer: prometheus.DefaultRegisterer,
 	})
 
@@ -607,6 +623,7 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 		endpointFetchBlockFails:        endpointFetchBlockFails,
 		endpointFetchLatestSuccess:     endpointFetchLatestSuccess,
 		endpointFetchBlockSuccess:      endpointFetchBlockSuccess,
+		endpointTrackerRequests:        endpointTrackerRequests,
 
 		// Router-scoped (with function)
 		routerTotalRelaysServiced: routerTotalRelaysServiced,
@@ -1175,6 +1192,48 @@ func (m *SmartRouterMetricsManager) RecordBlockFetch(spec, apiInterface, endpoin
 				m.AddEndpointFetchBlockFail(spec, apiInterface, providerName)
 			}
 		}
+	}
+}
+
+// TrackerRequestKind values for RecordTrackerRequest. Deliberately a closed set of two —
+// this is a Prometheus label, so it must never carry a raw method name.
+const (
+	// TrackerRequestKindLatestBlock — the "what is your latest block?" poll
+	// (eth_blockNumber, getLatestBlockhash, ...). Sent on every non-gated poll tick.
+	TrackerRequestKindLatestBlock = "latest_block"
+
+	// TrackerRequestKindBlockHash — a block-hash fetch (eth_getBlockByNumber, getBlock).
+	// Only fork detection asks for these, so this series is zero when it is off.
+	TrackerRequestKindBlockHash = "block_hash"
+)
+
+// AddEndpointTrackerRequest increments the tracker upstream-request counter.
+//
+// Guards the counter itself, not just the manager: MappedLabelsCounterVec.WithLabelValues has
+// no nil receiver check, and partially-built managers exist (test fixtures construct only the
+// counters they assert on). A metric must never be the thing that takes the poll goroutine down.
+func (m *SmartRouterMetricsManager) AddEndpointTrackerRequest(spec, apiInterface, endpointID, kind string) {
+	if m == nil || m.endpointTrackerRequests == nil {
+		return
+	}
+	labels := map[string]string{"spec": spec, "apiInterface": apiInterface, "endpoint_id": endpointID, "kind": kind}
+	m.endpointTrackerRequests.WithLabelValues(labels).Inc()
+}
+
+// RecordTrackerRequest records ONE upstream request sent by the per-endpoint chain tracker.
+// Fans out across every provider sharing the URL, the same way RecordBlockFetch does, so the
+// per-provider view reflects the real load each of them puts on that upstream.
+//
+// Counted at the transport chokepoint (EndpointPoller.sendRawRequest), so it reflects requests
+// the node actually received — not poll ticks. A tick suppressed by the relay traffic gate
+// sends nothing and is therefore not counted, which is the point: this is the series that
+// makes a traffic reduction provable.
+func (m *SmartRouterMetricsManager) RecordTrackerRequest(spec, apiInterface, endpointID, kind string) {
+	if m == nil {
+		return
+	}
+	for _, providerName := range m.resolveProviderNames(endpointID) {
+		m.AddEndpointTrackerRequest(spec, apiInterface, providerName, kind)
 	}
 }
 

--- a/protocol/metrics/url_fanout_test.go
+++ b/protocol/metrics/url_fanout_test.go
@@ -134,3 +134,14 @@ func TestRecordBlockFetch_FansOutAcrossSharedURL(t *testing.T) {
 	require.Equal(t, float64(1), bp1, "blockpi1 must be incremented")
 	require.Equal(t, float64(1), bp2, "blockpi2 must be incremented")
 }
+
+// TestRecordTrackerRequest_PartialManagerIsSafe: this fixture builds only the counters it
+// asserts on, which is exactly the shape that would panic if the helper trusted its counter
+// to be non-nil. The poll goroutine calls this on every upstream request, so it must not.
+func TestRecordTrackerRequest_PartialManagerIsSafe(t *testing.T) {
+	m := newSmartRouterForURLFanoutTest()
+	m.RegisterEndpoint("BASE", "jsonrpc", "https://base.example/rpc", "vendor1")
+	require.NotPanics(t, func() {
+		m.RecordTrackerRequest("BASE", "jsonrpc", "https://base.example/rpc", TrackerRequestKindLatestBlock)
+	})
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -1344,6 +1344,11 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 						// exponentialBackoff-stretched when the endpoint has been failing. This is the
 						// observable /debug/reset-probe-backoff returns to base (MAG-2395).
 						"PollIntervalMs": backoffByURL[url].Milliseconds(),
+						// HashPolling says whether this chain's tracker does block-hash work
+						// (fork detection) and, when it does not, WHY — "off-operator-choice"
+						// (--enable-fork-detection not set) vs "off-spec-no-block-by-num" (the
+						// chain cannot serve hashes at all, so the flag would not help).
+						"HashPolling": server.endpointChainTrackerManager.HashPollingMode().String(),
 					})
 				}
 			}
@@ -2970,6 +2975,11 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	cmdRPCSmartRouter.Flags().String(performance.PyroscopeTagsFlagName, "", "comma-separated list of tags in key=value format (e.g., instance=router-1,region=us-east)")
 	cmdRPCSmartRouter.Flags().String(performance.CacheFlagName, "", "address for a cache server to improve performance")
 	cmdRPCSmartRouter.Flags().Int(relaycore.ConsistencyBlockGapFactorFlagName, 0, "consistency-relief: widen the consistency endpoint-lag gate (blockLagForQosSync x factor; default 2). Allowed [2,8]; out-of-range reverts to default.")
+	// Block-hash polling (fork detection) is OFF by default — see EnableForkDetectionFlagName
+	// for why. Process-wide, which matters because one process can serve several chains (see
+	// smartrouter_multichain.yml): there is no per-chain form of this switch, so a deployment
+	// that wants fork detection on exactly one chain has to run that chain in its own process.
+	cmdRPCSmartRouter.Flags().Bool(endpointstate.EnableForkDetectionFlagName, false, "turn ON per-endpoint block-hash polling (fork detection). OFF by default: the chain tracker then asks each upstream only for its latest block. Process-wide -- it applies to EVERY chain this process serves and cannot be scoped to one of them. The live state per endpoint is reported as HashPolling on /debug/endpoint-state, and the request volume as rpc_endpoint_tracker_requests_total.")
 	// MAG-2160 back-compat shim: the global chain tracker (and the adaptive cadence this knob
 	// tuned) is gone — per-endpoint trackers poll at a fixed avgBlockTime/2 — but existing launch
 	// args (systemd/compose/helm) still pass the flag, and an UNREGISTERED flag fails process

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -222,9 +222,21 @@ func (rpcss *RPCSmartRouterServer) ServeRPCRequests(
 		ApiInterface:     listenEndpoint.ApiInterface,
 		AverageBlockTime: effectiveBlockTime,
 		BlocksToSave:     endpointstate.DefaultBlocksToSave,
+		// Block-hash polling / fork detection is OFF unless the operator turns it on. Read
+		// straight from viper (flags are bound in the command's RunE) rather than through a
+		// package global, so an embedded server with no flags set gets the same default.
+		// The key is absent in that case and GetBool returns false, which IS the default.
+		EnableForkDetection: viper.GetBool(endpointstate.EnableForkDetectionFlagName),
 		// Feed every positive poll/relay block into the per-chain tip (cheap monotonic write)
 		// and mirror the resulting guarded tip into the router-wide latest-block gauge (MAG-2629).
 		OnTipObservation: rpcss.onTipObservation,
+		// Count the tracker's upstream requests by kind. This is the series that makes the
+		// effect of --enable-fork-detection visible: rpc_endpoint_fetch_latest_{success,fails}
+		// count EVENTS (new block detected / latest-block fetch failed), not requests, so
+		// neither of them moves when request volume changes.
+		OnTrackerRequest: func(endpointURL, kind string) {
+			rpcss.smartRouterEndpointMetrics.RecordTrackerRequest(listenEndpoint.ChainID, listenEndpoint.ApiInterface, endpointURL, kind)
+		},
 		OnNewBlock: func(endpointURL string, fromBlock, toBlock int64) {
 			utils.LavaFormatTrace("endpoint ChainTracker detected new block",
 				utils.LogAttr("endpoint", endpointURL),


### PR DESCRIPTION
#Closes MAG-2920

Jira ticket: MAG-2920

## Why

Block-hash polling is the chain tracker's largest source of upstream requests to customer nodes, and **nothing in this router consumes its result**.

Measured on a live router against a real node (LAVA, one endpoint, steady state):

| | requests/min per endpoint |
|---|---|
| fork detection ON | **87.6** |
| fork detection OFF | **7.3** |

A **92% reduction**. Startup drops from **11 requests per endpoint to 1** (re-paid on every reconnect).

Harness measurements across chains:

| chain | quiet | busy |
|---|---|---|
| Solana | −28% | −47% |
| Ethereum / Base / Arbitrum | −65% | −82% |

The EVM share is larger because that path has no cache: the fork check fires a real `eth_getBlockByNumber` on **every tick**, even when the block number has not changed. Arbitrum measured 1,420 req/min per node, of which 945 were hash fetches.

## What fork detection actually produces today

One warning line in the log. No metric, no debug field, no routing or scoring effect.

The hash-returning `GetLatestBlockData` has **no caller anywhere in the tree**. Finalization proofs and data reliability are not wired in this fork — `finalized_blocks_hashes` is never populated, and `blocks_in_finalization_proof` is discarded (`_`) at every production call site.

Detection power is unchanged by keeping fewer blocks: a block commits to its parent, so a reorg anywhere below the head changes the head's hash too. The 10-block queue only ever told us fork *depth*, which nothing reads.

## What this PR does

The behaviour already existed as `HeadOnlyTracking` (MAG-2218, built for Canton). **This adds the switch, not the mode.**

`--enable-fork-detection`, default **false**.

The two causes of "no hash polling" stay distinguishable, because they mean different things to an operator debugging a live endpoint:

| reason | meaning |
|---|---|
| `off-spec-no-block-by-num` | the chain cannot serve hashes; turning the flag on would not help |
| `off-operator-choice` | the chain could, but fork detection is off |

The spec reason wins when both apply. Surfaced as `HashPolling` on `/debug/endpoint-state`, and logged once per chain at startup.

## New metric

`rpc_endpoint_tracker_requests_total{spec, apiInterface, endpoint_id, kind}`

The existing metrics cannot show any of this. `rpc_endpoint_fetch_latest_success` counts NEW BLOCK detections; `rpc_endpoint_fetch_latest_fails` counts LATEST-BLOCK fetch failures. Neither is on the hash path, so neither moves when request volume changes — which is why this traffic stayed invisible until it was measured by hand.

`kind` is a closed set (`latest_block`, `block_hash`). Counted at `sendRawRequest`, the single transport chokepoint all three request paths funnel through: **after** the no-connection guard (nothing was sent) and **before** the send (a failed request still cost the node work).

⚠️ **Expect `fetch_latest_success` to INCREASE** on endpoints with flaky hash fetches. Today a hash failure aborts the poll cycle before the new-block callback fires, so new blocks stop being counted at all. Without the hash step they get recorded again.

## Why the latest-block mechanism cannot break

It does not run through the hashed path. The poll observation fires in a `defer` at the top of `EndpointPoller.FetchLatestBlockNum` (and via the SVM `PollObserver` hook), **before** any hash work is considered. That observation feeds the endpointtip store, ChainState consensus, and consistency pre-validation — which prefers the tip store over the tracker atomic anyway.

Verified live with the flag off:

| check | result |
|---|---|
| Relay correctness (rest + tendermintrpc) | matches upstream exactly |
| Endpoints enabled | 3/3 |
| Tip sources | both `poll` and `relay` feeding |
| `ConsecutivePollFailures` | 0 |
| Poll cadence | base, no backoff |
| ChainState | initialized, tip fresh |
| QoS | `AvailabilityScore=1`, **`SelectionSync=1`**, `NodeErrorRate=0` |
| Traffic gate | 29 relays → **0 polls in 30s** |
| Log | 0 panics, 0 errors, 0 "No pairings" |

A control run **with the flag ON** was identical on every field except `HashPolling`. That includes `HasBaseline=false`, which is a property of a 1-2 endpoint pod and not something this change causes.

## Also

Solana no longer allocates its two ristretto caches in head-only mode. They serve only `FetchBlockHashByNum`, which this mode never calls, and each is sized for 100k entries **per endpoint**.

## Tests

- `head_only_svm_test.go` — the SOLANA/SVM + head-only combination that had **no coverage at all** (the existing head-only tests set no chain id, so they only exercised the generic fetcher). Includes that a poll observation is still recorded on every poll, which is the tip pipeline's only Solana feed.
- Resolver precedence, including flag-ON + spec-cannot-hash.
- Flag-to-tracker wiring (the resolver tests alone cannot see it).
- The request counter, both what it counts and what it must not.

All protocol packages pass; `go vet` clean.

## Rollout note

This changes behaviour for **every chain a process serves** — and one process can serve several (see `smartrouter_multichain.yml`). The expected effect is a large drop in upstream requests per node. That drop is the intended outcome, not an incident.


## Review fixes

- **`docs/METRICS.md`.** Adds the `rpc_endpoint_tracker_requests_total` row and the `kind` label, an `--enable-fork-detection` row in the metrics configuration table, and a note that separates tracker **requests** from the fetch **event** counters. The note also carries the two things a dashboard author will otherwise get wrong: `fetch_latest_success` can INCREASE when fork detection goes off, and this counter fans out per provider on a shared URL, so `endpoint_id` holds a provider name and a bare `sum()` counts one physical request once per provider.
- **Head-only init rejects a non-positive head.** A reply can parse cleanly and still carry no usable height — an SVM `result` object with no `context.slot` unmarshals to slot 0 with a nil error. Head-only returns straight after publishing the head, so nothing downstream catches it, and the tracker would publish head 0 and report itself started; an endpoint whose tip is 0 reads as "unknown" to consistency pre-validation rather than as broken. The hashed path never had this window because it cannot get past its hash fetches at block 0. Covered by `TestHeadOnlySVM_ParseableReplyWithNoSlotIsAFailedPoll` (no `context`, empty `context`, explicit `slot: 0`).
- **The startup line logs both directions.** It previously fired only when hash polling was off, so an operator who passed the flag had nothing in the log to confirm it took effect — and on a multichain process the spec reason can override the flag for some chains but not others.
- **Flag help.** Says the switch is process-wide with no per-chain form (a deployment that wants fork detection on exactly one chain has to run that chain in its own process), and names the debug field and the metric that report its live effect.

Verified after the fixes: `go build ./...` and `go vet ./protocol/...` clean; `protocol/{chaintracker,endpointstate,metrics,rpcsmartrouter}` all pass; the new tests pass under `-race -count=3`. (`TestChainTrackerCallbacks` and `TestChainTrackerFetchSpreadAcrossPollingTime` are flaky under `-race -count=2` on `main` as well — pre-existing, untouched here.)
