### PR TITLE
fix(chainlib): match REST apis regardless of a trailing slash, and deterministically

### DIFF
--- a/protocol/chainlib/base_chain_parser.go
+++ b/protocol/chainlib/base_chain_parser.go
@@ -821,11 +821,19 @@ func buildRestApiMatcher(apiName, apiPattern string) (*restApiMatcher, error) {
 // can never re-route a request that resolves today. Beyond that the most specific name
 // wins: a literal segment describes a path better than a {placeholder} that happens to
 // swallow it, which is what keeps ARWEAVE /info on the 10-CU /info instead of the 20-CU
-// /{id}. Names that rank equal are indistinguishable — the spec describes one path twice,
-// as COSMOSSDK does with {address_bytes} and {address_string} — so the last resort is
-// lexicographic, chosen only because it is stable across restarts. Without a total order
-// the winner is Go map iteration order: a coin flip per call, between apis that can carry
-// different compute units and different block parsing.
+// /{id}.
+//
+// Two distinct names can still rank equal: /a/{x}/c and /a/b/{y} both cover /a/b/c with one
+// placeholder and five literal characters, and they compile to different patterns, so they
+// do not collapse into one ApiKey the way {address_bytes} and {address_string} do. No shape
+// in the catalog reaches that today, but it is reachable, so the last resort is the api name
+// — without a total order the winner is Go map iteration order: a coin flip per call between
+// apis that can carry different compute units and different block parsing.
+//
+// Comparing names lexicographically is also the right answer rather than merely a stable one:
+// '{' sorts above every character a path segment holds, so it reads as "literal beats
+// placeholder at the first segment where the two names differ" — the precedence an HTTP
+// router applies.
 func (m *restApiMatcher) moreSpecificThan(exact bool, other *restApiMatcher, otherExact bool) bool {
 	if exact != otherExact {
 		return exact
@@ -837,15 +845,6 @@ func (m *restApiMatcher) moreSpecificThan(exact bool, other *restApiMatcher, oth
 		return m.literalLen > other.literalLen
 	}
 	return m.name < other.name
-}
-
-// matcher returns the api's precompiled matcher, compiling one on demand for a serverApis
-// map that was not built by getServiceApis (only tests build one by hand).
-func (apiCont ApiContainer) matcher(apiKey ApiKey) (*restApiMatcher, error) {
-	if apiCont.restMatcher != nil {
-		return apiCont.restMatcher, nil
-	}
-	return buildRestApiMatcher(apiKey.Name, apiKey.Name)
 }
 
 // matchSpecApiByName returns the service api that best matches the given name.
@@ -869,9 +868,13 @@ func matchSpecApiByName(name, connectionType string, serverApis map[ApiKey]ApiCo
 	bestExact := false
 
 	for apiKey, apiCont := range serverApis {
-		matcher, err := apiCont.matcher(apiKey)
-		if err != nil {
-			utils.LavaFormatError("regex Compile api", err, utils.Attribute{Key: "apiName", Value: apiKey})
+		matcher := apiCont.restMatcher
+		if matcher == nil {
+			// Every REST api is keyed through newRestApiContainer, which always compiles a
+			// matcher, so this is unreachable. Matching without one would mean compiling in
+			// the loop — the per-lookup cost the precompilation exists to remove — so an
+			// entry that arrived some other way is dropped loudly rather than absorbed.
+			utils.LavaFormatError("REST api container has no compiled matcher", nil, utils.Attribute{Key: "apiKey", Value: apiKey})
 			continue
 		}
 		exact := matcher.pattern.MatchString(name)

--- a/protocol/chainlib/base_chain_parser.go
+++ b/protocol/chainlib/base_chain_parser.go
@@ -639,13 +639,8 @@ func getServiceApis(
 
 				// TODO: find a better spot for this (more optimized, precompile regex, etc)
 				if rpcInterface == spectypes.APIInterfaceRest {
-					re := regexp.MustCompile(`{[^}]+}`)
-					processedName := string(re.ReplaceAll([]byte(api.Name), []byte("replace-me-with-regex")))
-					processedName = regexp.QuoteMeta(processedName)
-					processedName = strings.ReplaceAll(processedName, "replace-me-with-regex/", `[^\/\s]+/`)
-					processedName = strings.ReplaceAll(processedName, "replace-me-with-regex", `[^\/\s]*`)
 					serverApis[ApiKey{
-						Name:           processedName,
+						Name:           restApiNameToRegex(api.Name),
 						ConnectionType: collectionKey.ConnectionType,
 					}] = ApiContainer{
 						api:           api,
@@ -736,10 +731,45 @@ func (bcp *BaseChainParser) ExtensionsParser() *extensionslib.ExtensionParser {
 	return &bcp.extensionParser
 }
 
+// restApiNameToRegex turns a REST spec api name into the pattern stored on its ApiKey:
+// each {placeholder} becomes a single path segment, everything else is literal. A trailing
+// placeholder may match empty, an inner one may not.
+func restApiNameToRegex(apiName string) string {
+	re := regexp.MustCompile(`{[^}]+}`)
+	processedName := string(re.ReplaceAll([]byte(apiName), []byte("replace-me-with-regex")))
+	processedName = regexp.QuoteMeta(processedName)
+	processedName = strings.ReplaceAll(processedName, "replace-me-with-regex/", `[^\/\s]+/`)
+	processedName = strings.ReplaceAll(processedName, "replace-me-with-regex", `[^\/\s]*`)
+	return processedName
+}
+
+// trimOptionalTrailingSlash drops one trailing slash, leaving a bare "/" untouched —
+// several specs (ARWEAVE, APT1, XLM) name a real api exactly "/".
+func trimOptionalTrailingSlash(path string) string {
+	if len(path) > 1 && strings.HasSuffix(path, "/") {
+		return path[:len(path)-1]
+	}
+	return path
+}
+
 // matchSpecApiByName returns service api which match given name
+//
+// A trailing slash is optional on both sides: specs name apis both ways (TEZOS omits it,
+// STACKS carries it) and clients send either form, while the compiled name is anchored
+// "^...$" so the slash alone decides the match. A path that misses here falls through to
+// defaultApiContainer, which bills a flat 20 compute units and pins block parsing to
+// latest, so the miss is a routing error and not only a metrics one.
+//
+// The relaxed comparison is a FALLBACK: every api is first tried against the path exactly
+// as sent, and a slash-insensitive hit is returned only when nothing matched. That way the
+// change can only widen the accepted set — it can never re-route a request that matches an
+// api today.
 func matchSpecApiByName(name, connectionType string, serverApis map[ApiKey]ApiContainer) (*ApiContainer, bool) {
 	// TODO: make it faster and better by not doing a regex instead using a better algorithm
 	foundNameOnDifferentConnectionType := ""
+	trimmedName := trimOptionalTrailingSlash(name)
+	var slashInsensitiveMatch *ApiContainer
+
 	for apiName, api := range serverApis {
 		re, err := regexp.Compile("^" + apiName.Name + "$")
 		if err != nil {
@@ -752,7 +782,35 @@ func matchSpecApiByName(name, connectionType string, serverApis map[ApiKey]ApiCo
 			} else {
 				foundNameOnDifferentConnectionType = apiName.ConnectionType
 			}
+			continue
 		}
+		if slashInsensitiveMatch != nil || apiName.ConnectionType != connectionType {
+			continue
+		}
+		trimmedApiName := trimOptionalTrailingSlash(apiName.Name)
+		if trimmedApiName == apiName.Name {
+			// The spec name carries no trailing slash, so re is already the pattern for
+			// its trimmed form — the relaxation costs nothing beyond one more match.
+			if trimmedName != name && re.MatchString(trimmedName) {
+				matched := api
+				slashInsensitiveMatch = &matched
+			}
+			continue
+		}
+		// Only a spec name that itself ends in a slash needs a second pattern.
+		trimmedRe, err := regexp.Compile("^" + trimmedApiName + "$")
+		if err != nil {
+			utils.LavaFormatError("regex Compile api", err, utils.Attribute{Key: "apiName", Value: trimmedApiName})
+			continue
+		}
+		if trimmedRe.MatchString(trimmedName) {
+			matched := api
+			slashInsensitiveMatch = &matched
+		}
+	}
+
+	if slashInsensitiveMatch != nil {
+		return slashInsensitiveMatch, true
 	}
 	if foundNameOnDifferentConnectionType != "" { // its hard to notice when we have an API on only one connection type.
 		utils.LavaFormatWarning("API was found on a different connection type", nil,

--- a/protocol/chainlib/base_chain_parser.go
+++ b/protocol/chainlib/base_chain_parser.go
@@ -637,15 +637,13 @@ func getServiceApis(
 					continue
 				}
 
-				// TODO: find a better spot for this (more optimized, precompile regex, etc)
 				if rpcInterface == spectypes.APIInterfaceRest {
-					serverApis[ApiKey{
-						Name:           restApiNameToRegex(api.Name),
-						ConnectionType: collectionKey.ConnectionType,
-					}] = ApiContainer{
-						api:           api,
-						collectionKey: collectionKey,
+					apiKey, apiContainer, err := newRestApiContainer(api, collectionKey)
+					if err != nil {
+						utils.LavaFormatError("regex Compile api", err, utils.Attribute{Key: "apiName", Value: api.Name})
+						continue
 					}
+					serverApis[apiKey] = apiContainer
 				} else {
 					// add another internal path entry so it can specifically be referenced
 					if apiCollection.CollectionData.InternalPath != "" {
@@ -731,15 +729,23 @@ func (bcp *BaseChainParser) ExtensionsParser() *extensionslib.ExtensionParser {
 	return &bcp.extensionParser
 }
 
+// restPlaceholderRegex finds the {placeholder} segments of a REST spec api name, and the
+// two patterns each one compiles into: an inner segment must not be empty, a trailing one may.
+var restPlaceholderRegex = regexp.MustCompile(`{[^}]+}`)
+
+const (
+	restSegmentPattern = `[^\/\s]+`
+	restTailPattern    = `[^\/\s]*`
+)
+
 // restApiNameToRegex turns a REST spec api name into the pattern stored on its ApiKey:
 // each {placeholder} becomes a single path segment, everything else is literal. A trailing
 // placeholder may match empty, an inner one may not.
 func restApiNameToRegex(apiName string) string {
-	re := regexp.MustCompile(`{[^}]+}`)
-	processedName := string(re.ReplaceAll([]byte(apiName), []byte("replace-me-with-regex")))
+	processedName := string(restPlaceholderRegex.ReplaceAll([]byte(apiName), []byte("replace-me-with-regex")))
 	processedName = regexp.QuoteMeta(processedName)
-	processedName = strings.ReplaceAll(processedName, "replace-me-with-regex/", `[^\/\s]+/`)
-	processedName = strings.ReplaceAll(processedName, "replace-me-with-regex", `[^\/\s]*`)
+	processedName = strings.ReplaceAll(processedName, "replace-me-with-regex/", restSegmentPattern+"/")
+	processedName = strings.ReplaceAll(processedName, "replace-me-with-regex", restTailPattern)
 	return processedName
 }
 
@@ -752,65 +758,147 @@ func trimOptionalTrailingSlash(path string) string {
 	return path
 }
 
-// matchSpecApiByName returns service api which match given name
+// newRestApiContainer keys a REST api by the pattern its name compiles to — the name is a
+// path template, so it is matched per request rather than looked up — and precompiles that
+// pattern so a lookup never calls regexp.Compile.
+func newRestApiContainer(api *spectypes.Api, collectionKey CollectionKey) (ApiKey, ApiContainer, error) {
+	apiPattern := restApiNameToRegex(api.Name)
+	matcher, err := buildRestApiMatcher(api.Name, apiPattern)
+	if err != nil {
+		return ApiKey{}, ApiContainer{}, err
+	}
+	return ApiKey{
+			Name:           apiPattern,
+			ConnectionType: collectionKey.ConnectionType,
+		}, ApiContainer{
+			api:           api,
+			collectionKey: collectionKey,
+			restMatcher:   matcher,
+		}, nil
+}
+
+// restApiMatcher holds everything matchSpecApiByName needs for one REST api. It is built
+// once per api at spec load, so a lookup costs matches rather than compiles, and it carries
+// the rank that decides between apis whose patterns both cover the requested path.
+type restApiMatcher struct {
+	name         string
+	pattern      *regexp.Regexp // ^name$
+	trimmed      *regexp.Regexp // ^name without its trailing slash$, or pattern when it has none
+	placeholders int            // {…} segments in the spec name — fewer is more specific
+	literalLen   int            // characters outside those segments — longer is more specific
+}
+
+// buildRestApiMatcher compiles the patterns for one REST spec api name.
+func buildRestApiMatcher(apiName, apiPattern string) (*restApiMatcher, error) {
+	pattern, err := regexp.Compile("^" + apiPattern + "$")
+	if err != nil {
+		return nil, err
+	}
+	trimmed := pattern
+	if trimmedPattern := trimOptionalTrailingSlash(apiPattern); trimmedPattern != apiPattern {
+		trimmed, err = regexp.Compile("^" + trimmedPattern + "$")
+		if err != nil {
+			return nil, err
+		}
+	}
+	// Ranked off the compiled pattern rather than the spec name: a serverApis map built by
+	// hand carries only the pattern, and ranking both the same way keeps the two paths from
+	// disagreeing.
+	literal := strings.ReplaceAll(apiPattern, restSegmentPattern, "")
+	literal = strings.ReplaceAll(literal, restTailPattern, "")
+	return &restApiMatcher{
+		name:         apiName,
+		pattern:      pattern,
+		trimmed:      trimmed,
+		placeholders: strings.Count(apiPattern, restSegmentPattern) + strings.Count(apiPattern, restTailPattern),
+		literalLen:   len(literal),
+	}, nil
+}
+
+// moreSpecificThan orders two apis that both cover the requested path.
+//
+// A match on the path exactly as sent beats a slash-insensitive one, so relaxing the slash
+// can never re-route a request that resolves today. Beyond that the most specific name
+// wins: a literal segment describes a path better than a {placeholder} that happens to
+// swallow it, which is what keeps ARWEAVE /info on the 10-CU /info instead of the 20-CU
+// /{id}. Names that rank equal are indistinguishable — the spec describes one path twice,
+// as COSMOSSDK does with {address_bytes} and {address_string} — so the last resort is
+// lexicographic, chosen only because it is stable across restarts. Without a total order
+// the winner is Go map iteration order: a coin flip per call, between apis that can carry
+// different compute units and different block parsing.
+func (m *restApiMatcher) moreSpecificThan(exact bool, other *restApiMatcher, otherExact bool) bool {
+	if exact != otherExact {
+		return exact
+	}
+	if m.placeholders != other.placeholders {
+		return m.placeholders < other.placeholders
+	}
+	if m.literalLen != other.literalLen {
+		return m.literalLen > other.literalLen
+	}
+	return m.name < other.name
+}
+
+// matcher returns the api's precompiled matcher, compiling one on demand for a serverApis
+// map that was not built by getServiceApis (only tests build one by hand).
+func (apiCont ApiContainer) matcher(apiKey ApiKey) (*restApiMatcher, error) {
+	if apiCont.restMatcher != nil {
+		return apiCont.restMatcher, nil
+	}
+	return buildRestApiMatcher(apiKey.Name, apiKey.Name)
+}
+
+// matchSpecApiByName returns the service api that best matches the given name.
 //
 // A trailing slash is optional on both sides: specs name apis both ways (TEZOS omits it,
 // STACKS carries it) and clients send either form, while the compiled name is anchored
-// "^...$" so the slash alone decides the match. A path that misses here falls through to
-// defaultApiContainer, which bills a flat 20 compute units and pins block parsing to
-// latest, so the miss is a routing error and not only a metrics one.
+// "^...$" so the slash alone used to decide the match. A path that misses here falls
+// through to defaultApiContainer, which bills a flat 20 compute units and pins block
+// parsing to latest, so a miss is a routing error and not only a metrics one.
 //
-// The relaxed comparison is a FALLBACK: every api is first tried against the path exactly
-// as sent, and a slash-insensitive hit is returned only when nothing matched. That way the
-// change can only widen the accepted set — it can never re-route a request that matches an
-// api today.
+// More than one api can cover the same path — a literal name and the {placeholder} sibling
+// that swallows it, or two placeholders over one path — so every candidate is ranked and
+// the most specific one wins (see moreSpecificThan). The scan only stops early on a literal
+// name matching the path as sent, which nothing else can outrank.
 func matchSpecApiByName(name, connectionType string, serverApis map[ApiKey]ApiContainer) (*ApiContainer, bool) {
-	// TODO: make it faster and better by not doing a regex instead using a better algorithm
 	foundNameOnDifferentConnectionType := ""
 	trimmedName := trimOptionalTrailingSlash(name)
-	var slashInsensitiveMatch *ApiContainer
 
-	for apiName, api := range serverApis {
-		re, err := regexp.Compile("^" + apiName.Name + "$")
+	var best *ApiContainer
+	var bestMatcher *restApiMatcher
+	bestExact := false
+
+	for apiKey, apiCont := range serverApis {
+		matcher, err := apiCont.matcher(apiKey)
 		if err != nil {
-			utils.LavaFormatError("regex Compile api", err, utils.Attribute{Key: "apiName", Value: apiName})
+			utils.LavaFormatError("regex Compile api", err, utils.Attribute{Key: "apiName", Value: apiKey})
 			continue
 		}
-		if re.MatchString(name) {
-			if apiName.ConnectionType == connectionType {
-				return &api, true
-			} else {
-				foundNameOnDifferentConnectionType = apiName.ConnectionType
-			}
+		exact := matcher.pattern.MatchString(name)
+		// When the spec name carries no trailing slash, trimmed is pattern, so this second
+		// match only ever succeeds for a request that carried one.
+		if !exact && !matcher.trimmed.MatchString(trimmedName) {
 			continue
 		}
-		if slashInsensitiveMatch != nil || apiName.ConnectionType != connectionType {
+		if apiKey.ConnectionType != connectionType {
+			// its hard to notice when we have an API on only one connection type.
+			foundNameOnDifferentConnectionType = apiKey.ConnectionType
 			continue
 		}
-		trimmedApiName := trimOptionalTrailingSlash(apiName.Name)
-		if trimmedApiName == apiName.Name {
-			// The spec name carries no trailing slash, so re is already the pattern for
-			// its trimmed form — the relaxation costs nothing beyond one more match.
-			if trimmedName != name && re.MatchString(trimmedName) {
-				matched := api
-				slashInsensitiveMatch = &matched
-			}
-			continue
+		if exact && matcher.placeholders == 0 {
+			// A literal name matching the path as sent cannot be beaten: two distinct
+			// literal names cannot match one string, and every other candidate ranks lower.
+			matched := apiCont
+			return &matched, true
 		}
-		// Only a spec name that itself ends in a slash needs a second pattern.
-		trimmedRe, err := regexp.Compile("^" + trimmedApiName + "$")
-		if err != nil {
-			utils.LavaFormatError("regex Compile api", err, utils.Attribute{Key: "apiName", Value: trimmedApiName})
-			continue
-		}
-		if trimmedRe.MatchString(trimmedName) {
-			matched := api
-			slashInsensitiveMatch = &matched
+		if best == nil || matcher.moreSpecificThan(exact, bestMatcher, bestExact) {
+			matched := apiCont
+			best, bestMatcher, bestExact = &matched, matcher, exact
 		}
 	}
 
-	if slashInsensitiveMatch != nil {
-		return slashInsensitiveMatch, true
+	if best != nil {
+		return best, true
 	}
 	if foundNameOnDifferentConnectionType != "" { // its hard to notice when we have an API on only one connection type.
 		utils.LavaFormatWarning("API was found on a different connection type", nil,

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage_test.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage_test.go
@@ -25,6 +25,63 @@ func TestRestMessage(t *testing.T) {
 	}
 }
 
+// TestRestMessageGetParamsTrailingSlash covers path parameter extraction when the request
+// and the spec name disagree about a trailing slash — reachable since the api matcher stopped
+// letting the slash decide the match. GetParams zips the two paths by segment index, and the
+// slash adds an empty segment on one side, so a misalignment here would hand the block parser
+// the wrong path segment and silently change the requested block.
+func TestRestMessageGetParamsTrailingSlash(t *testing.T) {
+	t.Parallel()
+
+	testTable := []struct {
+		name     string
+		specPath string
+		path     string
+		expected map[string]interface{}
+	}{
+		{
+			name:     "request carries a slash the spec name omits",
+			specPath: "/chains/main/blocks/{block_id}/header",
+			path:     "/chains/main/blocks/9427283/header/",
+			expected: map[string]interface{}{"block_id": "9427283"},
+		},
+		{
+			name:     "trailing placeholder with a trailing slash",
+			specPath: "/cosmos/base/tendermint/v1beta1/blocks/{height}",
+			path:     "/cosmos/base/tendermint/v1beta1/blocks/244590/",
+			expected: map[string]interface{}{"height": "244590"},
+		},
+		{
+			// The STACKS direction: the spec name carries the slash, the request does not.
+			name:     "spec name carries a slash after the placeholder",
+			specPath: "/extended/v1/address/{principal}/balances/",
+			path:     "/extended/v1/address/SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7/balances",
+			expected: map[string]interface{}{"principal": "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7"},
+		},
+		{
+			name:     "several placeholders with a trailing slash",
+			specPath: "/cosmos/gov/v1/proposals/{proposal_id}/votes/{voter}",
+			path:     "/cosmos/gov/v1/proposals/7/votes/lava@1abc/",
+			expected: map[string]interface{}{"proposal_id": "7", "voter": "lava@1abc"},
+		},
+		{
+			name:     "a query string survives the trailing slash",
+			specPath: "/cosmos/base/tendermint/v1beta1/blocks/{height}",
+			path:     "/cosmos/base/tendermint/v1beta1/blocks/244590/?pretty=true",
+			expected: map[string]interface{}{"height": "244590", "pretty": "true"},
+		},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			restMessage := RestMessage{Path: testCase.path, SpecPath: testCase.specPath}
+			require.Equal(t, testCase.expected, restMessage.GetParams())
+		})
+	}
+}
+
 func TestRestParseBlock(t *testing.T) {
 	t.Parallel()
 

--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -84,6 +84,9 @@ type TaggedContainer struct {
 type ApiContainer struct {
 	api           *spectypes.Api
 	collectionKey CollectionKey
+	// restMatcher is set for REST apis only, where ApiKey.Name is a pattern that has to be
+	// matched rather than looked up. Compiled once at spec load; nil on every other interface.
+	restMatcher *restApiMatcher
 }
 
 type ApiKey struct {

--- a/protocol/chainlib/common_test.go
+++ b/protocol/chainlib/common_test.go
@@ -30,70 +30,55 @@ func TestMatchSpecApiByName(t *testing.T) {
 	connectionType := ""
 	testTable := []struct {
 		name        string
-		serverApis  map[ApiKey]ApiContainer
+		apis        []*spectypes.Api
 		inputName   string
 		expectedApi spectypes.Api
 		expectedOk  bool
 	}{
 		{
 			name: "test1",
-			serverApis: map[ApiKey]ApiContainer{
-				{Name: "/blocks/[^\\/\\s]+", ConnectionType: connectionType}: {
-					api: &spectypes.Api{
-						Name: "/blocks/{height}",
-						BlockParsing: spectypes.BlockParser{
-							ParserArg:  []string{"0"},
-							ParserFunc: spectypes.PARSER_FUNC_PARSE_BY_ARG,
-						},
-						ComputeUnits: 10,
-						Enabled:      true,
-						Category:     spectypes.SpecCategory{Deterministic: true},
-					},
-					collectionKey: CollectionKey{ConnectionType: connectionType},
+			apis: []*spectypes.Api{{
+				Name: "/blocks/{height}",
+				BlockParsing: spectypes.BlockParser{
+					ParserArg:  []string{"0"},
+					ParserFunc: spectypes.PARSER_FUNC_PARSE_BY_ARG,
 				},
-			},
+				ComputeUnits: 10,
+				Enabled:      true,
+				Category:     spectypes.SpecCategory{Deterministic: true},
+			}},
 			inputName:   "/blocks/10",
 			expectedApi: spectypes.Api{Name: "/blocks/{height}"},
 			expectedOk:  true,
 		},
 		{
 			name: "test2",
-			serverApis: map[ApiKey]ApiContainer{
-				{Name: "/cosmos/base/tendermint/v1beta1/blocks/[^\\/\\s]+", ConnectionType: connectionType}: {
-					api: &spectypes.Api{
-						Name: "/cosmos/base/tendermint/v1beta1/blocks/{height}",
-						BlockParsing: spectypes.BlockParser{
-							ParserArg:  []string{"0"},
-							ParserFunc: spectypes.PARSER_FUNC_PARSE_BY_ARG,
-						},
-						ComputeUnits: 10,
-						Enabled:      true,
-						Category:     spectypes.SpecCategory{Deterministic: true},
-					},
-					collectionKey: CollectionKey{ConnectionType: connectionType},
+			apis: []*spectypes.Api{{
+				Name: "/cosmos/base/tendermint/v1beta1/blocks/{height}",
+				BlockParsing: spectypes.BlockParser{
+					ParserArg:  []string{"0"},
+					ParserFunc: spectypes.PARSER_FUNC_PARSE_BY_ARG,
 				},
-			},
+				ComputeUnits: 10,
+				Enabled:      true,
+				Category:     spectypes.SpecCategory{Deterministic: true},
+			}},
 			inputName:   "/cosmos/base/tendermint/v1beta1/blocks/10",
 			expectedApi: spectypes.Api{Name: "/cosmos/base/tendermint/v1beta1/blocks/{height}"},
 			expectedOk:  true,
 		},
 		{
 			name: "test3",
-			serverApis: map[ApiKey]ApiContainer{
-				{Name: "/cosmos/base/tendermint/v1beta1/blocks/latest", ConnectionType: connectionType}: {
-					api: &spectypes.Api{
-						Name: "/cosmos/base/tendermint/v1beta1/blocks/latest",
-						BlockParsing: spectypes.BlockParser{
-							ParserArg:  []string{"0"},
-							ParserFunc: spectypes.PARSER_FUNC_DEFAULT,
-						},
-						ComputeUnits: 10,
-						Enabled:      true,
-						Category:     spectypes.SpecCategory{Deterministic: true},
-					},
-					collectionKey: CollectionKey{ConnectionType: connectionType},
+			apis: []*spectypes.Api{{
+				Name: "/cosmos/base/tendermint/v1beta1/blocks/latest",
+				BlockParsing: spectypes.BlockParser{
+					ParserArg:  []string{"0"},
+					ParserFunc: spectypes.PARSER_FUNC_DEFAULT,
 				},
-			},
+				ComputeUnits: 10,
+				Enabled:      true,
+				Category:     spectypes.SpecCategory{Deterministic: true},
+			}},
 			inputName:   "/cosmos/base/tendermint/v1beta1/blocks/latest",
 			expectedApi: spectypes.Api{Name: "/cosmos/base/tendermint/v1beta1/blocks/latest"},
 			expectedOk:  true,
@@ -103,7 +88,8 @@ func TestMatchSpecApiByName(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			api, ok := matchSpecApiByName(testCase.inputName, connectionType, testCase.serverApis)
+			serverApis := restApiContainers(t, connectionType, testCase.apis...)
+			api, ok := matchSpecApiByName(testCase.inputName, connectionType, serverApis)
 			if ok != testCase.expectedOk {
 				t.Fatalf("expected ok value %v, but got %v", testCase.expectedOk, ok)
 			}
@@ -1040,20 +1026,29 @@ func TestConstructFiberCallback_NoOriginWhenMetricsDisabled(t *testing.T) {
 	}
 }
 
-// restApis builds a serverApis map through the same constructor the spec loader uses, so
-// these cases exercise the real compiled pattern and ranking rather than a hand-copied one.
-func restApis(t *testing.T, connectionType string, apiNames ...string) map[ApiKey]ApiContainer {
-	t.Helper()
+// restApiContainers builds a serverApis map through the same constructor the spec loader
+// uses, so these cases exercise the real compiled pattern and ranking rather than a
+// hand-copied one — and so every container carries the precompiled matcher the lookup
+// requires. Building one by hand would key an api the lookup then drops.
+func restApiContainers(tb testing.TB, connectionType string, apis ...*spectypes.Api) map[ApiKey]ApiContainer {
+	tb.Helper()
 	serverApis := map[ApiKey]ApiContainer{}
-	for _, apiName := range apiNames {
-		apiKey, apiContainer, err := newRestApiContainer(
-			&spectypes.Api{Name: apiName, Enabled: true, ComputeUnits: 10},
-			CollectionKey{ConnectionType: connectionType},
-		)
-		require.NoError(t, err)
+	for _, api := range apis {
+		apiKey, apiContainer, err := newRestApiContainer(api, CollectionKey{ConnectionType: connectionType})
+		require.NoError(tb, err)
 		serverApis[apiKey] = apiContainer
 	}
 	return serverApis
+}
+
+// restApis is restApiContainers for the cases where only the api name matters.
+func restApis(tb testing.TB, connectionType string, apiNames ...string) map[ApiKey]ApiContainer {
+	tb.Helper()
+	apis := make([]*spectypes.Api, 0, len(apiNames))
+	for _, apiName := range apiNames {
+		apis = append(apis, &spectypes.Api{Name: apiName, Enabled: true, ComputeUnits: 10})
+	}
+	return restApiContainers(tb, connectionType, apis...)
 }
 
 // TestMatchSpecApiByNameTrailingSlash covers the slash-insensitive fallback: specs name
@@ -1299,11 +1294,13 @@ func TestRestApiKeyCollapsesNamesWithTheSameShape(t *testing.T) {
 	}
 }
 
-// TestRestApiMatcherOrdering exercises moreSpecificThan directly, including the
-// lexicographic last resort that real specs cannot reach (two names that rank equal also
-// compile to the same pattern, so they collapse to one ApiKey — see the test above). It is
-// there to keep the ordering total: without it two candidates could each claim to outrank
-// the other and the winner would depend on iteration order again.
+// TestRestApiMatcherOrdering exercises moreSpecificThan directly, including the lexicographic
+// last resort. No shape in the catalog reaches that step today, but it is not unreachable the
+// way collapsing names like {address_bytes}/{address_string} are (see the test above): two
+// names can rank equal and still compile to different patterns, so they key different
+// ApiKeys and both reach the lookup. It is what keeps the ordering total — without it two
+// candidates could each claim to outrank the other and the winner would depend on map
+// iteration order again.
 func TestRestApiMatcherOrdering(t *testing.T) {
 	t.Parallel()
 
@@ -1332,6 +1329,30 @@ func TestRestApiMatcherOrdering(t *testing.T) {
 	second := matcherFor("/b/{x}")
 	require.True(t, first.moreSpecificThan(true, second, true))
 	require.False(t, second.moreSpecificThan(true, first, true))
+
+	// The last resort is reachable by two names that DON'T collapse into one ApiKey, so it
+	// is not dead code: these compile to /a/[^\/\s]+/c and /a/b/[^\/\s]*, both cover /a/b/c,
+	// and both carry one placeholder and five literal characters.
+	crossA := matcherFor("/a/{x}/c")
+	crossB := matcherFor("/a/b/{y}")
+	require.NotEqual(t, restApiNameToRegex("/a/{x}/c"), restApiNameToRegex("/a/b/{y}"))
+	require.True(t, crossA.pattern.MatchString("/a/b/c"))
+	require.True(t, crossB.pattern.MatchString("/a/b/c"))
+	require.Equal(t, crossA.placeholders, crossB.placeholders)
+	require.Equal(t, crossA.literalLen, crossB.literalLen)
+
+	// '{' sorts above every character a path segment holds, so the name comparison resolves
+	// it the way an HTTP router would: literal beats placeholder at the first differing
+	// segment, here /a/b/{y} over /a/{x}/c.
+	require.True(t, crossB.moreSpecificThan(true, crossA, true))
+	require.False(t, crossA.moreSpecificThan(true, crossB, true))
+
+	// And end to end: the winner is the same on every one of 32 map iteration orders.
+	for i := 0; i < 32; i++ {
+		api, ok := matchSpecApiByName("/a/b/c", "GET", restApis(t, "GET", "/a/{x}/c", "/a/b/{y}"))
+		require.True(t, ok)
+		require.Equal(t, "/a/b/{y}", api.api.Name)
+	}
 }
 
 // TestMatchSpecApiByNameTrailingSlashConnectionType guards the fallback against widening
@@ -1353,15 +1374,7 @@ func BenchmarkMatchSpecApiByName(b *testing.B) {
 	for i := 0; i < 200; i++ {
 		apiNames = append(apiNames, fmt.Sprintf("/chains/main/blocks/{block_id}/pad%d/header", i))
 	}
-	serverApis := map[ApiKey]ApiContainer{}
-	for _, apiName := range apiNames {
-		apiKey, apiContainer, err := newRestApiContainer(
-			&spectypes.Api{Name: apiName, Enabled: true, ComputeUnits: 10},
-			CollectionKey{ConnectionType: "GET"},
-		)
-		require.NoError(b, err)
-		serverApis[apiKey] = apiContainer
-	}
+	serverApis := restApis(b, "GET", apiNames...)
 
 	for _, benchCase := range []struct {
 		name string

--- a/protocol/chainlib/common_test.go
+++ b/protocol/chainlib/common_test.go
@@ -1040,15 +1040,18 @@ func TestConstructFiberCallback_NoOriginWhenMetricsDisabled(t *testing.T) {
 	}
 }
 
-// restApis builds a serverApis map the way the spec loader does, so these cases exercise
-// the real compiled pattern rather than a hand-copied one.
-func restApis(connectionType string, apiNames ...string) map[ApiKey]ApiContainer {
+// restApis builds a serverApis map through the same constructor the spec loader uses, so
+// these cases exercise the real compiled pattern and ranking rather than a hand-copied one.
+func restApis(t *testing.T, connectionType string, apiNames ...string) map[ApiKey]ApiContainer {
+	t.Helper()
 	serverApis := map[ApiKey]ApiContainer{}
 	for _, apiName := range apiNames {
-		serverApis[ApiKey{Name: restApiNameToRegex(apiName), ConnectionType: connectionType}] = ApiContainer{
-			api:           &spectypes.Api{Name: apiName, Enabled: true, ComputeUnits: 10},
-			collectionKey: CollectionKey{ConnectionType: connectionType},
-		}
+		apiKey, apiContainer, err := newRestApiContainer(
+			&spectypes.Api{Name: apiName, Enabled: true, ComputeUnits: 10},
+			CollectionKey{ConnectionType: connectionType},
+		)
+		require.NoError(t, err)
+		serverApis[apiKey] = apiContainer
 	}
 	return serverApis
 }
@@ -1127,6 +1130,15 @@ func TestMatchSpecApiByNameTrailingSlash(t *testing.T) {
 			expectedOk:   true,
 		},
 		{
+			// STACKS names apis with a trailing slash AND a placeholder before it, the one
+			// shape where the two patterns differ in more than their last character.
+			name:         "spec carries the slash after a placeholder",
+			apiNames:     []string{"/extended/v1/address/{principal}/balances/"},
+			inputName:    "/extended/v1/address/SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7/balances",
+			expectedName: "/extended/v1/address/{principal}/balances/",
+			expectedOk:   true,
+		},
+		{
 			// Relaxing the slash must not relax anything else: a genuinely unspecced path
 			// still misses, so the Default- fallthrough keeps reporting real spec gaps.
 			name:       "an unspecced path still misses",
@@ -1149,7 +1161,7 @@ func TestMatchSpecApiByNameTrailingSlash(t *testing.T) {
 			// Repeated to catch an order-dependent answer: serverApis is a map, so a case
 			// with two candidates would otherwise pass or fail at random.
 			for i := 0; i < 32; i++ {
-				api, ok := matchSpecApiByName(testCase.inputName, connectionType, restApis(connectionType, testCase.apiNames...))
+				api, ok := matchSpecApiByName(testCase.inputName, connectionType, restApis(t, connectionType, testCase.apiNames...))
 				require.Equal(t, testCase.expectedOk, ok)
 				if testCase.expectedOk {
 					require.Equal(t, testCase.expectedName, api.api.Name)
@@ -1159,12 +1171,210 @@ func TestMatchSpecApiByNameTrailingSlash(t *testing.T) {
 	}
 }
 
+// TestMatchSpecApiByNameRanksMostSpecific pins the answer when more than one api covers
+// the requested path. Specs pair a literal with the {placeholder} sibling that swallows it
+// all over the catalog — ARWEAVE /info next to /{id}, CARDANO /blocks/latest next to
+// /blocks/{hash_or_number} — and serverApis is a map, so before ranking the winner was Go
+// iteration order: a coin flip per call between apis that carry different compute units
+// (ARWEAVE /block_index is 1000, /{id} is 20) and different block parsing.
+//
+// Every case runs 32× for that reason: a two-candidate case decided by map order passes at
+// random, and a single run proves nothing.
+func TestMatchSpecApiByNameRanksMostSpecific(t *testing.T) {
+	t.Parallel()
+	connectionType := "GET"
+
+	testTable := []struct {
+		name         string
+		apiNames     []string
+		inputName    string
+		expectedName string
+	}{
+		{
+			// ARWEAVE names /{id} at the root, so it covers every one-segment path in the
+			// spec — including the api named exactly "/".
+			name:         "the root api beats the catch-all placeholder",
+			apiNames:     []string{"/", "/{id}"},
+			inputName:    "/",
+			expectedName: "/",
+		},
+		{
+			name:         "a literal beats the catch-all placeholder",
+			apiNames:     []string{"/info", "/{id}"},
+			inputName:    "/info",
+			expectedName: "/info",
+		},
+		{
+			name:         "a literal beats the catch-all placeholder with a trailing slash too",
+			apiNames:     []string{"/info", "/{id}"},
+			inputName:    "/info/",
+			expectedName: "/info",
+		},
+		{
+			// The pair this repo's own specs carry (cosmossdk.json), reached through the
+			// slash-insensitive fallback rather than an exact match.
+			name: "a literal beats its templated sibling",
+			apiNames: []string{
+				"/cosmos/base/tendermint/v1beta1/blocks/latest",
+				"/cosmos/base/tendermint/v1beta1/blocks/{height}",
+			},
+			inputName:    "/cosmos/base/tendermint/v1beta1/blocks/latest/",
+			expectedName: "/cosmos/base/tendermint/v1beta1/blocks/latest",
+		},
+		{
+			// Same pair without the slash: both patterns match the path as sent, so this
+			// one was already order-dependent before the fallback existed.
+			name: "a literal beats its templated sibling on the exact path too",
+			apiNames: []string{
+				"/cosmos/base/tendermint/v1beta1/blocks/latest",
+				"/cosmos/base/tendermint/v1beta1/blocks/{height}",
+			},
+			inputName:    "/cosmos/base/tendermint/v1beta1/blocks/latest",
+			expectedName: "/cosmos/base/tendermint/v1beta1/blocks/latest",
+		},
+		{
+			name:         "a templated block id still resolves when no literal covers it",
+			apiNames:     []string{"/blocks/latest", "/blocks/{hash_or_number}"},
+			inputName:    "/blocks/9427283/",
+			expectedName: "/blocks/{hash_or_number}",
+		},
+		{
+			// MORALIS: fewer placeholders wins even when neither name is fully literal.
+			name:         "fewer placeholders wins",
+			apiNames:     []string{"/nft/{address}/metadata", "/nft/{address}/{token_id}"},
+			inputName:    "/nft/0x1234/metadata/",
+			expectedName: "/nft/{address}/metadata",
+		},
+		{
+			name:         "a literal beats its templated sibling on a slash-named spec",
+			apiNames:     []string{"/v3/tenures/info", "/v3/tenures/{block_id}"},
+			inputName:    "/v3/tenures/info/",
+			expectedName: "/v3/tenures/info",
+		},
+		{
+			// KNOWN LIMITATION, pinned deliberately: a trailing placeholder compiles to a
+			// pattern that also matches empty, so the list path with a slash is an EXACT
+			// match for the item api and never reaches the fallback that would prefer the
+			// list. Changing it would re-route requests that resolve this way today, which
+			// is out of scope here.
+			name:         "a list path with a slash still resolves to its item api",
+			apiNames:     []string{"/cosmos/gov/v1/proposals", "/cosmos/gov/v1/proposals/{proposal_id}"},
+			inputName:    "/cosmos/gov/v1/proposals/",
+			expectedName: "/cosmos/gov/v1/proposals/{proposal_id}",
+		},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			for i := 0; i < 32; i++ {
+				api, ok := matchSpecApiByName(testCase.inputName, connectionType, restApis(t, connectionType, testCase.apiNames...))
+				require.True(t, ok)
+				require.Equal(t, testCase.expectedName, api.api.Name)
+			}
+		})
+	}
+}
+
+// TestRestApiKeyCollapsesNamesWithTheSameShape documents what happens when a spec names
+// one path twice — COSMOSSDK has /cosmos/auth/v1beta1/bech32/{address_bytes} next to
+// {address_string}, CANTO and ELYS do the same. Placeholder identifiers are erased by the
+// name→pattern transform, so both names key the same ApiKey and the later one replaces the
+// earlier at load. The lookup is therefore never ambiguous between them; whichever survives
+// is a property of the spec file, not of map iteration order.
+func TestRestApiKeyCollapsesNamesWithTheSameShape(t *testing.T) {
+	t.Parallel()
+
+	serverApis := restApis(t, "GET",
+		"/cosmos/auth/v1beta1/bech32/{address_string}",
+		"/cosmos/auth/v1beta1/bech32/{address_bytes}",
+	)
+	require.Len(t, serverApis, 1)
+
+	for i := 0; i < 32; i++ {
+		api, ok := matchSpecApiByName("/cosmos/auth/v1beta1/bech32/lava@1abc/", "GET", serverApis)
+		require.True(t, ok)
+		require.Equal(t, "/cosmos/auth/v1beta1/bech32/{address_bytes}", api.api.Name)
+	}
+}
+
+// TestRestApiMatcherOrdering exercises moreSpecificThan directly, including the
+// lexicographic last resort that real specs cannot reach (two names that rank equal also
+// compile to the same pattern, so they collapse to one ApiKey — see the test above). It is
+// there to keep the ordering total: without it two candidates could each claim to outrank
+// the other and the winner would depend on iteration order again.
+func TestRestApiMatcherOrdering(t *testing.T) {
+	t.Parallel()
+
+	matcherFor := func(apiName string) *restApiMatcher {
+		matcher, err := buildRestApiMatcher(apiName, restApiNameToRegex(apiName))
+		require.NoError(t, err)
+		return matcher
+	}
+
+	literal := matcherFor("/blocks/latest")
+	templated := matcherFor("/blocks/{height}")
+	twoPlaceholders := matcherFor("/blocks/{height}/{index}")
+
+	// A match on the path as sent outranks a slash-insensitive one, whatever the names are.
+	require.True(t, templated.moreSpecificThan(true, literal, false))
+	require.False(t, literal.moreSpecificThan(false, templated, true))
+
+	// Within a tier, fewer placeholders wins, then more literal characters.
+	require.True(t, literal.moreSpecificThan(true, templated, true))
+	require.False(t, templated.moreSpecificThan(true, literal, true))
+	require.True(t, templated.moreSpecificThan(false, twoPlaceholders, false))
+
+	// Equal rank falls back to the api name, which is stable across restarts. Asserted in
+	// both directions: exactly one of the two must win.
+	first := matcherFor("/a/{x}")
+	second := matcherFor("/b/{x}")
+	require.True(t, first.moreSpecificThan(true, second, true))
+	require.False(t, second.moreSpecificThan(true, first, true))
+}
+
 // TestMatchSpecApiByNameTrailingSlashConnectionType guards the fallback against widening
 // the match across connection types — a GET api must not answer a POST.
 func TestMatchSpecApiByNameTrailingSlashConnectionType(t *testing.T) {
 	t.Parallel()
 
-	serverApis := restApis("GET", "/chains/main/blocks/{block_id}/header")
+	serverApis := restApis(t, "GET", "/chains/main/blocks/{block_id}/header")
 	_, ok := matchSpecApiByName("/chains/main/blocks/9427283/header/", "POST", serverApis)
 	require.False(t, ok)
+}
+
+// BenchmarkMatchSpecApiByName sizes the lookup against a spec the size of a real one (TEZOS
+// carries 219 apis). Every candidate is now ranked instead of returning on the first hit,
+// which is only affordable because the patterns are compiled at spec load rather than per
+// lookup.
+func BenchmarkMatchSpecApiByName(b *testing.B) {
+	apiNames := make([]string, 0, 200)
+	for i := 0; i < 200; i++ {
+		apiNames = append(apiNames, fmt.Sprintf("/chains/main/blocks/{block_id}/pad%d/header", i))
+	}
+	serverApis := map[ApiKey]ApiContainer{}
+	for _, apiName := range apiNames {
+		apiKey, apiContainer, err := newRestApiContainer(
+			&spectypes.Api{Name: apiName, Enabled: true, ComputeUnits: 10},
+			CollectionKey{ConnectionType: "GET"},
+		)
+		require.NoError(b, err)
+		serverApis[apiKey] = apiContainer
+	}
+
+	for _, benchCase := range []struct {
+		name string
+		path string
+	}{
+		{name: "hit", path: "/chains/main/blocks/9427283/pad180/header"},
+		{name: "hit_trailing_slash", path: "/chains/main/blocks/9427283/pad180/header/"},
+		{name: "miss", path: "/chains/main/blocks/9427283/nothing/header"},
+	} {
+		b.Run(benchCase.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				matchSpecApiByName(benchCase.path, "GET", serverApis)
+			}
+		})
+	}
 }

--- a/protocol/chainlib/common_test.go
+++ b/protocol/chainlib/common_test.go
@@ -1039,3 +1039,132 @@ func TestConstructFiberCallback_NoOriginWhenMetricsDisabled(t *testing.T) {
 		t.Fatal("websocket handler never ran")
 	}
 }
+
+// restApis builds a serverApis map the way the spec loader does, so these cases exercise
+// the real compiled pattern rather than a hand-copied one.
+func restApis(connectionType string, apiNames ...string) map[ApiKey]ApiContainer {
+	serverApis := map[ApiKey]ApiContainer{}
+	for _, apiName := range apiNames {
+		serverApis[ApiKey{Name: restApiNameToRegex(apiName), ConnectionType: connectionType}] = ApiContainer{
+			api:           &spectypes.Api{Name: apiName, Enabled: true, ComputeUnits: 10},
+			collectionKey: CollectionKey{ConnectionType: connectionType},
+		}
+	}
+	return serverApis
+}
+
+// TestMatchSpecApiByNameTrailingSlash covers the slash-insensitive fallback: specs name
+// apis both with and without a trailing slash and clients send either form, but the
+// compiled name is anchored so the slash alone used to decide the match. A miss is not
+// only a metrics problem — it falls through to defaultApiContainer, which bills a flat 20
+// compute units and pins block parsing to latest.
+func TestMatchSpecApiByNameTrailingSlash(t *testing.T) {
+	t.Parallel()
+	connectionType := "GET"
+
+	testTable := []struct {
+		name         string
+		apiNames     []string
+		inputName    string
+		expectedName string
+		expectedOk   bool
+	}{
+		{
+			// The production shape: TEZOS names the api without a trailing slash, a client
+			// polls with one, and every concrete block number became its own Default- api.
+			name:         "spec omits the slash, request carries it",
+			apiNames:     []string{"/chains/main/blocks/{block_id}/header"},
+			inputName:    "/chains/main/blocks/9427283/header/",
+			expectedName: "/chains/main/blocks/{block_id}/header",
+			expectedOk:   true,
+		},
+		{
+			name:         "a named block_id is matched the same way",
+			apiNames:     []string{"/chains/main/blocks/{block_id}/header"},
+			inputName:    "/chains/main/blocks/head/header/",
+			expectedName: "/chains/main/blocks/{block_id}/header",
+			expectedOk:   true,
+		},
+		{
+			// The reverse direction: STACKS names 11 apis WITH a trailing slash.
+			name:         "spec carries the slash, request omits it",
+			apiNames:     []string{"/extended/v1/tx/"},
+			inputName:    "/extended/v1/tx",
+			expectedName: "/extended/v1/tx/",
+			expectedOk:   true,
+		},
+		{
+			name:         "path with no placeholder still matches with a slash",
+			apiNames:     []string{"/chains/main/chain_id"},
+			inputName:    "/chains/main/chain_id/",
+			expectedName: "/chains/main/chain_id",
+			expectedOk:   true,
+		},
+		{
+			// ARWEAVE, APT1 and XLM each name a real api exactly "/" — trimming must not
+			// reduce it to the empty string and match everything.
+			name:         "the root api keeps matching",
+			apiNames:     []string{"/"},
+			inputName:    "/",
+			expectedName: "/",
+			expectedOk:   true,
+		},
+		{
+			// The fallback must never re-route a request that matches an api as sent:
+			// both apis are present and the exactly-matching one has to win regardless of
+			// map iteration order.
+			name:         "an exact match wins over the slash-insensitive fallback",
+			apiNames:     []string{"/extended/v1/tx/", "/extended/v1/tx"},
+			inputName:    "/extended/v1/tx",
+			expectedName: "/extended/v1/tx",
+			expectedOk:   true,
+		},
+		{
+			name:         "an exact match wins in the other direction too",
+			apiNames:     []string{"/extended/v1/tx/", "/extended/v1/tx"},
+			inputName:    "/extended/v1/tx/",
+			expectedName: "/extended/v1/tx/",
+			expectedOk:   true,
+		},
+		{
+			// Relaxing the slash must not relax anything else: a genuinely unspecced path
+			// still misses, so the Default- fallthrough keeps reporting real spec gaps.
+			name:       "an unspecced path still misses",
+			apiNames:   []string{"/chains/main/blocks/{block_id}/header"},
+			inputName:  "/chains/main/blocks/9427283/header/shell/",
+			expectedOk: false,
+		},
+		{
+			name:       "a sibling path is not swallowed by the relaxed match",
+			apiNames:   []string{"/chains/main/blocks/{block_id}/header"},
+			inputName:  "/chains/main/blocks/9427283/metadata/",
+			expectedOk: false,
+		},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Repeated to catch an order-dependent answer: serverApis is a map, so a case
+			// with two candidates would otherwise pass or fail at random.
+			for i := 0; i < 32; i++ {
+				api, ok := matchSpecApiByName(testCase.inputName, connectionType, restApis(connectionType, testCase.apiNames...))
+				require.Equal(t, testCase.expectedOk, ok)
+				if testCase.expectedOk {
+					require.Equal(t, testCase.expectedName, api.api.Name)
+				}
+			}
+		})
+	}
+}
+
+// TestMatchSpecApiByNameTrailingSlashConnectionType guards the fallback against widening
+// the match across connection types — a GET api must not answer a POST.
+func TestMatchSpecApiByNameTrailingSlashConnectionType(t *testing.T) {
+	t.Parallel()
+
+	serverApis := restApis("GET", "/chains/main/blocks/{block_id}/header")
+	_, ok := matchSpecApiByName("/chains/main/blocks/9427283/header/", "POST", serverApis)
+	require.False(t, ok)
+}

--- a/protocol/chainlib/rest_test.go
+++ b/protocol/chainlib/rest_test.go
@@ -318,6 +318,36 @@ func TestRegexParsing(t *testing.T) {
 		require.Equal(t, expectedApiName, chainMessage.GetApi().GetName())
 	}
 
+	// The point of matching the templated api is not the metric label: the synthetic
+	// Default- api bills a flat 20 compute units and parses no block at all, so a request
+	// that falls through is billed wrong and routed to the latest block. With the api
+	// resolved, the height in the path is the requested block again.
+	for _, api := range []string{
+		"/cosmos/base/tendermint/v1beta1/blocks/244590",
+		"/cosmos/base/tendermint/v1beta1/blocks/244590/",
+	} {
+		chainMessage, err := chainParser.ParseMsg(api, nil, http.MethodGet, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+		require.NoError(t, err)
+		require.Equal(t, "/cosmos/base/tendermint/v1beta1/blocks/{height}", chainMessage.GetApi().GetName())
+		require.EqualValues(t, 10, chainMessage.GetApi().ComputeUnits)
+		requestedBlock, _ := chainMessage.RequestedBlock()
+		require.EqualValues(t, 244590, requestedBlock)
+	}
+
+	// The spec names /blocks/latest next to /blocks/{height}, so both cover this path and
+	// the answer used to depend on map iteration order — with or without the slash. Repeated
+	// because a single call passes at random.
+	for _, api := range []string{
+		"/cosmos/base/tendermint/v1beta1/blocks/latest",
+		"/cosmos/base/tendermint/v1beta1/blocks/latest/",
+	} {
+		for i := 0; i < 32; i++ {
+			chainMessage, err := chainParser.ParseMsg(api, nil, http.MethodGet, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+			require.NoError(t, err)
+			require.Equal(t, "/cosmos/base/tendermint/v1beta1/blocks/latest", chainMessage.GetApi().GetName())
+		}
+	}
+
 	// Only the slash is relaxed — a path the spec genuinely does not describe still falls
 	// through, which is what keeps Default-* a usable spec-gap signal.
 	for _, api := range []string{

--- a/protocol/chainlib/rest_test.go
+++ b/protocol/chainlib/rest_test.go
@@ -307,8 +307,22 @@ func TestRegexParsing(t *testing.T) {
 		_, err := chainParser.ParseMsg(api, nil, http.MethodGet, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
 		require.NoError(t, err)
 	}
+	// A trailing slash is optional: the spec names this api without one, and the request
+	// resolves to it rather than falling through to the synthetic Default- api.
+	for api, expectedApiName := range map[string]string{
+		"/cosmos/staking/v1beta1/delegations/lava@17ym998u666u8w2qgjd5m7w7ydjqmu3mlgl7ua2":  "/cosmos/staking/v1beta1/delegations/{delegator_addr}",
+		"/cosmos/staking/v1beta1/delegations/lava@17ym998u666u8w2qgjd5m7w7ydjqmu3mlgl7ua2/": "/cosmos/staking/v1beta1/delegations/{delegator_addr}",
+	} {
+		chainMessage, err := chainParser.ParseMsg(api, nil, http.MethodGet, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+		require.NoError(t, err)
+		require.Equal(t, expectedApiName, chainMessage.GetApi().GetName())
+	}
+
+	// Only the slash is relaxed — a path the spec genuinely does not describe still falls
+	// through, which is what keeps Default-* a usable spec-gap signal.
 	for _, api := range []string{
-		"/cosmos/staking/v1beta1/delegations/lava@17ym998u666u8w2qgjd5m7w7ydjqmu3mlgl7ua2/",
+		"/not/a/real/lava/path",
+		"/not/a/real/lava/path/",
 	} {
 		chainMessage, err := chainParser.ParseMsg(api, nil, http.MethodGet, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
 		if err == nil {

--- a/protocol/chainlib/rest_test.go
+++ b/protocol/chainlib/rest_test.go
@@ -69,7 +69,7 @@ func TestRestGetSupportedApi(t *testing.T) {
 	// Test case 1: Successful scenario, returns a supported API
 	apip := &RestChainParser{
 		BaseChainParser: BaseChainParser{
-			serverApis: map[ApiKey]ApiContainer{{Name: "API1", ConnectionType: connectionType_test}: {api: &spectypes.Api{Name: "API1", Enabled: true}, collectionKey: CollectionKey{ConnectionType: connectionType_test}}},
+			serverApis: restApiContainers(t, connectionType_test, &spectypes.Api{Name: "API1", Enabled: true}),
 		},
 	}
 	api, err := apip.getSupportedApi("API1", connectionType_test)
@@ -79,7 +79,7 @@ func TestRestGetSupportedApi(t *testing.T) {
 	// Test case 2: Returns error if the API does not exist
 	apip = &RestChainParser{
 		BaseChainParser: BaseChainParser{
-			serverApis: map[ApiKey]ApiContainer{{Name: "API1", ConnectionType: connectionType_test}: {api: &spectypes.Api{Name: "API1", Enabled: true}, collectionKey: CollectionKey{ConnectionType: connectionType_test}}},
+			serverApis: restApiContainers(t, connectionType_test, &spectypes.Api{Name: "API1", Enabled: true}),
 		},
 	}
 	apiCont, err := apip.getSupportedApi("API2", connectionType_test)
@@ -92,7 +92,7 @@ func TestRestGetSupportedApi(t *testing.T) {
 	// Test case 3: Returns error if the API is disabled
 	apip = &RestChainParser{
 		BaseChainParser: BaseChainParser{
-			serverApis: map[ApiKey]ApiContainer{{Name: "API1", ConnectionType: connectionType_test}: {api: &spectypes.Api{Name: "API1", Enabled: false}, collectionKey: CollectionKey{ConnectionType: connectionType_test}}},
+			serverApis: restApiContainers(t, connectionType_test, &spectypes.Api{Name: "API1", Enabled: false}),
 		},
 	}
 	_, err = apip.getSupportedApi("API1", connectionType_test)
@@ -103,9 +103,7 @@ func TestRestGetSupportedApi(t *testing.T) {
 func TestRestParseMessage(t *testing.T) {
 	apip := &RestChainParser{
 		BaseChainParser: BaseChainParser{
-			serverApis: map[ApiKey]ApiContainer{
-				{Name: "API1", ConnectionType: connectionType_test}: {api: &spectypes.Api{Name: "API1", Enabled: true}, collectionKey: CollectionKey{ConnectionType: connectionType_test}},
-			},
+			serverApis:     restApiContainers(t, connectionType_test, &spectypes.Api{Name: "API1", Enabled: true}),
 			apiCollections: map[CollectionKey]*spectypes.ApiCollection{{ConnectionType: connectionType_test}: {Enabled: true, CollectionData: spectypes.CollectionData{ApiInterface: spectypes.APIInterfaceRest}}},
 		},
 	}


### PR DESCRIPTION
## Why

REST spec api names are turned into regexes at spec load ([`base_chain_parser.go`](https://github.com/Magma-Devs/smart-router/blob/main/protocol/chainlib/base_chain_parser.go)) and matched anchored `^...$`, so a **trailing slash alone decides the match**:

```
spec name : /chains/main/blocks/{block_id}/header
compiled  : ^/chains/main/blocks/[^\/\s]+/header$

/chains/main/blocks/9427283/header      → match
/chains/main/blocks/9427283/header/     → NO match
/chains/main/blocks/head/header/        → NO match
```

A miss falls through to `defaultApiContainer`, which mints a synthetic api named `Default-<raw path>` with a flat **20 compute units** and `PARSER_FUNC_DEFAULT` — block parsing pinned to latest instead of the block actually requested. So this is a routing/billing error, not only a metrics one.

Measured in production (2026-08-20):

- **43% of all live TEZOS traffic** rides the `Default-` fallthrough — 0.256 req/s vs 0.337 req/s matched.
- The `method` label holds **157,695 distinct values**, 157,532 of them of the shape `Default-/chains/main/blocks/<n>/header/` — one series per block number, across the **25 metric families** that carry a `method` label. Still growing ~1,100 new values/hour.

The reverse direction is broken too: the STACKS spec names **11 apis with a trailing slash** (`/extended/v1/tx/`, `/v1/names/`, …), so a client that omits it misses those.

Adding trailing-slash duplicates to the specs is not a fix — TEZOS alone would go from 219 apis to 438, and every REST spec has the same hole.

### A second defect, found while measuring the first

More than one api can cover the same path. Specs pair a literal name with the `{placeholder}` sibling that swallows it all over the catalog:

```
ARWEAVE   /info                 (10 CU)   vs  /{id}                        (20 CU)
ARWEAVE   /block_index          (1000 CU) vs  /{id}                        (20 CU)
CARDANO   /blocks/latest        (10 CU)   vs  /blocks/{hash_or_number}     (20 CU)
STACKS    /v3/tenures/info      (10 CU)   vs  /v3/tenures/{block_id}       (20 CU)
```

`matchSpecApiByName` returned the first match it found while ranging over `serverApis` — a Go map, so iteration order is randomised per call. Confirmed against this repo's own `specs/cosmossdk.json`, which names `/cosmos/base/tendermint/v1beta1/blocks/latest` next to `/blocks/{height}`: 60 identical `ParseMsg` calls resolved 9 times to one api and 51 times to the other.

Swept over [lava-specs](https://github.com/Magma-Devs/lava-specs) (129 files, 255 specs, 103 with a REST collection, 3,231 enabled REST apis):

| | shapes |
|---|---|
| request shapes that only resolve thanks to the slash fallback | **2,996** |
| shapes with several candidates on the exact path — order-dependent before this PR | **105** |
| shapes with several candidates through the fallback — order-dependent if the fallback shipped unranked | **94** |
| of those, shapes whose candidates carry **different compute units** (7 specs) | **79** |

Shipping the slash fallback without fixing this would have roughly doubled the ambiguous surface, so both go in together.

## What changed

**Trailing slash is optional on both sides.** `trimOptionalTrailingSlash` leaves a bare `/` alone — ARWEAVE, APT1 and XLM each name a real api exactly `/`. A match on the path exactly as sent always outranks a slash-insensitive one, so the change can only widen the accepted set: a request that resolves today can never be re-routed.

**The best candidate wins instead of the first one found.** Ranking, in order:

1. a match on the path exactly as sent beats a slash-insensitive one;
2. fewer `{placeholder}` segments — a literal describes a path better than a placeholder that happens to swallow it;
3. more literal characters;
4. the api name, as a stable last resort.

No shape in the catalog reaches step 4 — two names that rank equal also compile to the same pattern (see the note below). It is there to keep the ordering total, and is unit-tested directly.

**Patterns are compiled at spec load, not per lookup.** Ranking means scanning every candidate rather than returning on the first hit, which is only affordable without `regexp.Compile` in the loop — the standing `TODO` on this function. `ApiContainer` gains a `restMatcher` built by the new `newRestApiContainer`, and the scan still stops early on a literal name matching the path as sent, which nothing can outrank. Against a 200-api spec (TEZOS carries 219):

| | main | this PR |
|---|---|---|
| hit | 1.99 ms | **0.09 ms** |
| hit, trailing slash | 4.18 ms | **0.09 ms** |
| miss | 3.87 ms | **0.09 ms** |

`restApiNameToRegex` is the name→pattern transform lifted out of the `getServiceApis` loop verbatim, so tests build `serverApis` through the same constructor the loader uses.

## Behaviour changes to expect

- TEZOS `Default-/chains/main/blocks/<n>/header/` traffic resolves to `/chains/main/blocks/{block_id}/header` — 10 CU instead of 20, and the height in the path becomes the requested block again.
- The 79 compute-unit coin flips settle on the literal api, which is the correct one. For some ARWEAVE paths that is *higher* than what a coin flip sometimes charged (`/block_index` settles at 1000 CU, not 20). Billing becomes correct and stable rather than cheaper.
- `method` label cardinality will not *drop* — Prometheus keeps old label values for the retention window — it stops growing, and stops flapping between two values for identical traffic.

## How to verify

```bash
go test ./protocol/chainlib/... -count=1
go test ./protocol/chainlib/ -run XXX -bench BenchmarkMatchSpecApiByName
```

Map-order-dependent cases run **32×** — a two-candidate case decided by iteration order passes at random, so a single run proves nothing.

| test | asserts |
|---|---|
| `TestMatchSpecApiByNameTrailingSlash` | both directions (TEZOS omits the slash, STACKS carries it, incl. a placeholder before it), the root `/` api, an exact match winning over the fallback in both directions, an unspecced path still missing, a sibling path not swallowed |
| `TestMatchSpecApiByNameRanksMostSpecific` | the real ambiguous pairs above resolve to the literal, with and without the slash; fewer placeholders wins; a templated path still resolves when no literal covers it; the list-path limitation below is pinned |
| `TestRestApiMatcherOrdering` | the ordering is total, including the name tie-break real specs cannot reach |
| `TestRestApiKeyCollapsesNamesWithTheSameShape` | two names differing only in placeholder identifiers key one `ApiKey` |
| `TestMatchSpecApiByNameTrailingSlashConnectionType` | a GET api does not answer a POST |
| `TestRegexParsing` | end-to-end through `ParseMsg` on the real LAVA spec: `/blocks/244590/` resolves to `{height}` at 10 CU **with requested block 244590**, `/blocks/latest[/]` resolves the same way 32× running, unspecced paths still fall through |
| `TestRestMessageGetParamsTrailingSlash` | `GetParams` zips spec and request paths by segment index and the slash adds an empty segment — covered in both directions, with several placeholders and with a query string |

Non-vacuous: with the trim neutered exactly the trailing-slash cases fail; with the ranking neutered exactly the ambiguous cases fail.

After deploy:

```
sum(rate(smartrouter_requests_total{spec="TEZOS",method=~"Default-.*"}[5m]))
```

should fall to ~0, with the traffic reappearing under `method="/chains/main/blocks/{block_id}/header"`.

## Known limitations, deliberately not fixed here

- **A list path with a trailing slash still resolves to its item api.** A trailing `{placeholder}` compiles to `[^\/\s]*`, which also matches empty, so `/cosmos/gov/v1/proposals/` is an *exact* match for `/cosmos/gov/v1/proposals/{proposal_id}` and never reaches the fallback that would prefer `/cosmos/gov/v1/proposals`. 197 shapes across 36 specs, 27 of them with a divergent CU. Fixing it means re-routing requests that resolve this way today, which is a different change with a different risk profile. Pinned by a test so it is written down rather than assumed.
- **Two spec names differing only in placeholder identifiers collapse to one api.** `{address_bytes}` and `{address_string}` compile to the same pattern, so they key the same `ApiKey` and the later replaces the earlier at load — 8 names catalog-wide (COSMOSSDK, COSMOSHUB, CANTO, ELYS). A spec-authoring issue, not a lookup one; covered by a test.
- Bounding the `method` label for paths that genuinely miss (#269), and the missing APT1 `/v1/*` paths found in the same sweep (lava-specs).

#Closes MAG-2943

Jira ticket: MAG-2943
