### PR TITLE
feat(smart-router): shared tiered rate-limit hold-off registry

### DIFF
--- a/docs/RATE-LIMIT-HOLDOFF.md
+++ b/docs/RATE-LIMIT-HOLDOFF.md
@@ -3,6 +3,8 @@
 `protocol/holdoff` is the shared answer to "an upstream said 429 — when may we ask it
 again?". Every path that sends requests upstream records rate limits into one
 `holdoff.Registry` and consults it before sending, instead of growing a private backoff.
+Production consumers use the process-wide `holdoff.Shared`; composition roots may inject
+another registry, and tests use `NewRegistry` or the jitter-free `NewRegistryWithClock`.
 
 ## Semantics
 
@@ -13,15 +15,27 @@ again?". Every path that sends requests upstream records rate limits into one
   when its longest-held member does.
 - **Retry-After is the floor.** When the upstream said how long to wait
   (`common.RetryAfterFrom` on the typed error), the hold-off is at least that long,
-  bounded at 1h. Otherwise a per-URL exponential: 30s doubling per consecutive strike,
-  capped at 30m. Jitter extends each hold-off by up to +20% and never shortens it, so a
-  fleet held off by one vendor-wide limit does not return in a synchronized burst.
+  bounded at 1h including jitter. Otherwise a per-URL exponential: 30s doubling per
+  consecutive strike, capped at 30m before jitter. Jitter extends each hold-off by up to
+  +20% and never shortens it, so a fleet held off by one vendor-wide limit does not return
+  in a synchronized burst.
 - **Any answer clears.** An upstream that answered a request — success or a genuine
   failure — is no longer refusing us for load: the URL's strikes and the provider
   escalation are dropped, and later failures reach their normal handling at the normal
-  cadence. Strike memory also ages out after 1h of quiet.
+  cadence. Strike memory becomes eligible for reclamation after 1h of quiet and is
+  reclaimed lazily on the next recorded 429 anywhere in the registry.
 - **Internal only.** The registry and the Retry-After values drive internal retry and
   scheduling decisions. Nothing here is surfaced to the customer.
+
+## Query APIs
+
+- `HeldOff(provider, url)` answers the endpoint-level yes/no question.
+- `ReadyAt(provider, url)` returns the later of the URL and provider-wide deadlines for
+  soonest-to-expire selection. It returns the zero time for absent **and expired** state.
+- `ProviderReadyAt(provider)` answers whether the provider is held as a whole and when it
+  next has a recorded URL worth trying. The registry only knows URLs that have answered
+  429; if a provider has additional never-limited URLs, this query can conservatively
+  over-hold until the earliest recorded deadline expires.
 
 ## Consumer map
 

--- a/protocol/holdoff/holdoff.go
+++ b/protocol/holdoff/holdoff.go
@@ -31,6 +31,8 @@ import (
 	"math/rand"
 	"sync"
 	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
 )
 
 const (
@@ -42,10 +44,9 @@ const (
 	// maxUpstreamHoldoff — the vendor knows its own reset schedule better than we do.
 	MaxHoldoff = 30 * time.Minute
 
-	// maxUpstreamHoldoff bounds what a Retry-After header can demand, mirroring
-	// common.MaxRetryAfter so a hostile or broken upstream cannot park an endpoint
-	// indefinitely.
-	maxUpstreamHoldoff = time.Hour
+	// maxUpstreamHoldoff is the parser's Retry-After bound, shared here so capture and
+	// consumption cannot silently drift apart.
+	maxUpstreamHoldoff = common.MaxRetryAfter
 
 	// JitterFactor extends each hold-off by up to +20%, spreading expirations.
 	JitterFactor = 0.2
@@ -136,6 +137,9 @@ func (r *Registry) RecordRateLimit(provider, url string, retryAfter time.Duratio
 		d = maxUpstreamHoldoff
 	}
 	d += time.Duration(r.randFloat() * JitterFactor * float64(d))
+	if d > maxUpstreamHoldoff {
+		d = maxUpstreamHoldoff
+	}
 	e.readyAt = now.Add(d)
 	e.lastSeen = now
 
@@ -178,8 +182,7 @@ func (r *Registry) RecordAnswer(provider, url string) {
 // HeldOff reports whether requests to url should be avoided right now, either because
 // the URL itself is held off or its provider escalated.
 func (r *Registry) HeldOff(provider, url string) bool {
-	readyAt := r.ReadyAt(provider, url)
-	return readyAt.After(r.now())
+	return !r.ReadyAt(provider, url).IsZero()
 }
 
 // ReadyAt returns when url stops being held off — the later of its own hold-off and its
@@ -192,9 +195,13 @@ func (r *Registry) ReadyAt(provider, url string) time.Time {
 	if ps == nil {
 		return time.Time{}
 	}
+	now := r.now()
 	ready := ps.escalatedUntil
 	if e := ps.urls[url]; e != nil && e.readyAt.After(ready) {
 		ready = e.readyAt
+	}
+	if !ready.After(now) {
+		return time.Time{}
 	}
 	return ready
 }

--- a/protocol/holdoff/holdoff_test.go
+++ b/protocol/holdoff/holdoff_test.go
@@ -7,13 +7,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newTestRegistry pins the clock and disables jitter so durations are exact. Tests that
-// exercise jitter override randFloat explicitly.
+// newTestRegistry pins the clock through the public consumer-test constructor. Tests
+// that exercise jitter override randFloat explicitly.
 func newTestRegistry(start time.Time) (*Registry, *time.Time) {
 	now := start
-	r := NewRegistry()
-	r.now = func() time.Time { return now }
-	r.randFloat = func() float64 { return 0 }
+	r := NewRegistryWithClock(func() time.Time { return now })
 	return r, &now
 }
 
@@ -54,8 +52,9 @@ func TestRetryAfterIsTheFloor(t *testing.T) {
 
 func TestRetryAfterIsBounded(t *testing.T) {
 	r, _ := newTestRegistry(t0)
+	r.randFloat = func() float64 { return 1 } // worst case must not exceed the hard bound
 	d := r.RecordRateLimit("vendor", "u", 24*time.Hour)
-	require.Equal(t, maxUpstreamHoldoff, d)
+	require.Equal(t, maxUpstreamHoldoff, d, "the bound includes jitter")
 }
 
 func TestJitterOnlyExtends(t *testing.T) {
@@ -82,7 +81,7 @@ func TestAnswerClearsStrikesAndHoldoff(t *testing.T) {
 }
 
 func TestEscalationCoversTheWholeProvider(t *testing.T) {
-	r, _ := newTestRegistry(t0)
+	r, now := newTestRegistry(t0)
 
 	r.RecordRateLimit("vendor", "https://a.example/eth", 5*time.Minute)
 	require.False(t, r.HeldOff("vendor", "https://b.example/arb"),
@@ -96,6 +95,11 @@ func TestEscalationCoversTheWholeProvider(t *testing.T) {
 
 	// Another provider is untouched.
 	require.False(t, r.HeldOff("other", "https://d.example/eth"))
+
+	// An expired escalation must not leave an unrelated URL with a stale non-zero
+	// ReadyAt value.
+	*now = t0.Add(10*time.Minute + time.Second)
+	require.True(t, r.ReadyAt("vendor", "https://never-limited.example/base").IsZero())
 }
 
 func TestAnswerDropsTheEscalation(t *testing.T) {
@@ -116,6 +120,8 @@ func TestHoldoffExpires(t *testing.T) {
 
 	*now = t0.Add(InitialHoldoff + time.Second)
 	require.False(t, r.HeldOff("vendor", "u"))
+	require.True(t, r.ReadyAt("vendor", "u").IsZero(),
+		"an expired URL hold-off must use the same zero value as an absent one")
 }
 
 func TestStrikeMemoryAgesOut(t *testing.T) {


### PR DESCRIPTION
#Closes MAG-2947

Jira ticket: MAG-2947

Second PR of the 429/Retry-After stack (umbrella: MAG-2910). Sibling of PR #313 in smart-router — keep typed 429 errors readable through every wrap. The shared registry is now consumed on `main` by spec re-verification, relay selection, and recovery probing; WS/gRPC recognition and tracker polling remain under MAG-2949.

## Why

The audit on MAG-2910 found that `Retry-After` was captured on every HTTP transport and consumed by nothing: no path in the router waited longer after being told to slow down. Each path growing its own backoff would triple the tuning surface and still miss the account-wide nature of vendor caps, so the backoff state lives in one place.

## What changed

- New package `protocol/holdoff` — the shared rate-limit hold-off registry ([holdoff.go](protocol/holdoff/holdoff.go)):
  - **Tiered keying.** A 429 holds off the endpoint URL that returned it; when 2 distinct URLs of one provider are held off at once, the hold-off escalates to the provider name. The provider hold-off ends when its longest-held member does.
  - **Retry-After as the floor.** Otherwise the registry uses 30s doubling per consecutive strike, capped at 30m before jitter. One-sided jitter extends by up to +20% and never shortens; the final result is strictly bounded by `common.MaxRetryAfter` (1h), including jitter.
  - **Any answer clears.** Success or genuine failure clears the URL strikes and provider escalation. Expired strike memory becomes eligible after 1h of quiet and is reclaimed lazily on the next recorded 429.
  - **Explicit APIs.** Production uses process-wide `Shared`; composition roots and tests can inject `NewRegistry` or jitter-free `NewRegistryWithClock`. Consumers query `HeldOff`/`ReadyAt` per endpoint and `ProviderReadyAt` for provider-wide selection. `ReadyAt` returns zero for both absent and expired state.
  - The registry never sleeps, never synthesizes a customer-facing 429, and never decides consumer policy.
- Review hardening:
  - sample the clock under the registry lock and prevent stale non-zero `ReadyAt` results;
  - enforce the 1h bound after jitter and share the parser's `common.MaxRetryAfter` constant;
  - exercise `NewRegistryWithClock` in the package tests and cover endpoint/provider expiry plus cap-and-jitter interaction.
- `docs/RATE-LIMIT-HOLDOFF.md` documents the APIs, lazy reclamation, and one row per consumer path.

## How to verify

```
go build ./...
go vet ./protocol/holdoff/
go test ./protocol/holdoff/ ./protocol/common/ -count=1 -race
go test ./protocol/lavasession/...
go test ./protocol/rpcsmartrouter/...
```

12 holdoff tests pin the semantics: strike growth to the cap, Retry-After floor in both directions, the jitter-inclusive 1h bound, one-sided jitter, clear-on-answer and strike reset, escalation and its clearing, endpoint/provider expiry, strike-memory aging, the unknown-endpoint zero value, and provider-level readiness.
