### PR TITLE
fix(smart-router): a rate-limited relay is neither failure nor success

### DIFF
--- a/docs/RATE-LIMIT-HOLDOFF.md
+++ b/docs/RATE-LIMIT-HOLDOFF.md
@@ -31,8 +31,8 @@ off" means on its path. This table is the catalog; add a row when wiring a new c
 | Path | What "held off" means there | Records into the registry | Status |
 | --- | --- | --- | --- |
 | Spec re-verification (`spec_reverifier.go`) | Skip the probe, return the rate-limit error so reconciliation stays inconclusive — membership unchanged, streak untouched — without spending a request | 429 from `Validate` | live |
-| Hot relay path (endpoint selection) | Prefer endpoints that are not held off; when every endpoint is held off, fall back to the soonest-to-expire one — the customer is never answered with a synthesized 429 | HTTP 429 relay results | lands with MAG-2948 |
-| Recovery probe (`recovery_probe.go`) | Skip the replay while held off (verdict stays inconclusive), instead of burning replay-attempt budget on a vendor that said stop | 429 probe responses | lands with MAG-2948 |
+| Hot relay path (endpoint selection) | A rate-limited relay releases its session with no QoS sample in either direction, and selection prefers providers that are not held off; when every candidate is held off, the soonest-to-expire one stays in — the customer is never answered with a synthesized 429 | 429 relay results, both shapes (typed HTTP error, 2xx-body/gRPC classification) | live |
+| Recovery probe (`recovery_probe.go`) | Skip the replay while held off (verdict stays inconclusive), instead of burning replay-attempt budget on a vendor that said stop | 429 probe responses (Retry-After floor honoured) | live |
 | Chain tracker / endpoint poller | The poll backoff takes the upstream's Retry-After as a floor instead of guessing with the fail-count doubling | 429 poll responses | lands with MAG-2949 |
 | WS / gRPC transports | Recognition first: a 429 on the WS upgrade or a corroborated gRPC rate limit produces the typed sentinel these consumers key on | handshake / metadata 429s | lands with MAG-2949 |
 

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/endpointtip"
+	"github.com/magma-Devs/smart-router/protocol/holdoff"
 	metrics "github.com/magma-Devs/smart-router/protocol/metrics"
 	"github.com/magma-Devs/smart-router/protocol/provideroptimizer"
 	"github.com/magma-Devs/smart-router/protocol/qos"
@@ -69,6 +70,11 @@ type ConsumerSessionManager struct {
 	validAddresses []string
 	// provider addresses that were given a second chance instead of reporting them immediately
 	secondChanceGivenToAddresses map[string]struct{}
+
+	// rateLimitHoldoff is consulted at provider selection so requests prefer providers
+	// that are not currently held off after a 429 (docs/RATE-LIMIT-HOLDOFF.md).
+	// Production uses the process-wide holdoff.Shared; tests inject a clock-pinned one.
+	rateLimitHoldoff *holdoff.Registry
 
 	// contains a sorted list of blocked addresses, sorted by their cu used this epoch for higher chance of response
 	currentlyBlockedProviderAddresses []string
@@ -1258,6 +1264,59 @@ func resolveSelectedProviderAddress(selectedProvider string, addresses []string)
 }
 
 // Get a valid provider address.
+// filterRateLimitedProviders drops providers currently held off after a rate limit —
+// unless that would leave nothing choosable: the request must still be served (the
+// Retry-After stays internal, a customer is never answered with a synthesized 429), so
+// when every candidate is held off the soonest-to-expire one stays in.
+func (csm *ConsumerSessionManager) filterRateLimitedProviders(ctx context.Context, validAddresses []string, ignoredProvidersList map[string]struct{}) []string {
+	reg := csm.rateLimitHoldoff
+	if reg == nil {
+		return validAddresses
+	}
+	ready := make([]string, 0, len(validAddresses))
+	soonest := ""
+	var soonestAt time.Time
+	heldCount := 0
+	readyChoosable := 0
+	for _, addr := range validAddresses {
+		readyAt, held := reg.ProviderReadyAt(addr)
+		if !held {
+			ready = append(ready, addr)
+			if _, ignored := ignoredProvidersList[addr]; !ignored {
+				readyChoosable++
+			}
+			continue
+		}
+		heldCount++
+		if _, ignored := ignoredProvidersList[addr]; ignored {
+			continue // already out of this request — cannot be the fallback either
+		}
+		if soonest == "" || readyAt.Before(soonestAt) {
+			soonest, soonestAt = addr, readyAt
+		}
+	}
+	if heldCount == 0 {
+		return validAddresses
+	}
+	if readyChoosable > 0 {
+		utils.LavaFormatDebug("rate-limit hold-off: skipping held-off providers",
+			utils.LogAttr("held", heldCount),
+			utils.LogAttr("ready", readyChoosable),
+			utils.LogAttr("GUID", ctx),
+		)
+		return ready
+	}
+	if soonest == "" {
+		return ready // every held candidate is also ignored this request — nothing to add
+	}
+	utils.LavaFormatDebug("rate-limit hold-off: every candidate held off, keeping the soonest to expire",
+		utils.LogAttr("provider", soonest),
+		utils.LogAttr("readyAt", soonestAt),
+		utils.LogAttr("GUID", ctx),
+	)
+	return append(ready, soonest)
+}
+
 func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context, wantedProviders int, ignoredProvidersList map[string]struct{}, cu uint64, requestedBlock int64, addon string, extensions []string, stateful uint32, stickiness string, selectedProvider string) (addresses []string, err error) {
 	// cs.Lock must be Rlocked here.
 	ignoredProvidersListLength := len(ignoredProvidersList)
@@ -1368,6 +1427,11 @@ func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context
 			return addresses, err
 		}
 	}
+	// Rate-limit hold-off (docs/RATE-LIMIT-HOLDOFF.md): prefer providers that are not
+	// currently held off after a 429. A header-pinned provider and an existing sticky
+	// session bypass this above on purpose — an explicit ask outranks the hold-off.
+	validAddresses = csm.filterRateLimitedProviders(ctx, validAddresses, ignoredProvidersList)
+
 	var providers []string
 	if stateful == common.CONSISTENCY_SELECT_ALL_PROVIDERS && csm.providerOptimizer.Strategy() != provideroptimizer.StrategyCost {
 		providers = csm.getTopTenProvidersForStatefulCalls(validAddresses, ignoredProvidersList)
@@ -1998,6 +2062,14 @@ func (csm *ConsumerSessionManager) OnSessionCancelled(consumerSession *SingleCon
 	return csm.releaseWithoutPenalty(consumerSession, reason, "OnSessionCancelled")
 }
 
+// OnSessionRateLimited releases a session whose relay the upstream refused for rate. A
+// rate-limit is neither failure nor success — the endpoint is healthy but busy, and it
+// was not exercised — so no QoS sample lands in either direction. The hold-off registry,
+// not session scoring, is what keeps traffic away from it (docs/RATE-LIMIT-HOLDOFF.md).
+func (csm *ConsumerSessionManager) OnSessionRateLimited(consumerSession *SingleConsumerSession, reason error) error {
+	return csm.releaseWithoutPenalty(consumerSession, reason, "OnSessionRateLimited")
+}
+
 // Report session failure, mark it as blocked from future usages, report if timeout happened.
 func (csm *ConsumerSessionManager) OnSessionFailure(consumerSession *SingleConsumerSession, errorReceived error) error {
 	// consumerSession must be locked when getting here.
@@ -2506,6 +2578,7 @@ func NewConsumerSessionManager(
 		qosManager:             qos.NewQoSManager(),
 		getLavaBlockHeight:     func() int64 { return 0 }, // default to 0, should be set by caller
 		blockedBackupProviders: make(map[string]struct{}),
+		rateLimitHoldoff:       holdoff.Shared,
 	}
 	csm.rpcEndpoint = rpcEndpoint
 	csm.providerOptimizer = providerOptimizer

--- a/protocol/lavasession/rate_limit_filter_test.go
+++ b/protocol/lavasession/rate_limit_filter_test.go
@@ -1,0 +1,82 @@
+package lavasession
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/holdoff"
+	"github.com/stretchr/testify/require"
+)
+
+func filterFixture(t *testing.T) (*ConsumerSessionManager, *holdoff.Registry, *time.Time) {
+	t.Helper()
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	reg := holdoff.NewRegistryWithClock(func() time.Time { return now })
+	csm := &ConsumerSessionManager{rateLimitHoldoff: reg}
+	return csm, reg, &now
+}
+
+func TestFilterRateLimitedProviders_NoHoldsPassesThrough(t *testing.T) {
+	csm, _, _ := filterFixture(t)
+	in := []string{"a", "b", "c"}
+	require.Equal(t, in, csm.filterRateLimitedProviders(context.Background(), in, nil))
+}
+
+func TestFilterRateLimitedProviders_NilRegistryPassesThrough(t *testing.T) {
+	csm := &ConsumerSessionManager{}
+	in := []string{"a", "b"}
+	require.Equal(t, in, csm.filterRateLimitedProviders(context.Background(), in, nil))
+}
+
+func TestFilterRateLimitedProviders_DropsHeldProviders(t *testing.T) {
+	csm, reg, _ := filterFixture(t)
+	reg.RecordRateLimit("b", "url-b", 5*time.Minute)
+
+	got := csm.filterRateLimitedProviders(context.Background(), []string{"a", "b", "c"}, nil)
+	require.ElementsMatch(t, []string{"a", "c"}, got)
+}
+
+func TestFilterRateLimitedProviders_ExpiredHoldIsChoosableAgain(t *testing.T) {
+	csm, reg, now := filterFixture(t)
+	reg.RecordRateLimit("b", "url-b", time.Minute)
+	*now = now.Add(2 * time.Minute)
+
+	got := csm.filterRateLimitedProviders(context.Background(), []string{"a", "b"}, nil)
+	require.ElementsMatch(t, []string{"a", "b"}, got)
+}
+
+// When every candidate is held off, the soonest-to-expire one stays in — the request
+// must still be served, and the customer is never answered with a synthesized 429.
+func TestFilterRateLimitedProviders_AllHeldKeepsSoonestToExpire(t *testing.T) {
+	csm, reg, _ := filterFixture(t)
+	reg.RecordRateLimit("a", "url-a", 10*time.Minute)
+	reg.RecordRateLimit("b", "url-b", 2*time.Minute)
+	reg.RecordRateLimit("c", "url-c", 30*time.Minute)
+
+	got := csm.filterRateLimitedProviders(context.Background(), []string{"a", "b", "c"}, nil)
+	require.Equal(t, []string{"b"}, got)
+}
+
+// Ready-but-ignored providers do not count as choosable: if the only non-held providers
+// are already ignored for this request, the soonest-to-expire held one is kept.
+func TestFilterRateLimitedProviders_IgnoredReadyDoesNotCount(t *testing.T) {
+	csm, reg, _ := filterFixture(t)
+	reg.RecordRateLimit("b", "url-b", 2*time.Minute)
+	reg.RecordRateLimit("c", "url-c", 10*time.Minute)
+	ignored := map[string]struct{}{"a": {}}
+
+	got := csm.filterRateLimitedProviders(context.Background(), []string{"a", "b", "c"}, ignored)
+	require.ElementsMatch(t, []string{"a", "b"}, got, "ignored 'a' stays for downstream bookkeeping, held 'b' is the soonest-to-expire fallback")
+}
+
+// A held provider that is also ignored this request cannot be the fallback.
+func TestFilterRateLimitedProviders_HeldAndIgnoredCannotFallBack(t *testing.T) {
+	csm, reg, _ := filterFixture(t)
+	reg.RecordRateLimit("a", "url-a", 2*time.Minute)
+	reg.RecordRateLimit("b", "url-b", 10*time.Minute)
+	ignored := map[string]struct{}{"a": {}}
+
+	got := csm.filterRateLimitedProviders(context.Background(), []string{"a", "b"}, ignored)
+	require.Equal(t, []string{"b"}, got, "'a' is ignored, so 'b' is the only possible fallback despite expiring later")
+}

--- a/protocol/rpcsmartrouter/recovery_probe.go
+++ b/protocol/rpcsmartrouter/recovery_probe.go
@@ -178,6 +178,16 @@ func (rpcss *RPCSmartRouterServer) replayFailingRelay(ep *lavasession.EndpointWi
 	if ep == nil || ep.DirectConnection == nil || len(payload) == 0 {
 		return relayProbeInconclusive
 	}
+	holdoffProvider := ep.ProviderAddress
+	holdoffURL := ""
+	if ep.Endpoint != nil {
+		holdoffURL = ep.Endpoint.NetworkAddress
+	}
+	if relayHoldoff.HeldOff(holdoffProvider, holdoffURL) {
+		// The vendor said slow down; a replay now would spend probe budget to learn
+		// nothing. Inconclusive keeps the gate's evidence untouched, same as a fresh 429.
+		return relayProbeInconclusive
+	}
 	if relayTimeout < minRelayProbeTimeout {
 		relayTimeout = minRelayProbeTimeout
 	}
@@ -198,7 +208,10 @@ func (rpcss *RPCSmartRouterServer) replayFailingRelay(ep *lavasession.EndpointWi
 		if httpErr, ok := err.(*lavasession.HTTPStatusError); ok {
 			switch {
 			case httpErr.StatusCode == http.StatusTooManyRequests:
-				return relayProbeInconclusive // busy: the failing handler was never exercised
+				// busy: the failing handler was never exercised. Hold the endpoint off so
+				// the next replays skip it instead of re-asking on the probe cadence.
+				relayHoldoff.RecordRateLimit(holdoffProvider, holdoffURL, httpErr.RetryAfter)
+				return relayProbeInconclusive
 			case httpErr.StatusCode == http.StatusNotImplemented:
 				return relayProbeRecovered // capability answer, not a fault
 			default:
@@ -210,6 +223,7 @@ func (rpcss *RPCSmartRouterServer) replayFailingRelay(ep *lavasession.EndpointWi
 		}
 		classified, _ := classifyDirectRPCError(err, chainFamily, common.TransportJsonRPC)
 		if classified.IsRateLimited() {
+			relayHoldoff.RecordRateLimit(holdoffProvider, holdoffURL, 0)
 			return relayProbeInconclusive
 		}
 		if unhealthy, _ := classifyEndpointHealth(classified, false); unhealthy {
@@ -217,6 +231,7 @@ func (rpcss *RPCSmartRouterServer) replayFailingRelay(ep *lavasession.EndpointWi
 		}
 		// The relay path would not have disabled on this error — the health-affecting failure is
 		// gone, which is exactly what the gate needs to know.
+		relayHoldoff.RecordAnswer(holdoffProvider, holdoffURL)
 		return relayProbeRecovered
 	}
 	if resp == nil {
@@ -239,11 +254,13 @@ func (rpcss *RPCSmartRouterServer) replayFailingRelay(ep *lavasession.EndpointWi
 	if nodeErr.Error != nil {
 		classified := common.ClassifyError(nil, chainFamily, common.TransportJsonRPC, nodeErr.Error.Code, nodeErr.Error.Message)
 		if classified.IsRateLimited() {
+			relayHoldoff.RecordRateLimit(holdoffProvider, holdoffURL, 0)
 			return relayProbeInconclusive
 		}
 		if unhealthy, _ := classifyEndpointHealth(classified, false); unhealthy {
 			return relayProbeStillFailing
 		}
 	}
+	relayHoldoff.RecordAnswer(holdoffProvider, holdoffURL)
 	return relayProbeRecovered
 }

--- a/protocol/rpcsmartrouter/recovery_probe_test.go
+++ b/protocol/rpcsmartrouter/recovery_probe_test.go
@@ -303,6 +303,9 @@ func replayServer() *RPCSmartRouterServer {
 
 func replayWith(t *testing.T, conn *fakeDirectConn) relayProbeVerdict {
 	t.Helper()
+	// Hermetic hold-off state: a 429 case records into the registry, and without the
+	// reset it would make every later case skip the probe as held-off.
+	withFreshRelayHoldoff(t)
 	rpcss := replayServer()
 	epc := &lavasession.EndpointWithDirectConnection{
 		Endpoint:         &lavasession.Endpoint{NetworkAddress: "http://fake:8545"},

--- a/protocol/rpcsmartrouter/relay_rate_limit_test.go
+++ b/protocol/rpcsmartrouter/relay_rate_limit_test.go
@@ -1,0 +1,113 @@
+package rpcsmartrouter
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/holdoff"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/stretchr/testify/require"
+)
+
+// withFreshRelayHoldoff swaps the package's hold-off registry for a fresh one for the
+// duration of a test, restoring the shared instance on cleanup.
+func withFreshRelayHoldoff(t *testing.T) *holdoff.Registry {
+	t.Helper()
+	restore := relayHoldoff
+	reg := holdoff.NewRegistry()
+	relayHoldoff = reg
+	t.Cleanup(func() { relayHoldoff = restore })
+	return reg
+}
+
+// The session-release decision keys on this: a rate-limit in either arriving shape must
+// be neither failure nor success.
+func TestIsRateLimitedRelayOutcome(t *testing.T) {
+	t.Run("typed 429 error", func(t *testing.T) {
+		err := httpStatusRelayError(429, nil)
+		require.True(t, isRateLimitedRelayOutcome(err, &common.RelayResult{}))
+	})
+	t.Run("body-shape classification flag", func(t *testing.T) {
+		require.True(t, isRateLimitedRelayOutcome(nil, &common.RelayResult{IsRateLimited: true}))
+	})
+	t.Run("5xx is not a rate limit", func(t *testing.T) {
+		require.False(t, isRateLimitedRelayOutcome(httpStatusRelayError(503, nil), &common.RelayResult{}))
+	})
+	t.Run("plain transport error is not a rate limit", func(t *testing.T) {
+		require.False(t, isRateLimitedRelayOutcome(errors.New("connection refused"), &common.RelayResult{}))
+	})
+	t.Run("clean result is not a rate limit", func(t *testing.T) {
+		require.False(t, isRateLimitedRelayOutcome(nil, &common.RelayResult{StatusCode: 200}))
+	})
+}
+
+// A 429 replay records the endpoint into the hold-off registry, honouring the upstream's
+// Retry-After as the floor.
+func TestReplayFailingRelay_RecordsRateLimitIntoHoldoff(t *testing.T) {
+	reg := withFreshRelayHoldoff(t)
+	rpcss := replayServer()
+	conn := &fakeDirectConn{err: &lavasession.HTTPStatusError{StatusCode: 429, Status: "429", RetryAfter: 5 * time.Minute}}
+	epc := &lavasession.EndpointWithDirectConnection{
+		Endpoint:         &lavasession.Endpoint{NetworkAddress: "http://fake:8545"},
+		DirectConnection: conn,
+		ProviderAddress:  "provider1",
+	}
+
+	verdict := rpcss.replayFailingRelay(epc, "eth_call", testEvidence, testEvidenceTimeout)
+	require.Equal(t, relayProbeInconclusive, verdict)
+	require.True(t, reg.HeldOff("provider1", "http://fake:8545"))
+	// The floor: at least the vendor's ask (jitter may extend it).
+	require.False(t, reg.ReadyAt("provider1", "http://fake:8545").Before(time.Now().Add(5*time.Minute-time.Second)))
+}
+
+// While the endpoint is held off, the replay is skipped entirely — inconclusive verdict,
+// no request spent.
+func TestReplayFailingRelay_SkipsWhileHeldOff(t *testing.T) {
+	reg := withFreshRelayHoldoff(t)
+	reg.RecordRateLimit("provider1", "http://fake:8545", time.Minute)
+
+	rpcss := replayServer()
+	conn := &fakeDirectConn{resp: &lavasession.DirectRPCResponse{StatusCode: 200, Data: []byte(`{"jsonrpc":"2.0","id":1,"result":"0x1"}`)}}
+	epc := &lavasession.EndpointWithDirectConnection{
+		Endpoint:         &lavasession.Endpoint{NetworkAddress: "http://fake:8545"},
+		DirectConnection: conn,
+		ProviderAddress:  "provider1",
+	}
+
+	verdict := rpcss.replayFailingRelay(epc, "eth_call", testEvidence, testEvidenceTimeout)
+	require.Equal(t, relayProbeInconclusive, verdict)
+	require.Nil(t, conn.gotPayload, "a held-off endpoint must not be probed")
+}
+
+// A replay that recovers clears the endpoint's hold-off state — the upstream answered,
+// so it is no longer refusing us for load and its strikes reset.
+func TestReplayFailingRelay_RecoveredClearsHoldoff(t *testing.T) {
+	restore := relayHoldoff
+	t.Cleanup(func() { relayHoldoff = restore })
+	now := time.Now()
+	reg := holdoff.NewRegistryWithClock(func() time.Time { return now })
+	relayHoldoff = reg
+
+	// Two strikes, then let the hold-off expire.
+	reg.RecordRateLimit("provider1", "http://fake:8545", 0)
+	reg.RecordRateLimit("provider1", "http://fake:8545", 0)
+	now = now.Add(2 * time.Minute)
+	require.False(t, reg.HeldOff("provider1", "http://fake:8545"))
+
+	rpcss := replayServer()
+	conn := &fakeDirectConn{resp: &lavasession.DirectRPCResponse{StatusCode: 200, Data: []byte(`{"jsonrpc":"2.0","id":1,"result":"0x1"}`)}}
+	epc := &lavasession.EndpointWithDirectConnection{
+		Endpoint:         &lavasession.Endpoint{NetworkAddress: "http://fake:8545"},
+		DirectConnection: conn,
+		ProviderAddress:  "provider1",
+	}
+
+	verdict := rpcss.replayFailingRelay(epc, "eth_call", testEvidence, testEvidenceTimeout)
+	require.Equal(t, relayProbeRecovered, verdict)
+
+	// The recovery cleared the strikes: a fresh 429 starts from the initial penalty.
+	reg.RecordRateLimit("provider1", "http://fake:8545", 0)
+	require.Equal(t, now.Add(holdoff.InitialHoldoff), reg.ReadyAt("provider1", "http://fake:8545"))
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/endpointstate"
 	"github.com/magma-Devs/smart-router/protocol/endpointtip"
+	"github.com/magma-Devs/smart-router/protocol/holdoff"
 	"github.com/magma-Devs/smart-router/protocol/internal/chainqueries"
 	"github.com/magma-Devs/smart-router/protocol/lavaprotocol"
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
@@ -1939,6 +1940,14 @@ func (rpcss *RPCSmartRouterServer) sendRelayToDirectEndpoints(
 			statusCode := localRelayResult.StatusCode
 			shouldFailSession := shouldFailSessionForResult(err, localRelayResult)
 
+			// Hold-off registry keys for this attempt (docs/RATE-LIMIT-HOLDOFF.md): the
+			// provider name and the node URL actually dialed.
+			holdoffProvider := singleConsumerSession.Parent.PublicLavaAddress
+			holdoffURL := endpointAddress
+			if targetEndpoint != nil {
+				holdoffURL = targetEndpoint.NetworkAddress
+			}
+
 			if isClientCancel {
 				// We cancelled it, so the endpoint's availability was never actually tested —
 				// release the session and return its CU without a QoS penalty (MAG-2648).
@@ -1953,7 +1962,34 @@ func (rpcss *RPCSmartRouterServer) sendRelayToDirectEndpoints(
 						utils.LogAttr("GUID", goroutineCtx),
 					)
 				}
+			} else if isRateLimitedRelayOutcome(err, localRelayResult) {
+				// A rate-limit is neither failure nor success — the upstream is healthy but
+				// busy, and both scoring directions get it wrong: OnSessionFailure lets a
+				// busy vendor hard-block a healthy endpoint after 15 consecutive failures,
+				// OnSessionDone rewards the fast rejection with a latency sample that ranks
+				// the limiter above endpoints doing real work. Release without a QoS sample
+				// either way, and hold the endpoint off so the in-request retry and
+				// subsequent requests prefer somewhere else (docs/RATE-LIMIT-HOLDOFF.md).
+				retryAfter, _ := common.RetryAfterFrom(err)
+				heldFor := relayHoldoff.RecordRateLimit(holdoffProvider, holdoffURL, retryAfter)
+				releaseErr := err
+				if releaseErr == nil {
+					releaseErr = fmt.Errorf("upstream rate-limited the relay (HTTP %d)", statusCode)
+				}
+				utils.LavaFormatDebug("relay rate-limited by upstream, holding endpoint off",
+					utils.LogAttr("endpoint", endpointAddress),
+					utils.LogAttr("holdoff", heldFor.String()),
+					utils.LogAttr("GUID", goroutineCtx),
+				)
+				if errSession := rpcss.sessionManager.OnSessionRateLimited(singleConsumerSession, releaseErr); errSession != nil {
+					utils.LavaFormatWarning("OnSessionRateLimited failed for direct RPC", errSession,
+						utils.LogAttr("GUID", goroutineCtx),
+					)
+				}
 			} else if !shouldFailSession {
+				// The endpoint answered for real — success or a plain client error — so any
+				// standing rate-limit hold-off for it is stale.
+				relayHoldoff.RecordAnswer(holdoffProvider, holdoffURL)
 				// Success or client error (4xx except 429) - update session as success.
 				// targetEndpoint / directConn were resolved and the tracker ensured before
 				// dispatch (above), so harvestGen is the generation captured pre-relay.
@@ -4793,6 +4829,21 @@ func classifyHTTPStatus(code int) (shouldMarkUnhealthy, needsBackoff bool) {
 	default:
 		return false, false
 	}
+}
+
+// relayHoldoff is the hot path's and recovery probe's handle on the process-wide
+// rate-limit hold-off registry (docs/RATE-LIMIT-HOLDOFF.md). A package variable rather
+// than a server field so tests can swap in a clock-pinned registry and restore it.
+var relayHoldoff = holdoff.Shared
+
+// isRateLimitedRelayOutcome reports whether the relay attempt was refused for rate, in
+// either shape it arrives: a typed HTTP 429 error, or a 2xx-body / gRPC classification
+// that set IsRateLimited.
+func isRateLimitedRelayOutcome(err error, relayResult *common.RelayResult) bool {
+	if relayResult != nil && relayResult.IsRateLimited {
+		return true
+	}
+	return err != nil && errors.Is(err, common.StatusCodeError429)
 }
 
 // httpStatusRelayError is the error relayInnerDirect fails a relay with when the upstream


### PR DESCRIPTION
#Closes MAG-2948

Jira ticket: MAG-2948

> **Stacked** on PR #314 in smart-router (hold-off registry, MAG-2947) — PR #313 already merged and this branch is rebased past it. Until #314 merges, this diff shows its four commits too; the reviewable change here is the top commit. Gets a final rebase when #314 lands.

Fourth PR of the 429/Retry-After stack: the hot path.

## Why

The relay path scores the two shapes of rate-limit in inverted proportion to their severity:

- An explicit HTTP 429 becomes `err != nil`, and `shouldFailSessionForResult` short-circuits on err before its `IsRateLimited` carve-out — a full availability failure. Fifteen consecutive ones hard-block a healthy-but-busy endpoint, the outcome the rate-limit contract (`error_registry.go`) explicitly forbids.
- A 2xx-body or gRPC-text rate limit passes the gate and is reported as a full success: availability 1 plus a latency sample so fast it ranks the limiter above endpoints doing real work.
- No cooldown exists anywhere: the retry excludes the endpoint within the request, and the very next request re-picks it immediately.

## What changed

- **Session accounting**: both shapes now release the session via `OnSessionRateLimited` (the `releaseWithoutPenalty` primitive the client-cancel path already uses) — no QoS sample in either direction, no health verdict. The response the client receives is untouched.
- **Recording**: the attempt lands in the shared hold-off registry keyed (provider, node URL), Retry-After as the floor. An answered relay clears it.
- **Selection**: `getValidProviderAddresses` filters held-off providers before the optimizer chooses, so the in-request retry and subsequent requests prefer somewhere else. When every candidate is held off, the **soonest-to-expire** one stays in — the request is still served; Retry-After stays internal and a customer is never answered with a synthesized 429. A header-pinned provider and existing sticky sessions bypass the filter: an explicit ask outranks the hold-off.
- **Recovery probe**: a 429 replay records the endpoint (honouring `HTTPStatusError.RetryAfter`, which it previously held and ignored) and further replays are skipped while held — inconclusive without spending the request — instead of re-asking on the 5s probe cadence. An answered replay clears.

## How to verify

```
go build ./...
go test ./protocol/lavasession/ -run TestFilterRateLimited -v
go test ./protocol/rpcsmartrouter/ -run 'TestIsRateLimitedRelayOutcome|TestReplayFailingRelay' -v
go test ./protocol/lavasession/ ./protocol/rpcsmartrouter/ ./protocol/holdoff/
```