### PR TITLE
fix(smart-router): ws subscriptions hold off a rate-limited endpoint

### DIFF
--- a/docs/RATE-LIMIT-HOLDOFF.md
+++ b/docs/RATE-LIMIT-HOLDOFF.md
@@ -48,6 +48,7 @@ off" means on its path. This table is the catalog; add a row when wiring a new c
 | Hot relay path (endpoint selection) | A rate-limited relay releases its session with no QoS sample in either direction, and selection prefers providers that are not held off; when every candidate is held off, the soonest-to-expire one stays in — the customer is never answered with a synthesized 429 | 429 relay results, both shapes (typed HTTP error, 2xx-body/gRPC classification) | live |
 | Recovery probe (`recovery_probe.go`) | Skip the replay while held off (verdict stays inconclusive), instead of burning replay-attempt budget on a vendor that said stop | 429 probe responses (Retry-After floor honoured) | live |
 | Chain tracker / endpoint poller | The poll backoff takes the upstream's Retry-After as a floor instead of guessing with the fail-count doubling | 429 poll responses | lands with MAG-2949 |
+| WS subscriptions (`direct_ws_subscription_manager.go`) | A rate-limited connect/subscribe is held off instead of scored (no availability sample), selection skips held endpoints while something ready remains, and the pool's reconnect ladder is floored by the dial's Retry-After. Keyed per WS URL — no provider name exists on this path, so vendor-tier escalation does not apply | 429 handshakes and subscribe failures | live |
 | WS / gRPC transports | Recognition first: a 429 on the WS upgrade or a corroborated gRPC rate limit produces the typed sentinel these consumers key on | handshake / metadata 429s | lands with MAG-2949 |
 
 ## Relation to `common/retry_after.go`

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
@@ -3,6 +3,7 @@ package rpcsmartrouter
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -441,9 +442,48 @@ func (dwsm *DirectWSSubscriptionManager) selectEndpoint(ctx context.Context, cli
 //
 // tier and byURL come from one endpointsSnapshot so the optimizer's chosen URL is
 // resolved against the same generation of the index it was offered from.
+// notHeldOff returns the endpoints of tier that are not currently rate-limit held off.
+func notHeldOff(tier []*common.NodeUrl) []*common.NodeUrl {
+	ready := make([]*common.NodeUrl, 0, len(tier))
+	for _, ep := range tier {
+		if !relayHoldoff.HeldOff(ep.Url, ep.Url) {
+			ready = append(ready, ep)
+		}
+	}
+	return ready
+}
+
+// noteSubscribeFailure applies a failed connect/subscribe attempt's consequences. A
+// rate-limited attempt is held off instead of scored — the endpoint is busy, not broken,
+// and an availability sample of 0 is the demotion the rate-limit contract forbids
+// (docs/RATE-LIMIT-HOLDOFF.md). Anything else penalizes the optimizer as before. The WS
+// path works on bare node URLs with no provider name in scope, so the URL keys both
+// registry tiers — WS hold-offs are per-URL and do not escalate across a vendor.
+func (dwsm *DirectWSSubscriptionManager) noteSubscribeFailure(url string, err error) {
+	if errors.Is(err, common.StatusCodeError429) {
+		retryAfter, _ := common.RetryAfterFrom(err)
+		heldFor := relayHoldoff.RecordRateLimit(url, url, retryAfter)
+		utils.LavaFormatDebug("DirectWS: subscribe rate-limited by upstream, holding endpoint off",
+			utils.LogAttr("endpoint", sanitizeEndpointURL(url)),
+			utils.LogAttr("holdoff", heldFor.String()),
+		)
+		return
+	}
+	if dwsm.optimizer != nil {
+		dwsm.optimizer.AppendRelayFailure(url)
+	}
+}
+
 func (dwsm *DirectWSSubscriptionManager) selectFromTier(ctx context.Context, tier []*common.NodeUrl, byURL map[string]*common.NodeUrl, ignoredEndpoints map[string]struct{}) (*common.NodeUrl, error) {
 	if len(tier) == 0 {
 		return nil, fmt.Errorf("tier is empty")
+	}
+
+	// Rate-limit hold-off: prefer endpoints that are not currently held off after a 429.
+	// Only narrows the tier when something ready remains — a subscription must still be
+	// served when every endpoint is held off, so the full tier stays in that case.
+	if ready := notHeldOff(tier); len(ready) > 0 && len(ready) < len(tier) {
+		tier = ready
 	}
 
 	// Single endpoint or no optimizer: first-non-ignored.
@@ -665,10 +705,7 @@ func (dwsm *DirectWSSubscriptionManager) StartSubscription(
 	// Get connection
 	conn, err := pool.GetConnection(ctx)
 	if err != nil {
-		// Report failure to optimizer
-		if dwsm.optimizer != nil {
-			dwsm.optimizer.AppendRelayFailure(selectedEndpoint.Url)
-		}
+		dwsm.noteSubscribeFailure(selectedEndpoint.Url, err)
 		dwsm.failPendingSubscription(hashedParams)
 		go dwsm.metricsManager.SetFailedWsSubscriptionRequestMetric(dwsm.chainID, dwsm.apiInterface)
 		return nil, nil, fmt.Errorf("failed to get WebSocket connection: %w", err)
@@ -677,16 +714,15 @@ func (dwsm *DirectWSSubscriptionManager) StartSubscription(
 	// Create upstream subscription
 	upstreamSub, firstMsg, msgChan, err := dwsm.createUpstreamSubscription(ctx, conn, subscriptionParams, subscribeMethod)
 	if err != nil {
-		// Report failure to optimizer
-		if dwsm.optimizer != nil {
-			dwsm.optimizer.AppendRelayFailure(selectedEndpoint.Url)
-		}
+		dwsm.noteSubscribeFailure(selectedEndpoint.Url, err)
 		dwsm.failPendingSubscription(hashedParams)
 		go dwsm.metricsManager.SetFailedWsSubscriptionRequestMetric(dwsm.chainID, dwsm.apiInterface)
 		return nil, nil, fmt.Errorf("failed to create upstream subscription: %w", err)
 	}
 
-	// Report success to optimizer
+	// Report success to optimizer. The endpoint answered, so any standing rate-limit
+	// hold-off for it is stale.
+	relayHoldoff.RecordAnswer(selectedEndpoint.Url, selectedEndpoint.Url)
 	if dwsm.optimizer != nil {
 		latency := time.Since(startTime)
 		dwsm.optimizer.AppendRelayData(selectedEndpoint.Url, latency, 1, 0) // cu=1, syncBlock=0 (unknown)

--- a/protocol/rpcsmartrouter/upstream_ws_pool.go
+++ b/protocol/rpcsmartrouter/upstream_ws_pool.go
@@ -348,6 +348,16 @@ func (p *UpstreamWSPool) maybeScaleDown() {
 	}
 }
 
+// reconnectDelay floors the backoff ladder's delay with a rate-limited dial's
+// Retry-After: an upstream that named its own wait must not be re-dialed at the
+// 100ms–30s cadence. Any other failure keeps the ladder's delay.
+func reconnectDelay(base time.Duration, err error) time.Duration {
+	if retryAfter, ok := common.RetryAfterFrom(err); ok && retryAfter > base {
+		return retryAfter
+	}
+	return base
+}
+
 // ReconnectWithBackoff attempts to reconnect all unhealthy connections using exponential backoff.
 // This should be called when a connection error is detected.
 // Returns nil on success, or an error if max retries exceeded or context cancelled.
@@ -429,6 +439,8 @@ func (p *UpstreamWSPool) ReconnectWithBackoff(ctx context.Context) error {
 			return fmt.Errorf("max retries (%d) exceeded for endpoint %s: %w",
 				WebSocketMaxRetries, p.sanitizedURL, err)
 		}
+
+		delay = reconnectDelay(delay, err)
 
 		utils.LavaFormatDebug("WebSocket pool: reconnect failed, retrying",
 			utils.LogAttr("endpoint", p.sanitizedURL),

--- a/protocol/rpcsmartrouter/ws_rate_limit_test.go
+++ b/protocol/rpcsmartrouter/ws_rate_limit_test.go
@@ -1,0 +1,100 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcclient"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingOptimizer observes AppendRelayFailure calls, which the shared
+// fakeSubscriptionOptimizer deliberately no-ops.
+type recordingOptimizer struct {
+	fakeSubscriptionOptimizer
+	mu       sync.Mutex
+	failures []string
+}
+
+func (r *recordingOptimizer) AppendRelayFailure(providerAddress string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.failures = append(r.failures, providerAddress)
+}
+
+// A rate-limited subscribe is held off, not scored: no availability sample, a registry
+// hold-off with the upstream's Retry-After as the floor.
+func TestWSNoteSubscribeFailure_RateLimitHoldsOffInsteadOfScoring(t *testing.T) {
+	reg := withFreshRelayHoldoff(t)
+	opt := &recordingOptimizer{}
+	dwsm := &DirectWSSubscriptionManager{optimizer: opt}
+
+	dwsm.noteSubscribeFailure("wss://busy.example/ws", common.RateLimited(errors.New("handshake refused"), 2*time.Minute))
+
+	require.Empty(t, opt.failures, "a rate-limited subscribe must not produce an availability sample")
+	require.True(t, reg.HeldOff("wss://busy.example/ws", "wss://busy.example/ws"))
+}
+
+// Any other failure keeps today's scoring.
+func TestWSNoteSubscribeFailure_GenuineFailureStillScores(t *testing.T) {
+	reg := withFreshRelayHoldoff(t)
+	opt := &recordingOptimizer{}
+	dwsm := &DirectWSSubscriptionManager{optimizer: opt}
+
+	dwsm.noteSubscribeFailure("wss://broken.example/ws", errors.New("connection refused"))
+
+	require.Equal(t, []string{"wss://broken.example/ws"}, opt.failures)
+	require.False(t, reg.HeldOff("wss://broken.example/ws", "wss://broken.example/ws"))
+}
+
+// Selection skips held-off endpoints while something ready remains, and keeps the full
+// tier when nothing does — a subscription must still be served.
+func TestWSSelectFromTier_SkipsHeldOffEndpoints(t *testing.T) {
+	reg := withFreshRelayHoldoff(t)
+	dwsm := &DirectWSSubscriptionManager{} // no optimizer: first-non-ignored selection
+	tier := []*common.NodeUrl{{Url: "wss://a.example/ws"}, {Url: "wss://b.example/ws"}}
+
+	reg.RecordRateLimit("wss://a.example/ws", "wss://a.example/ws", time.Minute)
+	ep, err := dwsm.selectFromTier(context.Background(), tier, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, "wss://b.example/ws", ep.Url, "the held-off endpoint must not be picked")
+
+	reg.RecordRateLimit("wss://b.example/ws", "wss://b.example/ws", time.Minute)
+	ep, err = dwsm.selectFromTier(context.Background(), tier, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, ep, "with everything held off the tier still serves")
+}
+
+// The reconnect ladder honours a rate-limited dial's Retry-After, through the exact
+// wrapping production builds (rpcclient handshake error wrapped by connect's %w).
+func TestReconnectDelay_FloorsWithRetryAfter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		http.Error(w, "too many requests", http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, dialErr := rpcclient.DialWebsocket(ctx, "ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	require.Error(t, dialErr)
+	wrapped := fmt.Errorf("failed to dial WebSocket %s: %w", srv.URL, dialErr)
+
+	require.Equal(t, 30*time.Second, reconnectDelay(100*time.Millisecond, wrapped),
+		"the vendor's ask floors the ladder")
+	require.Equal(t, time.Minute, reconnectDelay(time.Minute, wrapped),
+		"a ladder delay already past the ask is kept")
+	require.Equal(t, 100*time.Millisecond, reconnectDelay(100*time.Millisecond, errors.New("connection refused")),
+		"a plain dial failure keeps the ladder")
+}
+
+// The interface stub must stay in sync: recordingOptimizer embeds the shared fake.
+var _ WebSocketEndpointOptimizer = (*recordingOptimizer)(nil)


### PR DESCRIPTION
#Closes MAG-2977

Jira ticket: MAG-2977

> **Stacked** on PR #317 in smart-router (hot-path rate-limit handling, MAG-2948) and PR #318 (ws/gRPC recognition, MAG-2949) — their commits show in this diff until they merge; the reviewable change here is the top commit. Gets a final rebase when they land.

Follow-up to the 429/Retry-After stack: the last consumer path where a rate limit was still punished.

## Why

PR #318 makes a 429 on the WS upgrade a typed error — but nothing on the subscription path consumed it. `direct_ws_subscription_manager.go` called `AppendRelayFailure` unconditionally on any connect/subscribe failure (an availability sample of 0 for an endpoint that is busy, not broken — the same inversion #317 fixed on the HTTP hot path), and the pool's reconnect ladder re-dialed a rate-limited upstream at its 100ms–30s cadence regardless of what the handshake asked.

## What changed

- `noteSubscribeFailure` — a rate-limited connect/subscribe records the endpoint into the shared hold-off registry (Retry-After as the floor) instead of scoring it; every other failure penalizes exactly as before.
- `selectFromTier` skips held-off endpoints while something ready remains; when everything is held, the full tier stays in — a subscription must still be served.
- A successful subscribe clears the endpoint's hold-off.
- `reconnectDelay` floors the reconnect ladder with the dial error's Retry-After.
- Keying is per WS URL on both registry tiers — this path works on bare node URLs with no provider name in scope, so vendor-tier escalation deliberately does not apply (documented in the consumer table).

## How to verify

```
go build ./...
go test ./protocol/rpcsmartrouter/ -run 'TestWSNoteSubscribeFailure|TestWSSelectFromTier|TestReconnectDelay' -v
go test ./protocol/rpcsmartrouter/
```

The reconnect test drives the exact production wrapping: a real `rpcclient.DialWebsocket` against a 429+Retry-After test server, wrapped by `connect`'s `%w`.
