### PR TITLE
feat(smart-router): expose rate-limit hold-off events as metrics

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -1,7 +1,9 @@
 # Smart Router — Metrics Reference
 
 Every metric the Smart Router exposes over Prometheus, with its type, labels, and
-meaning. All metrics are defined under [`protocol/metrics/`](../protocol/metrics/).
+meaning. Metrics are defined under [`protocol/metrics/`](../protocol/metrics/), except the
+[rate-limit hold-off](#rate-limit-hold-off) pair, which the registry that owns the events
+emits itself from [`protocol/holdoff/metrics.go`](../protocol/holdoff/metrics.go).
 
 ## Exposition
 
@@ -232,6 +234,36 @@ Once it is non-zero they are lossy — some batch types are being merged into `b
 | `smartrouter_retries_success_total` | Counter | `spec`, `apiInterface`, `method` | Retried requests that succeeded. |
 | `smartrouter_retries_failed_total` | Counter | `spec`, `apiInterface`, `method` | Retried requests that failed. |
 | `smartrouter_retry_attempts` | Histogram | `spec`, `apiInterface`, `method` | Attempts per retried request (buckets 1…10). |
+
+#### Rate-limit hold-off
+
+Emitted by the [hold-off registry](RATE-LIMIT-HOLDOFF.md) itself, so every consumer path
+(re-verify, hot path, recovery probe, ws subscriptions) is covered without wiring. A
+rate-limited relay releases its session with no QoS sample in either direction, so a
+vendor cap does not show up in `rpc_endpoint_selection_score` — this pair is the direct
+signal that an upstream is refusing us for load.
+
+| Metric | Type | Labels | Description |
+| --- | --- | --- | --- |
+| `smartrouter_rate_limit_holdoffs_total` | Counter | `provider`, `event` | Registry events. `event` is the closed set `recorded` (a 429 held an endpoint off), `escalated` (the hold-off widened to the whole provider name — counted once on the transition, not per refresh), `cleared` (an answer dropped a standing penalty — not counted when there was nothing to clear). |
+| `smartrouter_rate_limit_holdoff_seconds` | Histogram | `provider` | Applied hold-off duration per `recorded` event, in **seconds** (buckets `15, 30, 60, 120, 300, 600, 1800, 3600` — not the shared millisecond latency buckets). Shows upstream `Retry-After` magnitudes against the exponential default. |
+
+`provider` is the configured provider name on the relay / probe / re-verify paths. The
+ws-subscription path has no provider name and keys the registry by node URL; those keys
+are reduced to `scheme://host` before they become a label, because node URLs can embed
+API keys in their path or query and a credential must never reach a Prometheus series.
+
+```promql
+# upstreams currently tripping their caps
+sum by (provider) (increase(smartrouter_rate_limit_holdoffs_total{event="recorded"}[15m])) > 0
+
+# a vendor-wide cap: the hold-off escalated across a provider's URLs
+increase(smartrouter_rate_limit_holdoffs_total{event="escalated"}[1h]) > 0
+
+# how long upstreams are telling us to wait (p90)
+histogram_quantile(0.9,
+  sum by (provider, le) (rate(smartrouter_rate_limit_holdoff_seconds_bucket[1h])))
+```
 
 #### Consistency
 

--- a/docs/RATE-LIMIT-HOLDOFF.md
+++ b/docs/RATE-LIMIT-HOLDOFF.md
@@ -51,6 +51,19 @@ off" means on its path. This table is the catalog; add a row when wiring a new c
 | WS subscriptions (`direct_ws_subscription_manager.go`) | A rate-limited connect/subscribe is held off instead of scored (no availability sample), selection skips held endpoints while something ready remains, and the pool's reconnect ladder is floored by the dial's Retry-After. Keyed per WS URL — no provider name exists on this path, so vendor-tier escalation does not apply | 429 handshakes and subscribe failures | live |
 | WS / gRPC transports | Recognition first: a 429 on the WS upgrade or a corroborated gRPC rate limit produces the typed sentinel these consumers key on | handshake / metadata 429s | lands with MAG-2949 |
 
+## Metrics
+
+The registry emits its own events, so every consumer is covered without wiring:
+
+- `smartrouter_rate_limit_holdoffs_total{provider, event}` — `recorded` (a 429 held an
+  endpoint off), `escalated` (counted on the transition to a provider-wide hold-off),
+  `cleared` (an answer dropped a standing penalty).
+- `smartrouter_rate_limit_holdoff_seconds{provider}` — histogram of applied hold-offs,
+  showing upstream Retry-After magnitudes against the exponential default.
+
+URL-shaped registry keys (the ws path) are reduced to scheme://host before they become a
+label — node URLs can embed API keys and must never reach a Prometheus series.
+
 ## Relation to `common/retry_after.go`
 
 `protocol/common/retry_after.go` captures — it parses `Retry-After` and attaches it to

--- a/docs/RATE-LIMIT-HOLDOFF.md
+++ b/docs/RATE-LIMIT-HOLDOFF.md
@@ -53,7 +53,8 @@ off" means on its path. This table is the catalog; add a row when wiring a new c
 
 ## Metrics
 
-The registry emits its own events, so every consumer is covered without wiring:
+The registry emits its own events, so every consumer is covered without wiring
+(labels, buckets, and PromQL recipes in [METRICS.md](METRICS.md#rate-limit-hold-off)):
 
 - `smartrouter_rate_limit_holdoffs_total{provider, event}` — `recorded` (a 429 held an
   endpoint off), `escalated` (counted on the transition to a provider-wide hold-off),

--- a/protocol/holdoff/holdoff.go
+++ b/protocol/holdoff/holdoff.go
@@ -142,6 +142,7 @@ func (r *Registry) RecordRateLimit(provider, url string, retryAfter time.Duratio
 	}
 	e.readyAt = now.Add(d)
 	e.lastSeen = now
+	metricRecorded(provider, d)
 
 	// Escalate when enough distinct URLs of this provider are held off at once. The
 	// provider-wide hold-off ends when its longest-held member does — and any answered
@@ -157,6 +158,9 @@ func (r *Registry) RecordRateLimit(provider, url string, retryAfter time.Duratio
 		}
 	}
 	if held >= EscalationDistinctURLs {
+		if !ps.escalatedUntil.After(now) {
+			metricEscalated(provider) // counted on the transition, not per refresh
+		}
 		ps.escalatedUntil = latest
 	}
 	return d
@@ -171,6 +175,10 @@ func (r *Registry) RecordAnswer(provider, url string) {
 	ps := r.providers[provider]
 	if ps == nil {
 		return
+	}
+	_, hadEntry := ps.urls[url]
+	if hadEntry || ps.escalatedUntil.After(r.now()) {
+		metricCleared(provider) // only when the answer actually dropped a penalty
 	}
 	delete(ps.urls, url)
 	ps.escalatedUntil = time.Time{}

--- a/protocol/holdoff/metrics.go
+++ b/protocol/holdoff/metrics.go
@@ -1,0 +1,89 @@
+package holdoff
+
+import (
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Registry events surface as metrics so a vendor cap tripping in production shows on a
+// dashboard instead of only in debug logs. Instrumented here, at the registry, so every
+// consumer path (re-verify, hot path, recovery probe, ws subscriptions) is covered
+// uniformly and a new consumer cannot forget to wire it.
+var (
+	holdoffEvents    *prometheus.CounterVec
+	holdoffDurations *prometheus.HistogramVec
+)
+
+const (
+	eventRecorded  = "recorded"
+	eventEscalated = "escalated"
+	eventCleared   = "cleared"
+)
+
+func init() {
+	holdoffEvents = registerCounterVec(prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "smartrouter_rate_limit_holdoffs_total",
+		Help: "Rate-limit hold-off registry events: recorded (a 429 held an endpoint off), escalated (a vendor's hold-off widened to the provider name), cleared (an answer dropped the penalty).",
+	}, []string{"provider", "event"}))
+	holdoffDurations = registerHistogramVec(prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "smartrouter_rate_limit_holdoff_seconds",
+		Help:    "Applied hold-off durations, showing upstream Retry-After magnitudes against the exponential default.",
+		Buckets: []float64{15, 30, 60, 120, 300, 600, 1800, 3600},
+	}, []string{"provider"}))
+}
+
+// registerCounterVec is the repo's best-effort registration idiom: reuse an existing
+// collector on double-registration (tests, repeated init), never panic.
+func registerCounterVec(c *prometheus.CounterVec) *prometheus.CounterVec {
+	if err := prometheus.Register(c); err != nil {
+		if existing, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			if reused, ok := existing.ExistingCollector.(*prometheus.CounterVec); ok {
+				return reused
+			}
+		}
+	}
+	return c
+}
+
+func registerHistogramVec(h *prometheus.HistogramVec) *prometheus.HistogramVec {
+	if err := prometheus.Register(h); err != nil {
+		if existing, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			if reused, ok := existing.ExistingCollector.(*prometheus.HistogramVec); ok {
+				return reused
+			}
+		}
+	}
+	return h
+}
+
+// providerLabel makes a registry key safe as a metric label. The ws path keys the
+// registry by node URL, and node URLs can embed API keys in their path or query — those
+// must never become a Prometheus series. URL-shaped keys are reduced to scheme://host;
+// plain provider names pass through unchanged.
+func providerLabel(provider string) string {
+	if !strings.Contains(provider, "://") {
+		return provider
+	}
+	u, err := url.Parse(provider)
+	if err != nil || u.Host == "" {
+		return "invalid-url"
+	}
+	return u.Scheme + "://" + u.Host
+}
+
+func metricRecorded(provider string, applied time.Duration) {
+	label := providerLabel(provider)
+	holdoffEvents.WithLabelValues(label, eventRecorded).Inc()
+	holdoffDurations.WithLabelValues(label).Observe(applied.Seconds())
+}
+
+func metricEscalated(provider string) {
+	holdoffEvents.WithLabelValues(providerLabel(provider), eventEscalated).Inc()
+}
+
+func metricCleared(provider string) {
+	holdoffEvents.WithLabelValues(providerLabel(provider), eventCleared).Inc()
+}

--- a/protocol/holdoff/metrics_test.go
+++ b/protocol/holdoff/metrics_test.go
@@ -1,0 +1,49 @@
+package holdoff
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func eventCount(t *testing.T, provider, event string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(holdoffEvents.WithLabelValues(provider, event))
+}
+
+func TestMetrics_RecordEscalateClear(t *testing.T) {
+	r, _ := newTestRegistry(t0)
+	base := map[string]float64{
+		eventRecorded:  eventCount(t, "vendorM", eventRecorded),
+		eventEscalated: eventCount(t, "vendorM", eventEscalated),
+		eventCleared:   eventCount(t, "vendorM", eventCleared),
+	}
+
+	r.RecordRateLimit("vendorM", "a", 5*time.Minute)
+	require.Equal(t, base[eventRecorded]+1, eventCount(t, "vendorM", eventRecorded))
+	require.Equal(t, base[eventEscalated], eventCount(t, "vendorM", eventEscalated), "one URL does not escalate")
+
+	r.RecordRateLimit("vendorM", "b", 5*time.Minute)
+	require.Equal(t, base[eventEscalated]+1, eventCount(t, "vendorM", eventEscalated))
+
+	// A third strike while already escalated refreshes but does not re-count.
+	r.RecordRateLimit("vendorM", "c", 5*time.Minute)
+	require.Equal(t, base[eventEscalated]+1, eventCount(t, "vendorM", eventEscalated))
+
+	r.RecordAnswer("vendorM", "a")
+	require.Equal(t, base[eventCleared]+1, eventCount(t, "vendorM", eventCleared))
+
+	// An answer for an unknown URL of an unknown provider clears nothing.
+	r.RecordAnswer("vendorX", "never-seen")
+	require.Equal(t, float64(0), eventCount(t, "vendorX", eventCleared))
+}
+
+// URL-shaped keys must never reach a label verbatim — ws node URLs can embed API keys.
+func TestMetrics_ProviderLabelSanitizesURLs(t *testing.T) {
+	require.Equal(t, "wss://node.example.com", providerLabel("wss://node.example.com/ws/SECRET-API-KEY"))
+	require.Equal(t, "https://rpc.example.com:8545", providerLabel("https://rpc.example.com:8545/v1/KEY?token=x"))
+	require.Equal(t, "tatum", providerLabel("tatum"), "plain provider names pass through")
+	require.Equal(t, "invalid-url", providerLabel("://not-a-url"))
+}


### PR DESCRIPTION
#Closes MAG-2978

Jira ticket: MAG-2978

Follow-up to the 429/Retry-After stack: the hold-off registry decides when the router stops asking a rate-limited upstream, and until now that was visible only in debug logs — a vendor cap tripping in production had no dashboard signal.

## What changed

The registry emits its own events ([protocol/holdoff/metrics.go](protocol/holdoff/metrics.go)), so every consumer path — re-verify, hot path, recovery probe, ws subscriptions — is covered uniformly and a new consumer cannot forget to wire it:

- `smartrouter_rate_limit_holdoffs_total{provider, event}` — `recorded` (a 429 held an endpoint off), `escalated` (counted on the transition to a provider-wide hold-off, not per refresh), `cleared` (only when an answer actually dropped a standing penalty).
- `smartrouter_rate_limit_holdoff_seconds{provider}` — histogram of applied hold-offs, showing upstream Retry-After magnitudes against the exponential default.

Registration follows the repo's best-effort idiom (`error_metrics.go`): reuse on `AlreadyRegisteredError`, never panic.

**Docs:** [docs/METRICS.md](docs/METRICS.md) gains a *Rate-limit hold-off* section (closed event set, seconds-not-milliseconds buckets, label sanitization, starter PromQL), and its intro no longer claims every metric lives under `protocol/metrics/`. The public docs site gets the matching update in a separate PR in docs.

**Label safety:** the ws path keys the registry by node URL, and node URLs can embed API keys in path or query. URL-shaped keys are reduced to `scheme://host` before they become a label, so a credential never reaches a Prometheus series — pinned by test.

## How to verify

```
go build ./...
go test ./protocol/holdoff/ -count=1 -v
```

`TestMetrics_RecordEscalateClear` pins the counting semantics (escalate-on-transition, clear-only-on-real-penalty); `TestMetrics_ProviderLabelSanitizesURLs` pins the credential guard.

