### PR TITLE
feat(smart-router): make the per-endpoint poll cadence configurable

### DIFF
--- a/protocol/chaintracker/chain_tracker.go
+++ b/protocol/chaintracker/chain_tracker.go
@@ -76,9 +76,13 @@ const (
 	// defaultMaxRelaySkipsBeforePoll bounds how many consecutive poll cycles the traffic gate
 	// (MAG-2159) may skip before forcing one real poll for independent fork/liveness
 	// verification. Deliberately small: store-#2 staleness (the tracker atomic that consistency
-	// pre-validation reads) scales linearly as N * FlatPollInterval, so at N=4 with a
+	// pre-validation reads) scales linearly as N * FlatPollInterval, so at N=4 with the default
 	// FlatPollInterval of avgBlockTime/2 the atomic is at most ~2 blocks stale — far inside the
-	// default 10-block EndpointLagThreshold.
+	// default 10-block EndpointLagThreshold. endpointstate.MinPollDivisor floors the operator's
+	// cadence knob at one poll per block time, which keeps that worst case at ~5 blocks; a
+	// slower cadence would need this bound revisited. The exposure is in any case narrower than
+	// it reads: consistency pre-validation prefers the relay-fed tip store and only falls back
+	// to this atomic when the store is empty — precisely when the gate never skips.
 	defaultMaxRelaySkipsBeforePoll = 4
 	// MostFrequentPollingMultiplier is the fixed multiplier the legacy adaptive cadence uses
 	// (global tracker only — per-endpoint trackers run a fixed FlatPollInterval and never reach
@@ -817,7 +821,7 @@ func (cs *ChainTracker) CurrentPollInterval() time.Duration {
 // computePollInterval returns the next dedicated-poll interval.
 //
 // When flatPollInterval > 0 (per-endpoint trackers, MAG-2159 / Topic B) the cadence is
-// FIXED: exactly flatPollInterval (avgBlockTime/2), slowed only by failure backoff. The
+// FIXED: exactly flatPollInterval (avgBlockTime/divisor), slowed only by failure backoff. The
 // old adaptive /4, /2, /16 tiers are gone and the block-gap recalibration (which mutates
 // tickerBaseTime) is deliberately ignored here — relay harvest is the primary block
 // signal, so the dedicated poll is a sparse, predictable fallback. Because nothing consumes

--- a/protocol/chaintracker/config.go
+++ b/protocol/chaintracker/config.go
@@ -48,8 +48,9 @@ type ChainTrackerConfig struct {
 	// by failure backoff. The adaptive /4, /2, /16 tiers AND the block-gap recalibration
 	// are disconnected from scheduling (block-gap estimation still runs for block-time
 	// consumers, it just no longer moves the timer). Per-endpoint trackers set it to
-	// avgBlockTime/2 because relay harvest is the primary block signal, so the dedicated
-	// poll is a sparse fallback. Left 0 (the default) preserves the legacy adaptive
+	// avgBlockTime/divisor (default 2, operator-tunable — see
+	// endpointstate.PollDivisorFlagName) because relay harvest is the primary block signal,
+	// so the dedicated poll is a sparse fallback. Left 0 (the default) preserves the legacy adaptive
 	// cadence — used by the global tracker, whose readers are not yet harvest-fed.
 	//
 	// It is named for what it does (selects the fixed-interval scheduler), not a "floor":

--- a/protocol/endpointstate/endpoint_monitor.go
+++ b/protocol/endpointstate/endpoint_monitor.go
@@ -102,6 +102,11 @@ type EndpointMonitor struct {
 
 	// Chain-specific timing
 	averageBlockTime time.Duration
+	// flatPollInterval is the FIXED dedicated-poll cadence handed to every tracker this
+	// monitor creates (chaintracker.ChainTrackerConfig.FlatPollInterval):
+	// averageBlockTime/divisor, resolved ONCE at construction from the operator's
+	// PollIntervalDivisor. See poll_cadence.go for the knob and the bounds on it.
+	flatPollInterval time.Duration
 	// tipStaleAfter is the per-endpoint tip staleness horizon (T4/C-D): the shared
 	// chainstate.StalenessWindow, derived once and passed to every endpointtip.Store.Set to
 	// gate downward (reorg) moves.
@@ -119,9 +124,14 @@ type EndpointMonitor struct {
 	// a dedicated poll (MAG-2159 Topic B / Pass 2 — the "gate freshness threshold"). A
 	// relay observation younger than this means served traffic kept the tip at most ~one
 	// block stale, so this tick's dedicated poll is redundant and is borrowed instead of
-	// sent upstream (see freshRelayTip / EndpointPoller.relayGate). Defaults to
-	// averageBlockTime: ~1 block of staleness, conveniently 2x the flat poll interval
-	// (avgBlockTime/2), enough margin to suppress consecutive ticks without flapping.
+	// sent upstream (see freshRelayTip / EndpointPoller.relayGate). Always averageBlockTime:
+	// "~one block of staleness" is a property of the CHAIN, so it deliberately does NOT follow
+	// the poll divisor (poll_cadence.go). At the default divisor that is 2x the poll interval,
+	// ample margin to suppress consecutive ticks without flapping; at divisor 1 the margin is
+	// 1x, so an endpoint whose relays arrive around once per block time alternates skip/poll
+	// instead of reliably skipping. That costs one extra poll on a quiet endpoint, never
+	// correctness — the gate reads the RELAY tip's age, and a busy endpoint's tip is far
+	// fresher than either bound.
 	relayGateFreshness time.Duration
 
 	// Callbacks for events (optional)
@@ -151,6 +161,12 @@ type EndpointChainTrackerConfig struct {
 	ApiInterface     string
 	AverageBlockTime time.Duration
 	BlocksToSave     uint64
+
+	// PollIntervalDivisor sets the dedicated-poll cadence to AverageBlockTime/divisor.
+	// 0 (the default) means DefaultPollDivisor — two polls per block time. Lowering it to 1
+	// halves the tracker's upstream request volume. Out-of-range values warn and revert to
+	// the default rather than clamping. See PollDivisorFlagName.
+	PollIntervalDivisor int
 
 	// EnableForkDetection turns block-hash polling on. Off by default: the tracker then
 	// asks each endpoint only "what is your latest block?" and never fetches a hash. See
@@ -201,6 +217,12 @@ func NewEndpointMonitor(ctx context.Context, config EndpointChainTrackerConfig) 
 		avgBlockTime = DefaultAverageBlockTime
 	}
 
+	// Dedicated-poll cadence (poll_cadence.go). Validated and derived ONCE here so every
+	// tracker this monitor creates shares one interval, and so a rejected out-of-range value
+	// is reported once per chain rather than per tracker.
+	pollDivisor := resolvePollDivisor(config.PollIntervalDivisor, config.ChainID, config.ApiInterface)
+	flatPollInterval := resolveFlatPollInterval(avgBlockTime, pollDivisor)
+
 	ctxWithCancel, cancel := context.WithCancel(ctx)
 
 	manager := &EndpointMonitor{
@@ -215,6 +237,7 @@ func NewEndpointMonitor(ctx context.Context, config EndpointChainTrackerConfig) 
 		chainID:           config.ChainID,
 		apiInterface:      config.ApiInterface,
 		averageBlockTime:  avgBlockTime,
+		flatPollInterval:  flatPollInterval,
 		tipStaleAfter:     chainstate.StalenessWindow(avgBlockTime),
 		blocksToSave:      blocksToSave,
 		retryMinDelay:     defaultTrackerStartRetryMin,
@@ -245,6 +268,18 @@ func NewEndpointMonitor(ctx context.Context, config EndpointChainTrackerConfig) 
 		utils.LogAttr("enabled", !manager.hashPolling.HeadOnly()),
 		utils.LogAttr("reason", manager.hashPolling.String()),
 	)
+
+	// Log only the non-default cadence: an operator who tuned polling has to be able to
+	// confirm from the logs that the value survived validation, while the default needs no
+	// line of its own (it is already visible as PollIntervalMs on /debug/endpoint-state).
+	if pollDivisor != DefaultPollDivisor {
+		utils.LavaFormatInfo("per-endpoint chain tracker poll cadence overridden",
+			utils.LogAttr("chainID", config.ChainID),
+			utils.LogAttr("apiInterface", config.ApiInterface),
+			utils.LogAttr("divisor", pollDivisor),
+			utils.LogAttr("pollInterval", flatPollInterval),
+		)
+	}
 
 	return manager
 }
@@ -326,11 +361,12 @@ func (m *EndpointMonitor) GetOrCreateTracker(
 		// turning it off would swap in a DummyChainTracker, which polls nothing at all.
 		HeadOnlyTracking: m.hashPolling.HeadOnly(),
 		// MAG-2159 (Topic B): per-endpoint trackers use a FIXED flat cadence — the
-		// dedicated poll runs at exactly avgBlockTime/2 (slowed only by failure backoff),
-		// because relay harvest is the primary block signal and the poll is a sparse
-		// fallback. (The global tracker leaves this 0 and keeps its legacy adaptive
-		// cadence until Topic C.)
-		FlatPollInterval: m.averageBlockTime / 2,
+		// dedicated poll runs at exactly avgBlockTime/divisor (slowed only by failure
+		// backoff), because relay harvest is the primary block signal and the poll is a
+		// sparse fallback. The divisor defaults to DefaultPollDivisor and is operator-tunable
+		// (PollDivisorFlagName), resolved once in NewEndpointMonitor. (The global tracker
+		// leaves this 0 and keeps its legacy adaptive cadence until Topic C.)
+		FlatPollInterval: m.flatPollInterval,
 		// Traffic gate (Topic B): the dedicated poll skips its ENTIRE cycle when a fresh
 		// relay-harvested tip already covers the endpoint. The gate lives on the ChainTracker
 		// (above the generic/SVM wrapper split) so it suppresses Solana polls too — the old
@@ -664,7 +700,7 @@ func (m *EndpointMonitor) BackoffSnapshot() map[string]time.Duration {
 // PollNow forces ONE endpoint's ChainTracker to run its dedicated poll immediately and returns
 // that endpoint's observation record once the poll's result has been written (MAG-2649, behind
 // /debug/poll-now). It exists so a test can set a provider's state, trigger the poll, and read the
-// result — instead of waiting out the per-endpoint cadence (avgBlockTime/2).
+// result — instead of waiting out the per-endpoint cadence (avgBlockTime/divisor).
 //
 // polled reports whether THE RETURNED OBSERVATION IS THIS POLL'S. It is the caller's licence to
 // trust the record, and it separates outcomes that must never be conflated:

--- a/protocol/endpointstate/poll_cadence.go
+++ b/protocol/endpointstate/poll_cadence.go
@@ -1,0 +1,90 @@
+package endpointstate
+
+import (
+	"time"
+
+	"github.com/magma-Devs/smart-router/utils"
+)
+
+// PollDivisorFlagName is the operator knob for the per-endpoint dedicated-poll cadence.
+//
+// Each per-endpoint ChainTracker polls its upstream for the latest block on a FIXED
+// interval of avgBlockTime/divisor (chaintracker.ChainTrackerConfig.FlatPollInterval).
+// The built-in divisor is DefaultPollDivisor — two polls per block time. Lowering it to 1
+// halves the tracker's request volume against every upstream, which is the point: on a
+// metered customer node the dedicated poll is pure overhead the moment served traffic is
+// already keeping the tip current.
+//
+// It is a RATIO, not an absolute interval, on purpose. One process can serve several
+// chains (config/smartrouter_examples/smartrouter_multichain.yml) and each resolves its own
+// average_block_time from its spec, so a single ratio stays chain-relative — 12s/D on
+// Ethereum and 400ms/D on Solana from the same flag. An absolute "--poll-every=6s" would be
+// right for one chain and wrong for every other one the process serves.
+//
+// NOT to be confused with the deprecated --chain-tracker-polling-multiplier (a registered
+// no-op, see rpcsmartrouter.go): that one tuned the GLOBAL tracker's adaptive tiers, which
+// MAG-2160 deleted. This one selects the per-endpoint flat cadence, which is the only
+// cadence that still exists.
+const PollDivisorFlagName = "chain-tracker-poll-divisor"
+
+const (
+	// DefaultPollDivisor is the built-in cadence: avgBlockTime/2, two polls per block time.
+	// Used when the operator supplies nothing (0) or an out-of-range value.
+	DefaultPollDivisor = 2
+
+	// MinPollDivisor floors the cadence at ONE poll per block time. Polling slower than the
+	// chain produces blocks is deliberately out of reach here, because two windows derived
+	// from avgBlockTime elsewhere start to bind:
+	//
+	//   - the traffic gate may skip up to chaintracker.defaultMaxRelaySkipsBeforePoll (4)
+	//     consecutive cycles, so the poll atomic that consistency pre-validation falls back
+	//     to can be (skips+1) x interval stale. At divisor 1 that is ~5 block times against
+	//     a default 10-block EndpointLagThreshold — half the margin the built-in cadence has,
+	//     and the last value that keeps a comfortable one.
+	//   - chainstate.StalenessWindow and the probe's alive horizon are both ~10 x avgBlockTime;
+	//     an interval that approaches them scores healthy endpoints stale/not-alive.
+	//
+	// Going below 1 is therefore not a tuning decision but a redesign of those windows, and
+	// should arrive with them rather than through this knob.
+	MinPollDivisor = 1
+
+	// MaxPollDivisor caps how much FASTER than the built-in cadence an operator can poll.
+	// The cap is relative to the chain's own block time, which is the frame that matters:
+	// divisor 8 is 8 polls per block either way, but that is 8 requests per 12s on Ethereum
+	// and 8 per 400ms on Solana.
+	MaxPollDivisor = 8
+)
+
+// resolvePollDivisor validates an operator-supplied divisor, reverting to the built-in
+// default on 0 (nothing supplied) or an out-of-range value. Out-of-range warns rather than
+// silently clamping — an operator who asked for 20 polls per block should learn the request
+// was refused, not quietly receive 8 and read the metric as confirmation.
+//
+// Validation lives here, not in the command's RunE, so every construction path is covered
+// identically: the CLI flag, a config.yml key resolved through viper, and an embedded server
+// that sets the field directly.
+func resolvePollDivisor(divisor int, chainID, apiInterface string) int {
+	if divisor == 0 {
+		return DefaultPollDivisor
+	}
+	if divisor < MinPollDivisor || divisor > MaxPollDivisor {
+		utils.LavaFormatWarning("--"+PollDivisorFlagName+" out of allowed range; reverting to default", nil,
+			utils.LogAttr("provided", divisor),
+			utils.LogAttr("allowed", []int{MinPollDivisor, MaxPollDivisor}),
+			utils.LogAttr("default", DefaultPollDivisor),
+			utils.LogAttr("chainID", chainID),
+			utils.LogAttr("apiInterface", apiInterface),
+		)
+		return DefaultPollDivisor
+	}
+	return divisor
+}
+
+// resolveFlatPollInterval turns a (already floored) average block time and a validated
+// divisor into the tracker's flat poll interval. averageBlockTime is guaranteed positive by
+// the caller (NewEndpointMonitor floors a zero spec value to DefaultAverageBlockTime), and
+// divisor is guaranteed within [MinPollDivisor, MaxPollDivisor], so the result is always
+// positive — a zero would silently switch the tracker back to the legacy adaptive scheduler.
+func resolveFlatPollInterval(averageBlockTime time.Duration, divisor int) time.Duration {
+	return averageBlockTime / time.Duration(divisor)
+}

--- a/protocol/endpointstate/poll_cadence_test.go
+++ b/protocol/endpointstate/poll_cadence_test.go
@@ -1,0 +1,142 @@
+package endpointstate
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolvePollDivisor pins the validation contract: absent means default, in-range passes
+// through untouched, and anything outside the range REVERTS to the default rather than clamping
+// to the nearest bound. The distinction matters operationally — a clamp would let someone who
+// asked for 20 polls per block read the resulting metric as confirmation they got it.
+func TestResolvePollDivisor(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		provided int
+		want     int
+	}{
+		{name: "absent (0) takes the built-in default", provided: 0, want: DefaultPollDivisor},
+		{name: "1 is the slowest supported cadence: one poll per block time", provided: 1, want: 1},
+		{name: "the default may be passed explicitly", provided: DefaultPollDivisor, want: DefaultPollDivisor},
+		{name: "the upper bound is inclusive", provided: MaxPollDivisor, want: MaxPollDivisor},
+		{name: "above the range reverts, it does not clamp to Max", provided: MaxPollDivisor + 1, want: DefaultPollDivisor},
+		{name: "far above the range reverts", provided: 100, want: DefaultPollDivisor},
+		// A negative divisor would produce a negative interval, which time.NewTimer fires
+		// immediately on — a hot loop against the upstream. It must never reach the tracker.
+		{name: "negative reverts", provided: -1, want: DefaultPollDivisor},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, resolvePollDivisor(tc.provided, "ETH1", spectypes.APIInterfaceJsonRPC))
+		})
+	}
+}
+
+// TestResolveFlatPollInterval covers the derivation itself, including on a sub-second chain where
+// the divisor scales the interval down rather than up — the property that lets ONE process-wide
+// ratio serve chains whose block times differ by 30x.
+func TestResolveFlatPollInterval(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		avgBlockTime time.Duration
+		divisor      int
+		want         time.Duration
+	}{
+		{name: "ethereum at the default divisor", avgBlockTime: 12 * time.Second, divisor: DefaultPollDivisor, want: 6 * time.Second},
+		{name: "ethereum at divisor 1 halves the request rate", avgBlockTime: 12 * time.Second, divisor: 1, want: 12 * time.Second},
+		{name: "solana at divisor 1 stays sub-second", avgBlockTime: 400 * time.Millisecond, divisor: 1, want: 400 * time.Millisecond},
+		{name: "solana at the fastest allowed divisor", avgBlockTime: 400 * time.Millisecond, divisor: MaxPollDivisor, want: 50 * time.Millisecond},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, resolveFlatPollInterval(tc.avgBlockTime, tc.divisor))
+		})
+	}
+}
+
+// TestNewEndpointMonitor_ResolvesFlatPollInterval checks the resolution happens at construction,
+// against the FLOORED block time — a chain whose spec omits average_block_time must divide
+// DefaultAverageBlockTime, not zero, or the divisor would produce a 0 interval and silently switch
+// the tracker back to the legacy adaptive scheduler.
+func TestNewEndpointMonitor_ResolvesFlatPollInterval(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		avgBlockTime time.Duration
+		divisor      int
+		want         time.Duration
+	}{
+		{name: "default divisor", avgBlockTime: 12 * time.Second, divisor: 0, want: 6 * time.Second},
+		{name: "divisor 1", avgBlockTime: 12 * time.Second, divisor: 1, want: 12 * time.Second},
+		{name: "rejected divisor falls back to the default cadence", avgBlockTime: 12 * time.Second, divisor: 99, want: 6 * time.Second},
+		{name: "spec omits average_block_time: divides the floored default", avgBlockTime: 0, divisor: 1, want: DefaultAverageBlockTime},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			m := NewEndpointMonitor(ctx, EndpointChainTrackerConfig{
+				ChainID:             "ETH1",
+				ApiInterface:        spectypes.APIInterfaceJsonRPC,
+				AverageBlockTime:    tc.avgBlockTime,
+				PollIntervalDivisor: tc.divisor,
+			})
+			require.NotNil(t, m)
+			defer m.Stop()
+
+			require.Equal(t, tc.want, m.flatPollInterval)
+			require.Positive(t, m.flatPollInterval, "a zero interval would re-enable the adaptive scheduler")
+		})
+	}
+}
+
+// TestEndpointMonitor_PollDivisor_ReachesLiveTracker is the production-path proof. The tests above
+// exercise the resolution in isolation, and the chaintracker cadence tests set FlatPollInterval
+// directly — so without this one the wiring between them could be missing entirely and every other
+// test would still pass. It reads the cadence back through the same accessor /debug/endpoint-state
+// reports as PollIntervalMs.
+//
+// Both cases use a block time long enough that the poll timer cannot fire inside the test, so what
+// is asserted is the CONFIGURED cadence and never a backed-off or re-scheduled one.
+func TestEndpointMonitor_PollDivisor_ReachesLiveTracker(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		divisor int
+		want    time.Duration
+	}{
+		{name: "default divisor gives half the block time", divisor: 0, want: 30 * time.Second},
+		{name: "divisor 1 gives a full block time", divisor: 1, want: time.Minute},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			ensureRandSeeded()
+
+			const url = "http://eth-poll-divisor:8545"
+			m := NewEndpointMonitor(ctx, EndpointChainTrackerConfig{
+				ChainParser:         newRealChainParser(t, "ETH1", spectypes.APIInterfaceJsonRPC),
+				ChainID:             "ETH1",
+				ApiInterface:        spectypes.APIInterfaceJsonRPC,
+				AverageBlockTime:    time.Minute,
+				BlocksToSave:        1,
+				PollIntervalDivisor: tc.divisor,
+			})
+			require.NotNil(t, m)
+			defer m.Stop()
+
+			conn := &pollNowConn{url: url}
+			conn.block.Store(1000)
+			_, err := m.GetOrCreateTracker(&lavasession.Endpoint{NetworkAddress: url, Enabled: true}, conn)
+			require.NoError(t, err)
+
+			require.Eventually(t, func() bool {
+				state, _, exists := m.GetTrackerState(url)
+				return exists && state == EndpointChainTrackerPolling
+			}, 10*time.Second, 20*time.Millisecond, "the tracker must reach its poll loop before its cadence is read")
+
+			require.Equal(t, tc.want, m.BackoffSnapshot()[url])
+		})
+	}
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -61,9 +61,10 @@ const (
 	DebugProbesFlagName           = "debug-probes"
 
 	// deprecatedChainTrackerPollingMultiplierFlagName is the polling-relief knob main advertised
-	// for the GLOBAL chain tracker, which MAG-2160 removed (per-endpoint trackers poll at a fixed
-	// avgBlockTime/2). It stays registered as a deprecated NO-OP so deployments passing it don't
-	// fail at process start; a RunE warning tells operators the behavior is gone.
+	// for the GLOBAL chain tracker, which MAG-2160 removed (per-endpoint trackers poll at
+	// avgBlockTime/divisor). It stays registered as a deprecated NO-OP so deployments passing it
+	// don't fail at process start; a RunE warning tells operators the behavior is gone and points
+	// them at endpointstate.PollDivisorFlagName, which is the live replacement for the intent.
 	deprecatedChainTrackerPollingMultiplierFlagName = "chain-tracker-polling-multiplier"
 
 	// lavaAppName is the application name, previously app.Name.
@@ -1470,8 +1471,9 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 
 	// POST /debug/poll-now — force ONE endpoint's ChainTracker to run its dedicated poll right now,
 	// and answer only once that poll's result has been recorded (MAG-2649). Without it a test that
-	// checks what a poll records has to sit out the per-endpoint cadence (avgBlockTime/2 — ~6 s on
-	// Ethereum) before it can look; with it the sequence becomes set up state → trigger → read.
+	// checks what a poll records has to sit out the per-endpoint cadence (avgBlockTime/divisor —
+	// ~6-12 s on Ethereum) before it can look; with it the sequence becomes set up state →
+	// trigger → read.
 	//
 	// Fidelity is the whole point: this triggers the production poll cycle
 	// (chaintracker.ChainTracker.PollNow → fetchAllPreviousBlocksIfNecessary) on the tracker's own
@@ -2683,12 +2685,12 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 			// to the built-in default (not silent clamp).
 			//
 			// MAG-2160: --chain-tracker-polling-multiplier only ever tuned the global tracker's
-			// adaptive cadence, and the global tracker is gone (per-endpoint trackers run a fixed
-			// avgBlockTime/2 cadence with no runtime knob). The flag survives as a registered
+			// adaptive cadence, and the global tracker is gone. The flag survives as a registered
 			// deprecated NO-OP so existing launch args don't fail process start; warn here — via
-			// viper, so a config.yml value is caught too — that the polling-relief behavior is gone.
+			// viper, so a config.yml value is caught too — that this knob does nothing, and name
+			// --chain-tracker-poll-divisor, which tunes the per-endpoint cadence that replaced it.
 			if m := viper.GetInt(deprecatedChainTrackerPollingMultiplierFlagName); m != 0 {
-				utils.LavaFormatWarning("--"+deprecatedChainTrackerPollingMultiplierFlagName+" is deprecated and has NO EFFECT: the global chain tracker was removed (MAG-2160); per-endpoint trackers poll at a fixed avgBlockTime/2", nil, utils.LogAttr("provided", m))
+				utils.LavaFormatWarning("--"+deprecatedChainTrackerPollingMultiplierFlagName+" is deprecated and has NO EFFECT: the global chain tracker was removed (MAG-2160). Use --"+endpointstate.PollDivisorFlagName+" to tune the per-endpoint cadence (avgBlockTime/divisor)", nil, utils.LogAttr("provided", m))
 			}
 			if f := viper.GetInt(relaycore.ConsistencyBlockGapFactorFlagName); f != 0 {
 				if f < 2 || f > 8 {
@@ -2980,14 +2982,19 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	// smartrouter_multichain.yml): there is no per-chain form of this switch, so a deployment
 	// that wants fork detection on exactly one chain has to run that chain in its own process.
 	cmdRPCSmartRouter.Flags().Bool(endpointstate.EnableForkDetectionFlagName, false, "turn ON per-endpoint block-hash polling (fork detection). OFF by default: the chain tracker then asks each upstream only for its latest block. Process-wide -- it applies to EVERY chain this process serves and cannot be scoped to one of them. The live state per endpoint is reported as HashPolling on /debug/endpoint-state, and the request volume as rpc_endpoint_tracker_requests_total.")
+	// Dedicated-poll cadence. A ratio rather than an absolute interval, so ONE value stays
+	// correct across every chain this process serves (each divides its own spec block time).
+	// Validation lives in endpointstate so config.yml and embedded servers get it too.
+	// Process-wide in the same sense as the flag above.
+	cmdRPCSmartRouter.Flags().Int(endpointstate.PollDivisorFlagName, 0, fmt.Sprintf("polling-relief: per-endpoint chain tracker polls every avgBlockTime/divisor (default %d). Set 1 to halve tracker request volume. Allowed [%d,%d]; out-of-range reverts to default. Applies to EVERY chain this process serves.", endpointstate.DefaultPollDivisor, endpointstate.MinPollDivisor, endpointstate.MaxPollDivisor))
 	// MAG-2160 back-compat shim: the global chain tracker (and the adaptive cadence this knob
-	// tuned) is gone — per-endpoint trackers poll at a fixed avgBlockTime/2 — but existing launch
+	// tuned) is gone — per-endpoint trackers poll at avgBlockTime/divisor — but existing launch
 	// args (systemd/compose/helm) still pass the flag, and an UNREGISTERED flag fails process
 	// start (full pod outage on upgrade). Keep it registered as a deprecated no-op; the RunE
 	// warning tells polling-relief operators the behavior is gone (covers config.yml too, which
 	// cobra's own deprecation notice would miss).
-	cmdRPCSmartRouter.Flags().Int(deprecatedChainTrackerPollingMultiplierFlagName, 0, "DEPRECATED (no-op): the global chain tracker and its polling multiplier were removed (MAG-2160); per-endpoint trackers poll at a fixed avgBlockTime/2.")
-	if err := cmdRPCSmartRouter.Flags().MarkDeprecated(deprecatedChainTrackerPollingMultiplierFlagName, "it is a no-op: the global chain tracker was removed (MAG-2160)"); err != nil {
+	cmdRPCSmartRouter.Flags().Int(deprecatedChainTrackerPollingMultiplierFlagName, 0, "DEPRECATED (no-op): the global chain tracker and its polling multiplier were removed (MAG-2160). Use --"+endpointstate.PollDivisorFlagName+" instead.")
+	if err := cmdRPCSmartRouter.Flags().MarkDeprecated(deprecatedChainTrackerPollingMultiplierFlagName, "it is a no-op: the global chain tracker was removed (MAG-2160); use --"+endpointstate.PollDivisorFlagName+" instead"); err != nil {
 		utils.LavaFormatFatal("failed marking chain-tracker-polling-multiplier deprecated", err)
 	}
 	cmdRPCSmartRouter.Flags().Var(&strategyFlag, "strategy", fmt.Sprintf("the strategy to use to pick providers (%s)", strings.Join(strategyNames, "|")))

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -227,6 +227,10 @@ func (rpcss *RPCSmartRouterServer) ServeRPCRequests(
 		// package global, so an embedded server with no flags set gets the same default.
 		// The key is absent in that case and GetBool returns false, which IS the default.
 		EnableForkDetection: viper.GetBool(endpointstate.EnableForkDetectionFlagName),
+		// Dedicated-poll cadence, read from viper for the same reason as the flag above (an
+		// embedded server with no flags bound gets 0, which IS the default). endpointstate
+		// validates the value and reverts an out-of-range one.
+		PollIntervalDivisor: viper.GetInt(endpointstate.PollDivisorFlagName),
 		// Feed every positive poll/relay block into the per-chain tip (cheap monotonic write)
 		// and mirror the resulting guarded tip into the router-wide latest-block gauge (MAG-2629).
 		OnTipObservation: rpcss.onTipObservation,
@@ -2506,8 +2510,8 @@ func (s *probeLoopStats) snapshot() probeLoopSnapshot {
 // effectiveBlockTime (the floored block time), NOT the raw spec value, drives DefaultVerdictConfig:
 // the alive horizon (StalenessMultiplier × block time, floored at minProbeStaleness) must share the
 // SAME staleness horizon as ChainState and the monitor's poll cadence. With the raw 0 the horizon
-// floors to ~5s while the poll cadence is effectiveBlockTime/2 (~6s), so every healthy endpoint's
-// newest observation would routinely be "too old" at probe time — scoring the whole pod not-alive
+// floors to ~5s while the poll cadence is effectiveBlockTime/divisor (~6-12s), so every healthy
+// endpoint's newest observation would routinely be "too old" at probe time — scoring the pod not-alive
 // and decaying availability QoS on any chain whose spec omits average_block_time.
 //
 // The "keeping up" tolerance is sourced from the SAME per-chain threshold consistency pre-validation


### PR DESCRIPTION
#Closes MAG-2924

Jira ticket: MAG-2924

> #307 has merged. This branch is rebased onto `main` and is now a single commit.

## Why

The per-endpoint ChainTracker polls its upstream for the latest block at a hardcoded `avgBlockTime/2`. On a metered customer node that dedicated poll is pure overhead whenever served traffic is already keeping the tip current, and there was no way to relieve it: `--chain-tracker-polling-multiplier` only ever tuned the *global* tracker's adaptive tiers, and MAG-2160 deleted those (the flag survives as a registered no-op).

Paired with #307 (fork detection off), this is the second lever on tracker request volume: #307 removes the hash requests, this one halves the rate of what's left.

## What

`--chain-tracker-poll-divisor` — the cadence becomes `avgBlockTime/divisor`.

- **Default `2`** → `avgBlockTime/2`, behaviour unchanged.
- **`1`** → one poll per block time, halving tracker request volume against every upstream.
- Range `[1,8]`; out-of-range **warns and reverts to the default** rather than clamping.

Observable as `PollIntervalMs` on `/debug/endpoint-state` and in `rpc_endpoint_tracker_requests_total`. A non-default divisor also logs once per chain at startup.

## Design notes

**A ratio, not an absolute interval.** One process can serve several chains (`smartrouter_multichain.yml`) and each resolves its own `average_block_time` from its spec, so a single ratio stays chain-relative — 12s/D on Ethereum, 400ms/D on Solana from the same flag. An absolute `--poll-every=6s` would be right for one chain and wrong for every other one the process serves.

**The floor of 1 is load-bearing, not cosmetic.** Two windows derived from `avgBlockTime` bind below it:

- The traffic gate may skip up to `defaultMaxRelaySkipsBeforePoll` (4) consecutive cycles, so the poll atomic that consistency pre-validation falls back to can be `(skips+1) × interval` stale — ~5 block times at divisor 1, against a default 10-block `EndpointLagThreshold`.
- `chainstate.StalenessWindow` and the probe's alive horizon are both ~10 × `avgBlockTime`; an interval approaching them scores healthy endpoints stale/not-alive.

Going slower is a redesign of those windows, not a tuning decision, so it is out of reach here. Negative values are rejected on the same path — a negative interval makes `time.NewTimer` fire immediately, i.e. a hot loop against the upstream.

**`relayGateFreshness` deliberately does not follow the divisor.** It stays `avgBlockTime`: "~one block of staleness" is a property of the chain, not of the cadence. At divisor 1 its margin over the poll interval narrows from 2x to 1x, which costs one extra poll on an endpoint whose relays arrive around once per block time — and nothing else. The gate reads the *relay* tip's age, and a busy endpoint's tip is far fresher than either bound.

**Validation lives in `endpointstate`, not the command's RunE**, so the CLI flag, a `config.yml` key, and an embedded server that sets the field directly are covered identically. Reverting rather than clamping is deliberate: an operator who asked for 20 polls per block should not read the resulting metric as confirmation they got it.

The deprecated `--chain-tracker-polling-multiplier` now names this flag as the live replacement for its intent, in both its RunE warning and its cobra deprecation notice.

## Comment corrections

Several comments stated `avgBlockTime/2` as fact. Updated across `chaintracker` and `rpcsmartrouter`, including the skip-budget rationale at `chain_tracker.go:76` — its "~2 blocks stale" claim now records both the divisor-1 worst case and the fact that consistency pre-validation prefers the relay-fed tip store, so the atomic only decides for endpoints where the gate never skips.

## Testing

`protocol/endpointstate/poll_cadence_test.go` — 4 tests, 17 cases: divisor validation (absent / in-range / above-range / negative), the derivation on both a 12s and a 400ms chain, resolution against the *floored* block time (a spec omitting `average_block_time` must divide the default, not zero — a 0 interval would silently re-enable the legacy adaptive scheduler), and one end-to-end case.

`TestEndpointMonitor_PollDivisor_ReachesLiveTracker` is the one that earns its keep: it reads the cadence back off a **live** tracker through `BackoffSnapshot`, the same accessor `/debug/endpoint-state` uses. The chaintracker cadence tests set `FlatPollInterval` directly, so without it the monitor→tracker wiring could be missing entirely and every other test would still pass.

Full suites green: `endpointstate` 6.5s, `chaintracker` 12.1s, `rpcsmartrouter` 89.4s. `go vet` clean. Flag verified in the built binary's `--help`.

## Live verification (real router, real node)

Built the branch, ran the router against a live lava node (LAVA, 15s spec block time), and measured with `rpc_endpoint_tracker_requests_total` from #307. 120-second windows, no relay traffic (so the traffic gate cannot confound the rate):

| flag | `PollIntervalMs` | requests/120s | **req/min** | range warnings |
|---|---|---|---|---|
| *(none — default)* | 7500 | 14 | **7.0** | 0 |
| `--chain-tracker-poll-divisor 1` | **15000** | 7 | **3.5** | 0 |
| `--chain-tracker-poll-divisor 20` | 7500 | 14 | **7.0** | **1** |
| `--chain-tracker-poll-divisor 4` | 3750 | 28 | **14.0** | 0 |

Linear in both directions: 15000→3.5, 7500→7.0, 3750→14.0.

- **Divisor 1 halves request volume** — exactly, not approximately.
- **Default is unchanged** at 7500ms.
- **Out-of-range reverts _and_ warns** — `20` produced the default plus exactly one range warning, so the resulting metric cannot be misread as confirmation.

### Divisor 1 is healthy

Full battery at divisor 1, against a default-divisor control run with an identical procedure (same relay traffic, same settling time):

| check | divisor 1 | control (default) |
|---|---|---|
| Relay correctness | router height = upstream height | same |
| Endpoints enabled | 2/2 | 2/2 |
| `ConsecutivePollFailures` | 0 | 0 |
| `PollIntervalMs` | 15000 | 7500 |
| Tip sources | poll + relay both feeding | same |
| ChainState | `Initialized`, `TipFresh` | same |
| QoS availability | **1.0 / 1.0** | 1.0 / 1.0 |
| QoS sync | 0.915 / 0.903 | 0.914 / 0.953 |
| Selection composite | 0.924 / 0.922 | 0.924 / 0.932 |
| **Consistency rejections** | **0** | 0 |
| Log | 0 panics, 0 ERR, 0 "No pairings" | same |

Zero consistency rejections at divisor 1 is the number that matters for the floor argument above: the wider staleness window did not start gating endpoints.

**A false alarm worth recording.** The first divisor-1 sample showed one endpoint at availability 0.777 / composite 0.01, which looked like the slower cadence degrading it. It was a sampling artifact — that sample was taken seconds after startup while QoS was still converging, whereas the control had already served 12 relays over 24s. Re-run with an identical procedure, divisor 1 gives availability **1.0** and composite **0.922**, matching the control. No regression.

## Review notes (non-blocking)

1. **`0` reverts silently.** `--chain-tracker-poll-divisor 0` is out of range but yields the default with no warning, because `0` doubles as the "unset" sentinel. An `Int` flag cannot distinguish the two, so this is inherent rather than a bug — the same limitation `--consistency-block-gap-factor` has. Worth a line in the flag help if we care.

2. **The ceiling allows 4× *more* load than today.** Divisor 8 is four times the current rate — a poll every 50ms per endpoint on Solana, every 25ms on Aptos. Presumably deliberate, but the flag is framed as "polling-relief" and its upper bound is the opposite, so it is worth naming so nobody reaches for it casually.


## Rebase onto main

#307 merged as a squash commit, so its work reached `main` as a new commit while this branch still carried its own copy of it — git reported that duplicate as a conflict. Rebased `--onto main`, dropping the duplicate; the remaining commit applied with no textual conflict and its patch is byte-identical to the pre-rebase one.

Re-verified on the new base: `go build ./...` and `go vet ./protocol/...` clean, and `protocol/{endpointstate,chaintracker,rpcsmartrouter,metrics}` all pass.
