### PR TITLE
refactor!: remove the dead --chain-tracker-polling-multiplier flag

### DIFF
--- a/.github/workflows/pr-gate-build-artifact.yml
+++ b/.github/workflows/pr-gate-build-artifact.yml
@@ -498,6 +498,7 @@ jobs:
               ($arg == "--concurrent-providers") or
               ($arg == "--enable-periodic-probe-providers") or
               ($arg == "--periodic-probe-providers-interval") or
+              ($arg == "--chain-tracker-polling-multiplier") or
               (($arg | startswith("--provider-optimizer-")) and (($arg | contains("=")) | not));
             def retired_flag_assignment($arg):
               ($arg | startswith("--optimizer-qos-listen=")) or
@@ -506,6 +507,7 @@ jobs:
               ($arg | startswith("--concurrent-providers=")) or
               ($arg | startswith("--enable-periodic-probe-providers=")) or
               ($arg | startswith("--periodic-probe-providers-interval=")) or
+              ($arg | startswith("--chain-tracker-polling-multiplier=")) or
               (($arg | startswith("--provider-optimizer-")) and ($arg | contains("=")));
             def sanitize_arg($arg):
               if retired_flag_name($arg) then

--- a/.github/workflows/pr-gate-build-artifact.yml
+++ b/.github/workflows/pr-gate-build-artifact.yml
@@ -941,7 +941,6 @@ jobs:
               defaultProcessingTimeout: "30s"
               minRelayTimeout: "10s"
               maxBatchRequestSize: 0
-              chainTrackerPollingMultiplier: 0
               consistencyBlockGapFactor: 0
               providerOptimizerAvailabilityWeight: 0.3
               providerOptimizerLatencyWeight: 0.3

--- a/protocol/chaintracker/chain_tracker.go
+++ b/protocol/chaintracker/chain_tracker.go
@@ -88,9 +88,8 @@ const (
 	// (global tracker only — per-endpoint trackers run a fixed FlatPollInterval and never reach
 	// the adaptive tiers). It is the SOLE feeder of cs.pollingTimeMultiplier. The adaptive tiers
 	// compute base/(multiplier/4), so the multiplier must stay >= 4 to avoid a divide-by-zero;
-	// 16 satisfies that by construction. MAG-2160 removed the --chain-tracker-polling-multiplier
-	// runtime override (it only ever tuned the now-deleted global tracker), so there is no longer
-	// any operator-supplied value to range-validate.
+	// 16 satisfies that by construction. It is a fixed built-in with no operator-supplied
+	// value to range-validate.
 	MostFrequentPollingMultiplier = 16
 )
 
@@ -983,9 +982,8 @@ func newCustomChainTracker(chainFetcher ChainFetcher, config ChainTrackerConfig)
 
 	// The legacy adaptive cadence (global tracker only — per-endpoint trackers set
 	// FlatPollInterval and never reach the adaptive tiers) uses the fixed built-in
-	// MostFrequentPollingMultiplier (16, >= the divide-by-zero floor of 4). MAG-2160 removed
-	// the --chain-tracker-polling-multiplier runtime override along with the global tracker it
-	// tuned; the old per-tracker config.PollingTimeMultiplier knob was set by nobody and was
+	// MostFrequentPollingMultiplier (16, >= the divide-by-zero floor of 4). There is no runtime
+	// override: the old per-tracker config.PollingTimeMultiplier knob was set by nobody and was
 	// removed in the MAG-2159 knob consolidation.
 	pollingTime := MostFrequentPollingMultiplier
 

--- a/protocol/endpointstate/poll_cadence.go
+++ b/protocol/endpointstate/poll_cadence.go
@@ -20,11 +20,6 @@ import (
 // average_block_time from its spec, so a single ratio stays chain-relative — 12s/D on
 // Ethereum and 400ms/D on Solana from the same flag. An absolute "--poll-every=6s" would be
 // right for one chain and wrong for every other one the process serves.
-//
-// NOT to be confused with the deprecated --chain-tracker-polling-multiplier (a registered
-// no-op, see rpcsmartrouter.go): that one tuned the GLOBAL tracker's adaptive tiers, which
-// MAG-2160 deleted. This one selects the per-endpoint flat cadence, which is the only
-// cadence that still exists.
 const PollDivisorFlagName = "chain-tracker-poll-divisor"
 
 const (

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -60,13 +60,6 @@ const (
 	DebugRelaysFlagName           = "debug-relays"
 	DebugProbesFlagName           = "debug-probes"
 
-	// deprecatedChainTrackerPollingMultiplierFlagName is the polling-relief knob main advertised
-	// for the GLOBAL chain tracker, which MAG-2160 removed (per-endpoint trackers poll at
-	// avgBlockTime/divisor). It stays registered as a deprecated NO-OP so deployments passing it
-	// don't fail at process start; a RunE warning tells operators the behavior is gone and points
-	// them at endpointstate.PollDivisorFlagName, which is the live replacement for the intent.
-	deprecatedChainTrackerPollingMultiplierFlagName = "chain-tracker-polling-multiplier"
-
 	// lavaAppName is the application name, previously app.Name.
 	lavaAppName = "lava"
 	// lavaDefaultNodeHome is the default home directory, previously lavaDefaultNodeHome (~/.lava).
@@ -2683,15 +2676,6 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 			// (viper precedence: CLI-if-passed > config file > default). Still set before any
 			// consistency config is built. Zero = no relief; out-of-range values warn-and-revert
 			// to the built-in default (not silent clamp).
-			//
-			// MAG-2160: --chain-tracker-polling-multiplier only ever tuned the global tracker's
-			// adaptive cadence, and the global tracker is gone. The flag survives as a registered
-			// deprecated NO-OP so existing launch args don't fail process start; warn here — via
-			// viper, so a config.yml value is caught too — that this knob does nothing, and name
-			// --chain-tracker-poll-divisor, which tunes the per-endpoint cadence that replaced it.
-			if m := viper.GetInt(deprecatedChainTrackerPollingMultiplierFlagName); m != 0 {
-				utils.LavaFormatWarning("--"+deprecatedChainTrackerPollingMultiplierFlagName+" is deprecated and has NO EFFECT: the global chain tracker was removed (MAG-2160). Use --"+endpointstate.PollDivisorFlagName+" to tune the per-endpoint cadence (avgBlockTime/divisor)", nil, utils.LogAttr("provided", m))
-			}
 			if f := viper.GetInt(relaycore.ConsistencyBlockGapFactorFlagName); f != 0 {
 				if f < 2 || f > 8 {
 					utils.LavaFormatWarning("--"+relaycore.ConsistencyBlockGapFactorFlagName+" out of allowed range [2,8]; reverting to default", nil, utils.LogAttr("provided", f))
@@ -2987,16 +2971,6 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	// Validation lives in endpointstate so config.yml and embedded servers get it too.
 	// Process-wide in the same sense as the flag above.
 	cmdRPCSmartRouter.Flags().Int(endpointstate.PollDivisorFlagName, 0, fmt.Sprintf("polling-relief: per-endpoint chain tracker polls every avgBlockTime/divisor (default %d). Set 1 to halve tracker request volume. Allowed [%d,%d]; out-of-range reverts to default. Applies to EVERY chain this process serves.", endpointstate.DefaultPollDivisor, endpointstate.MinPollDivisor, endpointstate.MaxPollDivisor))
-	// MAG-2160 back-compat shim: the global chain tracker (and the adaptive cadence this knob
-	// tuned) is gone — per-endpoint trackers poll at avgBlockTime/divisor — but existing launch
-	// args (systemd/compose/helm) still pass the flag, and an UNREGISTERED flag fails process
-	// start (full pod outage on upgrade). Keep it registered as a deprecated no-op; the RunE
-	// warning tells polling-relief operators the behavior is gone (covers config.yml too, which
-	// cobra's own deprecation notice would miss).
-	cmdRPCSmartRouter.Flags().Int(deprecatedChainTrackerPollingMultiplierFlagName, 0, "DEPRECATED (no-op): the global chain tracker and its polling multiplier were removed (MAG-2160). Use --"+endpointstate.PollDivisorFlagName+" instead.")
-	if err := cmdRPCSmartRouter.Flags().MarkDeprecated(deprecatedChainTrackerPollingMultiplierFlagName, "it is a no-op: the global chain tracker was removed (MAG-2160); use --"+endpointstate.PollDivisorFlagName+" instead"); err != nil {
-		utils.LavaFormatFatal("failed marking chain-tracker-polling-multiplier deprecated", err)
-	}
 	cmdRPCSmartRouter.Flags().Var(&strategyFlag, "strategy", fmt.Sprintf("the strategy to use to pick providers (%s)", strings.Join(strategyNames, "|")))
 	defaultWeightedConfig := provideroptimizer.DefaultWeightedSelectorConfig()
 	cmdRPCSmartRouter.Flags().Float64(common.ProviderOptimizerAvailabilityWeight, defaultWeightedConfig.AvailabilityWeight, "weight assigned to provider availability when computing selection scores")


### PR DESCRIPTION
#Closes MAG-2931

Jira ticket: MAG-2931

Deletes a flag that has changed nothing since MAG-2160, and the deprecation shim that grew around it.

## Why

`--chain-tracker-polling-multiplier` tuned the adaptive polling tiers of the **global** chain tracker. MAG-2160 removed both. Per-endpoint trackers poll at `avgBlockTime/divisor` — a cadence this flag cannot reach — so it has been inert ever since.

It stayed registered as a no-op so existing launch args would not fail process start. For a knob that does nothing, that shim had grown:

| where | what |
|---|---|
| `rpcsmartrouter.go` | a package const + 5-line comment |
| `rpcsmartrouter.go` | `Flags().Int(...)` + `MarkDeprecated(...)` + 6-line comment |
| `rpcsmartrouter.go` | a RunE viper warning + 5-line comment, duplicating cobra's own deprecation notice |
| `endpointstate/poll_cadence.go` | a "NOT to be confused with" paragraph on `PollDivisorFlagName` |
| `chaintracker/chain_tracker.go` | two comment references |
| `.github/workflows/pr-gate-build-artifact.yml` | a `chainTrackerPollingMultiplier: 0` values fixture |

Net: **-38 lines, +4.**

## What stays

`chaintracker.MostFrequentPollingMultiplier` is **not** this flag — it is a live internal constant (16) feeding the legacy adaptive cadence and the sole feeder of `cs.pollingTimeMultiplier`. It stays exactly as it is; only the dead flag's name comes out of its comments.

## Breaking — merge order matters

Cobra rejects an unknown flag **before the router serves anything**:

```
$ smartrouter rpcsmartrouter --chain-tracker-polling-multiplier=4
Error: unknown flag: --chain-tracker-polling-multiplier
```

So every producer of the arg has to stop emitting it first:

- **[smart-router-helm-chart#119](https://github.com/Magma-Devs/smart-router-helm-chart/pull/119) (chart 5.19.0)** drops the `chainTrackerPollingMultiplier` key and the arg it rendered. **That has to merge and be released before this.** A stale `chainTrackerPollingMultiplier: 4` left in a customer values file is harmless on 5.19.0 — `miscellaneous.routers` does not close over its properties, so it validates, renders no arg and is ignored.
- **Hand-rolled launch args** — systemd units, compose files, scripts — the chart cannot cover those. They need the flag removed by hand.

Under `helm upgrade --wait --atomic` a router that exits 1 rolls the whole release back, so the failure is loud rather than silent. It is still an outage.

## The PR gate needed the flag too

`pr-gate-build-artifact.yml` rolls the PR image onto a live deployment **reusing that deployment's current args**. Unregistering the flag here means any environment still rendered by a chart older than 5.19.0 carries the arg, the PR image exits 1 with `unknown flag`, and every subsequent PR fails the gate on an unrelated diff.

The workflow already keeps a sanitizer for exactly this — it strips six previously-retired flags (`--optimizer-qos-listen`, `--geolocation`, `--concurrent-providers`, `--enable-periodic-probe-providers`, `--periodic-probe-providers-interval`, `--provider-optimizer-*`) out of the captured args before the rollout. The multiplier is now in both predicates, so `--chain-tracker-polling-multiplier 4` (name + value) and `--chain-tracker-polling-multiplier=4` are both dropped.

## Related

- [docs#31](https://github.com/Magma-Devs/docs/pull/31) (MAG-2929) — deletes the docs-site row rather than moving it to a deprecated section, for the same reason.
- #307 / #308 — the live replacements (`--enable-fork-detection`, `--chain-tracker-poll-divisor`), both merged.

## Test plan

| check | result |
|---|---|
| `go build ./...` | pass |
| `go vet ./protocol/{rpcsmartrouter,endpointstate,chaintracker}/...` | pass |
| `go test ./protocol/endpointstate/... ./protocol/chaintracker/...` | pass |
| `grep -r chain-tracker-polling-multiplier` (excl. vendor) | 0 hits |
| `--help` | lists `--chain-tracker-poll-divisor` + `--enable-fork-detection`, no multiplier |
| passing the removed flag | `Error: unknown flag` |
| `pr-gate-build-artifact.yml` parses | pass |
| gate sanitizer vs `["--chain-tracker-polling-multiplier","4"]` | flag + value dropped |
| gate sanitizer vs `["--chain-tracker-polling-multiplier=4"]` | dropped |
| gate sanitizer vs `["--chain-tracker-poll-divisor","1"]` | untouched |
