### PR TITLE
fix(smart-router): keep typed 429 errors readable through every wrap

### DIFF
--- a/protocol/chainlib/chain_fetcher.go
+++ b/protocol/chainlib/chain_fetcher.go
@@ -515,7 +515,7 @@ func (cf *ChainFetcher) FetchLatestBlockNum(ctx context.Context) (int64, error) 
 	}
 	reply, _, _, proxyUrl, chainId, err := cf.chainRouter.SendNodeMsg(ctx, nil, chainMessage, nil)
 	if err != nil {
-		return spectypes.NOT_APPLICABLE, utils.LavaFormatDebug(tagName+" failed sending chainMessage", []utils.Attribute{{Key: "chainID", Value: cf.endpoint.ChainID}, {Key: "APIInterface", Value: cf.endpoint.ApiInterface}, {Key: "error", Value: err}}...)
+		return spectypes.NOT_APPLICABLE, utils.LavaFormatDebugErr(tagName+" failed sending chainMessage", err, []utils.Attribute{{Key: "chainID", Value: cf.endpoint.ChainID}, {Key: "APIInterface", Value: cf.endpoint.ApiInterface}}...)
 	}
 	parserInput, err := FormatResponseForParsing(reply.RelayReply, chainMessage)
 	if err != nil {
@@ -613,7 +613,7 @@ func (cf *ChainFetcher) fetchSingleBlockHashByNum(ctx context.Context, blockNum 
 	reply, _, _, proxyUrl, chainId, err := cf.chainRouter.SendNodeMsg(ctx, nil, chainMessage, nil)
 	if err != nil {
 		timeTaken := time.Since(start)
-		return "", nil, utils.LavaFormatDebug(tagName+" failed sending chainMessage", []utils.Attribute{{Key: "sendTime", Value: timeTaken}, {Key: "error", Value: err}, {Key: "chainID", Value: cf.endpoint.ChainID}, {Key: "APIInterface", Value: cf.endpoint.ApiInterface}}...)
+		return "", nil, utils.LavaFormatDebugErr(tagName+" failed sending chainMessage", err, []utils.Attribute{{Key: "sendTime", Value: timeTaken}, {Key: "chainID", Value: cf.endpoint.ChainID}, {Key: "APIInterface", Value: cf.endpoint.ApiInterface}}...)
 	}
 
 	responseData := reply.RelayReply.Data

--- a/protocol/chainlib/chain_fetcher_retry_after_test.go
+++ b/protocol/chainlib/chain_fetcher_retry_after_test.go
@@ -1,0 +1,91 @@
+package chainlib
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcclient"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/magma-Devs/smart-router/utils"
+	specutils "github.com/magma-Devs/smart-router/utils/keeper"
+	"github.com/stretchr/testify/require"
+)
+
+// erringChainRouter fails every SendNodeMsg with a fixed error, standing in for the
+// chain proxy layer so the tests below exercise only ChainFetcher's wrapping.
+type erringChainRouter struct{ err error }
+
+func (r erringChainRouter) SendNodeMsg(ctx context.Context, ch chan interface{}, chainMessage ChainMessageForSend, extensions []string) (*RelayReplyWrapper, string, *rpcclient.ClientSubscription, common.NodeUrl, string, error) {
+	return nil, "", nil, common.NodeUrl{}, "", r.err
+}
+
+func (r erringChainRouter) ExtensionsSupported(internalPath string, extensions []string) bool {
+	return true
+}
+
+func newEthChainFetcherWithRouterErr(t *testing.T, routerErr error) *ChainFetcher {
+	t.Helper()
+	spec, err := specutils.GetSpecFromLocalDirs([]string{"../../specs/"}, "ETH1")
+	require.NoError(t, err)
+	cp, err := NewChainParser(spectypes.APIInterfaceJsonRPC)
+	require.NoError(t, err)
+	cp.SetSpec(spec)
+	return &ChainFetcher{
+		endpoint:    &lavasession.RPCProviderEndpoint{ChainID: "ETH1", ApiInterface: spectypes.APIInterfaceJsonRPC},
+		chainRouter: erringChainRouter{err: routerErr},
+		chainParser: cp,
+	}
+}
+
+// rateLimited429 builds the error shape the HTTP-family proxies produce for an upstream
+// 429: HandleStatusError's sentinel enriched by WithRetryAfter, wrapped once by the
+// proxy's LavaFormatWarning.
+func rateLimited429(retryAfterSeconds string) error {
+	h := http.Header{}
+	if retryAfterSeconds != "" {
+		h.Set("Retry-After", retryAfterSeconds)
+	}
+	return utils.LavaFormatWarning("Received invalid status code", common.WithRetryAfter(common.StatusCodeError429, h, time.Now()))
+}
+
+// The latest-block fetch used to pass the send error as a LavaFormatDebug attribute,
+// which returns a plain fmt.Errorf with no Unwrap — severing errors.Is and RetryAfterFrom
+// for every consumer (startup verification, epoch re-verification, the ChainTracker).
+func TestChainFetcher_FetchLatestBlockNum_PreservesRateLimitCause(t *testing.T) {
+	cf := newEthChainFetcherWithRouterErr(t, rateLimited429("120"))
+
+	_, err := cf.FetchLatestBlockNum(context.Background())
+	require.Error(t, err)
+	require.ErrorIs(t, err, common.StatusCodeError429)
+	d, ok := common.RetryAfterFrom(err)
+	require.True(t, ok, "Retry-After must survive the fetcher's wrapping")
+	require.Equal(t, 2*time.Minute, d)
+}
+
+// Same sever existed on the block-hash path (fork detection, tracker init).
+func TestChainFetcher_FetchBlockHashByNum_PreservesRateLimitCause(t *testing.T) {
+	cf := newEthChainFetcherWithRouterErr(t, rateLimited429("30"))
+
+	_, err := cf.FetchBlockHashByNum(context.Background(), 1)
+	require.Error(t, err)
+	require.ErrorIs(t, err, common.StatusCodeError429)
+	d, ok := common.RetryAfterFrom(err)
+	require.True(t, ok)
+	require.Equal(t, 30*time.Second, d)
+}
+
+// A plain transport failure must not read as a rate limit through the same wrapping.
+func TestChainFetcher_FetchLatestBlockNum_PlainErrorIsNotRateLimit(t *testing.T) {
+	cf := newEthChainFetcherWithRouterErr(t, errors.New("dial tcp 1.2.3.4:443: connect: connection refused"))
+
+	_, err := cf.FetchLatestBlockNum(context.Background())
+	require.Error(t, err)
+	require.NotErrorIs(t, err, common.StatusCodeError429)
+	_, ok := common.RetryAfterFrom(err)
+	require.False(t, ok)
+}

--- a/protocol/endpointstate/endpoint_monitor_test.go
+++ b/protocol/endpointstate/endpoint_monitor_test.go
@@ -18,9 +18,13 @@ import (
 type mockDirectRPCConnection struct {
 	url       string
 	responses map[string][]byte // request -> response
+	sendErr   error             // when set, SendRequest fails with it instead of answering
 }
 
 func (m *mockDirectRPCConnection) SendRequest(ctx context.Context, data []byte, headers map[string]string) (*lavasession.DirectRPCResponse, error) {
+	if m.sendErr != nil {
+		return nil, m.sendErr
+	}
 	// Return mock response based on request
 	if response, ok := m.responses[string(data)]; ok {
 		return &lavasession.DirectRPCResponse{

--- a/protocol/endpointstate/endpoint_poller.go
+++ b/protocol/endpointstate/endpoint_poller.go
@@ -143,11 +143,10 @@ func (ecf *EndpointPoller) FetchLatestBlockNum(ctx context.Context) (blockNum in
 	responseData, err := ecf.sendRawRequest(ctx, requestData, collectionData.Type, parsing.ApiName, metrics.TrackerRequestKindLatestBlock)
 	pollLatency = time.Since(reqStart)
 	if err != nil {
-		return spectypes.NOT_APPLICABLE, utils.LavaFormatDebug(tagName+" failed sending request",
+		return spectypes.NOT_APPLICABLE, utils.LavaFormatDebugErr(tagName+" failed sending request", err,
 			utils.LogAttr("chainID", ecf.chainID),
 			utils.LogAttr("apiInterface", ecf.apiInterface),
 			utils.LogAttr("endpoint", ecf.endpointURL),
-			utils.LogAttr("error", err),
 		)
 	}
 
@@ -278,9 +277,8 @@ func (ecf *EndpointPoller) fetchSingleBlockHash(
 	responseData, err := ecf.sendRawRequest(ctx, requestData, connectionType, parsing.ApiName, metrics.TrackerRequestKindBlockHash)
 	if err != nil {
 		timeTaken := time.Since(start)
-		return "", nil, utils.LavaFormatDebug(tagName+" failed sending request",
+		return "", nil, utils.LavaFormatDebugErr(tagName+" failed sending request", err,
 			utils.LogAttr("sendTime", timeTaken),
-			utils.LogAttr("error", err),
 			utils.LogAttr("chainID", ecf.chainID),
 			utils.LogAttr("endpoint", ecf.endpointURL),
 		)

--- a/protocol/endpointstate/retry_after_propagation_test.go
+++ b/protocol/endpointstate/retry_after_propagation_test.go
@@ -1,0 +1,68 @@
+package endpointstate
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// The poll path builds HTTPStatusError with the parsed Retry-After, then used to flatten
+// it into a LavaFormatDebug attribute one frame up — a plain string error with no Unwrap.
+// This pins the fix: the typed 429 and its Retry-After must survive FetchLatestBlockNum's
+// wrapping so the ChainTracker's backoff can read them.
+func TestEndpointPoller_FetchLatestBlockNum_PreservesRateLimit(t *testing.T) {
+	chainParser := newRealChainParser(t, "ETH1", spectypes.APIInterfaceJsonRPC)
+
+	url := "http://eth-ep:8545"
+	conn := &mockDirectRPCConnection{
+		url: url,
+		sendErr: &lavasession.HTTPStatusError{
+			StatusCode: 429,
+			Status:     "429",
+			RetryAfter: 90 * time.Second,
+		},
+	}
+	poller := NewEndpointPoller(
+		&lavasession.Endpoint{NetworkAddress: url, Enabled: true},
+		conn,
+		chainParser,
+		"ETH1",
+		spectypes.APIInterfaceJsonRPC,
+	)
+
+	_, err := poller.FetchLatestBlockNum(context.Background())
+	require.Error(t, err)
+	require.ErrorIs(t, err, common.StatusCodeError429)
+	d, ok := common.RetryAfterFrom(err)
+	require.True(t, ok, "Retry-After must survive the poller's wrapping")
+	require.Equal(t, 90*time.Second, d)
+}
+
+// A non-429 upstream rejection through the same path must not read as a rate limit.
+func TestEndpointPoller_FetchLatestBlockNum_ServerErrorIsNotRateLimit(t *testing.T) {
+	chainParser := newRealChainParser(t, "ETH1", spectypes.APIInterfaceJsonRPC)
+
+	url := "http://eth-ep:8545"
+	conn := &mockDirectRPCConnection{
+		url:     url,
+		sendErr: &lavasession.HTTPStatusError{StatusCode: 503, Status: "503"},
+	}
+	poller := NewEndpointPoller(
+		&lavasession.Endpoint{NetworkAddress: url, Enabled: true},
+		conn,
+		chainParser,
+		"ETH1",
+		spectypes.APIInterfaceJsonRPC,
+	)
+
+	_, err := poller.FetchLatestBlockNum(context.Background())
+	require.Error(t, err)
+	require.NotErrorIs(t, err, common.StatusCodeError429)
+	_, ok := common.RetryAfterFrom(err)
+	require.False(t, ok)
+}

--- a/protocol/rpcsmartrouter/http_status_relay_error_test.go
+++ b/protocol/rpcsmartrouter/http_status_relay_error_test.go
@@ -1,0 +1,49 @@
+package rpcsmartrouter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
+	"github.com/stretchr/testify/require"
+)
+
+// relayInnerDirect fails a >=500/429 relay with httpStatusRelayError. A 429 must carry
+// the typed sentinel and the upstream's Retry-After through the error, because the
+// discarded result is the only other place they existed.
+func TestHTTPStatusRelayError(t *testing.T) {
+	t.Run("429 with Retry-After header", func(t *testing.T) {
+		reply := &pairingtypes.RelayReply{Metadata: []pairingtypes.Metadata{
+			{Name: "Content-Type", Value: "application/json"},
+			{Name: "Retry-After", Value: "45"},
+		}}
+		err := httpStatusRelayError(429, reply)
+		require.ErrorIs(t, err, common.StatusCodeError429)
+		d, ok := common.RetryAfterFrom(err)
+		require.True(t, ok)
+		require.Equal(t, 45*time.Second, d)
+	})
+
+	t.Run("429 without header stays typed, no duration", func(t *testing.T) {
+		err := httpStatusRelayError(429, &pairingtypes.RelayReply{})
+		require.ErrorIs(t, err, common.StatusCodeError429)
+		_, ok := common.RetryAfterFrom(err)
+		require.False(t, ok)
+	})
+
+	t.Run("429 with nil reply does not panic", func(t *testing.T) {
+		err := httpStatusRelayError(429, nil)
+		require.ErrorIs(t, err, common.StatusCodeError429)
+	})
+
+	t.Run("5xx is not a rate limit", func(t *testing.T) {
+		err := httpStatusRelayError(503, &pairingtypes.RelayReply{Metadata: []pairingtypes.Metadata{
+			{Name: "Retry-After", Value: "45"},
+		}})
+		require.NotErrorIs(t, err, common.StatusCodeError429)
+		_, ok := common.RetryAfterFrom(err)
+		require.False(t, ok)
+		require.EqualError(t, err, "HTTP 503")
+	})
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -3953,8 +3953,20 @@ func (rpcss *RPCSmartRouterServer) relayInnerDirect(
 			)
 		}
 
-		// Return error to trigger backoff (but preserve result for client)
-		return relayLatency, fmt.Errorf("HTTP %d", statusCode), needsBackoff
+		// Copy the classifier's verdict into relayResult before failing the relay — the
+		// fault-axis flags (IsRateLimited above all) are only readable downstream through
+		// relayResult, and dying here left the rate-limit carve-out unreachable for real
+		// HTTP 429s. StatusCode is deliberately NOT copied: listeners surface a non-zero
+		// relayResult.StatusCode to the client, and what the client sees on a failed relay
+		// is the hot-path ticket's decision, not this propagation fix's.
+		relayResult.IsNodeError = result.IsNodeError
+		relayResult.IsNonRetryable = result.IsNonRetryable
+		relayResult.IsUnsupportedMethod = result.IsUnsupportedMethod
+		relayResult.IsRateLimited = result.IsRateLimited
+		relayResult.IsDataScope = result.IsDataScope
+		relayResult.ProviderInfo = result.ProviderInfo
+
+		return relayLatency, httpStatusRelayError(statusCode, result.Reply), needsBackoff
 	}
 
 	// Success - reset endpoint health. A node error the QoS path is scoring against this endpoint
@@ -4781,4 +4793,21 @@ func classifyHTTPStatus(code int) (shouldMarkUnhealthy, needsBackoff bool) {
 	default:
 		return false, false
 	}
+}
+
+// httpStatusRelayError is the error relayInnerDirect fails a relay with when the upstream
+// answered a >=500/429 status. A 429 travels as the typed sentinel with the upstream's
+// Retry-After attached, so errors.Is(err, common.StatusCodeError429) and
+// common.RetryAfterFrom read the same on the relay path as on every other transport.
+func httpStatusRelayError(statusCode int, reply *pairingtypes.RelayReply) error {
+	if statusCode != 429 {
+		return fmt.Errorf("HTTP %d", statusCode)
+	}
+	header := http.Header{}
+	if reply != nil {
+		for _, md := range reply.Metadata {
+			header.Add(md.Name, md.Value)
+		}
+	}
+	return common.WithRetryAfter(fmt.Errorf("HTTP %d: %w", statusCode, common.StatusCodeError429), header, time.Now())
 }

--- a/utils/lavalog.go
+++ b/utils/lavalog.go
@@ -633,6 +633,14 @@ func LavaFormatDebug(description string, attributes ...Attribute) error {
 	return LavaFormatLog(description, nil, attributes, LAVA_LOG_DEBUG)
 }
 
+// LavaFormatDebugErr logs at debug severity while keeping err as the returned error's
+// cause, so errors.Is/As still see it through the wrap. Passing err as an Attribute to
+// LavaFormatDebug instead severs the chain: the attribute form returns a plain
+// fmt.Errorf with no Unwrap, and typed errors (rate limits above all) become unreadable.
+func LavaFormatDebugErr(description string, err error, attributes ...Attribute) error {
+	return LavaFormatLog(description, err, attributes, LAVA_LOG_DEBUG)
+}
+
 func LavaFormatTrace(description string, attributes ...Attribute) error {
 	return LavaFormatLog(description, nil, attributes, LAVA_LOG_TRACE)
 }


### PR DESCRIPTION
#Closes MAG-2946

Jira ticket: MAG-2946

First PR of the 429/Retry-After stack (umbrella investigation on MAG-2910). Propagation only — no scoring, cadence, or membership change. The follow-ups (hold-off registry MAG-2947, re-verify consumer MAG-2910, hot-path selection MAG-2948, ws/gRPC + tracker MAG-2949) all depend on this signal surviving.

## Why

The `Retry-After` capture (`protocol/common/retry_after.go`) mints a typed rate-limit error on every HTTP transport — and then four call sites flatten it into a log string before any consumer can `errors.Is` / `common.RetryAfterFrom` it:

- `protocol/chainlib/chain_fetcher.go:518` and `:616` passed the send error as a `LavaFormatDebug` **attribute**. `LavaFormatDebug` has no err parameter, so `LavaFormatLog` gets `err=nil` and returns a plain `fmt.Errorf` — no `Unwrap`, chain severed. These two lines sit under `Validate`'s latest-block pre-fetch (startup verification AND every epoch re-verification), the ChainTracker poll/init, and fork-detection hash fetches.
- `protocol/endpointstate/endpoint_poller.go:146` and `:281` — same idiom, one frame **above** the site that parses `Retry-After` into `HTTPStatusError.RetryAfter` (`endpoint_poller.go:460`). The value was parsed and then destroyed before the ChainTracker's backoff could ever read it.

On the hot relay path the sever was one step later: `relayInnerDirect` returned on a 429/5xx **before** the block that copies the sender's result into `relayResult`, so the classifier's `IsRateLimited` was computed and then discarded, and the upstream's `Retry-After` died with the discarded reply.

## What changed

- `utils/lavalog.go` — new `LavaFormatDebugErr`: debug severity, err as the returned error's cause. The missing variant that made the sever idiom attractive in the first place.
- The four sites above now use it — log level unchanged, chain intact.
- `protocol/rpcsmartrouter/rpcsmartrouter_server.go` — the 429/5xx early-return now copies the fault-axis flags (`IsRateLimited`, `IsNodeError`, `IsNonRetryable`, `IsUnsupportedMethod`, `IsDataScope`) + `ProviderInfo` into `relayResult`, and fails the relay with `httpStatusRelayError`: for a 429 that is the typed sentinel with the reply's `Retry-After` attached, so the relay path reads the same as every other transport.
- `StatusCode` is deliberately **not** copied on the failure path: listeners surface a non-zero `relayResult.StatusCode` to the client, and what the client sees on a failed relay is MAG-2948's decision, not this fix's.

**Scope of the `relayResult` copy.** It makes the verdict *present*; it does not yet make anything act on it, and no current consumer reads it on this path. `shouldFailSessionForResult` short-circuits on `if err != nil` before it reaches the rate-limit carve-out, and this path still fails the relay — so the carve-out stays unreachable for a real HTTP 429. The relay processor is the same story: a response with `Err != nil` is bucketed into `protocolResponseErrors`, and `GetResultsSummary` reads the fault-axis flags only from node-error results. Teaching the gate to honour the carve-out is MAG-2948's, and it now has the signal to do it with. That dormancy is also why this PR carries no retry- or scoring-behaviour risk.

## How to verify

```
go build ./...
go test ./utils/... ./protocol/chainlib/... ./protocol/endpointstate/ ./protocol/rpcsmartrouter/ ./protocol/common/
go test ./protocol/chainlib/ -run 'TestChainFetcher_Fetch' -v
go test ./protocol/endpointstate/ -run 'TestEndpointPoller_FetchLatestBlockNum' -v
go test ./protocol/rpcsmartrouter/ -run 'TestHTTPStatusRelayError' -v
```

The new tests drive each fixed path through the wrapping production actually builds (stub router / stub connection failing with the real error shapes), and pin the negatives: a plain transport failure and a 503 wrapped identically must stay unclassified.

