### PR TITLE
fix(smart-router): a rate-limited re-verify is inconclusive, and held off

### DIFF
--- a/docs/RATE-LIMIT-HOLDOFF.md
+++ b/docs/RATE-LIMIT-HOLDOFF.md
@@ -30,7 +30,7 @@ off" means on its path. This table is the catalog; add a row when wiring a new c
 
 | Path | What "held off" means there | Records into the registry | Status |
 | --- | --- | --- | --- |
-| Spec re-verification (`spec_reverifier.go`) | Skip the probe, return the rate-limit error so reconciliation stays inconclusive — membership unchanged, streak untouched — without spending a request | 429 from `Validate` | lands with MAG-2910 |
+| Spec re-verification (`spec_reverifier.go`) | Skip the probe, return the rate-limit error so reconciliation stays inconclusive — membership unchanged, streak untouched — without spending a request | 429 from `Validate` | live |
 | Hot relay path (endpoint selection) | Prefer endpoints that are not held off; when every endpoint is held off, fall back to the soonest-to-expire one — the customer is never answered with a synthesized 429 | HTTP 429 relay results | lands with MAG-2948 |
 | Recovery probe (`recovery_probe.go`) | Skip the replay while held off (verdict stays inconclusive), instead of burning replay-attempt budget on a vendor that said stop | 429 probe responses | lands with MAG-2948 |
 | Chain tracker / endpoint poller | The poll backoff takes the upstream's Retry-After as a floor instead of guessing with the fail-count doubling | 429 poll responses | lands with MAG-2949 |

--- a/docs/RATE-LIMIT-HOLDOFF.md
+++ b/docs/RATE-LIMIT-HOLDOFF.md
@@ -1,0 +1,44 @@
+# Rate-limit hold-off registry
+
+`protocol/holdoff` is the shared answer to "an upstream said 429 — when may we ask it
+again?". Every path that sends requests upstream records rate limits into one
+`holdoff.Registry` and consults it before sending, instead of growing a private backoff.
+
+## Semantics
+
+- **Tiered keying.** A 429 holds off the endpoint URL that returned it. When 2 distinct
+  URLs of one provider name are held off at once, the hold-off escalates to the provider
+  name — a vendor cap is account-wide, and per-URL keying alone would let the process
+  keep hammering the account through its other chains. The provider-wide hold-off ends
+  when its longest-held member does.
+- **Retry-After is the floor.** When the upstream said how long to wait
+  (`common.RetryAfterFrom` on the typed error), the hold-off is at least that long,
+  bounded at 1h. Otherwise a per-URL exponential: 30s doubling per consecutive strike,
+  capped at 30m. Jitter extends each hold-off by up to +20% and never shortens it, so a
+  fleet held off by one vendor-wide limit does not return in a synchronized burst.
+- **Any answer clears.** An upstream that answered a request — success or a genuine
+  failure — is no longer refusing us for load: the URL's strikes and the provider
+  escalation are dropped, and later failures reach their normal handling at the normal
+  cadence. Strike memory also ages out after 1h of quiet.
+- **Internal only.** The registry and the Retry-After values drive internal retry and
+  scheduling decisions. Nothing here is surfaced to the customer.
+
+## Consumer map
+
+The registry never sleeps and never decides policy — each consumer defines what "held
+off" means on its path. This table is the catalog; add a row when wiring a new consumer.
+
+| Path | What "held off" means there | Records into the registry | Status |
+| --- | --- | --- | --- |
+| Spec re-verification (`spec_reverifier.go`) | Skip the probe, return the rate-limit error so reconciliation stays inconclusive — membership unchanged, streak untouched — without spending a request | 429 from `Validate` | lands with MAG-2910 |
+| Hot relay path (endpoint selection) | Prefer endpoints that are not held off; when every endpoint is held off, fall back to the soonest-to-expire one — the customer is never answered with a synthesized 429 | HTTP 429 relay results | lands with MAG-2948 |
+| Recovery probe (`recovery_probe.go`) | Skip the replay while held off (verdict stays inconclusive), instead of burning replay-attempt budget on a vendor that said stop | 429 probe responses | lands with MAG-2948 |
+| Chain tracker / endpoint poller | The poll backoff takes the upstream's Retry-After as a floor instead of guessing with the fail-count doubling | 429 poll responses | lands with MAG-2949 |
+| WS / gRPC transports | Recognition first: a 429 on the WS upgrade or a corroborated gRPC rate limit produces the typed sentinel these consumers key on | handshake / metadata 429s | lands with MAG-2949 |
+
+## Relation to `common/retry_after.go`
+
+`protocol/common/retry_after.go` captures — it parses `Retry-After` and attaches it to
+the typed rate-limit error at every HTTP call site. `protocol/holdoff` consumes — it
+turns those values into "don't ask this endpoint again yet". Capture without a consumer
+is inert; consumers without capture guess. Keep both wired.

--- a/protocol/holdoff/holdoff.go
+++ b/protocol/holdoff/holdoff.go
@@ -199,6 +199,48 @@ func (r *Registry) ReadyAt(provider, url string) time.Time {
 	return ready
 }
 
+// ProviderReadyAt reports whether provider is held off as a whole, and when it next has
+// a URL worth trying. A provider is held off while its name is escalated, or while every
+// URL the registry has been limited on is still held. The registry only knows URLs that
+// answered 429s — a provider with additional never-limited URLs reads as held until its
+// earliest recorded hold-off expires, which slightly over-holds; selection's
+// soonest-to-expire fallback bounds that cost.
+func (r *Registry) ProviderReadyAt(provider string) (readyAt time.Time, held bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ps := r.providers[provider]
+	if ps == nil {
+		return time.Time{}, false
+	}
+	now := r.now()
+
+	anyFree := false
+	minHeld := time.Time{}
+	heldURLs := 0
+	for _, e := range ps.urls {
+		if e.readyAt.After(now) {
+			heldURLs++
+			if minHeld.IsZero() || e.readyAt.Before(minHeld) {
+				minHeld = e.readyAt
+			}
+		} else {
+			anyFree = true
+		}
+	}
+
+	if ps.escalatedUntil.After(now) {
+		readyAt = ps.escalatedUntil
+		if !anyFree && minHeld.After(readyAt) {
+			readyAt = minHeld
+		}
+		return readyAt, true
+	}
+	if heldURLs == 0 || anyFree {
+		return time.Time{}, false
+	}
+	return minHeld, true
+}
+
 // exponentialFor is InitialHoldoff doubled per consecutive strike, capped at MaxHoldoff.
 func exponentialFor(strikes int) time.Duration {
 	d := InitialHoldoff

--- a/protocol/holdoff/holdoff.go
+++ b/protocol/holdoff/holdoff.go
@@ -1,0 +1,210 @@
+// Package holdoff is the shared rate-limit hold-off registry: the one place every path
+// that talks to an upstream (relay selection, spec re-verification, recovery probing,
+// block polling) records a 429 and asks "may I send to this endpoint now?".
+//
+// Semantics, settled on MAG-2947:
+//
+//   - Tiered keying. A single 429 holds off the endpoint URL that returned it. When
+//     EscalationDistinctURLs of one provider's URLs are held off at once, the hold-off
+//     escalates to the provider name — a vendor cap is account-wide, and per-URL keying
+//     alone lets a process keep hammering the account through its other chains.
+//
+//   - Retry-After is the floor. When the upstream said how long to wait, the hold-off is
+//     at least that long; otherwise a per-URL exponential (InitialHoldoff doubling per
+//     consecutive strike, capped at MaxHoldoff). Jitter only extends, never shortens —
+//     coming back before the vendor's ask defeats the point, coming back spread out is
+//     the point: a fleet held off by one vendor-wide limit must not return in a
+//     synchronized burst.
+//
+//   - Any answer clears. An upstream that answered a request — even with a genuine
+//     failure — is no longer refusing us for load, so the URL's strikes and the
+//     provider escalation are dropped and later failures reach their normal handling
+//     at the normal cadence.
+//
+// The registry never sleeps and never decides policy: consumers ask HeldOff/ReadyAt and
+// choose what "held off" means on their path (skip the probe, prefer another endpoint,
+// stretch the poll). The mapping of consumer paths to behaviour lives in
+// docs/RATE-LIMIT-HOLDOFF.md — add a row there when wiring a new consumer.
+package holdoff
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+const (
+	// InitialHoldoff is the first penalty for a URL whose upstream answered 429 without
+	// a usable Retry-After. Doubles per consecutive strike up to MaxHoldoff.
+	InitialHoldoff = 30 * time.Second
+
+	// MaxHoldoff caps the exponential. An upstream-sent Retry-After may exceed it, up to
+	// maxUpstreamHoldoff — the vendor knows its own reset schedule better than we do.
+	MaxHoldoff = 30 * time.Minute
+
+	// maxUpstreamHoldoff bounds what a Retry-After header can demand, mirroring
+	// common.MaxRetryAfter so a hostile or broken upstream cannot park an endpoint
+	// indefinitely.
+	maxUpstreamHoldoff = time.Hour
+
+	// JitterFactor extends each hold-off by up to +20%, spreading expirations.
+	JitterFactor = 0.2
+
+	// EscalationDistinctURLs is how many of a provider's URLs must be held off at once
+	// before the hold-off covers the whole provider name.
+	EscalationDistinctURLs = 2
+
+	// entryRetention is how long an expired, untouched entry keeps its strike memory.
+	// Past it the URL starts clean again — a 429 from yesterday says nothing about now.
+	entryRetention = time.Hour
+)
+
+type entry struct {
+	strikes  int
+	readyAt  time.Time
+	lastSeen time.Time
+}
+
+type providerState struct {
+	urls           map[string]*entry
+	escalatedUntil time.Time
+}
+
+// Registry is safe for concurrent use. The zero value is not usable; call NewRegistry.
+type Registry struct {
+	mu        sync.Mutex
+	providers map[string]*providerState
+
+	// now and randFloat are injection seams for tests; production uses time.Now and a
+	// seeded math/rand. randFloat is only called under mu.
+	now       func() time.Time
+	randFloat func() float64
+}
+
+func NewRegistry() *Registry {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return &Registry{
+		providers: map[string]*providerState{},
+		now:       time.Now,
+		randFloat: rng.Float64,
+	}
+}
+
+// RecordRateLimit notes a 429 from url, owned by provider. retryAfter is what the
+// upstream asked for (0 when it said nothing) and floors the hold-off. Returns the
+// applied hold-off so callers can log what was decided.
+func (r *Registry) RecordRateLimit(provider, url string, retryAfter time.Duration) time.Duration {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	now := r.now()
+	r.gcLocked(now)
+
+	ps := r.providers[provider]
+	if ps == nil {
+		ps = &providerState{urls: map[string]*entry{}}
+		r.providers[provider] = ps
+	}
+	e := ps.urls[url]
+	if e == nil {
+		e = &entry{}
+		ps.urls[url] = e
+	}
+
+	e.strikes++
+	d := exponentialFor(e.strikes)
+	if retryAfter > d {
+		d = retryAfter
+	}
+	if d > maxUpstreamHoldoff {
+		d = maxUpstreamHoldoff
+	}
+	d += time.Duration(r.randFloat() * JitterFactor * float64(d))
+	e.readyAt = now.Add(d)
+	e.lastSeen = now
+
+	// Escalate when enough distinct URLs of this provider are held off at once. The
+	// provider-wide hold-off ends when its longest-held member does — and any answered
+	// request drops it sooner.
+	held := 0
+	latest := time.Time{}
+	for _, ue := range ps.urls {
+		if ue.readyAt.After(now) {
+			held++
+			if ue.readyAt.After(latest) {
+				latest = ue.readyAt
+			}
+		}
+	}
+	if held >= EscalationDistinctURLs {
+		ps.escalatedUntil = latest
+	}
+	return d
+}
+
+// RecordAnswer notes that url answered a request — with anything at all, success or a
+// genuine failure. The URL starts clean and the provider escalation is dropped: an
+// account that is serving again must not stay locked out by stale strikes.
+func (r *Registry) RecordAnswer(provider, url string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ps := r.providers[provider]
+	if ps == nil {
+		return
+	}
+	delete(ps.urls, url)
+	ps.escalatedUntil = time.Time{}
+	if len(ps.urls) == 0 {
+		delete(r.providers, provider)
+	}
+}
+
+// HeldOff reports whether requests to url should be avoided right now, either because
+// the URL itself is held off or its provider escalated.
+func (r *Registry) HeldOff(provider, url string) bool {
+	readyAt := r.ReadyAt(provider, url)
+	return readyAt.After(r.now())
+}
+
+// ReadyAt returns when url stops being held off — the later of its own hold-off and its
+// provider's escalation. The zero time means it is not held off at all. Selection uses
+// this for the soonest-to-expire fallback when every endpoint is held off.
+func (r *Registry) ReadyAt(provider, url string) time.Time {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ps := r.providers[provider]
+	if ps == nil {
+		return time.Time{}
+	}
+	ready := ps.escalatedUntil
+	if e := ps.urls[url]; e != nil && e.readyAt.After(ready) {
+		ready = e.readyAt
+	}
+	return ready
+}
+
+// exponentialFor is InitialHoldoff doubled per consecutive strike, capped at MaxHoldoff.
+func exponentialFor(strikes int) time.Duration {
+	d := InitialHoldoff
+	for i := 1; i < strikes; i++ {
+		d *= 2
+		if d >= MaxHoldoff {
+			return MaxHoldoff
+		}
+	}
+	return d
+}
+
+// gcLocked forgets entries whose hold-off expired and that saw no 429 for
+// entryRetention, so strike memory does not accumulate forever. Called under mu.
+func (r *Registry) gcLocked(now time.Time) {
+	for provider, ps := range r.providers {
+		for url, e := range ps.urls {
+			if e.readyAt.Before(now) && now.Sub(e.lastSeen) > entryRetention {
+				delete(ps.urls, url)
+			}
+		}
+		if len(ps.urls) == 0 && ps.escalatedUntil.Before(now) {
+			delete(r.providers, provider)
+		}
+	}
+}

--- a/protocol/holdoff/holdoff.go
+++ b/protocol/holdoff/holdoff.go
@@ -70,6 +70,13 @@ type providerState struct {
 	escalatedUntil time.Time
 }
 
+// Shared is the process-wide registry every production consumer records into and
+// consults. One instance across chains and paths is what makes the provider-name
+// escalation tier meaningful: a vendor cap is account-wide, and a process probing
+// several chains through one vendor must slow all of them together. Tests build their
+// own via NewRegistry/NewRegistryWithClock instead of touching this one.
+var Shared = NewRegistry()
+
 // Registry is safe for concurrent use. The zero value is not usable; call NewRegistry.
 type Registry struct {
 	mu        sync.Mutex

--- a/protocol/holdoff/holdoff.go
+++ b/protocol/holdoff/holdoff.go
@@ -90,6 +90,16 @@ func NewRegistry() *Registry {
 	}
 }
 
+// NewRegistryWithClock is the deterministic variant for consumer tests: time comes from
+// the given clock and jitter is disabled, so applied hold-offs are exact.
+func NewRegistryWithClock(now func() time.Time) *Registry {
+	return &Registry{
+		providers: map[string]*providerState{},
+		now:       now,
+		randFloat: func() float64 { return 0 },
+	}
+}
+
 // RecordRateLimit notes a 429 from url, owned by provider. retryAfter is what the
 // upstream asked for (0 when it said nothing) and floors the hold-off. Returns the
 // applied hold-off so callers can log what was decided.

--- a/protocol/holdoff/holdoff_test.go
+++ b/protocol/holdoff/holdoff_test.go
@@ -1,0 +1,136 @@
+package holdoff
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newTestRegistry pins the clock and disables jitter so durations are exact. Tests that
+// exercise jitter override randFloat explicitly.
+func newTestRegistry(start time.Time) (*Registry, *time.Time) {
+	now := start
+	r := NewRegistry()
+	r.now = func() time.Time { return now }
+	r.randFloat = func() float64 { return 0 }
+	return r, &now
+}
+
+var t0 = time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+
+func TestFirstStrikeUsesInitialHoldoff(t *testing.T) {
+	r, _ := newTestRegistry(t0)
+	d := r.RecordRateLimit("vendor", "https://a.example/eth", 0)
+	require.Equal(t, InitialHoldoff, d)
+	require.True(t, r.HeldOff("vendor", "https://a.example/eth"))
+	require.Equal(t, t0.Add(InitialHoldoff), r.ReadyAt("vendor", "https://a.example/eth"))
+}
+
+func TestConsecutiveStrikesDoubleUpToCap(t *testing.T) {
+	r, _ := newTestRegistry(t0)
+	want := []time.Duration{
+		30 * time.Second, time.Minute, 2 * time.Minute, 4 * time.Minute,
+		8 * time.Minute, 16 * time.Minute, 30 * time.Minute, 30 * time.Minute,
+	}
+	for i, w := range want {
+		d := r.RecordRateLimit("vendor", "u", 0)
+		require.Equal(t, w, d, "strike %d", i+1)
+	}
+}
+
+func TestRetryAfterIsTheFloor(t *testing.T) {
+	r, _ := newTestRegistry(t0)
+
+	// Larger than the exponential: the vendor's ask wins.
+	d := r.RecordRateLimit("vendor", "u", 10*time.Minute)
+	require.Equal(t, 10*time.Minute, d)
+
+	// Smaller than the current exponential: the exponential wins (a vendor asking for
+	// 1s on the second consecutive strike does not shrink the penalty).
+	d = r.RecordRateLimit("vendor", "u", time.Second)
+	require.Equal(t, time.Minute, d)
+}
+
+func TestRetryAfterIsBounded(t *testing.T) {
+	r, _ := newTestRegistry(t0)
+	d := r.RecordRateLimit("vendor", "u", 24*time.Hour)
+	require.Equal(t, maxUpstreamHoldoff, d)
+}
+
+func TestJitterOnlyExtends(t *testing.T) {
+	r, _ := newTestRegistry(t0)
+	r.randFloat = func() float64 { return 1 } // worst case
+	d := r.RecordRateLimit("vendor", "u", 100*time.Second)
+	require.Equal(t, 120*time.Second, d, "jitter extends by at most JitterFactor")
+	require.GreaterOrEqual(t, d, 100*time.Second, "never shorter than the vendor's ask")
+}
+
+func TestAnswerClearsStrikesAndHoldoff(t *testing.T) {
+	r, _ := newTestRegistry(t0)
+	r.RecordRateLimit("vendor", "u", 0)
+	r.RecordRateLimit("vendor", "u", 0)
+	require.True(t, r.HeldOff("vendor", "u"))
+
+	r.RecordAnswer("vendor", "u")
+	require.False(t, r.HeldOff("vendor", "u"))
+	require.True(t, r.ReadyAt("vendor", "u").IsZero())
+
+	// Strikes reset: the next 429 starts from the initial penalty again.
+	d := r.RecordRateLimit("vendor", "u", 0)
+	require.Equal(t, InitialHoldoff, d)
+}
+
+func TestEscalationCoversTheWholeProvider(t *testing.T) {
+	r, _ := newTestRegistry(t0)
+
+	r.RecordRateLimit("vendor", "https://a.example/eth", 5*time.Minute)
+	require.False(t, r.HeldOff("vendor", "https://b.example/arb"),
+		"one held URL must not lock the provider")
+
+	r.RecordRateLimit("vendor", "https://b.example/arb", 10*time.Minute)
+	require.True(t, r.HeldOff("vendor", "https://c.example/base"),
+		"two held URLs escalate to the provider name")
+	require.Equal(t, t0.Add(10*time.Minute), r.ReadyAt("vendor", "https://c.example/base"),
+		"the provider hold-off ends when its longest-held member does")
+
+	// Another provider is untouched.
+	require.False(t, r.HeldOff("other", "https://d.example/eth"))
+}
+
+func TestAnswerDropsTheEscalation(t *testing.T) {
+	r, _ := newTestRegistry(t0)
+	r.RecordRateLimit("vendor", "a", 5*time.Minute)
+	r.RecordRateLimit("vendor", "b", 5*time.Minute)
+	require.True(t, r.HeldOff("vendor", "c"))
+
+	r.RecordAnswer("vendor", "a")
+	require.False(t, r.HeldOff("vendor", "c"), "an answering account is not capped")
+	require.True(t, r.HeldOff("vendor", "b"), "the other URL keeps its own hold-off")
+}
+
+func TestHoldoffExpires(t *testing.T) {
+	r, now := newTestRegistry(t0)
+	r.RecordRateLimit("vendor", "u", 0)
+	require.True(t, r.HeldOff("vendor", "u"))
+
+	*now = t0.Add(InitialHoldoff + time.Second)
+	require.False(t, r.HeldOff("vendor", "u"))
+}
+
+func TestStrikeMemoryAgesOut(t *testing.T) {
+	r, now := newTestRegistry(t0)
+	r.RecordRateLimit("vendor", "u", 0)
+	r.RecordRateLimit("vendor", "u", 0) // 2 strikes, next would be 2m
+
+	// Past the retention window with no further 429s, the URL starts clean.
+	*now = t0.Add(entryRetention + 2*time.Minute)
+	d := r.RecordRateLimit("vendor", "u", 0)
+	require.Equal(t, InitialHoldoff, d)
+}
+
+func TestUnknownIsNotHeldOff(t *testing.T) {
+	r, _ := newTestRegistry(t0)
+	require.False(t, r.HeldOff("vendor", "u"))
+	require.True(t, r.ReadyAt("vendor", "u").IsZero())
+}

--- a/protocol/holdoff/holdoff_test.go
+++ b/protocol/holdoff/holdoff_test.go
@@ -134,3 +134,47 @@ func TestUnknownIsNotHeldOff(t *testing.T) {
 	require.False(t, r.HeldOff("vendor", "u"))
 	require.True(t, r.ReadyAt("vendor", "u").IsZero())
 }
+
+func TestProviderReadyAt(t *testing.T) {
+	t.Run("unknown provider is not held", func(t *testing.T) {
+		r, _ := newTestRegistry(t0)
+		readyAt, held := r.ProviderReadyAt("vendor")
+		require.False(t, held)
+		require.True(t, readyAt.IsZero())
+	})
+
+	t.Run("all limited URLs held means the provider is held", func(t *testing.T) {
+		r, _ := newTestRegistry(t0)
+		r.RecordRateLimit("vendor", "a", 5*time.Minute)
+		readyAt, held := r.ProviderReadyAt("vendor")
+		require.True(t, held)
+		require.Equal(t, t0.Add(5*time.Minute), readyAt)
+	})
+
+	t.Run("a free URL frees the provider", func(t *testing.T) {
+		r, now := newTestRegistry(t0)
+		r.RecordRateLimit("vendor", "a", 0) // 30s
+		*now = t0.Add(InitialHoldoff + time.Second)
+		r.RecordRateLimit("vendor", "b", 5*time.Minute) // b held, a expired
+		_, held := r.ProviderReadyAt("vendor")
+		require.False(t, held, "an expired URL is worth trying, so the provider is not held")
+	})
+
+	t.Run("escalation holds even past a free URL", func(t *testing.T) {
+		r, now := newTestRegistry(t0)
+		r.RecordRateLimit("vendor", "a", 2*time.Minute)
+		r.RecordRateLimit("vendor", "b", 10*time.Minute) // escalates until t0+10m
+		*now = t0.Add(3 * time.Minute)                   // a expired, escalation active
+		readyAt, held := r.ProviderReadyAt("vendor")
+		require.True(t, held)
+		require.Equal(t, t0.Add(10*time.Minute), readyAt)
+	})
+
+	t.Run("soonest URL bounds the ready time", func(t *testing.T) {
+		r, _ := newTestRegistry(t0)
+		r.RecordRateLimit("vendor", "a", 3*time.Minute)
+		readyAt, held := r.ProviderReadyAt("vendor")
+		require.True(t, held)
+		require.Equal(t, t0.Add(3*time.Minute), readyAt)
+	})
+}

--- a/protocol/rpcsmartrouter/rate_limit_inconclusive_test.go
+++ b/protocol/rpcsmartrouter/rate_limit_inconclusive_test.go
@@ -1,0 +1,91 @@
+package rpcsmartrouter
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/utils"
+	"github.com/stretchr/testify/require"
+)
+
+// Detection is structural wherever a status code exists: ValidateStatusCodes mints
+// common.StatusCodeError429 and every HTTP-family proxy propagates it as LavaFormat's cause,
+// so errors.Is finds it through the wrapping. The cases below drive each transport the way
+// production produces it, so a path that starts discarding its typed error fails here rather
+// than silently demoting a healthy provider.
+func TestIsRateLimitFailure_ProductionShapes(t *testing.T) {
+	rateLimited := []struct {
+		name string
+		err  error
+	}{
+		{
+			"the bare sentinel",
+			common.StatusCodeError429,
+		},
+		{
+			// jsonrpc over http: ValidateStatusCodes mints the sentinel, the proxy wraps it.
+			"jsonrpc over http, one wrap",
+			utils.LavaFormatWarning("Received invalid status code", common.StatusCodeError429),
+		},
+		{
+			// rest / tendermint: same sentinel, reached through HandleStatusError. These two
+			// proxies used to pass nil here and render the code into an attribute instead,
+			// which left nothing for errors.Is to find.
+			"rest, sentinel through the full verify stack",
+			utils.LavaFormatWarning("[-] verify failed sending chainMessage",
+				utils.LavaFormatWarning("Received invalid status code", common.StatusCodeError429)),
+		},
+		{
+			// The latest-block path, which used to drop the cause into an attribute.
+			"wrapped sentinel via the GET_BLOCKNUM path",
+			utils.LavaFormatWarning("GET_BLOCKNUM failed sending chainMessage", common.StatusCodeError429),
+		},
+		{
+			// grpc is the one transport with no status code to check: grpc-go reports
+			// codes.Unavailable and the 429 survives only inside the status description.
+			"grpc transport, no status code exists",
+			errors.New(`[-] verify failed sending chainMessage ErrMsg: rpc error: code = Unavailable desc = unexpected HTTP status code received from server: 429 (Too Many Requests); transport: received unexpected content-type "application/json"`),
+		},
+	}
+	for _, tc := range rateLimited {
+		t.Run(tc.name, func(t *testing.T) {
+			require.True(t, isRateLimitFailure(tc.err), "must be read as rate-limited: %v", tc.err)
+		})
+	}
+
+	notRateLimited := []struct {
+		name string
+		err  error
+	}{
+		{"nil", nil},
+		{
+			// A genuine capability gap. Must still demote — this is the dwellir/STRK case.
+			"upstream cannot serve the addon",
+			errors.New("[-] verify failed to parse result {chainId:BERAB,Method:eth_getBlockByNumber,Response:{\"error\":{\"code\":-16503,\"message\":\"No healthy upstream available\"}}}"),
+		},
+		{
+			"node error unrelated to rate limiting",
+			errors.New("[-] verify failed sending chainMessage ErrMsg: txIndex 2: nonce too high"),
+		},
+		{
+			// A block number that happens to contain 429 must not be mistaken for a status code.
+			"block number containing 429",
+			errors.New("[-] verify failed to parse result {block:4293102,Method:eth_getBlockByNumber}"),
+		},
+		{
+			"connection refused",
+			errors.New("dial tcp 1.2.3.4:443: connect: connection refused"),
+		},
+		{
+			// A different status code must not ride the same path.
+			"504 sentinel, wrapped the same way",
+			utils.LavaFormatWarning("Received invalid status code", common.StatusCodeError504),
+		},
+	}
+	for _, tc := range notRateLimited {
+		t.Run(tc.name, func(t *testing.T) {
+			require.False(t, isRateLimitFailure(tc.err), "must NOT be read as rate-limited: %v", tc.err)
+		})
+	}
+}

--- a/protocol/rpcsmartrouter/rate_limit_reverify_test.go
+++ b/protocol/rpcsmartrouter/rate_limit_reverify_test.go
@@ -1,0 +1,127 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/holdoff"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/stretchr/testify/require"
+)
+
+// runCycles drives N consecutive re-verify cycles against the same inputs, threading the
+// surviving map forward exactly as updateEpoch does, and returns the final active set.
+// Each test gets its own hold-off registry so strikes cannot leak across tests through
+// the process-wide default.
+func runCycles(t *testing.T, inputs *chainReverifyInputs, active map[uint64]*lavasession.ConsumerSessionsWithProvider, n int) map[string]struct{} {
+	t.Helper()
+	if inputs.rateLimitHoldoff == nil {
+		inputs.rateLimitHoldoff = holdoff.NewRegistry()
+	}
+	for i := 0; i < n; i++ {
+		active, _, _ = applyReverification(context.Background(), inputs, active, reverifyTierStatic, uint64(100+i))
+	}
+	return collectNames(active)
+}
+
+// A rate-limited probe says the vendor refused us for asking too fast. It is not evidence the
+// provider cannot serve, so it must never demote — no matter how many cycles it persists for.
+// Before this, the fleet demoted providers that were serving traffic fine, because the
+// fleet's own synchronized verification burst blew a shared 200 rps vendor cap.
+func TestApplyReverification_RateLimitNeverDemotes(t *testing.T) {
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "jsonrpc"}
+
+	active := map[uint64]*lavasession.ConsumerSessionsWithProvider{0: makeSession("tatum")}
+	inputs := &chainReverifyInputs{
+		rpcEndpoint:                rpc,
+		convertProvidersToSessions: fakeConvert,
+		configuredStatic:           []*lavasession.RPCStaticProviderEndpoint{makeProvider("tatum")},
+		validateFn: func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+			return common.StatusCodeError429
+		},
+	}
+
+	// Ten cycles is five times the demote threshold; a counted failure would have demoted long ago.
+	got := runCycles(t, inputs, active, 10)
+	require.Contains(t, got, "tatum", "a rate-limited provider must stay paired")
+	require.Empty(t, inputs.demoteFailStreak, "a rate-limited cycle must not advance the demote streak")
+}
+
+// The guard must be narrow: a provider that genuinely cannot serve still has to go. This is the
+// dwellir-on-STRK case, where the upstream could not serve `trace` at all.
+func TestApplyReverification_RealFailureStillDemotes(t *testing.T) {
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "jsonrpc"}
+
+	active := map[uint64]*lavasession.ConsumerSessionsWithProvider{0: makeSession("dwellir")}
+	inputs := &chainReverifyInputs{
+		rpcEndpoint:                rpc,
+		convertProvidersToSessions: fakeConvert,
+		configuredStatic:           []*lavasession.RPCStaticProviderEndpoint{makeProvider("dwellir")},
+		validateFn: func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+			return errors.New("[-] verify failed to parse result: upstream does not serve trace")
+		},
+	}
+
+	got := runCycles(t, inputs, active, reverifyDemoteThreshold)
+	require.NotContains(t, got, "dwellir", "a genuine capability failure must still demote")
+}
+
+// A rate-limited probe on an inactive provider is not evidence of health either — it must not
+// promote one back into the pairing on no information.
+func TestApplyReverification_RateLimitDoesNotPromote(t *testing.T) {
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "jsonrpc"}
+
+	var converted []string
+	inputs := &chainReverifyInputs{
+		rpcEndpoint: rpc,
+		convertProvidersToSessions: func(p []*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
+			for _, ep := range p {
+				converted = append(converted, ep.Name)
+			}
+			return fakeConvert(p)
+		},
+		configuredStatic: []*lavasession.RPCStaticProviderEndpoint{makeProvider("absent")},
+		validateFn: func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+			return common.StatusCodeError429
+		},
+	}
+
+	got := runCycles(t, inputs, map[uint64]*lavasession.ConsumerSessionsWithProvider{}, 3)
+	require.Empty(t, got, "a rate-limited probe is not evidence of health")
+	require.Empty(t, converted, "must not promote on an inconclusive result")
+}
+
+// Mixed set: the rate-limited one survives, the broken one goes, in the same cycle.
+func TestApplyReverification_MixedRateLimitAndFailure(t *testing.T) {
+	withImmediateDemote(t)
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "jsonrpc"}
+
+	active := map[uint64]*lavasession.ConsumerSessionsWithProvider{
+		0: makeSession("busy"),
+		1: makeSession("broken"),
+		2: makeSession("healthy"),
+	}
+	inputs := &chainReverifyInputs{
+		rpcEndpoint:                rpc,
+		convertProvidersToSessions: fakeConvert,
+		configuredStatic: []*lavasession.RPCStaticProviderEndpoint{
+			makeProvider("busy"), makeProvider("broken"), makeProvider("healthy"),
+		},
+		validateFn: func(_ context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
+			switch p.Name {
+			case "busy":
+				return common.StatusCodeError429
+			case "broken":
+				return errors.New("upstream does not serve archive")
+			}
+			return nil
+		},
+	}
+
+	got := runCycles(t, inputs, active, 1)
+	require.Contains(t, got, "busy", "rate-limited stays")
+	require.Contains(t, got, "healthy", "healthy stays")
+	require.NotContains(t, got, "broken", "genuinely failing goes")
+}

--- a/protocol/rpcsmartrouter/reverify_holdoff_test.go
+++ b/protocol/rpcsmartrouter/reverify_holdoff_test.go
@@ -1,0 +1,102 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/holdoff"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/stretchr/testify/require"
+)
+
+// A provider that answered a probe with a rate-limit is held off, not re-probed: later
+// cycles inside the hold-off window must reach the same inconclusive verdict without
+// spending a request.
+func TestReverify_HoldoffSkipsProbeWhileHeld(t *testing.T) {
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "jsonrpc"}
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+
+	probes := 0
+	inputs := &chainReverifyInputs{
+		rpcEndpoint:                rpc,
+		convertProvidersToSessions: fakeConvert,
+		configuredStatic:           []*lavasession.RPCStaticProviderEndpoint{makeProvider("tatum")},
+		rateLimitHoldoff:           holdoff.NewRegistryWithClock(func() time.Time { return now }),
+		validateFn: func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+			probes++
+			return common.StatusCodeError429
+		},
+	}
+
+	active := map[uint64]*lavasession.ConsumerSessionsWithProvider{0: makeSession("tatum")}
+	got := runCycles(t, inputs, active, 5)
+
+	require.Equal(t, 1, probes, "held-off cycles must not spend a probe")
+	require.Contains(t, got, "tatum", "skipped cycles stay inconclusive — membership unchanged")
+	require.Empty(t, inputs.demoteFailStreak, "skipped cycles must not advance the demote streak")
+}
+
+// Once the hold-off expires the provider is probed again, and an answer — any answer —
+// clears the strikes, so a later 429 starts from the initial penalty.
+func TestReverify_AnswerAfterHoldoffClears(t *testing.T) {
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "jsonrpc"}
+	start := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	now := start
+	reg := holdoff.NewRegistryWithClock(func() time.Time { return now })
+
+	script := []error{common.StatusCodeError429, nil, common.StatusCodeError429}
+	probes := 0
+	inputs := &chainReverifyInputs{
+		rpcEndpoint:                rpc,
+		convertProvidersToSessions: fakeConvert,
+		configuredStatic:           []*lavasession.RPCStaticProviderEndpoint{makeProvider("tatum")},
+		rateLimitHoldoff:           reg,
+		validateFn: func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+			err := script[probes]
+			probes++
+			return err
+		},
+	}
+	active := map[uint64]*lavasession.ConsumerSessionsWithProvider{0: makeSession("tatum")}
+
+	// Cycle 1: 429 → held off for the initial penalty.
+	active, _, _ = applyReverification(context.Background(), inputs, active, reverifyTierStatic, 100)
+	require.Equal(t, 1, probes)
+	require.True(t, reg.HeldOff("tatum", "tatum"))
+
+	// Cycle 2, past expiry: probed again, answers cleanly → hold-off and strikes cleared.
+	now = start.Add(holdoff.InitialHoldoff + time.Second)
+	active, _, _ = applyReverification(context.Background(), inputs, active, reverifyTierStatic, 101)
+	require.Equal(t, 2, probes)
+	require.False(t, reg.HeldOff("tatum", "tatum"))
+
+	// Cycle 3: a fresh 429 starts from the initial penalty again, proving the reset.
+	active, _, _ = applyReverification(context.Background(), inputs, active, reverifyTierStatic, 102)
+	require.Equal(t, 3, probes)
+	require.Equal(t, now.Add(holdoff.InitialHoldoff), reg.ReadyAt("tatum", "tatum"))
+
+	require.Contains(t, collectNames(active), "tatum", "rate-limited cycles never demoted")
+}
+
+// The upstream's Retry-After floors the hold-off: a vendor asking for five minutes is
+// not re-probed after the default thirty seconds.
+func TestReverify_RetryAfterFloorsTheHoldoff(t *testing.T) {
+	rpc := &lavasession.RPCEndpoint{ChainID: "TEST", ApiInterface: "jsonrpc"}
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	reg := holdoff.NewRegistryWithClock(func() time.Time { return now })
+
+	inputs := &chainReverifyInputs{
+		rpcEndpoint:                rpc,
+		convertProvidersToSessions: fakeConvert,
+		configuredStatic:           []*lavasession.RPCStaticProviderEndpoint{makeProvider("tatum")},
+		rateLimitHoldoff:           reg,
+		validateFn: func(_ context.Context, _ *lavasession.RPCStaticProviderEndpoint) error {
+			return &common.RateLimitedError{RetryAfter: 5 * time.Minute}
+		},
+	}
+
+	runCycles(t, inputs, map[uint64]*lavasession.ConsumerSessionsWithProvider{0: makeSession("tatum")}, 1)
+	require.Equal(t, now.Add(5*time.Minute), reg.ReadyAt("tatum", "tatum"))
+}

--- a/protocol/rpcsmartrouter/spec_reverifier.go
+++ b/protocol/rpcsmartrouter/spec_reverifier.go
@@ -2,11 +2,14 @@ package rpcsmartrouter
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/magma-Devs/smart-router/protocol/chainlib"
 	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/holdoff"
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
 	"github.com/magma-Devs/smart-router/utils"
 )
@@ -85,6 +88,59 @@ type chainReverifyInputs struct {
 	// holds that lock across both tier calls. Lazily allocated so test fixtures that build
 	// chainReverifyInputs by hand need not.
 	demoteFailStreak map[string]int
+	// rateLimitHoldoff holds off providers that answered a probe with a rate-limit, so the
+	// pass stops adding load to an upstream that just told us it is over its limit. Nil
+	// falls back to the process-wide holdoff.Shared, so one vendor's cap slows every
+	// chain this process probes through it; tests inject their own.
+	rateLimitHoldoff *holdoff.Registry
+}
+
+// holdoffURLKey is the URL tier's key for a probed provider: its first node URL, so two
+// providers sharing a vendor name but hitting different endpoints are held off apart.
+func holdoffURLKey(p *lavasession.RPCStaticProviderEndpoint) string {
+	if len(p.NodeUrls) > 0 && p.NodeUrls[0].Url != "" {
+		return p.NodeUrls[0].Url
+	}
+	return p.Name
+}
+
+// rateLimitTextSignatures covers the one transport where no status code exists to check.
+//
+// Every HTTP-family transport reaches us as common.StatusCodeError429 — ValidateStatusCodes
+// mints it, each proxy propagates it as LavaFormat's cause, so Unwrap survives and errors.Is
+// below is the real check. gRPC is different in kind: there is no HTTP status in the error at
+// all. grpc-go reports codes.Unavailable and the vendor's 429 survives only inside the status
+// description, so there is nothing structural to match on.
+//
+// Verbatim from a production failure. Keep this list minimal — a new entry here is usually a
+// signal that some path is discarding a typed error, which is worth fixing at the source
+// instead.
+var rateLimitTextSignatures = []string{
+	"429 (Too Many Requests)", // grpc transport: no status code, only the status description
+}
+
+// isRateLimitFailure reports whether a failed validation was the upstream refusing us for
+// asking too fast, rather than the upstream being unable to serve what it declares.
+//
+// The distinction is already settled elsewhere in this codebase — see the IsRateLimited
+// comment on common.RelayResult: "the endpoint is healthy but busy. Callers back off but
+// must not mark it unhealthy, which is why the direct-RPC availability gate excludes it."
+// The relay path honours that; re-verification did not, and a rate-limited probe demoted
+// providers that were serving traffic perfectly well.
+func isRateLimitFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, common.StatusCodeError429) {
+		return true
+	}
+	msg := err.Error()
+	for _, sig := range rateLimitTextSignatures {
+		if strings.Contains(msg, sig) {
+			return true
+		}
+	}
+	return false
 }
 
 // applyReverification revalidates configured providers for one tier and
@@ -138,11 +194,44 @@ func applyReverification(
 	if len(configured) == 0 {
 		return fresh, nil, nil
 	}
-	validate := inputs.validateFn
-	if validate == nil {
-		validate = func(c context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
+	probe := inputs.validateFn
+	if probe == nil {
+		probe = func(c context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
 			return validateProvider(c, p, inputs.chainParser, SpecReVerifyAttemptTimeout)
 		}
+	}
+	if inputs.rateLimitHoldoff == nil {
+		inputs.rateLimitHoldoff = holdoff.Shared
+	}
+
+	// A provider that answered with a rate-limit is held off rather than re-probed. The
+	// skip returns the rate-limit error itself, so the reconciliation below reaches the
+	// same inconclusive verdict it would have from a fresh 429 — membership unchanged,
+	// streak untouched — without spending a request to learn it. Any other outcome clears
+	// the penalty: an upstream that is answering us again, even to report a genuine
+	// capability failure, is no longer refusing us for load.
+	validate := func(c context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
+		urlKey := holdoffURLKey(p)
+		if inputs.rateLimitHoldoff.HeldOff(p.Name, urlKey) {
+			utils.LavaFormatDebug("re-verify: provider held off after a rate-limit, skipping probe",
+				utils.LogAttr("chain", inputs.rpcEndpoint.ChainID),
+				utils.LogAttr("provider", p.Name),
+			)
+			return common.StatusCodeError429
+		}
+		err := probe(c, p)
+		if isRateLimitFailure(err) {
+			retryAfter, _ := common.RetryAfterFrom(err)
+			delay := inputs.rateLimitHoldoff.RecordRateLimit(p.Name, urlKey, retryAfter)
+			utils.LavaFormatWarning("re-verify: provider rate-limited, backing off", err,
+				utils.LogAttr("chain", inputs.rpcEndpoint.ChainID),
+				utils.LogAttr("provider", p.Name),
+				utils.LogAttr("holdoff", delay.String()),
+			)
+			return err
+		}
+		inputs.rateLimitHoldoff.RecordAnswer(p.Name, urlKey)
+		return err
 	}
 
 	// WaitGroup + buffered-channel semaphore. Replaces an earlier errgroup —
@@ -185,6 +274,22 @@ func applyReverification(
 					utils.LogAttr("provider", p.Name),
 				)
 			}
+			continue
+		}
+		if isRateLimitFailure(err) {
+			// Inconclusive, not failed: the upstream refused us for asking too fast and told
+			// us nothing about whether it can serve. Leave the streak untouched — advancing it
+			// would let a busy vendor demote a healthy provider — and leave membership as-is:
+			// an active provider stays paired, an inactive one is not promoted on no evidence.
+			if wasActive {
+				healthyNames[p.Name] = struct{}{}
+			}
+			utils.LavaFormatWarning("re-verify: "+tier.String()+" rate-limited, treating as inconclusive", err,
+				utils.LogAttr("chain", inputs.rpcEndpoint.ChainID),
+				utils.LogAttr("provider", p.Name),
+				utils.LogAttr("active", wasActive),
+				utils.LogAttr("consecutiveFailures", inputs.demoteFailStreak[streakKey]),
+			)
 			continue
 		}
 		if !wasActive {


### PR DESCRIPTION
#Closes MAG-2910

Jira ticket: MAG-2910

> **Stacked** on PR #314 in smart-router (hold-off registry, MAG-2947) — PR #313 already merged and this branch is rebased past it. Until #314 merges, this diff shows its four commits too; the reviewable change here is the top commit (`spec_reverifier.go` + three test files). Gets a final rebase when #314 lands.

Third PR of the 429/Retry-After stack. Supersedes the closed "a rate-limited probe is inconclusive" PR (its classification logic and test suite are salvaged here) and the closed "back off a rate-limited provider" PR (its hold-off semantics land here on the shared registry instead of a private backoff).

## Why

Re-verification treats a 429 like any other `Validate` failure: the demote streak advances and two consecutive rate-limited epochs drop the provider out of the pairing. A rate-limit says we asked too fast — nothing about whether the node serves what it declares. In production this demoted providers that were serving traffic fine, because the fleet's own synchronized verification burst blew a shared vendor cap. And nothing backed off: `Validate` retries 3× with zero delay and the epoch re-asks on the same schedule.

## What changed

- `isRateLimitFailure` — structural detection (`errors.Is` on `common.StatusCodeError429`, kept readable by the propagation PR), plus the one text signature gRPC forces (no status code exists there; MAG-2949 adds the typed path for gRPC).
- A rate-limited re-verify is **inconclusive**: streak untouched, membership unchanged, an inactive provider not promoted on no evidence. Genuine capability failures demote exactly as before.
- The pass **holds off** a rate-limited provider via the shared registry (`docs/RATE-LIMIT-HOLDOFF.md`): while held, the probe is skipped and the skip returns the rate-limit error, so reconciliation reaches the same inconclusive verdict without spending a request. Retry-After floors the hold-off; any other outcome clears it.

## How to verify

```
go build ./...
go test ./protocol/rpcsmartrouter/ -run 'TestIsRateLimitFailure|TestApplyReverification_RateLimit|TestApplyReverification_Real|TestApplyReverification_Mixed|TestReverify_' -v
go test ./protocol/rpcsmartrouter/ ./protocol/holdoff/
```

The suite covers: never-demotes across 10 rate-limited cycles, real failures still demote, no promotion on a 429, mixed sets, probe-skip-while-held (probe call counts), clear-on-answer with strike reset, and the Retry-After floor.