### PR TITLE
feat(smart-router): fleet tracker gate — share poll observations across pods

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -123,11 +123,16 @@ They split into **endpoint-scoped** (`rpc_endpoint_*`) and **router-scoped**
 > drops to zero on a live endpoint. On a multi-replica deployment, `peer` skips climbing while
 > `requests_total{kind="latest_block"}` flattens is the feature working.
 >
-> `peer` stuck at zero has three unrelated causes, and only `rpc_endpoint_tracker_gate_errors_total`
-> tells them apart: the cache backend is unreachable or slow (`op="fetch"` climbing); no peer has
-> anything to share, which on one replica is expected since a pod never borrows its own observation
-> (errors flat at zero); or the published TTL is clamped below the freshness window, which happens on
-> chains whose block time exceeds a few minutes (also errors flat at zero, but `publish` succeeding).
+> `peer` stuck at zero has several unrelated causes, and only `rpc_endpoint_tracker_gate_errors_total`
+> tells them apart:
+>
+> | Reading | Cause |
+> |---|---|
+> | `op="fetch"` climbing intermittently | the cache backend is unreachable or slow |
+> | both ops climbing steadily at full tick rate | the cache backend predates the observation RPCs (a rolling upgrade); a one-off warning is also logged |
+> | errors flat at zero | no peer has anything to share — expected on a single replica, since a pod never borrows its own observation |
+> | errors flat at zero, `publish` succeeding | the published TTL is clamped below the freshness window, on chains whose block time exceeds a few minutes |
+>
 > Errors are advisory — every failure degrades to a local poll — so a low, steady rate costs cadence
 > and nothing else.
 >

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -56,6 +56,8 @@ name and the `disabled` sentinel live in
   - `method` — RPC method name.
   - `kind` — closed-set request classifier (`rpc_endpoint_tracker_requests_total` only):
     `latest_block` or `block_hash`. Never a raw method name — that would be unbounded.
+  - `source` — closed-set gate classifier (`rpc_endpoint_tracker_gate_skips_total` only):
+    `relay` or `peer`.
   - `function` — relay function class; the `function` label lets one metric serve both
     the per-function breakdown and (via `sum by (...)`) the aggregate.
 - **Boolean gauges** encode `1 = true / healthy / present`, `0 = false / unhealthy / absent`.
@@ -91,6 +93,7 @@ They split into **endpoint-scoped** (`rpc_endpoint_*`) and **router-scoped**
 | `rpc_endpoint_fetch_latest_success` | Counter | `spec`, `apiInterface`, `endpoint_id` | New-block **detections** by the chain tracker, not successful requests — see the note below. |
 | `rpc_endpoint_fetch_block_success` | Counter | `spec`, `apiInterface`, `endpoint_id` | Successful specific-block fetches. |
 | `rpc_endpoint_tracker_requests_total` | Counter | `spec`, `apiInterface`, `endpoint_id`, `kind` | Upstream requests the per-endpoint chain tracker actually sent, by `kind` (`latest_block`, `block_hash`). The only metric that measures tracker **request volume** — see the note below. |
+| `rpc_endpoint_tracker_gate_skips_total` | Counter | `spec`, `apiInterface`, `endpoint_id`, `source` | Poll cycles the tracker's traffic gate suppressed (no upstream request sent), by `source`: `relay` (served traffic kept the tip fresh) or `peer` (another pod's poll, borrowed through the cache backend — needs `--shared-state` + `--cache-be`). The other half of the tracker's cadence next to `rpc_endpoint_tracker_requests_total`. |
 
 > **Tracker requests vs. fetch events.** `rpc_endpoint_fetch_latest_success` counts NEW BLOCK
 > detections and `rpc_endpoint_fetch_latest_fails` counts latest-block fetch failures. Neither
@@ -106,6 +109,17 @@ They split into **endpoint-scoped** (`rpc_endpoint_*`) and **router-scoped**
 > with `--enable-fork-detection`, and the drop to zero is what makes the traffic reduction
 > provable. `/debug/endpoint-state` reports the matching `HashPolling` reason per endpoint
 > (`on`, `off-operator-choice`, or `off-spec-no-block-by-num`).
+>
+> `rpc_endpoint_tracker_gate_skips_total` is the complement: one increment per poll tick the gate
+> suppressed, labelled by what made the poll redundant. `source="relay"` is the relay traffic gate
+> (served traffic kept the endpoint's tip fresh). `source="peer"` is the fleet gate: with
+> `--shared-state` and a cache backend, every pod publishes its successful polls to the cache and
+> borrows a fresh observation from another pod instead of polling, so an endpoint is polled about
+> once per interval fleet-wide rather than once per pod. A pod never borrows its own observation,
+> and the gate's skip budget still forces a local poll every few ticks, so `requests_total` never
+> drops to zero on a live endpoint. On a multi-replica deployment, `peer` skips climbing while
+> `requests_total{kind="latest_block"}` flattens is the feature working; `peer` stuck at zero with
+> shared state on means the pods are not reaching the same cache.
 >
 > Turning fork detection off can make `rpc_endpoint_fetch_latest_success` **increase** on
 > endpoints with flaky hash fetches. With it on, a failed hash fetch aborts the poll cycle before

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -123,15 +123,30 @@ They split into **endpoint-scoped** (`rpc_endpoint_*`) and **router-scoped**
 > drops to zero on a live endpoint. On a multi-replica deployment, `peer` skips climbing while
 > `requests_total{kind="latest_block"}` flattens is the feature working.
 >
-> `peer` stuck at zero has several unrelated causes, and only `rpc_endpoint_tracker_gate_errors_total`
-> tells them apart:
+> `peer` stuck at zero has several unrelated causes. `rpc_endpoint_tracker_gate_errors_total`
+> narrows it to two groups, and the log separates the pair that share a metric shape:
 >
 > | Reading | Cause |
 > |---|---|
-> | `op="fetch"` climbing intermittently | the cache backend is unreachable or slow |
-> | both ops climbing steadily at full tick rate | the cache backend predates the observation RPCs (a rolling upgrade); a one-off warning is also logged |
+> | `op="fetch"` climbing, `publish` flat | the cache backend is **slow** — reachable, but answering the gate's read past its budget (`min(200ms, pollInterval/4)`) while still inside `publish`'s 1s timeout |
+> | **both** ops climbing steadily at full tick rate | either the backend is **unreachable** or it **predates the observation RPCs** — these two are indistinguishable by metric; see the log line below |
 > | errors flat at zero | no peer has anything to share — expected on a single replica, since a pod never borrows its own observation |
-> | errors flat at zero, `publish` succeeding | the published TTL is clamped below the freshness window, on chains whose block time exceeds a few minutes |
+> | errors flat at zero, `publish` succeeding | the published TTL is clamped below the freshness window. The TTL is `min(2 × avgBlockTime, MaxEndpointObservationTTL=5m)` and must outlive a freshness window of `avgBlockTime`, so this bites only above a **5-minute** block time |
+>
+> Both ops climbing at full tick rate is ambiguous **by design** — `op` names the operation, not the
+> outcome — so use the log to tell the two apart:
+>
+> - **unreachable**: `cache service connection error detected, triggering reconnection` with
+>   `code = Unavailable`, followed by a reconnect loop that recovers on its own.
+> - **out of date**: `fleet tracker gate: the cache backend does not implement endpoint observations`,
+>   logged **once per listen endpoint** (one adapter is built per chain+interface), and it will not
+>   clear until the backend is upgraded.
+>
+> A URL mismatch between pods presents as `peer` at zero with errors **also** at zero, exactly like a
+> healthy single replica: observations are keyed by `chain | apiInterface | sha256(url)`, so pods that
+> disagree about an endpoint's URL by even one character publish into separate keys and never see each
+> other. If peers should be sharing and are not, confirm every pod polls the byte-identical URL before
+> suspecting the cache.
 >
 > Errors are advisory — every failure degrades to a local poll — so a low, steady rate costs cadence
 > and nothing else.

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -58,6 +58,8 @@ name and the `disabled` sentinel live in
     `latest_block` or `block_hash`. Never a raw method name — that would be unbounded.
   - `source` — closed-set gate classifier (`rpc_endpoint_tracker_gate_skips_total` only):
     `relay` or `peer`.
+  - `op` — closed-set fleet-store operation (`rpc_endpoint_tracker_gate_errors_total` only):
+    `fetch` or `publish`.
   - `function` — relay function class; the `function` label lets one metric serve both
     the per-function breakdown and (via `sum by (...)`) the aggregate.
 - **Boolean gauges** encode `1 = true / healthy / present`, `0 = false / unhealthy / absent`.
@@ -93,6 +95,7 @@ They split into **endpoint-scoped** (`rpc_endpoint_*`) and **router-scoped**
 | `rpc_endpoint_fetch_latest_success` | Counter | `spec`, `apiInterface`, `endpoint_id` | New-block **detections** by the chain tracker, not successful requests — see the note below. |
 | `rpc_endpoint_fetch_block_success` | Counter | `spec`, `apiInterface`, `endpoint_id` | Successful specific-block fetches. |
 | `rpc_endpoint_tracker_requests_total` | Counter | `spec`, `apiInterface`, `endpoint_id`, `kind` | Upstream requests the per-endpoint chain tracker actually sent, by `kind` (`latest_block`, `block_hash`). The only metric that measures tracker **request volume** — see the note below. |
+| `rpc_endpoint_tracker_gate_errors_total` | Counter | `spec`, `apiInterface`, `endpoint_id`, `op` | Failed calls to the shared fleet observation store, by `op`: `fetch` (reading a peer's observation before polling — the pod polled instead) or `publish` (sharing this pod's own observation). Non-zero means the cache backend is unreachable, slow, or older than the observation RPCs. |
 | `rpc_endpoint_tracker_gate_skips_total` | Counter | `spec`, `apiInterface`, `endpoint_id`, `source` | Poll cycles the tracker's traffic gate suppressed (no upstream request sent), by `source`: `relay` (served traffic kept the tip fresh) or `peer` (another pod's poll, borrowed through the cache backend — needs `--shared-state` + `--cache-be`). The other half of the tracker's cadence next to `rpc_endpoint_tracker_requests_total`. |
 
 > **Tracker requests vs. fetch events.** `rpc_endpoint_fetch_latest_success` counts NEW BLOCK
@@ -118,8 +121,15 @@ They split into **endpoint-scoped** (`rpc_endpoint_*`) and **router-scoped**
 > once per interval fleet-wide rather than once per pod. A pod never borrows its own observation,
 > and the gate's skip budget still forces a local poll every few ticks, so `requests_total` never
 > drops to zero on a live endpoint. On a multi-replica deployment, `peer` skips climbing while
-> `requests_total{kind="latest_block"}` flattens is the feature working; `peer` stuck at zero with
-> shared state on means the pods are not reaching the same cache.
+> `requests_total{kind="latest_block"}` flattens is the feature working.
+>
+> `peer` stuck at zero has three unrelated causes, and only `rpc_endpoint_tracker_gate_errors_total`
+> tells them apart: the cache backend is unreachable or slow (`op="fetch"` climbing); no peer has
+> anything to share, which on one replica is expected since a pod never borrows its own observation
+> (errors flat at zero); or the published TTL is clamped below the freshness window, which happens on
+> chains whose block time exceeds a few minutes (also errors flat at zero, but `publish` succeeding).
+> Errors are advisory — every failure degrades to a local poll — so a low, steady rate costs cadence
+> and nothing else.
 >
 > Turning fork detection off can make `rpc_endpoint_fetch_latest_success` **increase** on
 > endpoints with flaky hash fetches. With it on, a failed hash fetch aborts the poll cycle before

--- a/ecosystem/cache/endpoint_observations.go
+++ b/ecosystem/cache/endpoint_observations.go
@@ -1,0 +1,169 @@
+package cache
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	relaytypes "github.com/magma-Devs/smart-router/types/relay"
+	"github.com/magma-Devs/smart-router/utils"
+	emptypb "google.golang.org/protobuf/types/known/emptypb"
+)
+
+const (
+	// MinEndpointObservationTTL / MaxEndpointObservationTTL clamp the TTL a router asks for on
+	// a published endpoint observation. The floor guards against a writer that computes a
+	// zero/negative TTL (which would publish nothing useful); the ceiling guards against a
+	// dead pod's observation outliving every peer's freshness window by hours.
+	MinEndpointObservationTTL = 500 * time.Millisecond
+	MaxEndpointObservationTTL = 5 * time.Minute
+	// endpointObservationSweepEvery bounds how many writes land between expiry sweeps. The
+	// store is tiny (one entry per chain × interface × endpoint across the fleet), so a full
+	// sweep every N writes keeps it bounded without a background goroutine.
+	endpointObservationSweepEvery = 256
+)
+
+// endpointObservation is one pod's published poll result for one upstream endpoint, stamped
+// with the SERVER's receipt time. Readers get an age computed against the same clock, so a
+// writer's clock never enters the freshness decision (the fleet tracker gate, MAG-2981).
+type endpointObservation struct {
+	block     int64
+	podID     string
+	storedAt  time.Time
+	expiresAt time.Time
+}
+
+// endpointObservationStore holds the fleet's per-endpoint poll observations. It is a plain
+// mutex-guarded map rather than a ristretto store on purpose: ristretto's Set is asynchronous
+// and may drop a write under admission pressure, which is acceptable for relay responses but
+// not for a value a peer is about to make a skip-the-poll decision on. The set is small and
+// every entry carries a TTL, so a map with lazy expiry is both simpler and deterministic.
+type endpointObservationStore struct {
+	mu     sync.Mutex
+	byKey  map[string]endpointObservation
+	writes int
+	now    func() time.Time // injectable for tests; time.Now in production
+}
+
+func newEndpointObservationStore() *endpointObservationStore {
+	return &endpointObservationStore{byKey: make(map[string]endpointObservation), now: time.Now}
+}
+
+func endpointObservationKey(chainID, apiInterface, endpointID string) string {
+	return chainID + "|" + apiInterface + "|" + endpointID
+}
+
+// set publishes an observation, block-monotonic while the stored one is live: a lower block
+// from a slower peer must not regress what the fleet has already seen (the same straggler
+// rule the router's own tip store applies). An equal-or-higher block replaces the entry and
+// refreshes its stamp; an expired entry is always replaced. Returns whether the write applied.
+func (s *endpointObservationStore) set(key string, block int64, podID string, ttl time.Duration) bool {
+	if block <= 0 {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+	if cur, ok := s.byKey[key]; ok && now.Before(cur.expiresAt) && block < cur.block {
+		return false
+	}
+	s.byKey[key] = endpointObservation{block: block, podID: podID, storedAt: now, expiresAt: now.Add(ttl)}
+	s.writes++
+	if s.writes >= endpointObservationSweepEvery {
+		s.writes = 0
+		for k, v := range s.byKey {
+			if !now.Before(v.expiresAt) {
+				delete(s.byKey, k)
+			}
+		}
+	}
+	return true
+}
+
+// get returns the live observation's block, publisher, and age on this clock. Found is false
+// when nothing was published or the entry expired (expired entries are dropped on read).
+func (s *endpointObservationStore) get(key string) (block int64, podID string, age time.Duration, found bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cur, ok := s.byKey[key]
+	if !ok {
+		return 0, "", 0, false
+	}
+	now := s.now()
+	if !now.Before(cur.expiresAt) {
+		delete(s.byKey, key)
+		return 0, "", 0, false
+	}
+	return cur.block, cur.podID, now.Sub(cur.storedAt), true
+}
+
+func (s *endpointObservationStore) clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.byKey = make(map[string]endpointObservation)
+	s.writes = 0
+}
+
+func (s *endpointObservationStore) len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.byKey)
+}
+
+// clampEndpointObservationTTL bounds a requested TTL to [MinEndpointObservationTTL,
+// MaxEndpointObservationTTL].
+func clampEndpointObservationTTL(requested time.Duration) time.Duration {
+	if requested < MinEndpointObservationTTL {
+		return MinEndpointObservationTTL
+	}
+	if requested > MaxEndpointObservationTTL {
+		return MaxEndpointObservationTTL
+	}
+	return requested
+}
+
+// SetEndpointObservation publishes one pod's successful poll of an endpoint (MAG-2981). The
+// request carries only an opaque endpoint digest — never the URL — and the TTL is clamped so a
+// misconfigured writer can neither publish a dead-on-arrival entry nor a near-permanent one.
+func (s *RelayerCacheServer) SetEndpointObservation(ctx context.Context, req *relaytypes.EndpointObservationSet) (*emptypb.Empty, error) {
+	if s.CacheServer == nil || s.CacheServer.endpointObservations == nil {
+		return &emptypb.Empty{}, nil
+	}
+	if req.ChainId == "" || req.EndpointId == "" {
+		return nil, utils.LavaFormatError("invalid endpoint observation set, missing chain id or endpoint id", nil,
+			utils.LogAttr("chainId", req.ChainId),
+			utils.LogAttr("apiInterface", req.ApiInterface),
+		)
+	}
+	if req.Block <= 0 {
+		return nil, utils.LavaFormatError("invalid endpoint observation set, block is not positive", nil,
+			utils.LogAttr("chainId", req.ChainId),
+			utils.LogAttr("block", req.Block),
+		)
+	}
+	ttl := clampEndpointObservationTTL(time.Duration(req.TtlMs) * time.Millisecond)
+	key := endpointObservationKey(req.ChainId, req.ApiInterface, req.EndpointId)
+	applied := s.CacheServer.endpointObservations.set(key, req.Block, req.PodId, ttl)
+	utils.LavaFormatTrace("endpoint observation set",
+		utils.LogAttr("key", key),
+		utils.LogAttr("block", req.Block),
+		utils.LogAttr("ttl", ttl),
+		utils.LogAttr("applied", applied),
+	)
+	return &emptypb.Empty{}, nil
+}
+
+// GetEndpointObservation returns the freshest live peer observation of an endpoint, with its
+// age measured on this server's clock (MAG-2981). A miss is a normal reply with Found=false,
+// not an error: the caller treats it as "poll locally".
+func (s *RelayerCacheServer) GetEndpointObservation(ctx context.Context, req *relaytypes.EndpointObservationGet) (*relaytypes.EndpointObservationReply, error) {
+	if s.CacheServer == nil || s.CacheServer.endpointObservations == nil {
+		return &relaytypes.EndpointObservationReply{}, nil
+	}
+	key := endpointObservationKey(req.ChainId, req.ApiInterface, req.EndpointId)
+	block, podID, age, found := s.CacheServer.endpointObservations.get(key)
+	if !found {
+		return &relaytypes.EndpointObservationReply{}, nil
+	}
+	return &relaytypes.EndpointObservationReply{Found: true, Block: block, AgeMs: age.Milliseconds(), PodId: podID}, nil
+}

--- a/ecosystem/cache/endpoint_observations_test.go
+++ b/ecosystem/cache/endpoint_observations_test.go
@@ -1,0 +1,165 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	relaytypes "github.com/magma-Devs/smart-router/types/relay"
+	"github.com/stretchr/testify/require"
+	emptypb "google.golang.org/protobuf/types/known/emptypb"
+)
+
+// The fleet tracker gate's server half (MAG-2981): per-endpoint poll observations with a
+// server-clock age, block-monotonic while live, TTL-bounded, and cleared by FlushCache.
+
+// newClockedStore returns a store whose clock the test advances by hand.
+func newClockedStore(start time.Time) (*endpointObservationStore, *time.Time) {
+	now := start
+	s := newEndpointObservationStore()
+	s.now = func() time.Time { return now }
+	return s, &now
+}
+
+func TestEndpointObservationStore_AgeIsOnTheStoreClock(t *testing.T) {
+	s, now := newClockedStore(time.Unix(1_000_000, 0))
+	require.True(t, s.set("k", 100, "pod-a", time.Second))
+
+	*now = now.Add(300 * time.Millisecond)
+	block, podID, age, found := s.get("k")
+	require.True(t, found)
+	require.Equal(t, int64(100), block)
+	require.Equal(t, "pod-a", podID)
+	require.Equal(t, 300*time.Millisecond, age, "age is measured between the store's own stamps")
+}
+
+func TestEndpointObservationStore_BlockMonotonicWhileLive(t *testing.T) {
+	s, now := newClockedStore(time.Unix(1_000_000, 0))
+	require.True(t, s.set("k", 100, "pod-a", time.Second))
+
+	*now = now.Add(100 * time.Millisecond)
+	require.False(t, s.set("k", 99, "pod-b", time.Second), "a lower block from a slower peer is dropped while the entry is live")
+	block, podID, age, _ := s.get("k")
+	require.Equal(t, int64(100), block)
+	require.Equal(t, "pod-a", podID, "the rejected write must not take over the entry")
+	require.Equal(t, 100*time.Millisecond, age, "a rejected write must not refresh the stamp")
+
+	require.True(t, s.set("k", 100, "pod-b", time.Second), "an equal block replaces the entry and refreshes the stamp")
+	block, podID, age, _ = s.get("k")
+	require.Equal(t, int64(100), block)
+	require.Equal(t, "pod-b", podID)
+	require.Zero(t, age)
+
+	require.True(t, s.set("k", 101, "pod-a", time.Second), "a higher block always wins")
+	block, _, _, _ = s.get("k")
+	require.Equal(t, int64(101), block)
+
+	require.False(t, s.set("k", 0, "pod-a", time.Second), "a non-positive block is never stored")
+}
+
+func TestEndpointObservationStore_ExpiryAndReorgAfterExpiry(t *testing.T) {
+	s, now := newClockedStore(time.Unix(1_000_000, 0))
+	require.True(t, s.set("k", 100, "pod-a", time.Second))
+
+	*now = now.Add(time.Second)
+	_, _, _, found := s.get("k")
+	require.False(t, found, "an entry at its TTL is expired")
+	require.Equal(t, 0, s.len(), "an expired entry is dropped on read")
+
+	require.True(t, s.set("k", 100, "pod-a", time.Second))
+	*now = now.Add(2 * time.Second)
+	require.True(t, s.set("k", 50, "pod-b", time.Second), "once expired, a lower block (reorg / fresh restart) is accepted")
+	block, _, _, found := s.get("k")
+	require.True(t, found)
+	require.Equal(t, int64(50), block)
+}
+
+func TestEndpointObservationStore_SweepDropsExpiredEntries(t *testing.T) {
+	s, now := newClockedStore(time.Unix(1_000_000, 0))
+	for i := 0; i < endpointObservationSweepEvery-1; i++ {
+		require.True(t, s.set("old-"+string(rune('a'+i%26))+string(rune('a'+i/26)), 1, "p", time.Second))
+	}
+	before := s.len()
+	*now = now.Add(2 * time.Second)
+	require.True(t, s.set("fresh", 1, "p", time.Second), "this write crosses the sweep threshold")
+	require.Equal(t, 1, s.len(), "the sweep removed every expired entry (had %d)", before)
+}
+
+func TestClampEndpointObservationTTL(t *testing.T) {
+	require.Equal(t, MinEndpointObservationTTL, clampEndpointObservationTTL(0))
+	require.Equal(t, MinEndpointObservationTTL, clampEndpointObservationTTL(-time.Second))
+	require.Equal(t, 3*time.Second, clampEndpointObservationTTL(3*time.Second))
+	require.Equal(t, MaxEndpointObservationTTL, clampEndpointObservationTTL(time.Hour))
+}
+
+func TestEndpointObservationRPCs_RoundTripKeyIsolationAndFlush(t *testing.T) {
+	cs := &CacheServer{endpointObservations: newEndpointObservationStore()}
+	srv := &RelayerCacheServer{CacheServer: cs}
+	ctx := context.Background()
+
+	_, err := srv.SetEndpointObservation(ctx, &relaytypes.EndpointObservationSet{
+		ChainId: "ETH1", ApiInterface: "jsonrpc", EndpointId: "ep1", PodId: "pod-a", Block: 500, TtlMs: 5000,
+	})
+	require.NoError(t, err)
+
+	reply, err := srv.GetEndpointObservation(ctx, &relaytypes.EndpointObservationGet{ChainId: "ETH1", ApiInterface: "jsonrpc", EndpointId: "ep1"})
+	require.NoError(t, err)
+	require.True(t, reply.GetFound())
+	require.Equal(t, int64(500), reply.GetBlock())
+	require.Equal(t, "pod-a", reply.GetPodId())
+	require.Less(t, reply.GetAgeMs(), int64(1000))
+
+	for _, get := range []*relaytypes.EndpointObservationGet{
+		{ChainId: "ETH1", ApiInterface: "jsonrpc", EndpointId: "ep2"},
+		{ChainId: "ETH1", ApiInterface: "rest", EndpointId: "ep1"},
+		{ChainId: "SEP1", ApiInterface: "jsonrpc", EndpointId: "ep1"},
+	} {
+		reply, err := srv.GetEndpointObservation(ctx, get)
+		require.NoError(t, err)
+		require.False(t, reply.GetFound(), "a miss is a normal reply, not an error: %+v", get)
+	}
+
+	_, err = srv.FlushCache(ctx, &emptypb.Empty{})
+	require.NoError(t, err)
+	reply, err = srv.GetEndpointObservation(ctx, &relaytypes.EndpointObservationGet{ChainId: "ETH1", ApiInterface: "jsonrpc", EndpointId: "ep1"})
+	require.NoError(t, err)
+	require.False(t, reply.GetFound(), "FlushCache drops the fleet observations too")
+}
+
+func TestEndpointObservationRPCs_ValidationAndNilServer(t *testing.T) {
+	cs := &CacheServer{endpointObservations: newEndpointObservationStore()}
+	srv := &RelayerCacheServer{CacheServer: cs}
+	ctx := context.Background()
+
+	_, err := srv.SetEndpointObservation(ctx, &relaytypes.EndpointObservationSet{ChainId: "", EndpointId: "ep1", Block: 1})
+	require.Error(t, err, "missing chain id")
+	_, err = srv.SetEndpointObservation(ctx, &relaytypes.EndpointObservationSet{ChainId: "ETH1", EndpointId: "", Block: 1})
+	require.Error(t, err, "missing endpoint id")
+	_, err = srv.SetEndpointObservation(ctx, &relaytypes.EndpointObservationSet{ChainId: "ETH1", EndpointId: "ep1", Block: 0})
+	require.Error(t, err, "non-positive block")
+	require.Equal(t, 0, cs.endpointObservations.len(), "rejected writes store nothing")
+
+	// A server with no store (or no CacheServer) degrades to a no-op / miss, never a panic.
+	bare := &RelayerCacheServer{}
+	_, err = bare.SetEndpointObservation(ctx, &relaytypes.EndpointObservationSet{ChainId: "ETH1", EndpointId: "ep1", Block: 1})
+	require.NoError(t, err)
+	reply, err := bare.GetEndpointObservation(ctx, &relaytypes.EndpointObservationGet{ChainId: "ETH1", EndpointId: "ep1"})
+	require.NoError(t, err)
+	require.False(t, reply.GetFound())
+}
+
+func TestEndpointObservationWireTypes_RoundTrip(t *testing.T) {
+	set := &relaytypes.EndpointObservationSet{ChainId: "ETH1", ApiInterface: "jsonrpc", EndpointId: "ep1", PodId: "pod-a", Block: 7, TtlMs: 1500}
+	b, err := set.Marshal()
+	require.NoError(t, err)
+	var setBack relaytypes.EndpointObservationSet
+	require.NoError(t, setBack.Unmarshal(b))
+	require.Equal(t, *set, setBack)
+
+	reply := &relaytypes.EndpointObservationReply{Found: true, Block: 7, AgeMs: 12, PodId: "pod-a"}
+	b, err = reply.Marshal()
+	require.NoError(t, err)
+	var replyBack relaytypes.EndpointObservationReply
+	require.NoError(t, replyBack.Unmarshal(b))
+	require.Equal(t, *reply, replyBack)
+}

--- a/ecosystem/cache/handlers.go
+++ b/ecosystem/cache/handlers.go
@@ -411,6 +411,9 @@ func (s *RelayerCacheServer) FlushCache(ctx context.Context, req *emptypb.Empty)
 		c.Clear()
 		c.Wait()
 	}
+	if s.CacheServer.endpointObservations != nil {
+		s.CacheServer.endpointObservations.clear()
+	}
 	utils.LavaFormatInfo("cache server flushed by FlushCache RPC")
 	return &emptypb.Empty{}, nil
 }

--- a/ecosystem/cache/server.go
+++ b/ecosystem/cache/server.go
@@ -62,6 +62,9 @@ type CacheServer struct {
 	finalizedCache             *ristretto.Cache[string, any]
 	tempCache                  *ristretto.Cache[string, any] // cache for temporary inputs, such as latest blocks
 	blocksHashesToHeightsCache *ristretto.Cache[string, any]
+	// endpointObservations holds the fleet's per-endpoint poll observations for the fleet
+	// tracker gate (MAG-2981). See endpoint_observations.go for why it is not a ristretto store.
+	endpointObservations *endpointObservationStore
 
 	ExpirationFinalized             time.Duration
 	ExpirationNonFinalized          time.Duration
@@ -127,6 +130,8 @@ func (cs *CacheServer) InitCache(
 	if err != nil {
 		utils.LavaFormatFatal("could not create blocks hashes to heights cache", err)
 	}
+
+	cs.endpointObservations = newEndpointObservationStore()
 
 	go cs.periodicCacheSizeUpdate(ctx)
 }

--- a/protocol/chaintracker/config.go
+++ b/protocol/chaintracker/config.go
@@ -58,9 +58,10 @@ type ChainTrackerConfig struct {
 	FlatPollInterval time.Duration
 
 	// RelayTipFresh, when set, is the traffic gate (MAG-2159 / Topic B): it reports whether a
-	// FRESH relay-harvested tip already covers this endpoint. When it returns true the dedicated
+	// FRESH observation already covers this endpoint — a relay-harvested tip, or a peer pod's
+	// poll borrowed through the cache backend (MAG-2981). When it returns true the dedicated
 	// poll skips the ENTIRE cycle — no FetchLatestBlockNum and no fork-check FetchBlockHashByNum
-	// — because served traffic is keeping the tip current. The gate lives here, ABOVE the
+	// — because something else is keeping the tip current. The gate lives here, ABOVE the
 	// generic/SVM iChainFetcherWrapper split, so it suppresses both EVM and Solana polls (the
 	// per-poller hook could only ever see the generic path). A skip touches nothing: no upstream
 	// call, no poll-health write, and no SVM cache mutation. Per-endpoint trackers set this; the
@@ -69,7 +70,8 @@ type ChainTrackerConfig struct {
 
 	// MaxRelaySkipsBeforePoll bounds consecutive gate skips: after this many skipped cycles the
 	// tracker forces one real poll for independent fork/liveness verification, so relay traffic
-	// reporting a stable-but-wrong tip cannot suppress the dedicated poll forever. 0 selects
+	// (or a peer pod) reporting a stable-but-wrong tip cannot suppress the dedicated poll
+	// forever — and every pod keeps proving its OWN path to the upstream. 0 selects
 	// DefaultMaxRelaySkipsBeforePoll. Only meaningful when RelayTipFresh is set.
 	MaxRelaySkipsBeforePoll int
 }

--- a/protocol/endpointstate/endpoint_monitor.go
+++ b/protocol/endpointstate/endpoint_monitor.go
@@ -157,6 +157,10 @@ type EndpointMonitor struct {
 	// onGateSkip, if set, is invoked once per poll cycle the traffic gate suppressed, with the
 	// source that made the poll redundant (metrics.TrackerGateSkipSource*).
 	onGateSkip func(endpointURL, source string)
+	// onGateError, if set, is invoked whenever a fleet-store call fails, with the operation
+	// (metrics.TrackerGateOp*). Without it a broken cache backend and a fleet with nothing to
+	// share look identical: both report zero peer skips.
+	onGateError func(endpointURL, op string)
 	// onTrackerRequest counts upstream tracker requests. Deliberately NOT generation-gated
 	// the way observations are: a late request from a replaced tracker still reached the
 	// node, so dropping it would under-report real load.
@@ -204,6 +208,10 @@ type EndpointChainTrackerConfig struct {
 	// OnGateSkip, if set, is invoked once per poll cycle the traffic gate suppressed, with
 	// the source ("relay" or "peer"). Backs rpc_endpoint_tracker_gate_skips_total.
 	OnGateSkip func(endpointURL, source string)
+
+	// OnGateError, if set, is invoked on every failed fleet-store call, with the operation
+	// ("fetch" or "publish"). Backs rpc_endpoint_tracker_gate_errors_total.
+	OnGateError func(endpointURL, op string)
 
 	// OnTrackerRequest, if set, is invoked once per upstream request a tracker actually sends,
 	// with the endpoint URL and the request kind (metrics.TrackerRequestKind*). It backs the
@@ -274,6 +282,7 @@ func NewEndpointMonitor(ctx context.Context, config EndpointChainTrackerConfig) 
 		onFetchError:       config.OnFetchError,
 		onTipObservation:   config.OnTipObservation,
 		onGateSkip:         config.OnGateSkip,
+		onGateError:        config.OnGateError,
 		onTrackerRequest:   config.OnTrackerRequest,
 		peerObservations:   config.PeerObservations,
 		podID:              LocalPodID(),

--- a/protocol/endpointstate/endpoint_monitor.go
+++ b/protocol/endpointstate/endpoint_monitor.go
@@ -92,6 +92,10 @@ type EndpointMonitor struct {
 	// tracker's record for the same URL. Guarded by obsMu alongside observations.
 	generations map[string]uint64
 	nextObsGen  uint64
+	// lastPublished throttles what this pod publishes to the fleet store, per endpoint. Both
+	// first-hand record paths would otherwise publish on every observation, and a busy endpoint
+	// observes far more often than the fleet needs. See shouldPublishLocked. Guarded by obsMu.
+	lastPublished map[string]time.Time
 	// stopped is set by Stop. Once set, no further observation writes are accepted, so a
 	// late in-flight poll cannot resurrect an observation after shutdown.
 	stopped bool
@@ -252,6 +256,7 @@ func NewEndpointMonitor(ctx context.Context, config EndpointChainTrackerConfig) 
 		trackerLastErrors: make(map[string]string),
 		observations:      make(map[string]EndpointObservation),
 		generations:       make(map[string]uint64),
+		lastPublished:     make(map[string]time.Time),
 		chainParser:       config.ChainParser,
 		chainID:           config.ChainID,
 		apiInterface:      config.ApiInterface,
@@ -858,6 +863,7 @@ func (m *EndpointMonitor) RemoveTracker(endpointURL string) {
 	m.obsMu.Lock()
 	delete(m.observations, endpointURL)
 	delete(m.generations, endpointURL)
+	delete(m.lastPublished, endpointURL)
 	m.obsMu.Unlock()
 
 	// Drop this endpoint's tip from the shared store too, so a removed endpoint leaves no
@@ -936,6 +942,7 @@ func (m *EndpointMonitor) Stop() {
 	}
 	m.observations = make(map[string]EndpointObservation)
 	m.generations = make(map[string]uint64)
+	m.lastPublished = make(map[string]time.Time)
 	m.obsMu.Unlock()
 
 	utils.LavaFormatInfo("stopped EndpointMonitor",

--- a/protocol/endpointstate/endpoint_monitor.go
+++ b/protocol/endpointstate/endpoint_monitor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/endpointtip"
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/protocol/metrics"
 	spectypes "github.com/magma-Devs/smart-router/types/spec"
 	"github.com/magma-Devs/smart-router/utils"
 )
@@ -134,6 +135,11 @@ type EndpointMonitor struct {
 	// fresher than either bound.
 	relayGateFreshness time.Duration
 
+	// peerObservations is the fleet half of the traffic gate (MAG-2981): nil disables it. podID
+	// is what this pod publishes under and refuses to borrow from. See peer_observations.go.
+	peerObservations PeerObservationStore
+	podID            string
+
 	// Callbacks for events (optional)
 	onFork        func(endpointURL string, blockNum int64)
 	onNewBlock    func(endpointURL string, fromBlock, toBlock int64)
@@ -144,6 +150,9 @@ type EndpointMonitor struct {
 	// per-chain ChainState tip (SetLatestBlock). Fired AFTER obsMu is released so the tip lock
 	// is never taken while holding the observation lock. Set once at construction; immutable.
 	onTipObservation func(block int64)
+	// onGateSkip, if set, is invoked once per poll cycle the traffic gate suppressed, with the
+	// source that made the poll redundant (metrics.TrackerGateSkipSource*).
+	onGateSkip func(endpointURL, source string)
 	// onTrackerRequest counts upstream tracker requests. Deliberately NOT generation-gated
 	// the way observations are: a late request from a replaced tracker still reached the
 	// node, so dropping it would under-report real load.
@@ -182,6 +191,15 @@ type EndpointChainTrackerConfig struct {
 	// OnTipObservation, if set, feeds every positive poll/relay block into the per-chain
 	// ChainState tip (MAG-2160). See EndpointMonitor.onTipObservation.
 	OnTipObservation func(block int64)
+
+	// PeerObservations, when set, enables the fleet half of the traffic gate (MAG-2981): this
+	// pod publishes its successful polls to the store and borrows fresh observations from
+	// other pods instead of polling. Leave nil on a single-replica deployment.
+	PeerObservations PeerObservationStore
+
+	// OnGateSkip, if set, is invoked once per poll cycle the traffic gate suppressed, with
+	// the source ("relay" or "peer"). Backs rpc_endpoint_tracker_gate_skips_total.
+	OnGateSkip func(endpointURL, source string)
 
 	// OnTrackerRequest, if set, is invoked once per upstream request a tracker actually sends,
 	// with the endpoint URL and the request kind (metrics.TrackerRequestKind*). It backs the
@@ -250,7 +268,10 @@ func NewEndpointMonitor(ctx context.Context, config EndpointChainTrackerConfig) 
 		onConsistency:      config.OnConsistency,
 		onFetchError:       config.OnFetchError,
 		onTipObservation:   config.OnTipObservation,
+		onGateSkip:         config.OnGateSkip,
 		onTrackerRequest:   config.OnTrackerRequest,
+		peerObservations:   config.PeerObservations,
+		podID:              LocalPodID(),
 		ctx:                ctxWithCancel,
 		cancel:             cancel,
 	}
@@ -269,6 +290,15 @@ func NewEndpointMonitor(ctx context.Context, config EndpointChainTrackerConfig) 
 		utils.LogAttr("enabled", !manager.hashPolling.HeadOnly()),
 		utils.LogAttr("reason", manager.hashPolling.String()),
 	)
+
+	if manager.peerObservations != nil {
+		utils.LavaFormatInfo("fleet tracker gate enabled: borrowing peer poll observations from the cache backend",
+			utils.LogAttr("chainID", config.ChainID),
+			utils.LogAttr("apiInterface", config.ApiInterface),
+			utils.LogAttr("podID", manager.podID),
+			utils.LogAttr("freshness", manager.relayGateFreshness),
+		)
+	}
 
 	// Log only the non-default cadence: an operator who tuned polling has to be able to
 	// confirm from the logs that the value survived validation, while the default needs no
@@ -377,12 +407,22 @@ func (m *EndpointMonitor) GetOrCreateTracker(
 		// Traffic gate (Topic B): the dedicated poll skips its ENTIRE cycle when a fresh
 		// relay-harvested tip already covers the endpoint. The gate lives on the ChainTracker
 		// (above the generic/SVM wrapper split) so it suppresses Solana polls too — the old
-		// per-poller hook could only ever see the generic path. The gate fires only on a fresh
-		// RELAY observation (freshRelayTip), so an idle endpoint with no fresh relays still
-		// polls; a bounded number of consecutive skips then forces a verifying real poll.
+		// per-poller hook could only ever see the generic path. The gate fires on a fresh
+		// RELAY observation (freshRelayTip) or, when the fleet gate is wired, on a fresh PEER
+		// observation (freshPeerTip, MAG-2981) — never on this pod's own poll, so an idle
+		// endpoint on a single pod still polls; a bounded number of consecutive skips then
+		// forces a verifying real poll. Relay is checked first: it is a local read, and a
+		// busy endpoint's relay tip is fresher than any peer poll.
 		RelayTipFresh: func(now time.Time) bool {
-			_, ok := m.freshRelayTip(endpointURL, now)
-			return ok
+			if _, ok := m.freshRelayTip(endpointURL, now); ok {
+				m.noteGateSkip(endpointURL, metrics.TrackerGateSkipSourceRelay)
+				return true
+			}
+			if _, ok := m.freshPeerTip(endpointURL, gen, now); ok {
+				m.noteGateSkip(endpointURL, metrics.TrackerGateSkipSourcePeer)
+				return true
+			}
+			return false
 		},
 	}
 

--- a/protocol/endpointstate/observation.go
+++ b/protocol/endpointstate/observation.go
@@ -86,16 +86,16 @@ type EndpointObservation struct {
 func (m *EndpointMonitor) recordPollObservation(endpointURL string, gen uint64, block int64, latency time.Duration, err error, at time.Time) {
 	// Feed the per-chain tip AFTER releasing obsMu (registered before the unlock defer, so LIFO
 	// runs it last) — SetLatestBlock takes the ChainState lock, which must never nest inside
-	// obsMu. tipBlock stays 0 unless this poll recorded a positive block. polledBlock is every
-	// successful poll's block, store-accepted or not: the fleet gate publishes "I saw this
-	// endpoint at this block just now", and the store's own monotonic rule decides if it lands.
-	var tipBlock, polledBlock int64
+	// obsMu. tipBlock stays 0 unless this poll recorded a positive block, and publishBlock unless
+	// the tip store ACCEPTED it — a block behind our own fresh tip is a straggler the fleet store
+	// would reject too, and publishing it would burn a throttle window for nothing.
+	var tipBlock, publishBlock int64
 	defer func() {
 		if tipBlock > 0 && m.onTipObservation != nil {
 			m.onTipObservation(tipBlock)
 		}
-		if polledBlock > 0 {
-			m.publishPollObservation(endpointURL, polledBlock)
+		if publishBlock > 0 {
+			m.publishLocalObservation(endpointURL, publishBlock)
 		}
 	}()
 
@@ -126,7 +126,6 @@ func (m *EndpointMonitor) recordPollObservation(endpointURL string, gen uint64, 
 		o.LastPollLatency = latency
 		o.LastPollError = ""
 		o.ConsecutivePollFailures = 0
-		polledBlock = block
 		// The block triple lives in the single-source-of-truth endpointtip store, not on
 		// this record. Set applies the block-monotonic guard (T4) and reports whether it
 		// advanced the tip — only then do we feed the per-chain consensus tip. Called under
@@ -138,6 +137,9 @@ func (m *EndpointMonitor) recordPollObservation(endpointURL string, gen uint64, 
 			Source:     endpointtip.SourcePoll,
 		}, m.tipStaleAfter) {
 			tipBlock = block // feed the per-chain tip after unlock
+			if m.shouldPublishLocked(endpointURL, at) {
+				publishBlock = block
+			}
 		}
 	} else {
 		if err != nil {
@@ -179,12 +181,15 @@ func (m *EndpointMonitor) RecordRelayObservation(endpointURL string, gen uint64,
 		return false
 	}
 
-	// Feed the per-chain tip after releasing obsMu (see recordPollObservation). tipBlock stays
-	// 0 unless the relay write is accepted (generation + monotonic guards pass).
-	var tipBlock int64
+	// Feed the per-chain tip after releasing obsMu (see recordPollObservation). Both tipBlock and
+	// publishBlock stay 0 unless the write is accepted (generation + monotonic guards pass).
+	var tipBlock, publishBlock int64
 	defer func() {
 		if tipBlock > 0 && m.onTipObservation != nil {
 			m.onTipObservation(tipBlock)
+		}
+		if publishBlock > 0 {
+			m.publishLocalObservation(endpointURL, publishBlock)
 		}
 	}()
 
@@ -218,6 +223,12 @@ func (m *EndpointMonitor) RecordRelayObservation(endpointURL string, gen uint64,
 		Source:     endpointtip.SourceRelay,
 	}, m.tipStaleAfter) {
 		tipBlock = block // feed the per-chain tip after unlock
+		// A served relay is first-hand contact with the node, so it feeds the fleet store on the
+		// same terms as a poll — otherwise the pods that know an endpoint best publish least,
+		// because the traffic that gives them that knowledge is what suppresses their poll.
+		if m.shouldPublishLocked(endpointURL, at) {
+			publishBlock = block
+		}
 		return true
 	}
 	return false

--- a/protocol/endpointstate/observation.go
+++ b/protocol/endpointstate/observation.go
@@ -21,6 +21,9 @@ const (
 	ObservationSourcePoll = endpointtip.SourcePoll
 	// ObservationSourceRelay is a block harvested from a served relay response.
 	ObservationSourceRelay = endpointtip.SourceRelay
+	// ObservationSourcePeer is a block adopted from another pod's poll through the cache backend
+	// (the fleet tracker gate, MAG-2981 — see peer_observations.go).
+	ObservationSourcePeer = endpointtip.SourcePeer
 )
 
 // EndpointObservation is the per-endpoint observation contract (Topic A / MAG-2158).
@@ -83,11 +86,16 @@ type EndpointObservation struct {
 func (m *EndpointMonitor) recordPollObservation(endpointURL string, gen uint64, block int64, latency time.Duration, err error, at time.Time) {
 	// Feed the per-chain tip AFTER releasing obsMu (registered before the unlock defer, so LIFO
 	// runs it last) — SetLatestBlock takes the ChainState lock, which must never nest inside
-	// obsMu. tipBlock stays 0 unless this poll recorded a positive block.
-	var tipBlock int64
+	// obsMu. tipBlock stays 0 unless this poll recorded a positive block. polledBlock is every
+	// successful poll's block, store-accepted or not: the fleet gate publishes "I saw this
+	// endpoint at this block just now", and the store's own monotonic rule decides if it lands.
+	var tipBlock, polledBlock int64
 	defer func() {
 		if tipBlock > 0 && m.onTipObservation != nil {
 			m.onTipObservation(tipBlock)
+		}
+		if polledBlock > 0 {
+			m.publishPollObservation(endpointURL, polledBlock)
 		}
 	}()
 
@@ -118,6 +126,7 @@ func (m *EndpointMonitor) recordPollObservation(endpointURL string, gen uint64, 
 		o.LastPollLatency = latency
 		o.LastPollError = ""
 		o.ConsecutivePollFailures = 0
+		polledBlock = block
 		// The block triple lives in the single-source-of-truth endpointtip store, not on
 		// this record. Set applies the block-monotonic guard (T4) and reports whether it
 		// advanced the tip — only then do we feed the per-chain consensus tip. Called under

--- a/protocol/endpointstate/peer_gate_test.go
+++ b/protocol/endpointstate/peer_gate_test.go
@@ -83,6 +83,16 @@ func newPeerGatedMonitor(t *testing.T, freshness time.Duration, store PeerObserv
 	return m
 }
 
+// registerHealthyGenForTest registers a generation and records one successful poll — the state a
+// live tracker is in by the time the gate runs. freshPeerTip borrows only on proven local
+// reachability, so a test that wants a borrow must say the pod is healthy first. Seed a low block
+// and an `at` older than the peer observation, so the peer's block still wins the monotonic guard.
+func (m *EndpointMonitor) registerHealthyGenForTest(url string, block int64, at time.Time) uint64 {
+	gen := m.registerGenForTest(url)
+	m.recordPollObservation(url, gen, block, time.Millisecond, nil, at)
+	return gen
+}
+
 func TestEndpointID_IsStableAndOpaque(t *testing.T) {
 	const url = "https://rpc.example/v1/SECRET-API-KEY"
 	id := EndpointID(url)
@@ -99,12 +109,15 @@ func TestFreshPeerTip_PeerObservationSuppressesAndIsAdopted(t *testing.T) {
 	freshness := 400 * time.Millisecond
 	store := &fakePeerStore{}
 	m := newPeerGatedMonitor(t, freshness, store)
-	gen := m.registerGenForTest(url)
+
+	now := time.Now()
+	gen := m.registerHealthyGenForTest(url, 1, now.Add(-time.Second))
+	before, _ := m.GetObservation(url)
+	require.False(t, before.LastSuccessfulPoll.IsZero(), "the seed poll is the pod's own reachability evidence")
 
 	var fedTip atomic.Int64
 	m.onTipObservation = func(block int64) { fedTip.Store(block) }
 
-	now := time.Now()
 	store.set(5000, "other-pod/abcd", 100*time.Millisecond)
 
 	block, ok := m.freshPeerTip(url, gen, now)
@@ -116,7 +129,8 @@ func TestFreshPeerTip_PeerObservationSuppressesAndIsAdopted(t *testing.T) {
 	require.Equal(t, int64(5000), o.LatestBlock)
 	require.Equal(t, ObservationSourcePeer, o.Source, "adopted under SourcePeer")
 	require.WithinDuration(t, now.Add(-100*time.Millisecond), o.ObservedAt, time.Millisecond, "ObservedAt is now minus the store-measured age")
-	require.True(t, o.LastSuccessfulPoll.IsZero(), "a peer observation never touches poll-health")
+	require.Equal(t, before.LastSuccessfulPoll, o.LastSuccessfulPoll, "a peer observation never touches poll-health")
+	require.Zero(t, o.ConsecutivePollFailures)
 	require.Equal(t, int64(5000), fedTip.Load(), "an adopted peer block feeds the per-chain tip")
 }
 
@@ -124,13 +138,16 @@ func TestFreshPeerTip_NeverBorrowsOwnObservation(t *testing.T) {
 	const url = "http://ep:8545"
 	store := &fakePeerStore{}
 	m := newPeerGatedMonitor(t, 400*time.Millisecond, store)
-	gen := m.registerGenForTest(url)
+	now := time.Now()
+	gen := m.registerHealthyGenForTest(url, 1, now.Add(-time.Second))
 
 	store.set(5000, m.podID, 10*time.Millisecond)
-	_, ok := m.freshPeerTip(url, gen, time.Now())
+	_, ok := m.freshPeerTip(url, gen, now)
 	require.False(t, ok, "a pod's own published poll must never suppress its next poll")
-	_, exists := m.GetObservation(url)
-	require.False(t, exists, "nothing adopted")
+	require.Equal(t, int32(1), store.fetches.Load(), "the pod is locally healthy, so it got as far as the pod-id check")
+	o, _ := m.GetObservation(url)
+	require.Equal(t, int64(1), o.LatestBlock, "nothing adopted — the tip is still the pod's own poll")
+	require.Equal(t, ObservationSourcePoll, o.Source)
 }
 
 func TestFreshPeerTip_FreshnessBoundary(t *testing.T) {
@@ -138,7 +155,7 @@ func TestFreshPeerTip_FreshnessBoundary(t *testing.T) {
 	freshness := 400 * time.Millisecond
 	store := &fakePeerStore{}
 	m := newPeerGatedMonitor(t, freshness, store)
-	gen := m.registerGenForTest(url)
+	gen := m.registerHealthyGenForTest(url, 1, time.Now().Add(-time.Second))
 
 	store.set(5000, "other-pod/abcd", freshness)
 	_, ok := m.freshPeerTip(url, gen, time.Now())
@@ -156,7 +173,7 @@ func TestFreshPeerTip_MissErrorOrUnwiredMeansPoll(t *testing.T) {
 	t.Run("miss", func(t *testing.T) {
 		store := &fakePeerStore{}
 		m := newPeerGatedMonitor(t, 400*time.Millisecond, store)
-		gen := m.registerGenForTest(url)
+		gen := m.registerHealthyGenForTest(url, 1, now.Add(-time.Second))
 		_, ok := m.freshPeerTip(url, gen, now)
 		require.False(t, ok)
 		require.Equal(t, int32(1), store.fetches.Load())
@@ -165,28 +182,111 @@ func TestFreshPeerTip_MissErrorOrUnwiredMeansPoll(t *testing.T) {
 	t.Run("fetch error", func(t *testing.T) {
 		store := &fakePeerStore{fetchErr: errors.New("cache unavailable")}
 		m := newPeerGatedMonitor(t, 400*time.Millisecond, store)
-		gen := m.registerGenForTest(url)
+		gen := m.registerHealthyGenForTest(url, 1, now.Add(-time.Second))
 		_, ok := m.freshPeerTip(url, gen, now)
 		require.False(t, ok, "a store error must degrade to a local poll, never a skip")
+		require.Equal(t, int32(1), store.fetches.Load())
 	})
 
 	t.Run("no store wired", func(t *testing.T) {
 		m := newPeerGatedMonitor(t, 400*time.Millisecond, nil)
-		gen := m.registerGenForTest(url)
+		gen := m.registerHealthyGenForTest(url, 1, now.Add(-time.Second))
 		_, ok := m.freshPeerTip(url, gen, now)
 		require.False(t, ok)
+	})
+
+	t.Run("local polls failing", func(t *testing.T) {
+		store := &fakePeerStore{}
+		m := newPeerGatedMonitor(t, 400*time.Millisecond, store)
+		gen := m.registerHealthyGenForTest(url, 1, now.Add(-time.Second))
+		store.set(5000, "other-pod/abcd", 10*time.Millisecond)
+		m.recordPollObservation(url, gen, 0, 0, errors.New("connection refused"), now.Add(-500*time.Millisecond))
+		_, ok := m.freshPeerTip(url, gen, now)
+		require.False(t, ok, "a pod that cannot reach the endpoint must not borrow evidence that it can")
+		require.Equal(t, int32(0), store.fetches.Load(), "the health guard runs BEFORE the cache round-trip")
+	})
+
+	t.Run("never polled", func(t *testing.T) {
+		store := &fakePeerStore{}
+		m := newPeerGatedMonitor(t, 400*time.Millisecond, store)
+		gen := m.registerGenForTest(url) // generation only: no observation record at all
+		store.set(5000, "other-pod/abcd", 10*time.Millisecond)
+		_, ok := m.freshPeerTip(url, gen, now)
+		require.False(t, ok, "no local evidence yet → no borrow")
+		require.Equal(t, int32(0), store.fetches.Load())
 	})
 
 	t.Run("stale generation is not adopted", func(t *testing.T) {
 		store := &fakePeerStore{}
 		m := newPeerGatedMonitor(t, 400*time.Millisecond, store)
-		gen := m.registerGenForTest(url)
+		gen := m.registerHealthyGenForTest(url, 1, now.Add(-time.Second))
 		store.set(5000, "other-pod/abcd", 10*time.Millisecond)
 		_, ok := m.freshPeerTip(url, gen+1, now)
 		require.True(t, ok, "the cycle is still redundant")
-		_, exists := m.GetObservation(url)
-		require.False(t, exists, "a replaced tracker's generation writes nothing")
+		o, _ := m.GetObservation(url)
+		require.Equal(t, int64(1), o.LatestBlock, "a replaced tracker's generation writes nothing")
+		require.Equal(t, ObservationSourcePoll, o.Source)
 	})
+}
+
+// The gate's precondition as a cycle: a healthy pod borrows, one failed local poll withdraws the
+// borrow (without spending a cache round-trip), and the next successful poll restores it — so a
+// transient failure costs one extra poll, not a sustained cadence change.
+func TestFreshPeerTip_LocalFailureWithdrawsAndRestoresTheBorrow(t *testing.T) {
+	const url = "http://ep:8545"
+	store := &fakePeerStore{}
+	m := newPeerGatedMonitor(t, 400*time.Millisecond, store)
+	now := time.Now()
+	gen := m.registerHealthyGenForTest(url, 1, now.Add(-time.Second))
+	store.set(5000, "other-pod/abcd", 10*time.Millisecond)
+
+	_, ok := m.freshPeerTip(url, gen, now)
+	require.True(t, ok, "a healthy pod borrows")
+	require.Equal(t, int32(1), store.fetches.Load())
+
+	m.recordPollObservation(url, gen, 0, 0, errors.New("dial tcp: connect: connection refused"), now.Add(time.Millisecond))
+	_, ok = m.freshPeerTip(url, gen, now.Add(2*time.Millisecond))
+	require.False(t, ok, "one failed local poll withdraws the borrow")
+	require.Equal(t, int32(1), store.fetches.Load(), "and skips the cache round-trip entirely")
+
+	m.recordPollObservation(url, gen, 6000, time.Millisecond, nil, now.Add(3*time.Millisecond))
+	_, ok = m.freshPeerTip(url, gen, now.Add(4*time.Millisecond))
+	require.True(t, ok, "a successful local poll restores the borrow")
+	require.Equal(t, int32(2), store.fetches.Load())
+}
+
+// The F1 regression: probing.Verdict computes `alive` from LatestBlock + ObservedAt, and a failed
+// poll moves neither. So while this pod cannot reach the endpoint nothing may refresh ObservedAt,
+// or the staleness window never expires and the endpoint reads ALIVE forever on borrowed evidence.
+func TestFreshPeerTip_FailingPodStopsRefreshingObservedAt(t *testing.T) {
+	const url = "http://ep:8545"
+	store := &fakePeerStore{}
+	m := newPeerGatedMonitor(t, 400*time.Millisecond, store)
+	now := time.Now()
+	gen := m.registerHealthyGenForTest(url, 1, now.Add(-time.Second))
+
+	// Healthy pod, fresh peer note: the borrow is adopted and stamps the endpoint's tip.
+	store.set(5000, "other-pod/abcd", 10*time.Millisecond)
+	_, ok := m.freshPeerTip(url, gen, now)
+	require.True(t, ok)
+	adopted, _ := m.GetObservation(url)
+	require.Equal(t, int64(5000), adopted.LatestBlock)
+
+	// The pod's path breaks: its own polls fail while peers keep publishing newer observations.
+	for i := 1; i <= 5; i++ {
+		at := now.Add(time.Duration(i) * 10 * time.Millisecond)
+		m.recordPollObservation(url, gen, 0, 0, errors.New("connection refused"), at)
+		store.set(5000+int64(i), "other-pod/abcd", 10*time.Millisecond)
+		_, ok := m.freshPeerTip(url, gen, at.Add(time.Millisecond))
+		require.False(t, ok, "tick %d: a pod that cannot reach the endpoint must not borrow", i)
+	}
+
+	o, _ := m.GetObservation(url)
+	require.True(t, adopted.ObservedAt.Equal(o.ObservedAt),
+		"ObservedAt must be frozen at the last observation made while the pod was healthy: was %s, now %s", adopted.ObservedAt, o.ObservedAt)
+	require.Equal(t, int64(5000), o.LatestBlock, "no peer block is adopted while local polls fail")
+	require.Equal(t, 5, o.ConsecutivePollFailures)
+	require.Equal(t, int32(1), store.fetches.Load(), "only the one healthy tick reached the cache")
 }
 
 func TestRecordPollObservation_PublishesSuccessOnly(t *testing.T) {

--- a/protocol/endpointstate/peer_gate_test.go
+++ b/protocol/endpointstate/peer_gate_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/magma-Devs/smart-router/protocol/endpointtip"
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/protocol/metrics"
 	spectypes "github.com/magma-Devs/smart-router/types/spec"
 	"github.com/stretchr/testify/require"
 )
@@ -24,14 +25,15 @@ import (
 // fakePeerStore is an in-memory PeerObservationStore with one live observation and a
 // counter per method, so tests can assert what the monitor asked of it.
 type fakePeerStore struct {
-	mu        sync.Mutex
-	block     int64
-	podID     string
-	age       time.Duration
-	found     bool
-	fetchErr  error
-	fetches   atomic.Int32
-	publishes atomic.Int32
+	mu         sync.Mutex
+	block      int64
+	podID      string
+	age        time.Duration
+	found      bool
+	fetchErr   error
+	publishErr error
+	fetches    atomic.Int32
+	publishes  atomic.Int32
 
 	lastPublish struct {
 		chainID, apiInterface, endpointID, podID string
@@ -46,7 +48,7 @@ func (f *fakePeerStore) Publish(ctx context.Context, chainID, apiInterface, endp
 	f.publishes.Add(1)
 	f.lastPublish.chainID, f.lastPublish.apiInterface, f.lastPublish.endpointID, f.lastPublish.podID = chainID, apiInterface, endpointID, podID
 	f.lastPublish.block, f.lastPublish.ttl = block, ttl
-	return nil
+	return f.publishErr
 }
 
 func (f *fakePeerStore) Fetch(ctx context.Context, chainID, apiInterface, endpointID string) (int64, string, time.Duration, bool, error) {
@@ -302,6 +304,66 @@ func TestShouldPublish_ThrottledAcrossBothLocalPaths(t *testing.T) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	require.Equal(t, int64(7100), store.lastPublish.block)
+}
+
+// The cache read sits on the poll goroutine and the next tick is scheduled only after the cycle
+// returns, so its timeout is ADDED to the poll interval. Bounding it at a quarter of the interval
+// keeps a slow-but-reachable cache backend from costing more than the upstream request the gate
+// exists to avoid — on a 200ms-interval chain the flat 200ms ceiling would double the cycle time.
+func TestPeerFetchBudget_NeverExceedsAQuarterOfTheInterval(t *testing.T) {
+	// Ethereum-ish: 12s blocks → 6s interval. The flat ceiling is already far below a quarter.
+	eth := newPeerGatedMonitor(t, 12*time.Second, &fakePeerStore{})
+	require.Equal(t, 6*time.Second, eth.flatPollInterval)
+	require.Equal(t, peerFetchTimeout, eth.peerFetchBudget(), "a slow chain keeps the flat ceiling")
+
+	// Solana-ish: 400ms blocks → 200ms interval, where the flat ceiling IS the whole interval.
+	svm := newPeerGatedMonitor(t, 400*time.Millisecond, &fakePeerStore{})
+	require.Equal(t, 200*time.Millisecond, svm.flatPollInterval)
+	require.Equal(t, 50*time.Millisecond, svm.peerFetchBudget(), "a fast chain scales the budget down")
+	require.Less(t, svm.peerFetchBudget(), svm.flatPollInterval/2, "the gate can never dominate its own cycle")
+
+	// A monitor with no flat cadence (not a per-endpoint tracker) falls back to the ceiling.
+	bare := &EndpointMonitor{}
+	require.Equal(t, peerFetchTimeout, bare.peerFetchBudget())
+}
+
+// A failing fleet store is reported, per operation. Without this a broken cache backend and a fleet
+// with nothing to share look the same from outside: both leave peer skips at zero.
+func TestGateErrors_FetchAndPublishAreReported(t *testing.T) {
+	const url = "http://ep:8545"
+	var mu sync.Mutex
+	errs := map[string]int{}
+	store := &fakePeerStore{fetchErr: errors.New("cache unavailable"), publishErr: errors.New("cache unavailable")}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	m := NewEndpointMonitor(ctx, EndpointChainTrackerConfig{
+		ChainID:          "ETH1",
+		ApiInterface:     spectypes.APIInterfaceJsonRPC,
+		AverageBlockTime: 400 * time.Millisecond,
+		BlocksToSave:     1,
+		PeerObservations: store,
+		OnGateError: func(_ string, op string) {
+			mu.Lock()
+			defer mu.Unlock()
+			errs[op]++
+		},
+	})
+	t.Cleanup(m.Stop)
+
+	now := time.Now()
+	gen := m.registerHealthyGenForTest(url, 1, now.Add(-time.Second))
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return errs[metrics.TrackerGateOpPublish] == 1
+	}, time.Second, 5*time.Millisecond, "a failed publish is reported")
+
+	_, ok := m.freshPeerTip(url, gen, now)
+	require.False(t, ok, "a fetch error still degrades to a local poll")
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, 1, errs[metrics.TrackerGateOpFetch], "a failed fetch is reported")
 }
 
 // The gate's precondition as a cycle: a healthy pod borrows, one failed local poll withdraws the

--- a/protocol/endpointstate/peer_gate_test.go
+++ b/protocol/endpointstate/peer_gate_test.go
@@ -1,0 +1,360 @@
+package endpointstate
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/endpointtip"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// The fleet tracker gate (MAG-2981): a fresh poll observation published by ANOTHER pod
+// suppresses this pod's dedicated poll, the peer block is adopted under SourcePeer, and
+// every successful local poll is published. These tests pin the predicate's invariants
+// (self-exclusion, freshness, miss/error → poll), the publish contract, and the end-to-end
+// suppression through a real SOLANA tracker — the path the relay gate also proves.
+
+// fakePeerStore is an in-memory PeerObservationStore with one live observation and a
+// counter per method, so tests can assert what the monitor asked of it.
+type fakePeerStore struct {
+	mu        sync.Mutex
+	block     int64
+	podID     string
+	age       time.Duration
+	found     bool
+	fetchErr  error
+	fetches   atomic.Int32
+	publishes atomic.Int32
+
+	lastPublish struct {
+		chainID, apiInterface, endpointID, podID string
+		block                                    int64
+		ttl                                      time.Duration
+	}
+}
+
+func (f *fakePeerStore) Publish(ctx context.Context, chainID, apiInterface, endpointID, podID string, block int64, ttl time.Duration) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.publishes.Add(1)
+	f.lastPublish.chainID, f.lastPublish.apiInterface, f.lastPublish.endpointID, f.lastPublish.podID = chainID, apiInterface, endpointID, podID
+	f.lastPublish.block, f.lastPublish.ttl = block, ttl
+	return nil
+}
+
+func (f *fakePeerStore) Fetch(ctx context.Context, chainID, apiInterface, endpointID string) (int64, string, time.Duration, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.fetches.Add(1)
+	if f.fetchErr != nil {
+		return 0, "", 0, false, f.fetchErr
+	}
+	return f.block, f.podID, f.age, f.found, nil
+}
+
+func (f *fakePeerStore) set(block int64, podID string, age time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.block, f.podID, f.age, f.found = block, podID, age, true
+}
+
+// newPeerGatedMonitor builds a monitor with the fake store wired and a deterministic
+// freshness window (relayGateFreshness = avgBlockTime, shared by both gate halves).
+func newPeerGatedMonitor(t *testing.T, freshness time.Duration, store PeerObservationStore) *EndpointMonitor {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	m := NewEndpointMonitor(ctx, EndpointChainTrackerConfig{
+		ChainID:          "ETH1",
+		ApiInterface:     spectypes.APIInterfaceJsonRPC,
+		AverageBlockTime: freshness,
+		BlocksToSave:     1,
+		PeerObservations: store,
+	})
+	require.NotNil(t, m)
+	t.Cleanup(m.Stop)
+	return m
+}
+
+func TestEndpointID_IsStableAndOpaque(t *testing.T) {
+	const url = "https://rpc.example/v1/SECRET-API-KEY"
+	id := EndpointID(url)
+	require.Equal(t, id, EndpointID(url), "the same URL must digest identically on every pod")
+	require.NotEqual(t, id, EndpointID(url+"x"))
+	require.Len(t, id, 32, "16-byte digest, hex")
+	require.False(t, strings.Contains(id, "SECRET"), "the digest must not leak the URL")
+	require.NotEmpty(t, LocalPodID())
+	require.Equal(t, LocalPodID(), LocalPodID(), "pod id is stable for the process lifetime")
+}
+
+func TestFreshPeerTip_PeerObservationSuppressesAndIsAdopted(t *testing.T) {
+	const url = "http://ep:8545"
+	freshness := 400 * time.Millisecond
+	store := &fakePeerStore{}
+	m := newPeerGatedMonitor(t, freshness, store)
+	gen := m.registerGenForTest(url)
+
+	var fedTip atomic.Int64
+	m.onTipObservation = func(block int64) { fedTip.Store(block) }
+
+	now := time.Now()
+	store.set(5000, "other-pod/abcd", 100*time.Millisecond)
+
+	block, ok := m.freshPeerTip(url, gen, now)
+	require.True(t, ok, "a fresh observation from another pod suppresses the poll")
+	require.Equal(t, int64(5000), block)
+
+	o, exists := m.GetObservation(url)
+	require.True(t, exists)
+	require.Equal(t, int64(5000), o.LatestBlock)
+	require.Equal(t, ObservationSourcePeer, o.Source, "adopted under SourcePeer")
+	require.WithinDuration(t, now.Add(-100*time.Millisecond), o.ObservedAt, time.Millisecond, "ObservedAt is now minus the store-measured age")
+	require.True(t, o.LastSuccessfulPoll.IsZero(), "a peer observation never touches poll-health")
+	require.Equal(t, int64(5000), fedTip.Load(), "an adopted peer block feeds the per-chain tip")
+}
+
+func TestFreshPeerTip_NeverBorrowsOwnObservation(t *testing.T) {
+	const url = "http://ep:8545"
+	store := &fakePeerStore{}
+	m := newPeerGatedMonitor(t, 400*time.Millisecond, store)
+	gen := m.registerGenForTest(url)
+
+	store.set(5000, m.podID, 10*time.Millisecond)
+	_, ok := m.freshPeerTip(url, gen, time.Now())
+	require.False(t, ok, "a pod's own published poll must never suppress its next poll")
+	_, exists := m.GetObservation(url)
+	require.False(t, exists, "nothing adopted")
+}
+
+func TestFreshPeerTip_FreshnessBoundary(t *testing.T) {
+	const url = "http://ep:8545"
+	freshness := 400 * time.Millisecond
+	store := &fakePeerStore{}
+	m := newPeerGatedMonitor(t, freshness, store)
+	gen := m.registerGenForTest(url)
+
+	store.set(5000, "other-pod/abcd", freshness)
+	_, ok := m.freshPeerTip(url, gen, time.Now())
+	require.True(t, ok, "an observation exactly at the window still suppresses")
+
+	store.set(5001, "other-pod/abcd", freshness+time.Millisecond)
+	_, ok = m.freshPeerTip(url, gen, time.Now())
+	require.False(t, ok, "an observation past the window falls through to a real poll")
+}
+
+func TestFreshPeerTip_MissErrorOrUnwiredMeansPoll(t *testing.T) {
+	const url = "http://ep:8545"
+	now := time.Now()
+
+	t.Run("miss", func(t *testing.T) {
+		store := &fakePeerStore{}
+		m := newPeerGatedMonitor(t, 400*time.Millisecond, store)
+		gen := m.registerGenForTest(url)
+		_, ok := m.freshPeerTip(url, gen, now)
+		require.False(t, ok)
+		require.Equal(t, int32(1), store.fetches.Load())
+	})
+
+	t.Run("fetch error", func(t *testing.T) {
+		store := &fakePeerStore{fetchErr: errors.New("cache unavailable")}
+		m := newPeerGatedMonitor(t, 400*time.Millisecond, store)
+		gen := m.registerGenForTest(url)
+		_, ok := m.freshPeerTip(url, gen, now)
+		require.False(t, ok, "a store error must degrade to a local poll, never a skip")
+	})
+
+	t.Run("no store wired", func(t *testing.T) {
+		m := newPeerGatedMonitor(t, 400*time.Millisecond, nil)
+		gen := m.registerGenForTest(url)
+		_, ok := m.freshPeerTip(url, gen, now)
+		require.False(t, ok)
+	})
+
+	t.Run("stale generation is not adopted", func(t *testing.T) {
+		store := &fakePeerStore{}
+		m := newPeerGatedMonitor(t, 400*time.Millisecond, store)
+		gen := m.registerGenForTest(url)
+		store.set(5000, "other-pod/abcd", 10*time.Millisecond)
+		_, ok := m.freshPeerTip(url, gen+1, now)
+		require.True(t, ok, "the cycle is still redundant")
+		_, exists := m.GetObservation(url)
+		require.False(t, exists, "a replaced tracker's generation writes nothing")
+	})
+}
+
+func TestRecordPollObservation_PublishesSuccessOnly(t *testing.T) {
+	const url = "http://ep:8545"
+	freshness := 400 * time.Millisecond
+	store := &fakePeerStore{}
+	m := newPeerGatedMonitor(t, freshness, store)
+	gen := m.registerGenForTest(url)
+
+	m.recordPollObservation(url, gen, 0, 0, errors.New("boom"), time.Now())
+	time.Sleep(20 * time.Millisecond)
+	require.Equal(t, int32(0), store.publishes.Load(), "a failed poll publishes nothing")
+
+	m.recordPollObservation(url, gen, 7000, 3*time.Millisecond, nil, time.Now())
+	require.Eventually(t, func() bool { return store.publishes.Load() == 1 }, time.Second, 5*time.Millisecond)
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	require.Equal(t, "ETH1", store.lastPublish.chainID)
+	require.Equal(t, spectypes.APIInterfaceJsonRPC, store.lastPublish.apiInterface)
+	require.Equal(t, EndpointID(url), store.lastPublish.endpointID, "published under the digest, never the URL")
+	require.Equal(t, m.podID, store.lastPublish.podID)
+	require.Equal(t, int64(7000), store.lastPublish.block)
+	require.Equal(t, freshness*peerObservationTTLMultiplier, store.lastPublish.ttl)
+}
+
+// TestRecordPollObservation_PublishesEvenWhenLocalStoreRejects: a poll that returns a block
+// lower than a fresh peer-fed tip is a straggler for the LOCAL store but still a genuine
+// "I saw this endpoint just now" for the fleet; the fleet store applies its own rule.
+func TestRecordPollObservation_PublishesEvenWhenLocalStoreRejects(t *testing.T) {
+	const url = "http://ep:8545"
+	store := &fakePeerStore{}
+	m := newPeerGatedMonitor(t, 400*time.Millisecond, store)
+	gen := m.registerGenForTest(url)
+	now := time.Now()
+
+	require.True(t, m.recordPeerObservation(url, gen, 9000, now))
+	m.recordPollObservation(url, gen, 8990, time.Millisecond, nil, now.Add(time.Millisecond))
+
+	o, _ := m.GetObservation(url)
+	require.Equal(t, int64(9000), o.LatestBlock, "the local tip keeps the fresher, higher peer block")
+	require.Eventually(t, func() bool { return store.publishes.Load() == 1 }, time.Second, 5*time.Millisecond)
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	require.Equal(t, int64(8990), store.lastPublish.block)
+}
+
+// TestGate_RelayBeforePeer: a fresh relay tip answers the gate without touching the store,
+// and the skip source reported to OnGateSkip names the half that fired.
+func TestGate_RelayBeforePeer(t *testing.T) {
+	ensureRandSeeded()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const url = "https://solana-ep:443/"
+	store := &fakePeerStore{}
+	var skipsMu sync.Mutex
+	skips := map[string]int{}
+	m := NewEndpointMonitor(ctx, EndpointChainTrackerConfig{
+		ChainParser:      newRealChainParser(t, "SOLANA", spectypes.APIInterfaceJsonRPC),
+		ChainID:          "SOLANA",
+		ApiInterface:     spectypes.APIInterfaceJsonRPC,
+		AverageBlockTime: 100 * time.Millisecond,
+		BlocksToSave:     1,
+		PeerObservations: store,
+		OnGateSkip: func(_ string, source string) {
+			skipsMu.Lock()
+			defer skipsMu.Unlock()
+			skips[source]++
+		},
+	})
+	t.Cleanup(m.Stop)
+
+	conn := &countingDirectRPCConnection{
+		mockDirectRPCConnection: mockDirectRPCConnection{
+			url: url,
+			responses: map[string][]byte{
+				svmLatestBlockRequest: []byte(`{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":250000000},"value":{"blockhash":"solhash"}}}`),
+			},
+		},
+		matchSubstr: "getLatestBlockhash",
+	}
+	_, err := m.GetOrCreateTracker(&lavasession.Endpoint{NetworkAddress: url, Enabled: true}, conn)
+	require.NoError(t, err)
+	gen, ok := m.ObservationGeneration(url)
+	require.True(t, ok)
+
+	stop := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(25 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				m.RecordRelayObservation(url, gen, 250000000, time.Now())
+			}
+		}
+	}()
+	time.Sleep(600 * time.Millisecond)
+	close(stop)
+	time.Sleep(20 * time.Millisecond)
+
+	require.Equal(t, int32(0), store.fetches.Load(), "a fresh relay tip never consults the fleet store")
+	skipsMu.Lock()
+	defer skipsMu.Unlock()
+	require.Greater(t, skips["relay"], 0, "relay skips are reported")
+	require.Equal(t, 0, skips["peer"])
+}
+
+// TestEndpointMonitor_PeerGate_SuppressesUpstreamPoll is the end-to-end proof on the same
+// SOLANA path the relay gate uses: with a continuously fresh observation from ANOTHER pod in
+// the store and no relay traffic at all, a real tracker built by GetOrCreateTracker must skip
+// most of its getLatestBlockhash polls, still publish the polls it does make, and adopt the
+// peer block under SourcePeer. Without the gate wired it would poll on every tick (>=10).
+func TestEndpointMonitor_PeerGate_SuppressesUpstreamPoll(t *testing.T) {
+	ensureRandSeeded()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const url = "https://solana-ep:443/"
+	store := &fakePeerStore{}
+	store.set(250000005, "other-pod/abcd", 10*time.Millisecond) // always fresh vs the 100ms window
+
+	conn := &countingDirectRPCConnection{
+		mockDirectRPCConnection: mockDirectRPCConnection{
+			url: url,
+			responses: map[string][]byte{
+				svmLatestBlockRequest: []byte(`{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":250000000},"value":{"blockhash":"solhash"}}}`),
+			},
+		},
+		matchSubstr: "getLatestBlockhash",
+	}
+
+	var peerSkips atomic.Int32
+	// avgBlockTime 100ms => flat poll 50ms, gate freshness window 100ms.
+	m := NewEndpointMonitor(ctx, EndpointChainTrackerConfig{
+		ChainParser:      newRealChainParser(t, "SOLANA", spectypes.APIInterfaceJsonRPC),
+		ChainID:          "SOLANA",
+		ApiInterface:     spectypes.APIInterfaceJsonRPC,
+		AverageBlockTime: 100 * time.Millisecond,
+		BlocksToSave:     1,
+		PeerObservations: store,
+		OnGateSkip: func(_ string, source string) {
+			if source == "peer" {
+				peerSkips.Add(1)
+			}
+		},
+	})
+	t.Cleanup(m.Stop)
+
+	_, err := m.GetOrCreateTracker(&lavasession.Endpoint{NetworkAddress: url, Enabled: true}, conn)
+	require.NoError(t, err)
+
+	// ~600ms / 50ms ≈ 12 ticks. The gate forces ~1 real poll per 5 ticks plus init polls.
+	time.Sleep(600 * time.Millisecond)
+
+	polls := conn.matchedSends.Load()
+	require.LessOrEqual(t, polls, int32(6),
+		"a peer-gated SOLANA tracker must suppress most getLatestBlockhash polls; got %d", polls)
+	require.GreaterOrEqual(t, polls, int32(1),
+		"the skip budget must still force a local poll; got %d", polls)
+	require.Greater(t, peerSkips.Load(), int32(0), "peer skips are reported to OnGateSkip")
+	require.GreaterOrEqual(t, store.publishes.Load(), int32(1), "every successful local poll is published")
+
+	o, ok := m.GetObservation(url)
+	require.True(t, ok)
+	require.Equal(t, int64(250000005), o.LatestBlock, "the higher peer block is the endpoint's tip")
+	require.Equal(t, endpointtip.SourcePeer, o.Source)
+}

--- a/protocol/endpointstate/peer_gate_test.go
+++ b/protocol/endpointstate/peer_gate_test.go
@@ -229,6 +229,81 @@ func TestFreshPeerTip_MissErrorOrUnwiredMeansPoll(t *testing.T) {
 	})
 }
 
+// A served relay is first-hand contact with the node, so it publishes on the same terms as a poll.
+// Without this the pods that know an endpoint best publish least: relay traffic is exactly what
+// suppresses the poll that would have published.
+func TestRecordRelayObservation_PublishesLikeAPoll(t *testing.T) {
+	const url = "http://ep:8545"
+	freshness := 400 * time.Millisecond
+	store := &fakePeerStore{}
+	m := newPeerGatedMonitor(t, freshness, store)
+	gen := m.registerGenForTest(url)
+
+	require.True(t, m.RecordRelayObservation(url, gen, 7000, time.Now()))
+	require.Eventually(t, func() bool { return store.publishes.Load() == 1 }, time.Second, 5*time.Millisecond)
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	require.Equal(t, EndpointID(url), store.lastPublish.endpointID, "published under the digest, never the URL")
+	require.Equal(t, m.podID, store.lastPublish.podID)
+	require.Equal(t, int64(7000), store.lastPublish.block)
+	require.Equal(t, freshness*peerObservationTTLMultiplier, store.lastPublish.ttl)
+}
+
+// The invariant that keeps a note from circulating without anyone contacting the node: a borrowed
+// value is second-hand, so it must never be republished. Were it, each pod's republish would look
+// like someone else's work to every other pod and refresh the fleet note's stamp, so a stale block
+// would read as permanently fresh across the whole fleet.
+func TestRecordPeerObservation_NeverPublishes(t *testing.T) {
+	const url = "http://ep:8545"
+	store := &fakePeerStore{}
+	m := newPeerGatedMonitor(t, 400*time.Millisecond, store)
+	now := time.Now()
+	gen := m.registerHealthyGenForTest(url, 1, now.Add(-time.Second))
+	require.Eventually(t, func() bool { return store.publishes.Load() == 1 }, time.Second, 5*time.Millisecond)
+
+	store.set(5000, "other-pod/abcd", 10*time.Millisecond)
+	_, ok := m.freshPeerTip(url, gen, now)
+	require.True(t, ok, "the borrow happened")
+	o, _ := m.GetObservation(url)
+	require.Equal(t, ObservationSourcePeer, o.Source)
+
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(1), store.publishes.Load(), "adopting a peer value must publish nothing")
+}
+
+// Both first-hand paths share ONE per-endpoint throttle, so a busy endpoint cannot publish once per
+// served relay. The window is half the freshness horizon, which keeps the note continuously
+// borrowable with margin.
+func TestShouldPublish_ThrottledAcrossBothLocalPaths(t *testing.T) {
+	const url = "http://ep:8545"
+	freshness := 400 * time.Millisecond
+	store := &fakePeerStore{}
+	m := newPeerGatedMonitor(t, freshness, store)
+	gen := m.registerGenForTest(url)
+	now := time.Now()
+
+	m.recordPollObservation(url, gen, 7000, time.Millisecond, nil, now)
+	require.Eventually(t, func() bool { return store.publishes.Load() == 1 }, time.Second, 5*time.Millisecond)
+
+	// A relay 1ms later is throttled by the poll's publish — the throttle is per endpoint, not
+	// per path.
+	m.RecordRelayObservation(url, gen, 7001, now.Add(time.Millisecond))
+	// ...and so is a burst of further relays inside the window.
+	for i := 2; i < 20; i++ {
+		m.RecordRelayObservation(url, gen, 7000+int64(i), now.Add(time.Duration(i)*time.Millisecond))
+	}
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(1), store.publishes.Load(), "everything inside freshness/2 shares one publish")
+
+	// Past the window, the next first-hand observation publishes again — from either path.
+	m.RecordRelayObservation(url, gen, 7100, now.Add(freshness/2))
+	require.Eventually(t, func() bool { return store.publishes.Load() == 2 }, time.Second, 5*time.Millisecond)
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	require.Equal(t, int64(7100), store.lastPublish.block)
+}
+
 // The gate's precondition as a cycle: a healthy pod borrows, one failed local poll withdraws the
 // borrow (without spending a cache round-trip), and the next successful poll restores it — so a
 // transient failure costs one extra poll, not a sustained cadence change.
@@ -313,10 +388,14 @@ func TestRecordPollObservation_PublishesSuccessOnly(t *testing.T) {
 	require.Equal(t, freshness*peerObservationTTLMultiplier, store.lastPublish.ttl)
 }
 
-// TestRecordPollObservation_PublishesEvenWhenLocalStoreRejects: a poll that returns a block
-// lower than a fresh peer-fed tip is a straggler for the LOCAL store but still a genuine
-// "I saw this endpoint just now" for the fleet; the fleet store applies its own rule.
-func TestRecordPollObservation_PublishesEvenWhenLocalStoreRejects(t *testing.T) {
+// A first-hand observation BEHIND our own fresh tip — a straggler, routine when relays complete out
+// of order — publishes nothing and burns no throttle window. The fleet store applies the same
+// monotonic rule, so the write would be rejected there too; what it would really cost is the next
+// publish's window, and losing one is enough to reopen the gap freshness/2 exists to prevent.
+//
+// This replaces a test asserting the opposite. Publishing regardless was right while a wasted
+// publish cost one RPC and nothing else; adding the throttle repriced it.
+func TestRecordPollObservation_StragglerDoesNotPublishOrBurnTheWindow(t *testing.T) {
 	const url = "http://ep:8545"
 	store := &fakePeerStore{}
 	m := newPeerGatedMonitor(t, 400*time.Millisecond, store)
@@ -328,10 +407,34 @@ func TestRecordPollObservation_PublishesEvenWhenLocalStoreRejects(t *testing.T) 
 
 	o, _ := m.GetObservation(url)
 	require.Equal(t, int64(9000), o.LatestBlock, "the local tip keeps the fresher, higher peer block")
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(0), store.publishes.Load(), "a rejected write publishes nothing")
+
+	// And because it burned no window, the next ACCEPTED observation still publishes immediately.
+	m.recordPollObservation(url, gen, 9001, time.Millisecond, nil, now.Add(2*time.Millisecond))
 	require.Eventually(t, func() bool { return store.publishes.Load() == 1 }, time.Second, 5*time.Millisecond)
 	store.mu.Lock()
 	defer store.mu.Unlock()
-	require.Equal(t, int64(8990), store.lastPublish.block)
+	require.Equal(t, int64(9001), store.lastPublish.block)
+}
+
+// The gate is Set's RETURN, not "the block advanced": Set accepts an equal block unconditionally, so
+// an endpoint parked on one block keeps publishing every window. Tying publishing to block movement
+// instead would stop feeding the fleet exactly when a chain stalls — while it is still being checked.
+func TestRecordPollObservation_UnchangedBlockStillPublishes(t *testing.T) {
+	const url = "http://ep:8545"
+	freshness := 400 * time.Millisecond
+	store := &fakePeerStore{}
+	m := newPeerGatedMonitor(t, freshness, store)
+	gen := m.registerGenForTest(url)
+	now := time.Now()
+
+	m.recordPollObservation(url, gen, 7000, time.Millisecond, nil, now)
+	require.Eventually(t, func() bool { return store.publishes.Load() == 1 }, time.Second, 5*time.Millisecond)
+
+	m.recordPollObservation(url, gen, 7000, time.Millisecond, nil, now.Add(freshness/2))
+	require.Eventually(t, func() bool { return store.publishes.Load() == 2 }, time.Second, 5*time.Millisecond,
+		"the same block a window later still refreshes the fleet note")
 }
 
 // TestGate_RelayBeforePeer: a fresh relay tip answers the gate without touching the store,

--- a/protocol/endpointstate/peer_observations.go
+++ b/protocol/endpointstate/peer_observations.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/magma-Devs/smart-router/protocol/endpointtip"
+	"github.com/magma-Devs/smart-router/protocol/metrics"
 	"github.com/magma-Devs/smart-router/protocol/performance"
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
 	"github.com/magma-Devs/smart-router/utils"
@@ -61,6 +62,26 @@ func (m *EndpointMonitor) noteGateSkip(endpointURL, source string) {
 	if m.onGateSkip != nil {
 		m.onGateSkip(endpointURL, source)
 	}
+}
+
+// noteGateError forwards a failed fleet-store call to the OnGateError consumer, if any.
+func (m *EndpointMonitor) noteGateError(endpointURL, op string) {
+	if m.onGateError != nil {
+		m.onGateError(endpointURL, op)
+	}
+}
+
+// peerFetchBudget bounds the gate's cache read against THIS monitor's cadence: never more than a
+// quarter of the poll interval. The read sits on the poll goroutine, and the next tick is scheduled
+// only after the cycle returns, so its latency is ADDED to the interval rather than overlapped with
+// it. At the flat 200ms ceiling alone, a slow-but-reachable cache backend would double the cycle
+// time of a 200ms-interval chain — the gate would then cost more than the upstream request it
+// exists to avoid. A cache that cannot answer within a quarter of the cycle is one to poll past.
+func (m *EndpointMonitor) peerFetchBudget() time.Duration {
+	if m.flatPollInterval <= 0 {
+		return peerFetchTimeout
+	}
+	return min(peerFetchTimeout, m.flatPollInterval/4)
 }
 
 const (
@@ -200,6 +221,7 @@ func (m *EndpointMonitor) publishLocalObservation(endpointURL string, block int6
 		defer cancel()
 		err := m.peerObservations.Publish(ctx, m.chainID, m.apiInterface, EndpointID(endpointURL), m.podID, block, m.relayGateFreshness*peerObservationTTLMultiplier)
 		if err != nil && m.ctx.Err() == nil {
+			m.noteGateError(endpointURL, metrics.TrackerGateOpPublish)
 			utils.LavaFormatDebug("fleet gate: publishing local observation failed",
 				utils.LogAttr("chainID", m.chainID),
 				utils.LogAttr("apiInterface", m.apiInterface),
@@ -240,11 +262,12 @@ func (m *EndpointMonitor) freshPeerTip(endpointURL string, gen uint64, now time.
 	if !m.localPollHealthy(endpointURL) {
 		return 0, false
 	}
-	ctx, cancel := context.WithTimeout(m.ctx, peerFetchTimeout)
+	ctx, cancel := context.WithTimeout(m.ctx, m.peerFetchBudget())
 	defer cancel()
 	block, podID, age, found, err := m.peerObservations.Fetch(ctx, m.chainID, m.apiInterface, EndpointID(endpointURL))
 	if err != nil {
 		if m.ctx.Err() == nil {
+			m.noteGateError(endpointURL, metrics.TrackerGateOpFetch)
 			utils.LavaFormatDebug("fleet gate: fetching peer observation failed, polling locally",
 				utils.LogAttr("chainID", m.chainID),
 				utils.LogAttr("endpoint", endpointURL),

--- a/protocol/endpointstate/peer_observations.go
+++ b/protocol/endpointstate/peer_observations.go
@@ -1,0 +1,250 @@
+package endpointstate
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/endpointtip"
+	"github.com/magma-Devs/smart-router/protocol/performance"
+	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
+	"github.com/magma-Devs/smart-router/utils"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// The fleet tracker gate (MAG-2981).
+//
+// Every router pod runs its own per-endpoint ChainTracker, so the tracker's upstream request
+// volume scales with the replica count: N pods × M endpoints × (divisor / blockTime). The relay
+// traffic gate (MAG-2159) already skips a poll cycle when served traffic keeps the tip fresh;
+// this file lets a FRESH OBSERVATION FROM A PEER POD do the same. Each pod publishes every
+// successful poll to the cache backend, and before polling it asks the backend whether a peer
+// polled the same endpoint recently. If one did, the cycle is skipped and the peer's block is
+// adopted into this pod's tip store under SourcePeer, which keeps the ALIVE / keeping-up
+// verdicts and the QoS sync reference fed. Latency is never shared: a peer's round-trip says
+// nothing about this pod's path to the endpoint.
+//
+// Three invariants keep it safe:
+//   - A pod never borrows its OWN observation (PodId check) — otherwise one poll would throttle
+//     every subsequent poll, the self-throttle the relay gate's Source==Relay rule forbids.
+//   - The tracker's skip budget (chaintracker.maxRelaySkipsBeforePoll) counts peer skips too,
+//     so every pod still polls every endpoint locally on a bounded cadence — a pod-local
+//     connectivity fault or a lying upstream stays detectable.
+//   - Re-enabling a disabled endpoint still requires a LOCAL successful poll
+//     (probing.Verdict reads LastSuccessfulPoll, which a peer observation never touches).
+//
+// With self-exclusion, N pods on one endpoint converge to one real poll per interval plus each
+// pod's forced poll every (skip budget + 1) cycles.
+
+// PeerObservationStore is the fleet-side half of the gate. Production wires the cache backend
+// (NewCachePeerObservations); tests supply an in-memory fake.
+type PeerObservationStore interface {
+	// Publish records this pod's successful poll of an endpoint. ttl bounds how long the
+	// store keeps it. Errors are advisory — a lost publish costs a peer one real poll.
+	Publish(ctx context.Context, chainID, apiInterface, endpointID, podID string, block int64, ttl time.Duration) error
+	// Fetch returns the freshest live observation of an endpoint: the block, who published
+	// it, and its age on the STORE's clock. found=false is a normal miss.
+	Fetch(ctx context.Context, chainID, apiInterface, endpointID string) (block int64, podID string, age time.Duration, found bool, err error)
+}
+
+// noteGateSkip forwards a suppressed poll cycle to the OnGateSkip consumer, if any.
+func (m *EndpointMonitor) noteGateSkip(endpointURL, source string) {
+	if m.onGateSkip != nil {
+		m.onGateSkip(endpointURL, source)
+	}
+}
+
+const (
+	// peerFetchTimeout bounds the gate's synchronous read on the tracker's poll goroutine. The
+	// cache backend is an in-cluster hop; a read that takes longer than this is treated as a
+	// miss (poll locally) rather than delaying the cadence further.
+	peerFetchTimeout = 200 * time.Millisecond
+	// peerPublishTimeout bounds the fire-and-forget publish after a successful poll.
+	peerPublishTimeout = time.Second
+	// peerObservationTTLMultiplier sizes the published TTL relative to the gate's freshness
+	// window: an entry must outlive the window it is judged against, with margin for the
+	// reader's own clock-free age check, but not linger for minutes after the pod dies.
+	peerObservationTTLMultiplier = 2
+)
+
+// EndpointID is the opaque digest a URL is published under. The raw URL carries the provider
+// API key, so it never crosses the cache wire or lands in the cache server's logs; every pod
+// with the same URL string derives the same digest, which is all the fleet needs to agree on.
+func EndpointID(endpointURL string) string {
+	sum := sha256.Sum256([]byte(endpointURL))
+	return hex.EncodeToString(sum[:16])
+}
+
+var (
+	localPodIDOnce sync.Once
+	localPodID     string
+)
+
+// LocalPodID identifies this router process to its peers. Hostname (the pod name under
+// Kubernetes) plus a random suffix, so two processes on one host — or a restarted pod reusing
+// a name — never mistake each other's observations for their own.
+func LocalPodID() string {
+	localPodIDOnce.Do(func() {
+		host, _ := os.Hostname()
+		var b [4]byte
+		_, _ = rand.Read(b[:])
+		localPodID = host + "/" + hex.EncodeToString(b[:])
+	})
+	return localPodID
+}
+
+// cachePeerObservations adapts the cache backend client to PeerObservationStore.
+type cachePeerObservations struct {
+	cache *performance.Cache
+	// unimplementedOnce rate-limits the warning for a cache backend that predates the
+	// observation RPCs (a rolling upgrade window): every call would otherwise log, on every
+	// poll tick, for every endpoint. The gate degrades to "poll locally" either way.
+	unimplementedOnce sync.Once
+}
+
+// unimplemented reports whether err is the cache backend refusing an RPC it does not know,
+// warning once per process.
+func (c *cachePeerObservations) unimplemented(err error) bool {
+	if status.Code(err) != codes.Unimplemented {
+		return false
+	}
+	c.unimplementedOnce.Do(func() {
+		utils.LavaFormatWarning("fleet tracker gate: the cache backend does not implement endpoint observations; polling locally until it is upgraded", err)
+	})
+	return true
+}
+
+// NewCachePeerObservations wraps the cache backend client as the fleet observation store.
+// Returns nil when no cache is configured, which disables the peer gate.
+func NewCachePeerObservations(cache *performance.Cache) PeerObservationStore {
+	if cache == nil {
+		return nil
+	}
+	return &cachePeerObservations{cache: cache}
+}
+
+func (c *cachePeerObservations) Publish(ctx context.Context, chainID, apiInterface, endpointID, podID string, block int64, ttl time.Duration) error {
+	err := c.cache.SetEndpointObservation(ctx, &pairingtypes.EndpointObservationSet{
+		ChainId:      chainID,
+		ApiInterface: apiInterface,
+		EndpointId:   endpointID,
+		PodId:        podID,
+		Block:        block,
+		TtlMs:        ttl.Milliseconds(),
+	})
+	if c.unimplemented(err) {
+		return nil
+	}
+	return err
+}
+
+func (c *cachePeerObservations) Fetch(ctx context.Context, chainID, apiInterface, endpointID string) (int64, string, time.Duration, bool, error) {
+	reply, err := c.cache.GetEndpointObservation(ctx, &pairingtypes.EndpointObservationGet{
+		ChainId:      chainID,
+		ApiInterface: apiInterface,
+		EndpointId:   endpointID,
+	})
+	if err != nil {
+		if c.unimplemented(err) {
+			return 0, "", 0, false, nil
+		}
+		return 0, "", 0, false, err
+	}
+	if !reply.GetFound() {
+		return 0, "", 0, false, nil
+	}
+	return reply.GetBlock(), reply.GetPodId(), time.Duration(reply.GetAgeMs()) * time.Millisecond, true, nil
+}
+
+// publishPollObservation pushes a successful local poll to the fleet store off the poll
+// goroutine. Skipped entirely when no store is wired.
+func (m *EndpointMonitor) publishPollObservation(endpointURL string, block int64) {
+	if m.peerObservations == nil || block <= 0 {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(m.ctx, peerPublishTimeout)
+		defer cancel()
+		err := m.peerObservations.Publish(ctx, m.chainID, m.apiInterface, EndpointID(endpointURL), m.podID, block, m.relayGateFreshness*peerObservationTTLMultiplier)
+		if err != nil && m.ctx.Err() == nil {
+			utils.LavaFormatDebug("fleet gate: publishing poll observation failed",
+				utils.LogAttr("chainID", m.chainID),
+				utils.LogAttr("apiInterface", m.apiInterface),
+				utils.LogAttr("endpoint", endpointURL),
+				utils.LogAttr("error", err),
+			)
+		}
+	}()
+}
+
+// freshPeerTip is the peer half of the traffic gate. It reports true — and adopts the peer's
+// block into this endpoint's tip under SourcePeer — only when a live observation exists, it was
+// published by ANOTHER pod, and it is younger than the gate freshness window (the same
+// "~one block of staleness" horizon the relay gate uses). Any error or miss means "poll
+// locally". gen is the tracker's observation generation (see recordPollObservation).
+func (m *EndpointMonitor) freshPeerTip(endpointURL string, gen uint64, now time.Time) (int64, bool) {
+	if m.peerObservations == nil {
+		return 0, false
+	}
+	ctx, cancel := context.WithTimeout(m.ctx, peerFetchTimeout)
+	defer cancel()
+	block, podID, age, found, err := m.peerObservations.Fetch(ctx, m.chainID, m.apiInterface, EndpointID(endpointURL))
+	if err != nil {
+		if m.ctx.Err() == nil {
+			utils.LavaFormatDebug("fleet gate: fetching peer observation failed, polling locally",
+				utils.LogAttr("chainID", m.chainID),
+				utils.LogAttr("endpoint", endpointURL),
+				utils.LogAttr("error", err),
+			)
+		}
+		return 0, false
+	}
+	if !found || block <= 0 || podID == m.podID || age > m.relayGateFreshness {
+		return 0, false
+	}
+	m.recordPeerObservation(endpointURL, gen, block, now.Add(-age))
+	return block, true
+}
+
+// recordPeerObservation adopts a peer pod's poll result into this endpoint's tip triple
+// (Source = Peer). Like RecordRelayObservation it never touches the poll-health fields, is
+// generation-gated, goes through the store's block-monotonic guard, and feeds the per-chain
+// ChainState tip only when the write advanced the stored tip.
+func (m *EndpointMonitor) recordPeerObservation(endpointURL string, gen uint64, block int64, at time.Time) bool {
+	if block <= 0 {
+		return false
+	}
+	var tipBlock int64
+	defer func() {
+		if tipBlock > 0 && m.onTipObservation != nil {
+			m.onTipObservation(tipBlock)
+		}
+	}()
+
+	m.obsMu.Lock()
+	defer m.obsMu.Unlock()
+
+	if m.stopped {
+		return false
+	}
+	if liveGen, ok := m.generations[endpointURL]; !ok || liveGen != gen {
+		return false
+	}
+	if _, exists := m.observations[endpointURL]; !exists {
+		m.observations[endpointURL] = EndpointObservation{}
+	}
+	if endpointtip.Default().Set(m.tipKey(endpointURL), endpointtip.Tip{
+		Block:      block,
+		ObservedAt: at,
+		Source:     endpointtip.SourcePeer,
+	}, m.tipStaleAfter) {
+		tipBlock = block
+		return true
+	}
+	return false
+}

--- a/protocol/endpointstate/peer_observations.go
+++ b/protocol/endpointstate/peer_observations.go
@@ -128,20 +128,27 @@ type cachePeerObservations struct {
 	cache *performance.Cache
 	// unimplementedOnce rate-limits the warning for a cache backend that predates the
 	// observation RPCs (a rolling upgrade window): every call would otherwise log, on every
-	// poll tick, for every endpoint. The gate degrades to "poll locally" either way.
+	// poll tick, for every endpoint. One adapter is built per chain+interface, so the warning
+	// is once per listen endpoint, not once per process. The gate degrades to "poll locally"
+	// either way; only the LOG is rate-limited, never the error (see warnIfUnimplemented).
 	unimplementedOnce sync.Once
 }
 
-// unimplemented reports whether err is the cache backend refusing an RPC it does not know,
-// warning once per process.
-func (c *cachePeerObservations) unimplemented(err error) bool {
+// warnIfUnimplemented logs once per chain+interface when the cache backend refuses an RPC it does
+// not know — the rolling-upgrade window.
+//
+// It does NOT swallow the error. Every error already degrades to a local poll, so returning it
+// changes no behaviour; what it changes is visibility. Swallowed, an out-of-date backend produced
+// zero gate errors AND zero peer skips, which reads exactly like a healthy fleet with nothing to
+// share — the one state rpc_endpoint_tracker_gate_errors_total was added to expose. Surfaced, it is
+// a steady climb at full tick rate, which nothing else looks like.
+func (c *cachePeerObservations) warnIfUnimplemented(err error) {
 	if status.Code(err) != codes.Unimplemented {
-		return false
+		return
 	}
 	c.unimplementedOnce.Do(func() {
 		utils.LavaFormatWarning("fleet tracker gate: the cache backend does not implement endpoint observations; polling locally until it is upgraded", err)
 	})
-	return true
 }
 
 // NewCachePeerObservations wraps the cache backend client as the fleet observation store.
@@ -162,9 +169,7 @@ func (c *cachePeerObservations) Publish(ctx context.Context, chainID, apiInterfa
 		Block:        block,
 		TtlMs:        ttl.Milliseconds(),
 	})
-	if c.unimplemented(err) {
-		return nil
-	}
+	c.warnIfUnimplemented(err)
 	return err
 }
 
@@ -175,9 +180,7 @@ func (c *cachePeerObservations) Fetch(ctx context.Context, chainID, apiInterface
 		EndpointId:   endpointID,
 	})
 	if err != nil {
-		if c.unimplemented(err) {
-			return 0, "", 0, false, nil
-		}
+		c.warnIfUnimplemented(err)
 		return 0, "", 0, false, err
 	}
 	if !reply.GetFound() {

--- a/protocol/endpointstate/peer_observations.go
+++ b/protocol/endpointstate/peer_observations.go
@@ -165,9 +165,33 @@ func (c *cachePeerObservations) Fetch(ctx context.Context, chainID, apiInterface
 	return reply.GetBlock(), reply.GetPodId(), time.Duration(reply.GetAgeMs()) * time.Millisecond, true, nil
 }
 
-// publishPollObservation pushes a successful local poll to the fleet store off the poll
-// goroutine. Skipped entirely when no store is wired.
-func (m *EndpointMonitor) publishPollObservation(endpointURL string, block int64) {
+// shouldPublishLocked reports whether to publish this pod's observation of endpointURL to the
+// fleet store, and stamps the attempt when it says yes. Caller holds obsMu, and calls this ONLY for
+// an observation the tip store accepted — a straggler the local store rejected would be rejected by
+// the fleet store's identical monotonic rule as well, so publishing it spends a window for nothing.
+//
+// Throttled to one publish per half freshness window: the note only has to stay continuously
+// borrowable, while a busy endpoint observes far more often than that — on Solana most served
+// relays carry a tip. Half the window rather than the whole one so jitter cannot reopen the gap
+// this publishing exists to close: a note published at t is borrowable until t+freshness, and the
+// next publish lands at t+freshness/2.
+func (m *EndpointMonitor) shouldPublishLocked(endpointURL string, at time.Time) bool {
+	if m.peerObservations == nil {
+		return false
+	}
+	if last, ok := m.lastPublished[endpointURL]; ok && at.Sub(last) < m.relayGateFreshness/2 {
+		return false
+	}
+	m.lastPublished[endpointURL] = at
+	return true
+}
+
+// publishLocalObservation pushes what this pod learned by contacting the node ITSELF — a
+// successful poll or a served relay — to the fleet store, off the calling goroutine. A borrowed
+// (SourcePeer) value must never reach here: republishing one refreshes the fleet note's timestamp
+// without anyone having contacted the node, so a stale block would look permanently fresh to every
+// pod. Skipped entirely when no store is wired.
+func (m *EndpointMonitor) publishLocalObservation(endpointURL string, block int64) {
 	if m.peerObservations == nil || block <= 0 {
 		return
 	}
@@ -176,7 +200,7 @@ func (m *EndpointMonitor) publishPollObservation(endpointURL string, block int64
 		defer cancel()
 		err := m.peerObservations.Publish(ctx, m.chainID, m.apiInterface, EndpointID(endpointURL), m.podID, block, m.relayGateFreshness*peerObservationTTLMultiplier)
 		if err != nil && m.ctx.Err() == nil {
-			utils.LavaFormatDebug("fleet gate: publishing poll observation failed",
+			utils.LavaFormatDebug("fleet gate: publishing local observation failed",
 				utils.LogAttr("chainID", m.chainID),
 				utils.LogAttr("apiInterface", m.apiInterface),
 				utils.LogAttr("endpoint", endpointURL),
@@ -240,6 +264,9 @@ func (m *EndpointMonitor) freshPeerTip(endpointURL string, gen uint64, now time.
 // (Source = Peer). Like RecordRelayObservation it never touches the poll-health fields, is
 // generation-gated, goes through the store's block-monotonic guard, and feeds the per-chain
 // ChainState tip only when the write advanced the stored tip.
+//
+// It deliberately does NOT publish: this pod learned nothing first-hand. See
+// publishLocalObservation.
 func (m *EndpointMonitor) recordPeerObservation(endpointURL string, gen uint64, block int64, at time.Time) bool {
 	if block <= 0 {
 		return false

--- a/protocol/endpointstate/peer_observations.go
+++ b/protocol/endpointstate/peer_observations.go
@@ -26,12 +26,16 @@ import (
 // successful poll to the cache backend, and before polling it asks the backend whether a peer
 // polled the same endpoint recently. If one did, the cycle is skipped and the peer's block is
 // adopted into this pod's tip store under SourcePeer, which keeps the ALIVE / keeping-up
-// verdicts and the QoS sync reference fed. Latency is never shared: a peer's round-trip says
-// nothing about this pod's path to the endpoint.
+// verdicts and the QoS sync reference fed — but only for an endpoint this pod is itself still
+// reaching (invariant 2). Latency is never shared: a peer's round-trip says nothing about this
+// pod's path to the endpoint.
 //
-// Three invariants keep it safe:
+// Four invariants keep it safe:
 //   - A pod never borrows its OWN observation (PodId check) — otherwise one poll would throttle
 //     every subsequent poll, the self-throttle the relay gate's Source==Relay rule forbids.
+//   - A pod only borrows while its OWN last poll SUCCEEDED (localPollHealthy) — an adopted block
+//     refreshes ObservedAt, which probing.Verdict reads as `alive`, so a pod that lost its path
+//     to an endpoint would otherwise read it ALIVE forever on borrowed evidence.
 //   - The tracker's skip budget (chaintracker.maxRelaySkipsBeforePoll) counts peer skips too,
 //     so every pod still polls every endpoint locally on a bounded cadence — a pod-local
 //     connectivity fault or a lying upstream stays detectable.
@@ -182,13 +186,34 @@ func (m *EndpointMonitor) publishPollObservation(endpointURL string, block int64
 	}()
 }
 
+// localPollHealthy reports whether THIS pod's last poll of the endpoint succeeded — the gate's
+// precondition. An adopted peer block refreshes ObservedAt, which is all probing.Verdict reads
+// for `alive` (a failed poll moves neither it nor LatestBlock), so without this a pod that lost
+// its path would read the endpoint ALIVE forever instead of disabling it after one staleness
+// window. ConsecutivePollFailures does climb, but nothing reads it for liveness.
+//
+// No record means unhealthy: a live tracker always has one (the init fetch records before the
+// poll loop starts), so absence is unexpected and costs one local poll.
+func (m *EndpointMonitor) localPollHealthy(endpointURL string) bool {
+	m.obsMu.RLock()
+	defer m.obsMu.RUnlock()
+	o, ok := m.observations[endpointURL]
+	return ok && o.ConsecutivePollFailures == 0
+}
+
 // freshPeerTip is the peer half of the traffic gate. It reports true — and adopts the peer's
-// block into this endpoint's tip under SourcePeer — only when a live observation exists, it was
-// published by ANOTHER pod, and it is younger than the gate freshness window (the same
-// "~one block of staleness" horizon the relay gate uses). Any error or miss means "poll
-// locally". gen is the tracker's observation generation (see recordPollObservation).
+// block into this endpoint's tip under SourcePeer — only when this pod's own last poll of the
+// endpoint succeeded, a live observation exists, it was published by ANOTHER pod, and it is
+// younger than the gate freshness window (the same "~one block of staleness" horizon the relay
+// gate uses). Any error or miss means "poll locally". gen is the tracker's observation
+// generation (see recordPollObservation).
 func (m *EndpointMonitor) freshPeerTip(endpointURL string, gen uint64, now time.Time) (int64, bool) {
 	if m.peerObservations == nil {
+		return 0, false
+	}
+	// Before the fetch: a failing pod must not spend a cache round-trip on an answer it cannot
+	// use, and dropping the gate returns it to full-cadence local polling.
+	if !m.localPollHealthy(endpointURL) {
 		return 0, false
 	}
 	ctx, cancel := context.WithTimeout(m.ctx, peerFetchTimeout)

--- a/protocol/endpointstate/peer_observations_grpc_test.go
+++ b/protocol/endpointstate/peer_observations_grpc_test.go
@@ -1,0 +1,67 @@
+package endpointstate
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/ecosystem/cache"
+	"github.com/magma-Devs/smart-router/protocol/performance"
+	relaytypes "github.com/magma-Devs/smart-router/types/relay"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// The cache-backed PeerObservationStore over a real in-process gRPC hop: proves the new RPCs
+// round-trip through the JSON wire codec end to end, and that a cache backend that predates
+// them (Unimplemented) degrades to "poll locally" without surfacing an error.
+
+func startCacheGRPC(t *testing.T, srv relaytypes.RelayerCacheServer) *performance.Cache {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	s := grpc.NewServer()
+	relaytypes.RegisterRelayerCacheServer(s, srv)
+	go func() { _ = s.Serve(lis) }()
+	t.Cleanup(s.Stop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	c, err := performance.InitCache(ctx, lis.Addr().String())
+	require.NoError(t, err)
+	require.Eventually(t, c.CacheActive, 5*time.Second, 10*time.Millisecond)
+	return c
+}
+
+func TestCachePeerObservations_RoundTripOverGRPC(t *testing.T) {
+	cs := &cache.CacheServer{CacheMaxCost: 1 << 20}
+	cs.InitCache(context.Background(), time.Hour, time.Second, time.Second, time.Hour, "disabled", 1, 1)
+	store := NewCachePeerObservations(startCacheGRPC(t, &cache.RelayerCacheServer{CacheServer: cs}))
+	require.NotNil(t, store)
+	ctx := context.Background()
+
+	_, _, _, found, err := store.Fetch(ctx, "ETH1", "jsonrpc", EndpointID("http://ep"))
+	require.NoError(t, err)
+	require.False(t, found, "nothing published yet is a clean miss")
+
+	require.NoError(t, store.Publish(ctx, "ETH1", "jsonrpc", EndpointID("http://ep"), "pod-a", 1234, 2*time.Second))
+	block, podID, age, found, err := store.Fetch(ctx, "ETH1", "jsonrpc", EndpointID("http://ep"))
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, int64(1234), block)
+	require.Equal(t, "pod-a", podID)
+	require.Less(t, age, time.Second)
+
+	require.Nil(t, NewCachePeerObservations(nil), "no cache backend → no store → gate off")
+}
+
+func TestCachePeerObservations_OlderBackendDegradesToLocalPoll(t *testing.T) {
+	store := NewCachePeerObservations(startCacheGRPC(t, relaytypes.UnimplementedRelayerCacheServer{}))
+	ctx := context.Background()
+
+	require.NoError(t, store.Publish(ctx, "ETH1", "jsonrpc", "ep", "pod-a", 1, time.Second), "Unimplemented on publish is swallowed")
+	_, _, _, found, err := store.Fetch(ctx, "ETH1", "jsonrpc", "ep")
+	require.NoError(t, err, "Unimplemented on fetch is a miss, not an error")
+	require.False(t, found)
+}

--- a/protocol/endpointstate/peer_observations_grpc_test.go
+++ b/protocol/endpointstate/peer_observations_grpc_test.go
@@ -11,6 +11,8 @@ import (
 	relaytypes "github.com/magma-Devs/smart-router/types/relay"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // The cache-backed PeerObservationStore over a real in-process gRPC hop: proves the new RPCs
@@ -56,12 +58,21 @@ func TestCachePeerObservations_RoundTripOverGRPC(t *testing.T) {
 	require.Nil(t, NewCachePeerObservations(nil), "no cache backend → no store → gate off")
 }
 
-func TestCachePeerObservations_OlderBackendDegradesToLocalPoll(t *testing.T) {
+// A cache backend that predates the observation RPCs SURFACES Unimplemented rather than swallowing
+// it. Behaviour is unchanged — every error degrades to a local poll — but the error now reaches
+// rpc_endpoint_tracker_gate_errors_total. Swallowed, an out-of-date backend showed zero errors AND
+// zero peer skips, indistinguishable from a healthy fleet with nothing to share, which is the exact
+// state that metric exists to expose. (This test previously asserted the swallow.)
+func TestCachePeerObservations_OlderBackendSurfacesUnimplemented(t *testing.T) {
 	store := NewCachePeerObservations(startCacheGRPC(t, relaytypes.UnimplementedRelayerCacheServer{}))
 	ctx := context.Background()
 
-	require.NoError(t, store.Publish(ctx, "ETH1", "jsonrpc", "ep", "pod-a", 1, time.Second), "Unimplemented on publish is swallowed")
+	err := store.Publish(ctx, "ETH1", "jsonrpc", "ep", "pod-a", 1, time.Second)
+	require.Error(t, err, "an old backend must be visible, not silently tolerated")
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+
 	_, _, _, found, err := store.Fetch(ctx, "ETH1", "jsonrpc", "ep")
-	require.NoError(t, err, "Unimplemented on fetch is a miss, not an error")
-	require.False(t, found)
+	require.Error(t, err)
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+	require.False(t, found, "and it is still not a usable observation, so the pod polls locally")
 }

--- a/protocol/endpointtip/store.go
+++ b/protocol/endpointtip/store.go
@@ -29,6 +29,10 @@ const (
 	SourcePoll
 	// SourceRelay is a tip harvested from a served relay response.
 	SourceRelay
+	// SourcePeer is a tip adopted from another router pod's poll observation, read from the
+	// shared cache backend (the fleet tracker gate, MAG-2981). It carries the block and its
+	// age, never a latency: a peer's round-trip says nothing about this pod's path.
+	SourcePeer
 )
 
 func (s Source) String() string {
@@ -37,6 +41,8 @@ func (s Source) String() string {
 		return "poll"
 	case SourceRelay:
 		return "relay"
+	case SourcePeer:
+		return "peer"
 	default:
 		return "unknown"
 	}

--- a/protocol/endpointtip/store_test.go
+++ b/protocol/endpointtip/store_test.go
@@ -181,3 +181,12 @@ func TestStore_RemoveAndReset(t *testing.T) {
 func TestDefault_Singleton(t *testing.T) {
 	require.Same(t, Default(), Default())
 }
+
+func TestSource_String_Peer(t *testing.T) {
+	if got := SourcePeer.String(); got != "peer" {
+		t.Fatalf("SourcePeer.String() = %q, want %q", got, "peer")
+	}
+	if got := Source(99).String(); got != "unknown" {
+		t.Fatalf("unknown source = %q", got)
+	}
+}

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -2296,8 +2296,13 @@ func (csm *ConsumerSessionManager) OnSessionDone(
 		if drsc, ok := consumerSession.Connection.(*DirectRPCSessionConnection); ok && drsc.Endpoint != nil {
 			// Read the per-endpoint tip from the shared single-source-of-truth store (keyed
 			// by chain+apiInterface+url). This used to read drsc.Endpoint.LatestBlock, a
-			// second copy written ungated; the store is fed only through the gated poll/relay
+			// second copy written ungated; the store is fed through the gated poll/relay
 			// observers, so a lagging provider is demoted against a consistent tip.
+			//
+			// It can also carry a PEER pod's observation (the fleet tracker gate), i.e. a height
+			// this pod did not itself serve. Accepted deliberately — block height is a property
+			// of the endpoint, not of the path to it — but it means a provider lagging only on
+			// THIS pod's path may not be demoted.
 			info := csm.RPCEndpoint()
 			tipKey := endpointtip.Key(info.ChainID, info.ApiInterface, drsc.Endpoint.NetworkAddress)
 			if endpointBlock := endpointtip.Default().Block(tipKey); endpointBlock > 0 {

--- a/protocol/metrics/smartrouter_metrics_manager.go
+++ b/protocol/metrics/smartrouter_metrics_manager.go
@@ -61,6 +61,7 @@ type SmartRouterMetricsManager struct {
 	endpointFetchLatestSuccess     *MappedLabelsCounterVec // rpc_endpoint_fetch_latest_success
 	endpointFetchBlockSuccess      *MappedLabelsCounterVec // rpc_endpoint_fetch_block_success
 	endpointTrackerRequests        *MappedLabelsCounterVec // rpc_endpoint_tracker_requests_total
+	endpointTrackerGateSkips       *MappedLabelsCounterVec // rpc_endpoint_tracker_gate_skips_total
 
 	// Router-scoped metrics (labels: spec, apiInterface, function)
 	routerTotalRelaysServiced *prometheus.CounterVec   // smartrouter_total_relays_serviced
@@ -279,6 +280,18 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 		Name:       "rpc_endpoint_tracker_requests_total",
 		Help:       "Total upstream requests sent by the per-endpoint chain tracker, by kind (latest_block, block_hash).",
 		Labels:     []string{"spec", "apiInterface", "endpoint_id", "kind"},
+		Registerer: prometheus.DefaultRegisterer,
+	})
+
+	// Counts the poll cycles the tracker's traffic gate suppressed, split by what made the
+	// poll redundant: source="relay" (served traffic kept the tip fresh) or source="peer"
+	// (another pod's poll, borrowed through the cache backend — the fleet gate, MAG-2981).
+	// Together with rpc_endpoint_tracker_requests_total this shows both halves of the
+	// tracker's cadence: requests sent, and ticks that sent nothing and why.
+	endpointTrackerGateSkips := NewMappedLabelsCounterVec(MappedLabelsMetricOpts{
+		Name:       "rpc_endpoint_tracker_gate_skips_total",
+		Help:       "Total per-endpoint tracker poll cycles suppressed by the traffic gate, by source (relay, peer).",
+		Labels:     []string{"spec", "apiInterface", "endpoint_id", "source"},
 		Registerer: prometheus.DefaultRegisterer,
 	})
 
@@ -635,6 +648,7 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 		endpointFetchLatestSuccess:     endpointFetchLatestSuccess,
 		endpointFetchBlockSuccess:      endpointFetchBlockSuccess,
 		endpointTrackerRequests:        endpointTrackerRequests,
+		endpointTrackerGateSkips:       endpointTrackerGateSkips,
 
 		// Router-scoped (with function)
 		routerTotalRelaysServiced: routerTotalRelaysServiced,
@@ -1233,6 +1247,28 @@ func (m *SmartRouterMetricsManager) AddEndpointTrackerRequest(spec, apiInterface
 	}
 	labels := map[string]string{"spec": spec, "apiInterface": apiInterface, "endpoint_id": endpointID, "kind": kind}
 	m.endpointTrackerRequests.WithLabelValues(labels).Inc()
+}
+
+// TrackerGateSkipSource values for RecordTrackerGateSkip. A closed set of two, mirroring the
+// two signals that can make a dedicated poll redundant.
+const (
+	// TrackerGateSkipSourceRelay — served relay traffic kept this endpoint's tip fresh.
+	TrackerGateSkipSourceRelay = "relay"
+	// TrackerGateSkipSourcePeer — another pod polled this endpoint and published the result
+	// to the cache backend (MAG-2981).
+	TrackerGateSkipSourcePeer = "peer"
+)
+
+// RecordTrackerGateSkip records ONE poll cycle the traffic gate suppressed for an endpoint,
+// fanned out across every provider sharing the URL like RecordTrackerRequest.
+func (m *SmartRouterMetricsManager) RecordTrackerGateSkip(spec, apiInterface, endpointID, source string) {
+	if m == nil || m.endpointTrackerGateSkips == nil {
+		return
+	}
+	for _, providerName := range m.resolveProviderNames(endpointID) {
+		labels := map[string]string{"spec": spec, "apiInterface": apiInterface, "endpoint_id": providerName, "source": source}
+		m.endpointTrackerGateSkips.WithLabelValues(labels).Inc()
+	}
 }
 
 // RecordTrackerRequest records ONE upstream request sent by the per-endpoint chain tracker.

--- a/protocol/metrics/smartrouter_metrics_manager.go
+++ b/protocol/metrics/smartrouter_metrics_manager.go
@@ -62,6 +62,7 @@ type SmartRouterMetricsManager struct {
 	endpointFetchBlockSuccess      *MappedLabelsCounterVec // rpc_endpoint_fetch_block_success
 	endpointTrackerRequests        *MappedLabelsCounterVec // rpc_endpoint_tracker_requests_total
 	endpointTrackerGateSkips       *MappedLabelsCounterVec // rpc_endpoint_tracker_gate_skips_total
+	endpointTrackerGateErrors      *MappedLabelsCounterVec // rpc_endpoint_tracker_gate_errors_total
 
 	// Router-scoped metrics (labels: spec, apiInterface, function)
 	routerTotalRelaysServiced *prometheus.CounterVec   // smartrouter_total_relays_serviced
@@ -292,6 +293,16 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 		Name:       "rpc_endpoint_tracker_gate_skips_total",
 		Help:       "Total per-endpoint tracker poll cycles suppressed by the traffic gate, by source (relay, peer).",
 		Labels:     []string{"spec", "apiInterface", "endpoint_id", "source"},
+		Registerer: prometheus.DefaultRegisterer,
+	})
+
+	// Counts FAILED calls to the fleet observation store, by operation. Without it a broken
+	// cache backend and a fleet with nothing to share are indistinguishable — both leave
+	// rpc_endpoint_tracker_gate_skips_total{source="peer"} at zero.
+	endpointTrackerGateErrors := NewMappedLabelsCounterVec(MappedLabelsMetricOpts{
+		Name:       "rpc_endpoint_tracker_gate_errors_total",
+		Help:       "Total failed fleet-observation-store calls made by the per-endpoint tracker gate, by op (fetch, publish).",
+		Labels:     []string{"spec", "apiInterface", "endpoint_id", "op"},
 		Registerer: prometheus.DefaultRegisterer,
 	})
 
@@ -649,6 +660,7 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 		endpointFetchBlockSuccess:      endpointFetchBlockSuccess,
 		endpointTrackerRequests:        endpointTrackerRequests,
 		endpointTrackerGateSkips:       endpointTrackerGateSkips,
+		endpointTrackerGateErrors:      endpointTrackerGateErrors,
 
 		// Router-scoped (with function)
 		routerTotalRelaysServiced: routerTotalRelaysServiced,
@@ -1258,6 +1270,28 @@ const (
 	// to the cache backend (MAG-2981).
 	TrackerGateSkipSourcePeer = "peer"
 )
+
+// TrackerGateOp values for RecordTrackerGateError: the two calls the gate makes to the fleet
+// observation store.
+const (
+	// TrackerGateOpFetch — reading a peer's observation before polling failed, so the pod polled.
+	TrackerGateOpFetch = "fetch"
+	// TrackerGateOpPublish — publishing this pod's own observation to the fleet store failed.
+	TrackerGateOpPublish = "publish"
+)
+
+// RecordTrackerGateError records ONE failed fleet-store call, fanned out like RecordTrackerGateSkip.
+// It is what separates "the cache backend is unreachable or slow" from "no peer has anything to
+// share": both otherwise present only as peer skips sitting at zero.
+func (m *SmartRouterMetricsManager) RecordTrackerGateError(spec, apiInterface, endpointID, op string) {
+	if m == nil || m.endpointTrackerGateErrors == nil {
+		return
+	}
+	for _, providerName := range m.resolveProviderNames(endpointID) {
+		labels := map[string]string{"spec": spec, "apiInterface": apiInterface, "endpoint_id": providerName, "op": op}
+		m.endpointTrackerGateErrors.WithLabelValues(labels).Inc()
+	}
+}
 
 // RecordTrackerGateSkip records ONE poll cycle the traffic gate suppressed for an endpoint,
 // fanned out across every provider sharing the URL like RecordTrackerRequest.

--- a/protocol/performance/cache.go
+++ b/protocol/performance/cache.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
-	"github.com/magma-Devs/smart-router/utils"
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
+	"github.com/magma-Devs/smart-router/utils"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/protocol/performance/cache.go
+++ b/protocol/performance/cache.go
@@ -222,3 +222,42 @@ func (cache *Cache) Flush(ctx context.Context) error {
 	}
 	return err
 }
+
+// SetEndpointObservation publishes one successful poll of an upstream endpoint to the cache
+// backend so peer pods can borrow it (the fleet tracker gate, MAG-2981). Fire-and-forget at the
+// call site: a failed publish only costs a peer one real poll.
+func (cache *Cache) SetEndpointObservation(ctx context.Context, set *pairingtypes.EndpointObservationSet) error {
+	if cache == nil {
+		return NotInitializedError
+	}
+
+	client := cache.clientStore.getClient()
+	if client == nil {
+		return NotConnectedError
+	}
+
+	_, err := client.SetEndpointObservation(ctx, set)
+	if err != nil {
+		cache.clientStore.resetOnConnectionError(err)
+	}
+	return err
+}
+
+// GetEndpointObservation reads the freshest peer observation of an upstream endpoint. A miss
+// is a reply with Found=false, not an error.
+func (cache *Cache) GetEndpointObservation(ctx context.Context, get *pairingtypes.EndpointObservationGet) (*pairingtypes.EndpointObservationReply, error) {
+	if cache == nil {
+		return nil, NotInitializedError
+	}
+
+	client := cache.clientStore.getClient()
+	if client == nil {
+		return nil, NotConnectedError
+	}
+
+	reply, err := client.GetEndpointObservation(ctx, get)
+	if err != nil {
+		cache.clientStore.resetOnConnectionError(err)
+	}
+	return reply, err
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -3192,7 +3192,7 @@ rpcsmartrouter smartrouter_examples/smartrouter_eth.yml --cache-be "127.0.0.1:77
 	cmdRPCSmartRouter.Flags().String(common.CorsMethodsFlag, "GET,POST,PUT,DELETE,OPTIONS", "set up Allowed OPTIONS methods, defaults to: \"GET,POST,PUT,DELETE,OPTIONS\"")
 	cmdRPCSmartRouter.Flags().String(common.CorsExposeHeadersFlag, "", "Set up CORS Access-Control-Expose-Headers — response headers a browser may read (e.g. \"Lava-Provider-Address\", or \"*\" for all). Empty by default (only simple response headers are readable from JS).")
 	cmdRPCSmartRouter.Flags().String(common.CDNCacheDurationFlag, "86400", "set up preflight options response cache duration, default 86400 (24h in seconds)")
-	cmdRPCSmartRouter.Flags().Bool(common.SharedStateFlag, false, "Share the consumer consistency state with the cache service. this should be used with cache backend enabled if you want to state sync multiple rpc consumers")
+	cmdRPCSmartRouter.Flags().Bool(common.SharedStateFlag, false, "Share state across router replicas through the cache backend (requires --cache-be): the consumer consistency seen-block, and per-endpoint chain-tracker poll observations so an upstream is polled about once per interval fleet-wide instead of once per pod")
 	// relays health check related flags
 	cmdRPCSmartRouter.Flags().Bool(common.RelaysHealthEnableFlag, RelaysHealthEnableFlagDefault, "enables relays health check")
 	cmdRPCSmartRouter.Flags().Duration(common.RelayHealthIntervalFlag, RelayHealthIntervalFlagDefault, "interval between relay health checks")

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"net/http"
 	"os/signal"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -3378,7 +3379,7 @@ func (rpsr *RPCSmartRouter) updateEpoch(ctx context.Context, epoch uint64) {
 			var promotedStatic, promotedBackup []string
 			freshProviderSessions, demotedStatic, promotedStatic = applyReverification(ctx, inputs, freshProviderSessions, reverifyTierStatic, epoch)
 			freshBackupSessions, demotedBackup, promotedBackup = applyReverification(ctx, inputs, freshBackupSessions, reverifyTierBackup, epoch)
-			demotedSessions = append(demotedStatic, demotedBackup...)
+			demotedSessions = slices.Concat(demotedStatic, demotedBackup)
 
 			// A promoted provider supersedes any pending failed-init retry, the same
 			// invariant rebuildPairingFromConfig enforces. Without this the provider stays

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -238,6 +238,15 @@ func (rpcss *RPCSmartRouterServer) ServeRPCRequests(
 		// Feed every positive poll/relay block into the per-chain tip (cheap monotonic write)
 		// and mirror the resulting guarded tip into the router-wide latest-block gauge (MAG-2629).
 		OnTipObservation: rpcss.onTipObservation,
+		// Fleet tracker gate (MAG-2981): with --shared-state AND a cache backend, pods share
+		// their poll observations so an endpoint is polled about once per interval fleet-wide.
+		// Gated on the same flag as the chain-level shared tip — it is the operator's "this
+		// chain runs on several replicas behind one cache" signal, already set by the helm
+		// chart when maxReplicas > 1. nil (single replica or no cache) leaves the gate off.
+		PeerObservations: rpcss.peerObservationStore(),
+		OnGateSkip: func(endpointURL, source string) {
+			rpcss.smartRouterEndpointMetrics.RecordTrackerGateSkip(listenEndpoint.ChainID, listenEndpoint.ApiInterface, endpointURL, source)
+		},
 		// Count the tracker's upstream requests by kind. This is the series that makes the
 		// effect of --enable-fork-detection visible: rpc_endpoint_fetch_latest_{success,fails}
 		// count EVENTS (new block detected / latest-block fetch failed), not requests, so
@@ -3208,6 +3217,15 @@ func isFinalizedForCacheWrite(requestedBlock, replyLatestBlock, trackedLatestBlo
 		latest = trackedLatestBlock
 	}
 	return spectypes.IsFinalizedBlock(requestedBlock, latest, finalizationDistance)
+}
+
+// peerObservationStore returns the fleet observation store for the per-endpoint tracker gate,
+// or nil when shared state is off or no cache backend is configured (MAG-2981).
+func (rpcss *RPCSmartRouterServer) peerObservationStore() endpointstate.PeerObservationStore {
+	if !rpcss.sharedState || rpcss.cache == nil {
+		return nil
+	}
+	return endpointstate.NewCachePeerObservations(rpcss.cache)
 }
 
 // adoptSharedStateTip feeds a peer pod's chain tip — read from the shared cache under the

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -247,6 +247,9 @@ func (rpcss *RPCSmartRouterServer) ServeRPCRequests(
 		OnGateSkip: func(endpointURL, source string) {
 			rpcss.smartRouterEndpointMetrics.RecordTrackerGateSkip(listenEndpoint.ChainID, listenEndpoint.ApiInterface, endpointURL, source)
 		},
+		OnGateError: func(endpointURL, op string) {
+			rpcss.smartRouterEndpointMetrics.RecordTrackerGateError(listenEndpoint.ChainID, listenEndpoint.ApiInterface, endpointURL, op)
+		},
 		// Count the tracker's upstream requests by kind. This is the series that makes the
 		// effect of --enable-fork-detection visible: rpc_endpoint_fetch_latest_{success,fails}
 		// count EVENTS (new block detected / latest-block fetch failed), not requests, so

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2312,7 +2312,12 @@ func (rpcss *RPCSmartRouterServer) recordRelayBlockObservation(endpoint *lavases
 // has ever been written; a non-positive store value means "unknown", so we defer to the atomic.
 //
 // Safe to return a lower block: the sole caller is consistency pre-validation, where a lower tip
-// means "more likely behind" → a conservative reject, never an over-optimistic pass.
+// means "more likely behind" → a conservative reject.
+//
+// The tip may also be a PEER pod's observation borrowed through the cache backend (the fleet
+// tracker gate), which can read higher than this pod has seen. Accepted deliberately: the
+// reference it is compared against is the guarded chain tip, so a too-high endpoint value can
+// only mask that ONE endpoint's lag — it can never reject an honest one.
 func endpointTipPreferStore(pollAtomic, storeTip int64) int64 {
 	if storeTip > 0 {
 		return storeTip

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -1454,9 +1454,9 @@ func promoteConsistencyFallback(
 	failedSessions lavasession.ConsumerSessionsMap,
 	filterErr error,
 	state *consistencyFallbackState,
-) (lavasession.ConsumerSessionsMap, lavasession.ConsumerSessionsMap, error, int) {
+) (lavasession.ConsumerSessionsMap, lavasession.ConsumerSessionsMap, int, error) {
 	if state == nil || !errors.Is(filterErr, lavasession.ConsistencyPreValidationError) {
-		return validSessions, failedSessions, filterErr, 0
+		return validSessions, failedSessions, 0, filterErr
 	}
 
 	if validSessions == nil {
@@ -1473,7 +1473,7 @@ func promoteConsistencyFallback(
 	if promoted > 0 {
 		filterErr = nil
 	}
-	return validSessions, failedSessions, filterErr, promoted
+	return validSessions, failedSessions, promoted, filterErr
 }
 
 // shouldFailSessionForResult decides whether a completed direct-RPC relay is reported to the
@@ -1601,7 +1601,7 @@ func (rpcss *RPCSmartRouterServer) sendRelayToDirectEndpoints(
 
 	// Pre-request consistency validation: filter out endpoints that are too far behind
 	validSessions, failedSessions, filterErr := rpcss.filterEndpointsByConsistency(ctx, sessions, protocolMessage)
-	validSessions, failedSessions, filterErr, promotedFallbacks := promoteConsistencyFallback(
+	validSessions, failedSessions, promotedFallbacks, filterErr := promoteConsistencyFallback(
 		validSessions,
 		failedSessions,
 		filterErr,
@@ -4606,7 +4606,7 @@ func (rpcss *RPCSmartRouterServer) appendHeadersToRelayResult(ctx context.Contex
 	// we still need to return early as there's no way to attach headers to the error response.
 	// The cross-validation info is included in the error message and metrics have been emitted.
 	if relayResult == nil {
-		return
+		return pendingProviders
 	}
 
 	// Add selection stats header if feature is enabled

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -3070,7 +3070,7 @@ func TestPromoteConsistencyFallback(t *testing.T) {
 		"previously-rejected": &lavasession.SessionInfo{},
 		"new-stale-provider":  &lavasession.SessionInfo{},
 	}
-	valid, remainingFailed, err, promoted := promoteConsistencyFallback(
+	valid, remainingFailed, promoted, err := promoteConsistencyFallback(
 		nil,
 		failed,
 		lavasession.ConsistencyPreValidationError,

--- a/types/relay/cache.go
+++ b/types/relay/cache.go
@@ -246,3 +246,65 @@ func (c *CacheHash) GetChainId() string {
 	}
 	return ""
 }
+
+// EndpointObservationSet publishes one pod's successful poll of one upstream endpoint to the
+// cache backend so peer pods can borrow it (the fleet tracker gate, MAG-2981). EndpointId is an
+// opaque, stable digest of the endpoint URL computed by the router — the raw URL carries the
+// provider API key and never crosses this wire. PodId names the publishing router instance so
+// a reader can ignore its own observation (a pod's own poll must never suppress its next poll).
+// Ttl bounds how long the server keeps the observation; the server stamps its own receipt time
+// and never trusts a writer clock.
+type EndpointObservationSet struct {
+	ChainId      string `json:"chain_id"`
+	ApiInterface string `json:"api_interface"`
+	EndpointId   string `json:"endpoint_id"`
+	PodId        string `json:"pod_id"`
+	Block        int64  `json:"block"`
+	TtlMs        int64  `json:"ttl_ms"`
+}
+
+// EndpointObservationGet asks the cache backend for the freshest peer observation of one endpoint.
+type EndpointObservationGet struct {
+	ChainId      string `json:"chain_id"`
+	ApiInterface string `json:"api_interface"`
+	EndpointId   string `json:"endpoint_id"`
+}
+
+// EndpointObservationReply carries a peer observation back to a router. Found=false means no
+// live observation exists (never published, or expired). AgeMs is measured on the SERVER clock
+// between the stored receipt stamp and this read, so two pods with skewed clocks still agree on
+// how old the observation is.
+type EndpointObservationReply struct {
+	Found bool   `json:"found"`
+	Block int64  `json:"block"`
+	AgeMs int64  `json:"age_ms"`
+	PodId string `json:"pod_id"`
+}
+
+func (r *EndpointObservationReply) GetPodId() string {
+	if r != nil {
+		return r.PodId
+	}
+	return ""
+}
+
+func (r *EndpointObservationReply) GetFound() bool {
+	if r != nil {
+		return r.Found
+	}
+	return false
+}
+
+func (r *EndpointObservationReply) GetBlock() int64 {
+	if r != nil {
+		return r.Block
+	}
+	return 0
+}
+
+func (r *EndpointObservationReply) GetAgeMs() int64 {
+	if r != nil {
+		return r.AgeMs
+	}
+	return 0
+}

--- a/types/relay/grpc_service.go
+++ b/types/relay/grpc_service.go
@@ -122,15 +122,23 @@ func _Relayer_Relay_Handler(srv interface{}, ctx context.Context, dec func(inter
 	if err := dec(in); err != nil {
 		return nil, err
 	}
+	server, ok := srv.(RelayerServer)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "unexpected server type %T for Relay", srv)
+	}
 	if interceptor == nil {
-		return srv.(RelayerServer).Relay(ctx, in)
+		return server.Relay(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: "/smartrouter.pairing.Relayer/Relay",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(RelayerServer).Relay(ctx, req.(*RelayRequest))
+		typed, ok := req.(*RelayRequest)
+		if !ok {
+			return nil, status.Errorf(codes.Internal, "unexpected request type %T for Relay", req)
+		}
+		return server.Relay(ctx, typed)
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -140,15 +148,23 @@ func _Relayer_Probe_Handler(srv interface{}, ctx context.Context, dec func(inter
 	if err := dec(in); err != nil {
 		return nil, err
 	}
+	server, ok := srv.(RelayerServer)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "unexpected server type %T for Probe", srv)
+	}
 	if interceptor == nil {
-		return srv.(RelayerServer).Probe(ctx, in)
+		return server.Probe(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: "/smartrouter.pairing.Relayer/Probe",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(RelayerServer).Probe(ctx, req.(*ProbeRequest))
+		typed, ok := req.(*ProbeRequest)
+		if !ok {
+			return nil, status.Errorf(codes.Internal, "unexpected request type %T for Probe", req)
+		}
+		return server.Probe(ctx, typed)
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -158,7 +174,11 @@ func _Relayer_RelaySubscribe_Handler(srv interface{}, stream grpc.ServerStream) 
 	if err := stream.RecvMsg(m); err != nil {
 		return err
 	}
-	return srv.(RelayerServer).RelaySubscribe(m, &relayerRelaySubscribeServer{stream})
+	server, ok := srv.(RelayerServer)
+	if !ok {
+		return status.Errorf(codes.Internal, "unexpected server type %T for RelaySubscribe", srv)
+	}
+	return server.RelaySubscribe(m, &relayerRelaySubscribeServer{stream})
 }
 
 type relayerRelaySubscribeServer struct {
@@ -326,15 +346,23 @@ func _RelayerCache_GetRelay_Handler(srv interface{}, ctx context.Context, dec fu
 	if err := dec(in); err != nil {
 		return nil, err
 	}
+	server, ok := srv.(RelayerCacheServer)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "unexpected server type %T for GetRelay", srv)
+	}
 	if interceptor == nil {
-		return srv.(RelayerCacheServer).GetRelay(ctx, in)
+		return server.GetRelay(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: "/smartrouter.pairing.RelayerCache/GetRelay",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(RelayerCacheServer).GetRelay(ctx, req.(*RelayCacheGet))
+		typed, ok := req.(*RelayCacheGet)
+		if !ok {
+			return nil, status.Errorf(codes.Internal, "unexpected request type %T for GetRelay", req)
+		}
+		return server.GetRelay(ctx, typed)
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -344,15 +372,23 @@ func _RelayerCache_SetRelay_Handler(srv interface{}, ctx context.Context, dec fu
 	if err := dec(in); err != nil {
 		return nil, err
 	}
+	server, ok := srv.(RelayerCacheServer)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "unexpected server type %T for SetRelay", srv)
+	}
 	if interceptor == nil {
-		return srv.(RelayerCacheServer).SetRelay(ctx, in)
+		return server.SetRelay(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: "/smartrouter.pairing.RelayerCache/SetRelay",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(RelayerCacheServer).SetRelay(ctx, req.(*RelayCacheSet))
+		typed, ok := req.(*RelayCacheSet)
+		if !ok {
+			return nil, status.Errorf(codes.Internal, "unexpected request type %T for SetRelay", req)
+		}
+		return server.SetRelay(ctx, typed)
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -362,15 +398,23 @@ func _RelayerCache_Health_Handler(srv interface{}, ctx context.Context, dec func
 	if err := dec(in); err != nil {
 		return nil, err
 	}
+	server, ok := srv.(RelayerCacheServer)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "unexpected server type %T for Health", srv)
+	}
 	if interceptor == nil {
-		return srv.(RelayerCacheServer).Health(ctx, in)
+		return server.Health(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: "/smartrouter.pairing.RelayerCache/Health",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(RelayerCacheServer).Health(ctx, req.(*emptypb.Empty))
+		typed, ok := req.(*emptypb.Empty)
+		if !ok {
+			return nil, status.Errorf(codes.Internal, "unexpected request type %T for Health", req)
+		}
+		return server.Health(ctx, typed)
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -380,15 +424,23 @@ func _RelayerCache_FlushCache_Handler(srv interface{}, ctx context.Context, dec 
 	if err := dec(in); err != nil {
 		return nil, err
 	}
+	server, ok := srv.(RelayerCacheServer)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "unexpected server type %T for FlushCache", srv)
+	}
 	if interceptor == nil {
-		return srv.(RelayerCacheServer).FlushCache(ctx, in)
+		return server.FlushCache(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: "/smartrouter.pairing.RelayerCache/FlushCache",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(RelayerCacheServer).FlushCache(ctx, req.(*emptypb.Empty))
+		typed, ok := req.(*emptypb.Empty)
+		if !ok {
+			return nil, status.Errorf(codes.Internal, "unexpected request type %T for FlushCache", req)
+		}
+		return server.FlushCache(ctx, typed)
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -398,15 +450,23 @@ func _RelayerCache_SetEndpointObservation_Handler(srv interface{}, ctx context.C
 	if err := dec(in); err != nil {
 		return nil, err
 	}
+	server, ok := srv.(RelayerCacheServer)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "unexpected server type %T for SetEndpointObservation", srv)
+	}
 	if interceptor == nil {
-		return srv.(RelayerCacheServer).SetEndpointObservation(ctx, in)
+		return server.SetEndpointObservation(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: "/smartrouter.pairing.RelayerCache/SetEndpointObservation",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(RelayerCacheServer).SetEndpointObservation(ctx, req.(*EndpointObservationSet))
+		typed, ok := req.(*EndpointObservationSet)
+		if !ok {
+			return nil, status.Errorf(codes.Internal, "unexpected request type %T for SetEndpointObservation", req)
+		}
+		return server.SetEndpointObservation(ctx, typed)
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -416,15 +476,23 @@ func _RelayerCache_GetEndpointObservation_Handler(srv interface{}, ctx context.C
 	if err := dec(in); err != nil {
 		return nil, err
 	}
+	server, ok := srv.(RelayerCacheServer)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "unexpected server type %T for GetEndpointObservation", srv)
+	}
 	if interceptor == nil {
-		return srv.(RelayerCacheServer).GetEndpointObservation(ctx, in)
+		return server.GetEndpointObservation(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: "/smartrouter.pairing.RelayerCache/GetEndpointObservation",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(RelayerCacheServer).GetEndpointObservation(ctx, req.(*EndpointObservationGet))
+		typed, ok := req.(*EndpointObservationGet)
+		if !ok {
+			return nil, status.Errorf(codes.Internal, "unexpected request type %T for GetEndpointObservation", req)
+		}
+		return server.GetEndpointObservation(ctx, typed)
 	}
 	return interceptor(ctx, in, info, handler)
 }

--- a/types/relay/grpc_service.go
+++ b/types/relay/grpc_service.go
@@ -204,6 +204,8 @@ type RelayerCacheClient interface {
 	SetRelay(ctx context.Context, in *RelayCacheSet, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	Health(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*CacheUsage, error)
 	FlushCache(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	SetEndpointObservation(ctx context.Context, in *EndpointObservationSet, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	GetEndpointObservation(ctx context.Context, in *EndpointObservationGet, opts ...grpc.CallOption) (*EndpointObservationReply, error)
 }
 
 // RelayerCacheServer is the server API for the RelayerCache service.
@@ -214,6 +216,12 @@ type RelayerCacheServer interface {
 	// FlushCache drops every entry across the cache server's stores. Intended
 	// for /debug/reset-all on the smart router; never called on the hot path.
 	FlushCache(context.Context, *emptypb.Empty) (*emptypb.Empty, error)
+	// SetEndpointObservation stores one pod's poll observation of an upstream endpoint and
+	// GetEndpointObservation reads the freshest one back, both keyed by chain + api interface
+	// + endpoint digest. They back the fleet tracker gate (MAG-2981): peer pods borrow a fresh
+	// observation instead of each polling the same upstream.
+	SetEndpointObservation(context.Context, *EndpointObservationSet) (*emptypb.Empty, error)
+	GetEndpointObservation(context.Context, *EndpointObservationGet) (*EndpointObservationReply, error)
 }
 
 // UnimplementedRelayerCacheServer must be embedded to satisfy RelayerCacheServer
@@ -234,6 +242,14 @@ func (UnimplementedRelayerCacheServer) Health(_ context.Context, _ *emptypb.Empt
 
 func (UnimplementedRelayerCacheServer) FlushCache(_ context.Context, _ *emptypb.Empty) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method FlushCache not implemented")
+}
+
+func (UnimplementedRelayerCacheServer) SetEndpointObservation(_ context.Context, _ *EndpointObservationSet) (*emptypb.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SetEndpointObservation not implemented")
+}
+
+func (UnimplementedRelayerCacheServer) GetEndpointObservation(_ context.Context, _ *EndpointObservationGet) (*EndpointObservationReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetEndpointObservation not implemented")
 }
 
 // relayerCacheClient wraps a grpc.ClientConnInterface for the RelayerCache service.
@@ -276,6 +292,24 @@ func (c *relayerCacheClient) Health(ctx context.Context, in *emptypb.Empty, opts
 func (c *relayerCacheClient) FlushCache(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*emptypb.Empty, error) {
 	out := new(emptypb.Empty)
 	err := c.cc.Invoke(ctx, "/smartrouter.pairing.RelayerCache/FlushCache", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *relayerCacheClient) SetEndpointObservation(ctx context.Context, in *EndpointObservationSet, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, "/smartrouter.pairing.RelayerCache/SetEndpointObservation", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *relayerCacheClient) GetEndpointObservation(ctx context.Context, in *EndpointObservationGet, opts ...grpc.CallOption) (*EndpointObservationReply, error) {
+	out := new(EndpointObservationReply)
+	err := c.cc.Invoke(ctx, "/smartrouter.pairing.RelayerCache/GetEndpointObservation", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -359,6 +393,42 @@ func _RelayerCache_FlushCache_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _RelayerCache_SetEndpointObservation_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(EndpointObservationSet)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RelayerCacheServer).SetEndpointObservation(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/smartrouter.pairing.RelayerCache/SetEndpointObservation",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RelayerCacheServer).SetEndpointObservation(ctx, req.(*EndpointObservationSet))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RelayerCache_GetEndpointObservation_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(EndpointObservationGet)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RelayerCacheServer).GetEndpointObservation(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/smartrouter.pairing.RelayerCache/GetEndpointObservation",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RelayerCacheServer).GetEndpointObservation(ctx, req.(*EndpointObservationGet))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _RelayerCache_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "smartrouter.pairing.RelayerCache",
 	HandlerType: (*RelayerCacheServer)(nil),
@@ -378,6 +448,14 @@ var _RelayerCache_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "FlushCache",
 			Handler:    _RelayerCache_FlushCache_Handler,
+		},
+		{
+			MethodName: "SetEndpointObservation",
+			Handler:    _RelayerCache_SetEndpointObservation_Handler,
+		},
+		{
+			MethodName: "GetEndpointObservation",
+			Handler:    _RelayerCache_GetEndpointObservation_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/types/relay/proto_compat.go
+++ b/types/relay/proto_compat.go
@@ -118,3 +118,45 @@ func (m *CacheUsage) String() string {
 
 func (m *CacheUsage) Marshal() ([]byte, error) { return json.Marshal(m) }
 func (m *CacheUsage) Unmarshal(b []byte) error  { return json.Unmarshal(b, m) }
+
+// ---------------------------------------------------------------------------
+// EndpointObservationSet
+// ---------------------------------------------------------------------------
+
+func (m *EndpointObservationSet) Reset()        { *m = EndpointObservationSet{} }
+func (m *EndpointObservationSet) ProtoMessage() {}
+func (m *EndpointObservationSet) String() string {
+	b, _ := json.Marshal(m)
+	return string(b)
+}
+
+func (m *EndpointObservationSet) Marshal() ([]byte, error) { return json.Marshal(m) }
+func (m *EndpointObservationSet) Unmarshal(b []byte) error  { return json.Unmarshal(b, m) }
+
+// ---------------------------------------------------------------------------
+// EndpointObservationGet
+// ---------------------------------------------------------------------------
+
+func (m *EndpointObservationGet) Reset()        { *m = EndpointObservationGet{} }
+func (m *EndpointObservationGet) ProtoMessage() {}
+func (m *EndpointObservationGet) String() string {
+	b, _ := json.Marshal(m)
+	return string(b)
+}
+
+func (m *EndpointObservationGet) Marshal() ([]byte, error) { return json.Marshal(m) }
+func (m *EndpointObservationGet) Unmarshal(b []byte) error  { return json.Unmarshal(b, m) }
+
+// ---------------------------------------------------------------------------
+// EndpointObservationReply
+// ---------------------------------------------------------------------------
+
+func (m *EndpointObservationReply) Reset()        { *m = EndpointObservationReply{} }
+func (m *EndpointObservationReply) ProtoMessage() {}
+func (m *EndpointObservationReply) String() string {
+	b, _ := json.Marshal(m)
+	return string(b)
+}
+
+func (m *EndpointObservationReply) Marshal() ([]byte, error) { return json.Marshal(m) }
+func (m *EndpointObservationReply) Unmarshal(b []byte) error  { return json.Unmarshal(b, m) }

--- a/types/relay/proto_compat.go
+++ b/types/relay/proto_compat.go
@@ -25,7 +25,7 @@ func (m *ProbeRequest) String() string {
 }
 
 func (m *ProbeRequest) Marshal() ([]byte, error) { return json.Marshal(m) }
-func (m *ProbeRequest) Unmarshal(b []byte) error  { return json.Unmarshal(b, m) }
+func (m *ProbeRequest) Unmarshal(b []byte) error { return json.Unmarshal(b, m) }
 
 // ---------------------------------------------------------------------------
 // ProbeReply
@@ -39,7 +39,7 @@ func (m *ProbeReply) String() string {
 }
 
 func (m *ProbeReply) Marshal() ([]byte, error) { return json.Marshal(m) }
-func (m *ProbeReply) Unmarshal(b []byte) error  { return json.Unmarshal(b, m) }
+func (m *ProbeReply) Unmarshal(b []byte) error { return json.Unmarshal(b, m) }
 
 // ---------------------------------------------------------------------------
 // RelayRequest — Marshal/Unmarshal already defined in relay.go; add identity
@@ -75,7 +75,7 @@ func (m *RelayCacheGet) String() string {
 }
 
 func (m *RelayCacheGet) Marshal() ([]byte, error) { return json.Marshal(m) }
-func (m *RelayCacheGet) Unmarshal(b []byte) error  { return json.Unmarshal(b, m) }
+func (m *RelayCacheGet) Unmarshal(b []byte) error { return json.Unmarshal(b, m) }
 
 // ---------------------------------------------------------------------------
 // CacheRelayReply
@@ -89,7 +89,7 @@ func (m *CacheRelayReply) String() string {
 }
 
 func (m *CacheRelayReply) Marshal() ([]byte, error) { return json.Marshal(m) }
-func (m *CacheRelayReply) Unmarshal(b []byte) error  { return json.Unmarshal(b, m) }
+func (m *CacheRelayReply) Unmarshal(b []byte) error { return json.Unmarshal(b, m) }
 
 // ---------------------------------------------------------------------------
 // RelayCacheSet
@@ -103,7 +103,7 @@ func (m *RelayCacheSet) String() string {
 }
 
 func (m *RelayCacheSet) Marshal() ([]byte, error) { return json.Marshal(m) }
-func (m *RelayCacheSet) Unmarshal(b []byte) error  { return json.Unmarshal(b, m) }
+func (m *RelayCacheSet) Unmarshal(b []byte) error { return json.Unmarshal(b, m) }
 
 // ---------------------------------------------------------------------------
 // CacheUsage
@@ -117,7 +117,7 @@ func (m *CacheUsage) String() string {
 }
 
 func (m *CacheUsage) Marshal() ([]byte, error) { return json.Marshal(m) }
-func (m *CacheUsage) Unmarshal(b []byte) error  { return json.Unmarshal(b, m) }
+func (m *CacheUsage) Unmarshal(b []byte) error { return json.Unmarshal(b, m) }
 
 // ---------------------------------------------------------------------------
 // EndpointObservationSet
@@ -131,7 +131,7 @@ func (m *EndpointObservationSet) String() string {
 }
 
 func (m *EndpointObservationSet) Marshal() ([]byte, error) { return json.Marshal(m) }
-func (m *EndpointObservationSet) Unmarshal(b []byte) error  { return json.Unmarshal(b, m) }
+func (m *EndpointObservationSet) Unmarshal(b []byte) error { return json.Unmarshal(b, m) }
 
 // ---------------------------------------------------------------------------
 // EndpointObservationGet
@@ -145,7 +145,7 @@ func (m *EndpointObservationGet) String() string {
 }
 
 func (m *EndpointObservationGet) Marshal() ([]byte, error) { return json.Marshal(m) }
-func (m *EndpointObservationGet) Unmarshal(b []byte) error  { return json.Unmarshal(b, m) }
+func (m *EndpointObservationGet) Unmarshal(b []byte) error { return json.Unmarshal(b, m) }
 
 // ---------------------------------------------------------------------------
 // EndpointObservationReply
@@ -159,4 +159,4 @@ func (m *EndpointObservationReply) String() string {
 }
 
 func (m *EndpointObservationReply) Marshal() ([]byte, error) { return json.Marshal(m) }
-func (m *EndpointObservationReply) Unmarshal(b []byte) error  { return json.Unmarshal(b, m) }
+func (m *EndpointObservationReply) Unmarshal(b []byte) error { return json.Unmarshal(b, m) }


### PR DESCRIPTION
#Closes MAG-2981

Jira ticket: MAG-2981

## Why

Every router pod runs its own per-endpoint ChainTracker, so tracker request volume scales with the replica count: `N pods × M endpoints × (divisor / blockTime)`. A production snapshot measured ~10M tracker requests/day fleet-wide (152k in 22 minutes) with no user traffic behind them. The relay traffic gate (MAG-2159) only helps endpoints that serve relays; an idle chain polls at full cadence on every pod.

This PR lets a fresh poll observation **from a peer pod** satisfy the same gate. Each pod publishes every successful poll to the cache backend; before polling, it asks whether another pod polled the endpoint within the gate freshness window. If so it skips the cycle and adopts the peer's block under a new `SourcePeer` tip source, which keeps the ALIVE / keeping-up verdicts and the QoS sync reference fed. Latency is never shared.

With N pods on one endpoint this converges to ~1 real poll per interval fleet-wide, plus each pod's forced local poll every (skip budget + 1) ticks.

## Safety properties

- **A pod never borrows its own observation** — a pod id travels on the wire and the reader ignores its own. Without this, one poll would throttle every subsequent poll (the self-throttle the relay gate's `Source == Relay` rule forbids). A single replica keeps polling exactly as today.
- **The existing skip budget counts peer skips** (`maxRelaySkipsBeforePoll`, 4), so every pod still polls every endpoint locally every 5th tick — pod-local connectivity faults and lying upstreams stay detectable.
- **Re-enabling a disabled endpoint still needs a LOCAL successful poll** — `probing.Verdict` reads `LastSuccessfulPoll`, which a peer observation never touches.
- **Endpoint URLs never cross the wire** — they carry provider API keys, so the key is `chain|interface|sha256(url)`.
- **Clock skew cannot matter** — the cache server stamps receipt on its own clock and returns an age measured against that same clock.
- **Older cache backend** (rolling upgrade window) answers `Unimplemented` → treated as a miss, one warning, local polling continues.

## What changed

- `types/relay/cache.go`, `grpc_service.go`, `proto_compat.go` — two new RPCs on the RelayerCache service: `SetEndpointObservation` / `GetEndpointObservation` (hand-rolled JSON-over-gRPC like the rest).
- `ecosystem/cache/endpoint_observations.go` — server handlers + a mutex-map store with TTL and a block-monotonic-while-live rule. Deliberately **not** ristretto: its Set is async and may drop a write under admission pressure, which is fine for relay responses but not for a value a peer is about to make a skip-the-poll decision on. `FlushCache` clears it too.
- `protocol/endpointtip/store.go` — `SourcePeer` ("peer"), visible on `/debug/endpoint-state`.
- `protocol/endpointstate/peer_observations.go` — `PeerObservationStore` interface, cache-backed adapter, `EndpointID` digest, `LocalPodID`, `freshPeerTip` (the gate half) and `recordPeerObservation` (generation-gated, same monotonic guard as relay adoption).
- `protocol/endpointstate/endpoint_monitor.go:409` — the `RelayTipFresh` closure now checks relay first (local read), then peer. `observation.go:86` — every successful poll is published (store-accepted or not; the fleet store applies its own rule).
- `protocol/rpcsmartrouter/rpcsmartrouter_server.go:238` — wired only when `--shared-state` **and** `--cache-be` are set; both already come from the helm chart when `maxReplicas > 1`, so no chart change is needed.
- `protocol/metrics` + `docs/METRICS.md` — `rpc_endpoint_tracker_gate_skips_total{source="relay"|"peer"}`, the complement of `rpc_endpoint_tracker_requests_total`. On a multi-replica deployment, `peer` climbing while `requests_total{kind="latest_block"}` flattens is the feature working.
- `--shared-state` help text updated to describe both things it now shares.

## How to verify

```
go test ./protocol/endpointstate/ ./protocol/endpointtip/ ./ecosystem/cache/ ./protocol/chaintracker/ -race -count=1
```

New tests cover: the gate predicate (peer fresh → skip + adopt; own pod id → poll; freshness boundary; miss / error / unwired → poll; stale generation not adopted), publish-on-success-only, relay-before-peer ordering, an end-to-end SOLANA tracker proving upstream polls are suppressed with only a peer observation present, the cache store's clock/monotonic/TTL/sweep rules, RPC validation, wire round-trip, and a real in-process gRPC hop including the `Unimplemented` degradation.

On a cluster: with two or more replicas behind one cache, `rate(rpc_endpoint_tracker_requests_total{kind="latest_block"}[5m])` summed across pods should drop toward one pod's worth per endpoint, and `rpc_endpoint_tracker_gate_skips_total{source="peer"}` should be non-zero on every pod.

## Follow-ups (not in this PR)

- Docs-site (`docs/deployment/cache.md` "Sharing state across routers" and the `--shared-state` row in `reference/cli.md`) to describe the tracker half — separate docs PR per the usual split.
- The two other tracker-load levers discussed alongside this: an absolute minimum poll interval for sub-second chains, and an idle-chain cadence demotion.
