### PR TITLE
feat(smart-router): recognize 429s on ws + gRPC, floor the tracker poll

### DIFF
--- a/protocol/chainlib/chainproxy/rpcclient/websocket.go
+++ b/protocol/chainlib/chainproxy/rpcclient/websocket.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/magma-Devs/smart-router/protocol/common"
 )
 
 const (
@@ -40,8 +41,10 @@ const (
 var wsBufferPool = new(sync.Pool)
 
 type wsHandshakeError struct {
-	err    error
-	status string
+	err        error
+	status     string
+	statusCode int
+	retryAfter time.Duration
 }
 
 func (e wsHandshakeError) Error() string {
@@ -50,6 +53,17 @@ func (e wsHandshakeError) Error() string {
 		s += " (HTTP status " + e.status + ")"
 	}
 	return s
+}
+
+// Unwrap presents a 429 upgrade rejection as the typed rate-limit error, so
+// errors.Is(err, common.StatusCodeError429) and common.RetryAfterFrom read the same on a
+// refused WS handshake as on every HTTP transport. Any other status unwraps to the dial
+// error itself.
+func (e wsHandshakeError) Unwrap() error {
+	if e.statusCode == http.StatusTooManyRequests {
+		return &common.RateLimitedError{RetryAfter: e.retryAfter}
+	}
+	return e.err
 }
 
 // DialWebsocketWithDialer creates a new RPC client that communicates with a JSON-RPC server
@@ -64,7 +78,11 @@ func DialWebsocketWithDialer(ctx context.Context, endpoint string, dialer websoc
 		if err != nil {
 			hErr := wsHandshakeError{err: err}
 			if resp != nil {
+				// Capture the rejection while the response is in scope — the status code
+				// types a 429 (see Unwrap), and Retry-After is what any backoff needs.
 				hErr.status = resp.Status
+				hErr.statusCode = resp.StatusCode
+				hErr.retryAfter, _ = common.ParseRetryAfter(resp.Header, time.Now())
 			}
 			return nil, hErr
 		}

--- a/protocol/chainlib/chainproxy/rpcclient/ws_handshake_429_test.go
+++ b/protocol/chainlib/chainproxy/rpcclient/ws_handshake_429_test.go
@@ -1,0 +1,54 @@
+package rpcclient
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// A 429 on the WS upgrade must surface as the typed rate-limit error with the upstream's
+// Retry-After attached — the handshake used to keep only the status string and drop the
+// headers, leaving the rejection invisible to every consumer.
+func TestDialWebsocket_429UpgradeIsTypedRateLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "120")
+		http.Error(w, "too many requests", http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := DialWebsocket(ctx, wsURL, nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, common.StatusCodeError429)
+	d, ok := common.RetryAfterFrom(err)
+	require.True(t, ok, "Retry-After must survive the handshake error")
+	require.Equal(t, 2*time.Minute, d)
+}
+
+// A non-429 rejection keeps today's shape: the dial error, status in the message, no
+// rate-limit typing.
+func TestDialWebsocket_ServerErrorUpgradeIsNotRateLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := DialWebsocket(ctx, wsURL, nil)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, common.StatusCodeError429)
+	_, ok := common.RetryAfterFrom(err)
+	require.False(t, ok)
+}

--- a/protocol/chainlib/grpc.go
+++ b/protocol/chainlib/grpc.go
@@ -684,6 +684,19 @@ func (cp *GrpcChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{}, 
 	defer cancel()
 	err = conn.Invoke(connectCtx, "/"+nodeMessage.Path, msg, response, grpc.Header(&respHeaders))
 	if err != nil {
+		// A corroborated rate limit fails the send with the typed sentinel — matching the
+		// HTTP transports — instead of being converted into a node-error reply. gRPC has
+		// no status code to check, so common.RateLimitFromGRPC keys on the known texts,
+		// or on RESOURCE_EXHAUSTED corroborated by a retry delay in the metadata.
+		if st, ok := status.FromError(err); ok {
+			if retryAfter, limited := common.RateLimitFromGRPC(uint32(st.Code()), st.Message(), respHeaders); limited {
+				return nil, "", nil, utils.LavaFormatWarning("gRPC node rate-limited the request", common.RateLimited(err, retryAfter),
+					utils.Attribute{Key: "GUID", Value: ctx},
+					utils.Attribute{Key: "chainID", Value: cp.BaseChainProxy.ChainID},
+					utils.Attribute{Key: "apiName", Value: nodeMessage.Path},
+				)
+			}
+		}
 		// Validate if the error is related to the provider connection to the node or it is a valid error
 		// in case the error is valid (e.g. bad input parameters) the error will return in the form of a valid error reply
 		if parsedError := cp.HandleNodeError(ctx, err); parsedError != nil {

--- a/protocol/chaintracker/chain_tracker.go
+++ b/protocol/chaintracker/chain_tracker.go
@@ -169,6 +169,11 @@ type ChainTracker struct {
 	// surfaced by /debug/endpoint-state as PollIntervalMs (MAG-2395). Written only by the poll
 	// goroutine (updateTimer), read by any goroutine.
 	currentPollIntervalNanos atomic.Int64
+	// rateLimitedUntil (unix nanos, 0 = none) is the instant the polled upstream asked us to
+	// stay away until, taken from the typed rate-limit error's Retry-After. computePollInterval
+	// floors the next interval with it, so a 429 with "Retry-After: 300" is not re-polled at the
+	// generic backoff's 60s ceiling. Written on each real poll outcome, cleared by any answer.
+	rateLimitedUntil atomic.Int64
 	// resetBackoffCh signals the poll goroutine to clear the failure backoff — zero fetchFails and
 	// reschedule the next poll at base cadence. Buffered(1) with a non-blocking send in
 	// ResetBackoff, so /debug/reset-probe-backoff never blocks on the poll goroutine (MAG-2395).
@@ -530,7 +535,7 @@ func (cs *ChainTracker) fetchAllPreviousBlocksIfNecessary(ctx context.Context, f
 	gotNewBlock := cs.gotNewBlock(ctx, newLatestBlock)
 	forked, err := cs.forkChanged(ctx, newLatestBlock)
 	if err != nil {
-		return false, utils.LavaFormatDebug("could not fetchLatestBlock Hash in ChainTracker", utils.Attribute{Key: "error", Value: err}, utils.Attribute{Key: "block", Value: newLatestBlock}, utils.Attribute{Key: "endpoint", Value: cs.endpoint})
+		return false, utils.LavaFormatDebugErr("could not fetchLatestBlock Hash in ChainTracker", err, utils.Attribute{Key: "block", Value: newLatestBlock}, utils.Attribute{Key: "endpoint", Value: cs.endpoint})
 	}
 	prev_latest := cs.GetAtomicLatestBlockNum()
 	if gotNewBlock || forked {
@@ -667,6 +672,11 @@ func (cs *ChainTracker) start(ctx context.Context, pollingTime time.Duration) er
 				// resulting counter uniformly — a healthy endpoint (fetchFails==0) keeps the normal
 				// cadence; a failing one stays backed off between the bounded forced verification polls.
 				fetchFails = nextFetchFails(fetchFails, skipped, err != nil)
+				if !skipped {
+					// A gate skip contacted nobody, so it can neither set nor clear the
+					// rate-limit floor; a real poll's outcome does both.
+					cs.noteFetchOutcome(err)
+				}
 				cs.updateTimer(pollingTime, fetchFails)
 				if err != nil {
 					if fetchFails > maxFails {
@@ -710,6 +720,9 @@ func (cs *ChainTracker) start(ctx context.Context, pollingTime time.Duration) er
 				fetchCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
 				_, pollErr := cs.fetchAllPreviousBlocksIfNecessary(fetchCtx, true)
 				cancel()
+				// The schedule itself is untouched (see above), but the poll was real, so it
+				// still informs the rate-limit floor the NEXT timer-driven reschedule reads.
+				cs.noteFetchOutcome(pollErr)
 				req.resp <- pollErr // buffered(1): never blocks, even if the requester gave up
 			case <-cs.resetBackoffCh:
 				// /debug/reset-probe-backoff (MAG-2395): clear the failure backoff and reschedule the
@@ -832,7 +845,7 @@ func (cs *ChainTracker) CurrentPollInterval() time.Duration {
 // adaptive tiers are preserved, since its readers are not yet harvest-fed.
 func (cs *ChainTracker) computePollInterval(tickerBaseTime time.Duration, fetchFails uint64) time.Duration {
 	if cs.flatPollInterval > 0 {
-		return exponentialBackoff(cs.flatPollInterval, fetchFails)
+		return cs.floorWithRetryAfter(exponentialBackoff(cs.flatPollInterval, fetchFails))
 	}
 
 	var newPollingTime time.Duration
@@ -845,7 +858,35 @@ func (cs *ChainTracker) computePollInterval(tickerBaseTime time.Duration, fetchF
 	} else {
 		newPollingTime = tickerBaseTime / cs.pollingTimeMultiplier
 	}
-	return exponentialBackoff(newPollingTime, fetchFails)
+	return cs.floorWithRetryAfter(exponentialBackoff(newPollingTime, fetchFails))
+}
+
+// noteFetchOutcome keeps the rate-limit floor current: a poll that failed with the typed
+// rate-limit error records how long the upstream asked us to stay away; any other real
+// poll outcome — success or a different failure — clears it, because the upstream
+// answered and its Retry-After is spent.
+func (cs *ChainTracker) noteFetchOutcome(err error) {
+	if d, ok := common.RetryAfterFrom(err); ok {
+		cs.rateLimitedUntil.Store(time.Now().Add(d).UnixNano())
+		return
+	}
+	cs.rateLimitedUntil.Store(0)
+}
+
+// floorWithRetryAfter stretches the computed poll interval to honour an upstream's
+// Retry-After when it named a longer wait than the generic failure backoff — a 429 with
+// "Retry-After: 300" must not be re-polled at the backoff's 60s ceiling. It never
+// shortens an interval.
+func (cs *ChainTracker) floorWithRetryAfter(interval time.Duration) time.Duration {
+	until := cs.rateLimitedUntil.Load()
+	if until == 0 {
+		return interval
+	}
+	wait := time.Until(time.Unix(0, until))
+	if wait <= interval {
+		return interval
+	}
+	return wait
 }
 
 func (cs *ChainTracker) fetchInitDataWithRetry(ctx context.Context) (err error) {

--- a/protocol/chaintracker/retry_after_floor_test.go
+++ b/protocol/chaintracker/retry_after_floor_test.go
@@ -1,0 +1,42 @@
+package chaintracker
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// The poll cadence must honour an upstream's Retry-After when it names a longer wait
+// than the generic failure backoff — and fall back to the backoff once it passes or the
+// upstream answers again.
+func TestComputePollInterval_RetryAfterFloors(t *testing.T) {
+	cs := &ChainTracker{flatPollInterval: 6 * time.Second}
+
+	// Baseline: flat cadence with backoff, no floor.
+	require.Equal(t, 6*time.Second, cs.computePollInterval(0, 0))
+	require.Equal(t, 12*time.Second, cs.computePollInterval(0, 1))
+
+	// A rate-limited poll with Retry-After far above the backoff ceiling floors the
+	// interval to (about) the requested wait.
+	cs.noteFetchOutcome(common.RateLimited(errors.New("HTTP 429"), 5*time.Minute))
+	got := cs.computePollInterval(0, 1)
+	require.Greater(t, got, 4*time.Minute, "interval must honour the upstream's Retry-After")
+	require.LessOrEqual(t, got, 5*time.Minute)
+
+	// A Retry-After shorter than the computed interval never shortens it.
+	cs.noteFetchOutcome(common.RateLimited(errors.New("HTTP 429"), time.Second))
+	require.Equal(t, 12*time.Second, cs.computePollInterval(0, 1))
+
+	// Any answered poll clears the floor.
+	cs.noteFetchOutcome(common.RateLimited(errors.New("HTTP 429"), 5*time.Minute))
+	cs.noteFetchOutcome(nil)
+	require.Equal(t, 6*time.Second, cs.computePollInterval(0, 0))
+
+	// A non-rate-limit failure clears it too — the upstream answered, its ask is spent.
+	cs.noteFetchOutcome(common.RateLimited(errors.New("HTTP 429"), 5*time.Minute))
+	cs.noteFetchOutcome(errors.New("connection refused"))
+	require.Equal(t, 6*time.Second, cs.computePollInterval(0, 0))
+}

--- a/protocol/common/rate_limit_grpc_test.go
+++ b/protocol/common/rate_limit_grpc_test.go
@@ -1,0 +1,81 @@
+package common
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRateLimitFromGRPC(t *testing.T) {
+	t.Run("vendor 429 text inside codes.Unavailable", func(t *testing.T) {
+		_, limited := RateLimitFromGRPC(14, "unexpected HTTP status code received from server: 429 (Too Many Requests)", nil)
+		require.True(t, limited)
+	})
+	t.Run("rate limit text", func(t *testing.T) {
+		_, limited := RateLimitFromGRPC(8, "rate limit exceeded", nil)
+		require.True(t, limited)
+	})
+	t.Run("enhance_your_calm", func(t *testing.T) {
+		_, limited := RateLimitFromGRPC(14, "http2: ENHANCE_YOUR_CALM", nil)
+		require.True(t, limited)
+	})
+	t.Run("RESOURCE_EXHAUSTED alone is not a rate limit", func(t *testing.T) {
+		// grpc-go mints the same code for an oversized message.
+		_, limited := RateLimitFromGRPC(8, "grpc: received message larger than max (5000000 vs. 4194304)", nil)
+		require.False(t, limited)
+	})
+	t.Run("RESOURCE_EXHAUSTED corroborated by pushback metadata", func(t *testing.T) {
+		md := map[string][]string{"grpc-retry-pushback-ms": {"2500"}}
+		d, limited := RateLimitFromGRPC(8, "resource exhausted", md)
+		require.True(t, limited)
+		require.Equal(t, 2500*time.Millisecond, d)
+	})
+	t.Run("RESOURCE_EXHAUSTED corroborated by retry-after metadata", func(t *testing.T) {
+		md := map[string][]string{"retry-after": {"30"}}
+		d, limited := RateLimitFromGRPC(8, "resource exhausted", md)
+		require.True(t, limited)
+		require.Equal(t, 30*time.Second, d)
+	})
+	t.Run("text match carries the metadata delay", func(t *testing.T) {
+		md := map[string][]string{"retry-after": {"60"}}
+		d, limited := RateLimitFromGRPC(14, "too many requests", md)
+		require.True(t, limited)
+		require.Equal(t, time.Minute, d)
+	})
+	t.Run("plain unavailable is not a rate limit", func(t *testing.T) {
+		_, limited := RateLimitFromGRPC(14, "connection refused", nil)
+		require.False(t, limited)
+	})
+	t.Run("pushback is clamped", func(t *testing.T) {
+		md := map[string][]string{"grpc-retry-pushback-ms": {"999999999"}}
+		d, limited := RateLimitFromGRPC(8, "rate limit", md)
+		require.True(t, limited)
+		require.Equal(t, MaxRetryAfter, d)
+	})
+}
+
+func TestRateLimitedConstructor(t *testing.T) {
+	t.Run("types the error and carries the delay", func(t *testing.T) {
+		src := errors.New("gRPC error 8: rate limit exceeded")
+		err := RateLimited(src, 45*time.Second)
+		require.ErrorIs(t, err, StatusCodeError429)
+		d, ok := RetryAfterFrom(err)
+		require.True(t, ok)
+		require.Equal(t, 45*time.Second, d)
+		require.Contains(t, err.Error(), "rate limit exceeded")
+	})
+	t.Run("no delay still types", func(t *testing.T) {
+		err := RateLimited(errors.New("busy"), 0)
+		require.ErrorIs(t, err, StatusCodeError429)
+		_, ok := RetryAfterFrom(err)
+		require.False(t, ok)
+	})
+	t.Run("delay is clamped", func(t *testing.T) {
+		err := RateLimited(nil, 48*time.Hour)
+		d, ok := RetryAfterFrom(err)
+		require.True(t, ok)
+		require.Equal(t, MaxRetryAfter, d)
+	})
+}

--- a/protocol/common/retry_after.go
+++ b/protocol/common/retry_after.go
@@ -2,8 +2,10 @@ package common
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -100,6 +102,78 @@ func retryAfterReferenceTime(h http.Header, now time.Time) time.Time {
 		return date
 	}
 	return now
+}
+
+// RateLimited types err as an upstream rate refusal carrying retryAfter, for transports
+// where WithRetryAfter's HTTP-header form does not apply (gRPC metadata, WS handshakes).
+// The sentinel lands in the chain, so errors.Is(result, StatusCodeError429) holds, and
+// RetryAfterFrom returns retryAfter when positive (clamped to MaxRetryAfter).
+func RateLimited(err error, retryAfter time.Duration) error {
+	cause := StatusCodeError429
+	if err != nil {
+		cause = fmt.Errorf("%w: %w", StatusCodeError429, err)
+	}
+	if retryAfter <= 0 {
+		return cause
+	}
+	if retryAfter > MaxRetryAfter {
+		retryAfter = MaxRetryAfter
+	}
+	return &RateLimitedError{RetryAfter: retryAfter, cause: cause}
+}
+
+// RateLimitFromGRPC reports whether a gRPC failure is the upstream refusing us for rate,
+// and the wait it asked for (0 when it said nothing usable). md is the response metadata
+// (gRPC keys are lowercase).
+//
+// gRPC carries no HTTP status, so the decision needs corroboration:
+//   - a known rate-limit text in the status message always counts — including the "429
+//     (Too Many Requests)" a vendor's HTTP edge leaves inside codes.Unavailable;
+//   - RESOURCE_EXHAUSTED (code 8) counts only when the metadata carries a retry delay.
+//     Alone it never suffices: grpc-go mints the same code for an oversized message.
+func RateLimitFromGRPC(code uint32, message string, md map[string][]string) (time.Duration, bool) {
+	retryAfter := grpcRetryDelayFromMD(md)
+	msg := strings.ToLower(message)
+	for _, sig := range []string{"too many requests", "rate limit", "ratelimit", "enhance_your_calm"} {
+		if strings.Contains(msg, sig) {
+			return retryAfter, true
+		}
+	}
+	const grpcResourceExhausted = 8
+	if code == grpcResourceExhausted && retryAfter > 0 {
+		return retryAfter, true
+	}
+	return 0, false
+}
+
+// grpcRetryDelayFromMD reads the delay an upstream attached to a gRPC failure: the
+// grpc-retry-pushback-ms convention, or a retry-after header a fronting HTTP proxy left
+// in. Keys are matched lowercase — http.Header canonicalization does not apply to gRPC
+// metadata. Clamped to MaxRetryAfter like every other capture.
+func grpcRetryDelayFromMD(md map[string][]string) time.Duration {
+	first := func(key string) string {
+		if vs := md[key]; len(vs) > 0 {
+			return vs[0]
+		}
+		return ""
+	}
+	if raw := first("grpc-retry-pushback-ms"); raw != "" {
+		if ms, err := strconv.Atoi(strings.TrimSpace(raw)); err == nil && ms > 0 {
+			d := time.Duration(ms) * time.Millisecond
+			if d > MaxRetryAfter {
+				return MaxRetryAfter
+			}
+			return d
+		}
+	}
+	if raw := first("retry-after"); raw != "" {
+		h := http.Header{}
+		h.Set("Retry-After", raw)
+		if d, ok := ParseRetryAfter(h, time.Now()); ok {
+			return d
+		}
+	}
+	return 0
 }
 
 // WithRetryAfter enriches a rate-limit error with the upstream's Retry-After, if it sent one.

--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -1699,6 +1699,12 @@ func (g *GRPCDirectRPCConnection) handleGRPCError(ctx context.Context, err error
 		return nil, utils.LavaFormatError("failed to marshal gRPC error response", marshalErr)
 	}
 
+	// A corroborated rate limit — a known rate-limit text, or RESOURCE_EXHAUSTED with a
+	// retry delay in the metadata — types the error, so errors.Is(err,
+	// common.StatusCodeError429) and common.RetryAfterFrom read the same on gRPC as on
+	// every HTTP transport (see GRPCStatusError.Unwrap).
+	retryAfter, rateLimited := common.RateLimitFromGRPC(errorCode, errorMessage, respHeaders)
+
 	// Return the error response with metadata
 	// The caller can inspect the response to determine if it's an error
 	return &DirectRPCResponse{
@@ -1706,9 +1712,11 @@ func (g *GRPCDirectRPCConnection) handleGRPCError(ctx context.Context, err error
 			Metadata:   respHeaders, // Include any headers received before the error
 			StatusCode: int(errorCode),
 		}, &GRPCStatusError{
-			Code:    errorCode,
-			Message: errorMessage,
-			cause:   err,
+			Code:        errorCode,
+			Message:     errorMessage,
+			cause:       err,
+			rateLimited: rateLimited,
+			retryAfter:  retryAfter,
 		}
 }
 
@@ -1723,6 +1731,11 @@ type GRPCStatusError struct {
 	Code    uint32
 	Message string
 	cause   error
+	// rateLimited + retryAfter are set by handleGRPCError when the failure is a
+	// corroborated upstream rate refusal (common.RateLimitFromGRPC). They scope Unwrap
+	// so the typed rate-limit error is visible on the gRPC path too.
+	rateLimited bool
+	retryAfter  time.Duration
 }
 
 func (e *GRPCStatusError) Error() string {
@@ -1733,7 +1746,16 @@ func (e *GRPCStatusError) Error() string {
 // wrapper. Note this makes status.Code(err) resolve to the underlying gRPC code
 // rather than Unknown; SessionOutOfSyncGRPCCode is 677 and so cannot collide with
 // any real code, which grpc_status_error_test.go pins.
-func (e *GRPCStatusError) Unwrap() error { return e.cause }
+//
+// A corroborated rate limit unwraps to common.RateLimitedError instead, mirroring
+// HTTPStatusError: rate-limit is the terminal classification, and the typed sentinel is
+// what every consumer keys on.
+func (e *GRPCStatusError) Unwrap() error {
+	if e.rateLimited {
+		return &common.RateLimitedError{RetryAfter: e.retryAfter}
+	}
+	return e.cause
+}
 
 func (g *GRPCDirectRPCConnection) GetProtocol() DirectRPCProtocol {
 	return DirectRPCProtocolGRPC

--- a/protocol/lavasession/grpc_rate_limit_test.go
+++ b/protocol/lavasession/grpc_rate_limit_test.go
@@ -1,0 +1,53 @@
+package lavasession
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// A corroborated gRPC rate limit must come out of handleGRPCError typed — errors.Is on
+// the sentinel and RetryAfterFrom reading the metadata delay — exactly like the HTTP
+// transports.
+func TestHandleGRPCError_CorroboratedRateLimitIsTyped(t *testing.T) {
+	g := &GRPCDirectRPCConnection{}
+	md := metadata.MD{"retry-after": []string{"30"}}
+
+	resp, err := g.handleGRPCError(context.Background(), status.Error(codes.ResourceExhausted, "rate limit exceeded"), md)
+	require.NotNil(t, resp, "the error response is still returned for the caller to inspect")
+	require.Error(t, err)
+	require.ErrorIs(t, err, common.StatusCodeError429)
+	d, ok := common.RetryAfterFrom(err)
+	require.True(t, ok)
+	require.Equal(t, 30*time.Second, d)
+}
+
+// RESOURCE_EXHAUSTED without corroboration is how grpc-go reports an oversized message —
+// it must not read as a rate limit.
+func TestHandleGRPCError_ResourceExhaustedAloneIsNotRateLimit(t *testing.T) {
+	g := &GRPCDirectRPCConnection{}
+
+	_, err := g.handleGRPCError(context.Background(), status.Error(codes.ResourceExhausted, "grpc: received message larger than max (5000000 vs. 4194304)"), nil)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, common.StatusCodeError429)
+	// The original cause stays reachable when no rate limit re-scopes Unwrap.
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+}
+
+// A vendor's HTTP edge leaves the 429 text inside codes.Unavailable — the one shape with
+// no status code and no metadata.
+func TestHandleGRPCError_UnavailableWith429TextIsTyped(t *testing.T) {
+	g := &GRPCDirectRPCConnection{}
+
+	_, err := g.handleGRPCError(context.Background(), status.Error(codes.Unavailable, "unexpected HTTP status code received from server: 429 (Too Many Requests)"), nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, common.StatusCodeError429)
+	_, ok := common.RetryAfterFrom(err)
+	require.False(t, ok, "no delay was offered")
+}


### PR DESCRIPTION
#Closes MAG-2949

Jira ticket: MAG-2949

Fifth PR of the 429/Retry-After stack: the transports where a 429 was invisible, and the poller that ignored what it had already parsed.

## What changed

- **WS handshake** (`chainproxy/rpcclient/websocket.go`) — the dial kept only `resp.Status` as a string and dropped the headers, so a 429 upgrade rejection looked like any dial failure to all four WS consumers (jsonRPC ws, tendermint ws, upstream ws pool, direct WS connection). `wsHandshakeError` now records the status code and parsed Retry-After, and `Unwrap` presents a 429 as the typed rate-limit error.
- **gRPC** — no HTTP status exists, so recognition needs corroboration. `common.RateLimitFromGRPC` keys on the known rate-limit texts (including the `429 (Too Many Requests)` a vendor's HTTP edge leaves inside `codes.Unavailable`), or on `RESOURCE_EXHAUSTED` backed by a retry delay in the response metadata (`grpc-retry-pushback-ms` / `retry-after`). Code 8 alone never suffices — grpc-go mints it for an oversized message too. Both gRPC paths consult it: `GRPCStatusError.Unwrap` scopes to the typed error on the direct connection, and the chainlib proxy fails the send typed instead of converting the rejection into a node-error reply. `common.RateLimited` is the constructor for these no-HTTP-status transports.
- **Chain tracker floor** (`chaintracker`) — the poll backoff was `base<<fails` capped at 60s regardless of what the upstream asked, while the parsed Retry-After sat one call frame away. The poll loop now notes each real poll's outcome and `computePollInterval` floors the next interval with it, so a 429 with `Retry-After: 300` is not re-asked at the ceiling. Any answered poll clears the floor; a traffic-gate skip (which contacts nobody) neither sets nor clears it. The fork-hash fetch also stops severing the typed error.

## How to verify

```
go build ./...
go test ./protocol/common/ -run 'TestRateLimitFromGRPC|TestRateLimitedConstructor' -v
go test ./protocol/chainlib/chainproxy/rpcclient/ -run 'TestDialWebsocket_' -v
go test ./protocol/chaintracker/ -run TestComputePollInterval_RetryAfterFloors -v
go test ./protocol/lavasession/ -run 'TestHandleGRPCError_' -v
```

Negative cases pinned: oversized-message code 8 stays unclassified, a 503 upgrade stays untyped, a short Retry-After never shortens the poll interval.