### PR TITLE
fix(smart-router): a rate-limited Validate attempt ends the retry burst

### DIFF
--- a/protocol/chainlib/chain_fetcher.go
+++ b/protocol/chainlib/chain_fetcher.go
@@ -3,6 +3,7 @@ package chainlib
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync/atomic"
@@ -121,6 +122,14 @@ func needsLatestBlock(url common.NodeUrl, verifications []VerificationContainer)
 	return false
 }
 
+// stopValidateRetries reports whether a failed attempt should end Validate's zero-delay
+// retry budget early. The budget exists for a cold-booting node; a rate-limited attempt
+// is different in kind — the extra requests land inside the same limiter window and only
+// add to the load that produced the 429.
+func stopValidateRetries(err error) bool {
+	return err == nil || errors.Is(err, common.StatusCodeError429)
+}
+
 func (cf *ChainFetcher) Validate(ctx context.Context) error {
 	for _, url := range cf.endpoint.NodeUrls {
 		utils.LavaFormatInfo("starting validation for url", utils.LogAttr("url", url.String()))
@@ -137,7 +146,7 @@ func (cf *ChainFetcher) Validate(ctx context.Context) error {
 		if needsLatestBlock(url, verifications) {
 			for attempts := 0; attempts < 3; attempts++ {
 				latestBlock, err = cf.FetchLatestBlockNum(ctx)
-				if err == nil {
+				if stopValidateRetries(err) {
 					break
 				}
 			}
@@ -157,7 +166,7 @@ func (cf *ChainFetcher) Validate(ctx context.Context) error {
 			var err error
 			for attempts := 0; attempts < 3; attempts++ {
 				err = cf.Verify(ctx, verification, uint64(latestBlock))
-				if err == nil {
+				if stopValidateRetries(err) {
 					break
 				}
 			}
@@ -222,7 +231,7 @@ func (cf *ChainFetcher) ValidateCollect(ctx context.Context) []NodeURLValidation
 		if needsLatestBlock(url, verifications) {
 			for attempts := 0; attempts < 3; attempts++ {
 				latestBlock, err = cf.FetchLatestBlockNum(ctx)
-				if err == nil {
+				if stopValidateRetries(err) {
 					break
 				}
 			}
@@ -236,7 +245,7 @@ func (cf *ChainFetcher) ValidateCollect(ctx context.Context) []NodeURLValidation
 			var verifyErr error
 			for attempts := 0; attempts < 3; attempts++ {
 				verifyErr = cf.Verify(ctx, verification, uint64(latestBlock))
-				if verifyErr == nil {
+				if stopValidateRetries(verifyErr) {
 					break
 				}
 			}

--- a/protocol/chainlib/chain_fetcher_validate_burst_test.go
+++ b/protocol/chainlib/chain_fetcher_validate_burst_test.go
@@ -1,0 +1,86 @@
+package chainlib
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcclient"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	specutils "github.com/magma-Devs/smart-router/utils/keeper"
+	"github.com/stretchr/testify/require"
+)
+
+// countingChainRouter fails every send with a fixed error and counts attempts per api
+// name, so the tests below can see exactly how many requests Validate's retry loops
+// spend against a refusing upstream.
+type countingChainRouter struct {
+	mu    sync.Mutex
+	calls map[string]int
+	err   error
+}
+
+func (r *countingChainRouter) SendNodeMsg(ctx context.Context, ch chan interface{}, chainMessage ChainMessageForSend, extensions []string) (*RelayReplyWrapper, string, *rpcclient.ClientSubscription, common.NodeUrl, string, error) {
+	r.mu.Lock()
+	r.calls[chainMessage.GetApi().Name]++
+	r.mu.Unlock()
+	return nil, "", nil, common.NodeUrl{}, "", r.err
+}
+
+func (r *countingChainRouter) ExtensionsSupported(internalPath string, extensions []string) bool {
+	return true
+}
+
+func (r *countingChainRouter) maxAttempts() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	maxCount := 0
+	for _, c := range r.calls {
+		if c > maxCount {
+			maxCount = c
+		}
+	}
+	return maxCount
+}
+
+func newEthValidateFetcher(t *testing.T, router ChainRouter) *ChainFetcher {
+	t.Helper()
+	spec, err := specutils.GetSpecFromLocalDirs([]string{"../../specs/"}, "ETH1")
+	require.NoError(t, err)
+	cp, err := NewChainParser(spectypes.APIInterfaceJsonRPC)
+	require.NoError(t, err)
+	cp.SetSpec(spec)
+	return &ChainFetcher{
+		endpoint: &lavasession.RPCProviderEndpoint{
+			ChainID:      "ETH1",
+			ApiInterface: spectypes.APIInterfaceJsonRPC,
+			NodeUrls:     []common.NodeUrl{{Url: "http://node:8545"}},
+		},
+		chainRouter: router,
+		chainParser: cp,
+	}
+}
+
+// A rate-limited attempt ends the retry budget: retrying back-to-back inside the same
+// limiter window cannot succeed and only adds to the load that produced the 429.
+func TestValidate_RateLimitStopsTheRetryBurst(t *testing.T) {
+	router := &countingChainRouter{calls: map[string]int{}, err: rateLimited429("60")}
+	cf := newEthValidateFetcher(t, router)
+
+	_ = cf.Validate(context.Background())
+	require.Positive(t, len(router.calls), "validation must have sent something")
+	require.Equal(t, 1, router.maxAttempts(), "a rate-limited attempt must not be retried back-to-back; got %v", router.calls)
+}
+
+// Any other failure keeps the full budget — the zero-delay retries exist for a node
+// that is still booting, and that behaviour must not change.
+func TestValidate_OtherFailuresKeepThreeAttempts(t *testing.T) {
+	router := &countingChainRouter{calls: map[string]int{}, err: errors.New("connection refused")}
+	cf := newEthValidateFetcher(t, router)
+
+	_ = cf.Validate(context.Background())
+	require.Equal(t, 3, router.maxAttempts(), "a plain failure keeps the 3-attempt startup budget; got %v", router.calls)
+}


### PR DESCRIPTION
#Closes MAG-2976

Jira ticket: MAG-2976

Closes the last finding of the MAG-2910 audit that no other PR in the 429/Retry-After stack covers. Depends only on merged PR #313 in smart-router (typed-429 propagation) — single commit on main, independently mergeable.

## Why

`Validate` retries its latest-block fetch and each verification 3 times back-to-back with zero delay ("we give several chances for starting up") — a budget written for a cold-booting node. Against a rate limiter it is counterproductive: all three attempts land inside the same limiter window, fail identically, and the two extra requests only add to the load that produced the 429. This burst runs on every startup verification and every epoch re-verification, for every configured provider, five in parallel — it is the fleet-side amplifier of the shared-vendor-cap incident that started this stack.

The re-verify hold-off (PR #316) stops the pass from re-probing across epochs; this closes the burst inside a single `Validate` call.

## What changed

- `stopValidateRetries` — the retry loops break early when the attempt failed with the typed rate-limit error. Applied to all four loops: `Validate`'s latest-block + verification loops, and `ValidateCollect`'s (the `smartrouter health` command) same pair.
- The error propagates unchanged, so downstream classification (inconclusive in re-verify) is untouched. Every other failure keeps the full 3-attempt budget.

## How to verify

```
go build ./...
go test ./protocol/chainlib/ -run 'TestValidate_' -v
go test ./protocol/chainlib/...
```

The two tests drive `Validate` through a real ETH1 parser against a counting router: a rate-limited upstream is asked exactly once per probe, a plainly-failing one still gets its 3 startup attempts.
