### PR TITLE
perf(chainlib): skip the slash-insensitive REST match when neither side has a slash

### DIFF
--- a/protocol/chainlib/base_chain_parser.go
+++ b/protocol/chainlib/base_chain_parser.go
@@ -862,6 +862,10 @@ func (m *restApiMatcher) moreSpecificThan(exact bool, other *restApiMatcher, oth
 func matchSpecApiByName(name, connectionType string, serverApis map[ApiKey]ApiContainer) (*ApiContainer, bool) {
 	foundNameOnDifferentConnectionType := ""
 	trimmedName := trimOptionalTrailingSlash(name)
+	// Whether the request carried a trailing slash at all. When it did not, trimmedName is
+	// name, so for an api whose own name carries none either the slash-insensitive match in
+	// the loop is the exact match re-run against the same string — see below.
+	requestHadTrailingSlash := trimmedName != name
 
 	var best *ApiContainer
 	var bestMatcher *restApiMatcher
@@ -878,10 +882,18 @@ func matchSpecApiByName(name, connectionType string, serverApis map[ApiKey]ApiCo
 			continue
 		}
 		exact := matcher.pattern.MatchString(name)
-		// When the spec name carries no trailing slash, trimmed is pattern, so this second
-		// match only ever succeeds for a request that carried one.
-		if !exact && !matcher.trimmed.MatchString(trimmedName) {
-			continue
+		if !exact {
+			// With a slash on neither side, trimmed is pattern and trimmedName is name, so
+			// the match below is the one above against the same string and can only fail
+			// again. That is the common case — most requests arrive without a trailing
+			// slash, and only STACKS names apis with one — so it is skipped rather than
+			// paid for on every candidate of every lookup.
+			if !requestHadTrailingSlash && matcher.trimmed == matcher.pattern {
+				continue
+			}
+			if !matcher.trimmed.MatchString(trimmedName) {
+				continue
+			}
 		}
 		if apiKey.ConnectionType != connectionType {
 			// its hard to notice when we have an API on only one connection type.

--- a/protocol/chainlib/common_test.go
+++ b/protocol/chainlib/common_test.go
@@ -1355,6 +1355,27 @@ func TestRestApiMatcherOrdering(t *testing.T) {
 	}
 }
 
+// TestBuildRestApiMatcherReusesPatternWithoutTrailingSlash pins the invariant the
+// matchSpecApiByName fast path keys on: an api name without a trailing slash reuses
+// pattern as trimmed — the same *regexp.Regexp — and the lookup spots the case by
+// pointer comparison. Recompiling trimmed unconditionally would keep every behaviour
+// test green while silently disabling the skip on every candidate of every lookup.
+func TestBuildRestApiMatcherReusesPatternWithoutTrailingSlash(t *testing.T) {
+	t.Parallel()
+
+	for apiName, reused := range map[string]bool{
+		"/blocks/latest":    true,
+		"/blocks/{height}":  true,
+		"/":                 true,  // a bare root is left alone by the trim
+		"/extended/v1/tx/":  false, // STACKS-style trailing slash needs its own pattern
+		"/v1/names/{name}/": false,
+	} {
+		matcher, err := buildRestApiMatcher(apiName, restApiNameToRegex(apiName))
+		require.NoError(t, err, "api: %s", apiName)
+		require.Equal(t, reused, matcher.trimmed == matcher.pattern, "api: %s", apiName)
+	}
+}
+
 // TestMatchSpecApiByNameTrailingSlashConnectionType guards the fallback against widening
 // the match across connection types — a GET api must not answer a POST.
 func TestMatchSpecApiByNameTrailingSlashConnectionType(t *testing.T) {


### PR DESCRIPTION
## Why

Follow-up to #312, from review of that PR. Not folded into it because #312 is approved and this is a pure speed change with no behaviour attached.

`matchSpecApiByName` tries every api against the path exactly as sent, then against the path with a trailing slash trimmed:

```go
exact := matcher.pattern.MatchString(name)
if !exact && !matcher.trimmed.MatchString(trimmedName) {
    continue
}
```

When the request carried no trailing slash, `trimmedName` **is** `name`. When the api name carries none either, `buildRestApiMatcher` reuses `pattern` as `trimmed` — the same `*regexp.Regexp`. So the second `MatchString` is the first one re-run against the same string, and can only fail again.

That is the common case on both sides. Most requests arrive without a trailing slash, and STACKS is the only spec in the catalog that names apis with one — 11 of 3,231 enabled REST apis. So nearly every candidate of nearly every lookup paid for a match that was already decided one line earlier, on a path that runs per REST request under `serverApis`' read lock.

## What changed

One condition. `requestHadTrailingSlash` is computed once per lookup, and the two compiled patterns are compared by pointer, which is enough to spot the case:

```go
if !exact {
    if !requestHadTrailingSlash && matcher.trimmed == matcher.pattern {
        continue
    }
    if !matcher.trimmed.MatchString(trimmedName) {
        continue
    }
}
```

Against the 200-api benchmark from #312 (TEZOS carries 219), mean of 4 runs at 500 iterations, same machine:

| | before | after | |
|---|---|---|---|
| hit | 50.2 µs | **27.4 µs** | 1.8× |
| miss | 35.1 µs | **19.4 µs** | 1.8× |
| hit, trailing slash | 44.2 µs | 44.0 µs | unchanged — genuinely needs both |

For scale: `main` before #312 was ~2,000–4,000 µs on this benchmark. #312 captured nearly all of that; this is the remainder.

## Behaviour changes to expect

None. The skipped call is provably the one already made — same regexp pointer, same input string, so the same answer.

## How to verify

```bash
go test ./protocol/chainlib/... -count=1
go test ./protocol/chainlib/ -run XXX -bench BenchmarkMatchSpecApiByName -benchtime=500x -count=4
```

Non-vacuous: the guard's `requestHadTrailingSlash` condition is load-bearing and the existing trailing-slash cases pin it. Dropping it so the guard fires whenever the api name has no slash fails `TestMatchSpecApiByNameTrailingSlash` (`spec omits the slash, request carries it`, `a named block_id is matched the same way`, `path with no placeholder still matches with a slash`), `TestMatchSpecApiByNameRanksMostSpecific` (5 cases) and `TestRegexParsing`. No new *behaviour* test is needed — that coverage already exists and already fails on a wrong guard.

What the behaviour suite does **not** pin is the invariant the skip keys on: `buildRestApiMatcher` reusing `pattern` as `trimmed` for a slash-less api name. Recompiling `trimmed` unconditionally — a semantically identical regex at a different address — keeps every behaviour test green while the skip silently never fires again: a perf regression with no test signal, on the hot path #312 exists to protect. `TestBuildRestApiMatcherReusesPatternWithoutTrailingSlash` pins the pointer reuse in both directions: slash-less names must reuse, slash-carrying names (STACKS) must get their own pattern.

## Note on the base branch

Originally targeted `mag-2943` so the diff showed the single commit on top of #312. #312 has landed on `main`, so this is now rebased onto `main` and retargeted.

#Closes MAG-2943

Jira ticket: MAG-2943