### PR TITLE
refactor(lavasession): drop the unreachable gRPC compression knob


### DIFF
--- a/protocol/lavasession/common.go
+++ b/protocol/lavasession/common.go
@@ -20,7 +20,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/encoding/gzip"
 )
 
 var MaxSessionsAllowedPerProvider = 1000 // Max number of sessions allowed per provider, configurable via flag
@@ -78,7 +77,7 @@ func IsSessionSyncLoss(err error) bool {
 	return code == codes.Code(SessionOutOfSyncGRPCCode) || errors.Is(err, SessionOutOfSyncError)
 }
 
-func ConnectGRPCClient(ctx context.Context, address string, allowInsecure bool, skipTLS bool, allowCompression bool) (*grpc.ClientConn, error) {
+func ConnectGRPCClient(ctx context.Context, address string, allowInsecure bool, skipTLS bool) (*grpc.ClientConn, error) {
 	var opts []grpc.DialOption
 
 	if skipTLS {
@@ -107,13 +106,6 @@ func ConnectGRPCClient(ctx context.Context, address string, allowInsecure bool, 
 		opts = append(opts, grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 			return net.Dial("tcp", addr)
 		}))
-	}
-
-	// allow gzip compression for grpc.
-	if allowCompression {
-		opts = append(opts, grpc.WithDefaultCallOptions(
-			grpc.UseCompressor(gzip.Name), // Use gzip compression for provider consumer communication
-		))
 	}
 
 	conn, err := grpc.DialContext(ctx, address, opts...)

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -1351,7 +1351,7 @@ func TestContext(t *testing.T) {
 
 func TestGrpcClientHang(t *testing.T) {
 	ctx := context.Background()
-	conn, err := ConnectGRPCClient(ctx, grpcListener, true, false, false)
+	conn, err := ConnectGRPCClient(ctx, grpcListener, true, false)
 	require.NoError(t, err)
 	client := pairingtypes.NewRelayerClient(conn)
 	err = conn.Close()

--- a/protocol/lavasession/consumer_types.go
+++ b/protocol/lavasession/consumer_types.go
@@ -84,9 +84,8 @@ const (
 )
 
 var (
-	AllowInsecureConnectionToProviders                   = false
-	AllowGRPCCompressionForConsumerProviderCommunication = false
-	MaximumStreamsOverASingleConnection                  = uint64(DefaultMaximumStreamsOverASingleConnection)
+	AllowInsecureConnectionToProviders  = false
+	MaximumStreamsOverASingleConnection = uint64(DefaultMaximumStreamsOverASingleConnection)
 )
 
 type UsedProvidersInf interface {
@@ -923,7 +922,7 @@ func (cswp *ConsumerSessionsWithProvider) decreaseUsedComputeUnits(cu uint64) er
 func (cswp *ConsumerSessionsWithProvider) ConnectRawClientWithTimeout(ctx context.Context, addr string) (pairingtypes.RelayerClient, *grpc.ClientConn, error) {
 	connectCtx, cancel := context.WithTimeout(ctx, TimeoutForEstablishingAConnection)
 	defer cancel()
-	conn, err := ConnectGRPCClient(connectCtx, addr, AllowInsecureConnectionToProviders, false, AllowGRPCCompressionForConsumerProviderCommunication)
+	conn, err := ConnectGRPCClient(connectCtx, addr, AllowInsecureConnectionToProviders, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/protocol/lavasession/consumer_types.go
+++ b/protocol/lavasession/consumer_types.go
@@ -78,7 +78,6 @@ func (drsc *DirectRPCSessionConnection) GetEndpointAddress() string {
 
 const (
 	AllowInsecureConnectionToProvidersFlag     = "allow-insecure-provider-dialing"
-	AllowGRPCCompressionFlag                   = "enable-application-level-compression"
 	MaximumStreamsOverASingleConnectionFlag    = "maximum-streams-per-connection"
 	DefaultMaximumStreamsOverASingleConnection = 100
 	WeightMultiplierForStaticProviders         = 10

--- a/protocol/performance/cache.go
+++ b/protocol/performance/cache.go
@@ -56,7 +56,7 @@ func (r *relayerCacheClientStore) connectGRPCConnectionToRelayerCacheService() (
 	connectCtx, cancel := context.WithTimeout(r.ctx, 3*time.Second)
 	defer cancel()
 
-	conn, err := lavasession.ConnectGRPCClient(connectCtx, r.address, false, true, false)
+	conn, err := lavasession.ConnectGRPCClient(connectCtx, r.address, false, true)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
#Closes MAG-2940

Jira ticket: MAG-2940

Deletes an unreachable gRPC-compression knob: a flag-name const nothing registers, the package var nothing assigns, and the `ConnectGRPCClient` parameter they fed — which is `false` at every call site.

## Why

`AllowGRPCCompressionFlag = "enable-application-level-compression"` was declared in `protocol/lavasession/consumer_types.go` and never used again. It is not registered on any command, so the flag string is unreachable: passing `--enable-application-level-compression` fails with `unknown flag` like any other typo.

Pulling that thread, the rest of the knob is dead too:

| symbol | state |
|---|---|
| `AllowGRPCCompressionFlag` | declared once, never registered, never read |
| `AllowGRPCCompressionForConsumerProviderCommunication` | initialised `false`, never assigned anywhere since the initial commit |
| `ConnectGRPCClient(..., allowCompression bool)` | `false` at **all three** call sites |
| the `grpc.UseCompressor(gzip.Name)` branch it guards | unreachable |

The flag was presumably wired up alongside the `WithCompression` benchmark in `common_test.go`; the benchmark stayed, the knob to act on it never landed.

**No behavior change** — every caller already took the `false` path. Net **-15 / +6**.

## What changed

- `protocol/lavasession/consumer_types.go` — const + var deleted; call site drops the argument.
- `protocol/lavasession/common.go` — parameter, unreachable gzip branch and the now-unused `google.golang.org/grpc/encoding/gzip` import deleted.
- `protocol/performance/cache.go:59`, `protocol/lavasession/consumer_session_manager_test.go:1354` — call sites drop the trailing `false`.

The `WithCompression` benchmark in `common_test.go` builds its own dial options rather than calling `ConnectGRPCClient`, so it still measures exactly what it always did and is untouched.

Only the four files' own hunks are in the diff. `gofmt -w` on the touched files also wanted to reorder an unrelated pre-existing import block in `cache.go`; that was reverted to keep this focused. The repo has 21 other gofmt-unclean files, so this PR doesn't take that on.

## Sweep result, for the record

The same pass checked every flag the router registers — 96 registrations across the `rpcsmartrouter`, `health`, `test`, `cache` and `connection` commands — resolving each to its string value and looking for a real read (`viper.Get*`, `Flags().Get*`, or a bound `*Var` target). Every one is live. Once #309 lands there is no `MarkDeprecated` flag left either. This was the only dead knob the sweep found in this repo.

The other half of MAG-2940 is Magma-Devs/docs#33 — `docs/reference/cli.md` still documents `--enable-periodic-probe-providers` and `--periodic-probe-providers-interval`, which no longer exist in the router. Both PRs carry `#Closes MAG-2940`; the ticket transitions on whichever merges first.

## How to verify

```
go build ./...
go vet ./protocol/lavasession/... ./protocol/performance/...
go test ./protocol/lavasession/...
grep -rn --include='*.go' 'AllowGRPCCompression\|allowCompression' . | grep -v vendor/   # 0 hits
```

| check | result |
|---|---|
| `go build ./...` | pass |
| `go vet ./protocol/{lavasession,performance}/...` | pass |
| `go test ./protocol/lavasession/...` | ok, 31.6s |
| `gofmt -l` on the four touched files | clean |
| residual references | 0 |
