### PR TITLE
feat(smart-router): allow a poll cadence slower than the chain's block time (MAG-2985)

### DIFF
--- a/protocol/chaintracker/chain_tracker.go
+++ b/protocol/chaintracker/chain_tracker.go
@@ -73,7 +73,7 @@ const (
 	maxFails               = 10
 	GoodStabilityThreshold = 0.3
 	PollingUpdateLength    = 10
-	// defaultMaxRelaySkipsBeforePoll bounds how many consecutive poll cycles the traffic gate
+	// DefaultMaxRelaySkipsBeforePoll bounds how many consecutive poll cycles the traffic gate
 	// (MAG-2159) may skip before forcing one real poll for independent fork/liveness
 	// verification. Deliberately small: store-#2 staleness (the tracker atomic that consistency
 	// pre-validation reads) scales linearly as N * FlatPollInterval, so at N=4 with the default
@@ -83,7 +83,7 @@ const (
 	// slower cadence would need this bound revisited. The exposure is in any case narrower than
 	// it reads: consistency pre-validation prefers the relay-fed tip store and only falls back
 	// to this atomic when the store is empty — precisely when the gate never skips.
-	defaultMaxRelaySkipsBeforePoll = 4
+	DefaultMaxRelaySkipsBeforePoll = 4
 	// MostFrequentPollingMultiplier is the fixed multiplier the legacy adaptive cadence uses
 	// (global tracker only — per-endpoint trackers run a fixed FlatPollInterval and never reach
 	// the adaptive tiers). It is the SOLE feeder of cs.pollingTimeMultiplier. The adaptive tiers
@@ -1031,7 +1031,7 @@ func newCustomChainTracker(chainFetcher ChainFetcher, config ChainTrackerConfig)
 	// Traffic-gate skip bound (MAG-2159): default when the caller leaves it 0.
 	maxRelaySkips := config.MaxRelaySkipsBeforePoll
 	if maxRelaySkips <= 0 {
-		maxRelaySkips = defaultMaxRelaySkipsBeforePoll
+		maxRelaySkips = DefaultMaxRelaySkipsBeforePoll
 	}
 
 	if chainFetcher == nil {

--- a/protocol/chaintracker/chain_tracker_gate_test.go
+++ b/protocol/chaintracker/chain_tracker_gate_test.go
@@ -146,7 +146,7 @@ func TestTrafficGate_BoundedVerification(t *testing.T) {
 // the legacy behavior is untouched.
 func TestTrafficGate_NilGate_GlobalTrackerAlwaysPolls(t *testing.T) {
 	fetcher := &countingGateFetcher{}
-	ct := newGateTracker(t, "ETH1", fetcher, nil, defaultMaxRelaySkipsBeforePoll)
+	ct := newGateTracker(t, "ETH1", fetcher, nil, DefaultMaxRelaySkipsBeforePoll)
 	for i := 0; i < 5; i++ {
 		skipped, _ := ct.fetchAllPreviousBlocksIfNecessary(context.Background(), false)
 		require.False(t, skipped, "an ungated tracker never skips")

--- a/protocol/chaintracker/config.go
+++ b/protocol/chaintracker/config.go
@@ -70,7 +70,7 @@ type ChainTrackerConfig struct {
 	// MaxRelaySkipsBeforePoll bounds consecutive gate skips: after this many skipped cycles the
 	// tracker forces one real poll for independent fork/liveness verification, so relay traffic
 	// reporting a stable-but-wrong tip cannot suppress the dedicated poll forever. 0 selects
-	// defaultMaxRelaySkipsBeforePoll. Only meaningful when RelayTipFresh is set.
+	// DefaultMaxRelaySkipsBeforePoll. Only meaningful when RelayTipFresh is set.
 	MaxRelaySkipsBeforePoll int
 }
 

--- a/protocol/chaintracker/poll_now_internal_test.go
+++ b/protocol/chaintracker/poll_now_internal_test.go
@@ -111,7 +111,7 @@ func TestChainTracker_PollNow_LeavesCadenceUntouched(t *testing.T) {
 // budget, since a real poll did happen.
 func TestChainTracker_PollNow_BypassesTrafficGate(t *testing.T) {
 	fetcher := &countingGateFetcher{}
-	ct := newGateTracker(t, "ETH1", fetcher, func(time.Time) bool { return true }, defaultMaxRelaySkipsBeforePoll)
+	ct := newGateTracker(t, "ETH1", fetcher, func(time.Time) bool { return true }, DefaultMaxRelaySkipsBeforePoll)
 
 	skipped, err := ct.fetchAllPreviousBlocksIfNecessary(context.Background(), false)
 	require.True(t, skipped, "a fresh relay tip skips the ordinary cycle")

--- a/protocol/endpointstate/endpoint_monitor.go
+++ b/protocol/endpointstate/endpoint_monitor.go
@@ -273,14 +273,20 @@ func NewEndpointMonitor(ctx context.Context, config EndpointChainTrackerConfig) 
 	// Log only the non-default cadence: an operator who tuned polling has to be able to
 	// confirm from the logs that the value survived validation, while the default needs no
 	// line of its own (it is already visible as PollIntervalMs on /debug/endpoint-state).
-	if pollDivisor != DefaultPollDivisor {
-		utils.LavaFormatInfo("per-endpoint chain tracker poll cadence overridden",
-			utils.LogAttr("chainID", config.ChainID),
-			utils.LogAttr("apiInterface", config.ApiInterface),
-			utils.LogAttr("divisor", pollDivisor),
-			utils.LogAttr("pollInterval", flatPollInterval),
-		)
-	}
+	// Logged unconditionally, once per chain+interface, the same way the fork-detection
+	// decision above is. Reporting only the overridden case left the default silent, so an
+	// operator reading a log could not tell "the flag did nothing" from "the flag never
+	// arrived" — and the failure mode this knob actually has is a value that silently reverts
+	// (out of range, or truncated to the unset sentinel by an older binary). The resolved
+	// interval, not the requested divisor, is the thing worth stating.
+	utils.LavaFormatInfo("per-endpoint chain tracker poll cadence resolved",
+		utils.LogAttr("chainID", config.ChainID),
+		utils.LogAttr("apiInterface", config.ApiInterface),
+		utils.LogAttr("averageBlockTime", avgBlockTime),
+		utils.LogAttr("divisor", pollDivisor),
+		utils.LogAttr("pollInterval", flatPollInterval),
+		utils.LogAttr("overridden", pollDivisor != DefaultPollDivisor),
+	)
 
 	return manager
 }

--- a/protocol/endpointstate/endpoint_monitor.go
+++ b/protocol/endpointstate/endpoint_monitor.go
@@ -163,10 +163,10 @@ type EndpointChainTrackerConfig struct {
 	BlocksToSave     uint64
 
 	// PollIntervalDivisor sets the dedicated-poll cadence to AverageBlockTime/divisor.
-	// 0 (the default) means DefaultPollDivisor — two polls per block time. Lowering it to 1
-	// halves the tracker's upstream request volume. Out-of-range values warn and revert to
-	// the default rather than clamping. See PollDivisorFlagName.
-	PollIntervalDivisor int
+	// Fractional values are meaningful and are the point of the low end: 0.25 is one poll per
+	// four block times. 0 selects DefaultPollDivisor; see poll_cadence.go for the bounds and
+	// for what actually constrains the slow end.
+	PollIntervalDivisor float64
 
 	// EnableForkDetection turns block-hash polling on. Off by default: the tracker then
 	// asks each endpoint only "what is your latest block?" and never fetches a hash. See
@@ -222,6 +222,7 @@ func NewEndpointMonitor(ctx context.Context, config EndpointChainTrackerConfig) 
 	// is reported once per chain rather than per tracker.
 	pollDivisor := resolvePollDivisor(config.PollIntervalDivisor, config.ChainID, config.ApiInterface)
 	flatPollInterval := resolveFlatPollInterval(avgBlockTime, pollDivisor)
+	warnIfCadenceOutrunsStaleness(flatPollInterval, avgBlockTime, config.ChainID, config.ApiInterface)
 
 	ctxWithCancel, cancel := context.WithCancel(ctx)
 

--- a/protocol/endpointstate/poll_cadence.go
+++ b/protocol/endpointstate/poll_cadence.go
@@ -1,7 +1,11 @@
 package endpointstate
 
 import (
+	"math"
 	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/chainstate"
+	"github.com/magma-Devs/smart-router/protocol/chaintracker"
 
 	"github.com/magma-Devs/smart-router/utils"
 )
@@ -25,29 +29,36 @@ const PollDivisorFlagName = "chain-tracker-poll-divisor"
 const (
 	// DefaultPollDivisor is the built-in cadence: avgBlockTime/2, two polls per block time.
 	// Used when the operator supplies nothing (0) or an out-of-range value.
-	DefaultPollDivisor = 2
+	DefaultPollDivisor = 2.0
 
-	// MinPollDivisor floors the cadence at ONE poll per block time. Polling slower than the
-	// chain produces blocks is deliberately out of reach here, because two windows derived
-	// from avgBlockTime elsewhere start to bind:
+	// MinPollDivisor allows polling as slowly as one poll per FOUR block times
+	// (avgBlockTime/0.25). It is fractional on purpose: the knob is a ratio to block time, and
+	// the useful relief on a fast chain lies below one poll per block, not above it.
 	//
-	//   - the traffic gate may skip up to chaintracker.defaultMaxRelaySkipsBeforePoll (4)
-	//     consecutive cycles, so the poll atomic that consistency pre-validation falls back
-	//     to can be (skips+1) x interval stale. At divisor 1 that is ~5 block times against
-	//     a default 10-block EndpointLagThreshold — half the margin the built-in cadence has,
-	//     and the last value that keeps a comfortable one.
-	//   - chainstate.StalenessWindow and the probe's alive horizon are both ~10 x avgBlockTime;
-	//     an interval that approaches them scores healthy endpoints stale/not-alive.
+	// What actually bounds it is chainstate.StalenessWindow (max(10 x avgBlockTime, 2s)) — the
+	// horizon past which an observation stops counting for consensus, the tip reads "unknown",
+	// and the probe's alive check (which reuses the same constant by design) scores a healthy
+	// endpoint not-alive. The window does NOT move with this knob; the knob moves how long the
+	// tip can go unrefreshed, which is the other side of that comparison:
 	//
-	// Going below 1 is therefore not a tuning decision but a redesign of those windows, and
-	// should arrive with them rather than through this knob.
-	MinPollDivisor = 1
+	//   idle endpoint  — nothing but the poll refreshes the tip, so the gap IS the interval.
+	//                    At 0.25 that is 4 x avgBlockTime, comfortably inside the 10x window.
+	//   served endpoint — relay harvest refreshes the same tip, so the gap is bounded by traffic,
+	//                    not by this knob.
+	//
+	// The exposure is the seam between them: an endpoint that trips the traffic gate and then
+	// goes quiet is refreshed by neither, and the worst-case gap becomes
+	// (chaintracker.DefaultMaxRelaySkipsBeforePoll + 1) x interval — 20 x avgBlockTime at 0.25,
+	// which is past the window. That coupling is a property of the PRODUCT of this knob and the
+	// skip budget, not of either alone, so warnIfCadenceOutrunsStaleness reports it at startup
+	// rather than this constant pretending to prevent it.
+	MinPollDivisor = 0.25
 
 	// MaxPollDivisor caps how much FASTER than the built-in cadence an operator can poll.
 	// The cap is relative to the chain's own block time, which is the frame that matters:
 	// divisor 8 is 8 polls per block either way, but that is 8 requests per 12s on Ethereum
 	// and 8 per 400ms on Solana.
-	MaxPollDivisor = 8
+	MaxPollDivisor = 8.0
 )
 
 // resolvePollDivisor validates an operator-supplied divisor, reverting to the built-in
@@ -58,14 +69,25 @@ const (
 // Validation lives here, not in the command's RunE, so every construction path is covered
 // identically: the CLI flag, a config.yml key resolved through viper, and an embedded server
 // that sets the field directly.
-func resolvePollDivisor(divisor int, chainID, apiInterface string) int {
+func resolvePollDivisor(divisor float64, chainID, apiInterface string) float64 {
 	if divisor == 0 {
+		return DefaultPollDivisor
+	}
+	// NaN fails every comparison below, so it would slip through an ordinary range check and
+	// then make the interval NaN — which time.Duration turns into a huge negative, i.e. a timer
+	// that fires immediately and hot-loops the upstream. Reject it explicitly.
+	if math.IsNaN(divisor) {
+		utils.LavaFormatWarning("--"+PollDivisorFlagName+" is not a number; reverting to default", nil,
+			utils.LogAttr("default", DefaultPollDivisor),
+			utils.LogAttr("chainID", chainID),
+			utils.LogAttr("apiInterface", apiInterface),
+		)
 		return DefaultPollDivisor
 	}
 	if divisor < MinPollDivisor || divisor > MaxPollDivisor {
 		utils.LavaFormatWarning("--"+PollDivisorFlagName+" out of allowed range; reverting to default", nil,
 			utils.LogAttr("provided", divisor),
-			utils.LogAttr("allowed", []int{MinPollDivisor, MaxPollDivisor}),
+			utils.LogAttr("allowed", []float64{MinPollDivisor, MaxPollDivisor}),
 			utils.LogAttr("default", DefaultPollDivisor),
 			utils.LogAttr("chainID", chainID),
 			utils.LogAttr("apiInterface", apiInterface),
@@ -80,6 +102,49 @@ func resolvePollDivisor(divisor int, chainID, apiInterface string) int {
 // the caller (NewEndpointMonitor floors a zero spec value to DefaultAverageBlockTime), and
 // divisor is guaranteed within [MinPollDivisor, MaxPollDivisor], so the result is always
 // positive — a zero would silently switch the tracker back to the legacy adaptive scheduler.
-func resolveFlatPollInterval(averageBlockTime time.Duration, divisor int) time.Duration {
-	return averageBlockTime / time.Duration(divisor)
+//
+// The division is done in float64 and only then converted: time.Duration(divisor) would
+// truncate every fractional divisor to an integer, turning 0.25 into 0 and the whole
+// expression into a divide-by-zero panic.
+func resolveFlatPollInterval(averageBlockTime time.Duration, divisor float64) time.Duration {
+	interval := time.Duration(float64(averageBlockTime) / divisor)
+	// Defensive: a sub-nanosecond result would round to 0 and re-enable the adaptive scheduler.
+	// Unreachable with the validated bounds above (the smallest is avgBlockTime/8), but the
+	// cost of being wrong here is a silent scheduler swap, so it is not left to reasoning.
+	if interval <= 0 {
+		return averageBlockTime
+	}
+	return interval
+}
+
+// warnIfCadenceOutrunsStaleness reports, once per chain at startup, a cadence whose worst-case
+// gap between real polls exceeds chainstate.StalenessWindow — the horizon past which an
+// observation stops counting for consensus, the tip reads "unknown", and the probe's alive check
+// (which reuses the same constant) scores a healthy endpoint not-alive.
+//
+// The hazard is a PRODUCT, not a single setting: the traffic gate may skip up to
+// chaintracker.DefaultMaxRelaySkipsBeforePoll consecutive cycles, so the longest a tip can go
+// unrefreshed by a poll is (skips+1) x interval. Neither the divisor nor the skip budget is
+// unsafe alone, which is exactly why a range check on either one cannot catch this.
+//
+// It warns rather than rejects. The gap is only reachable in one seam — an endpoint that trips
+// the gate and then goes quiet, so neither relays nor polls refresh it — and an idle endpoint
+// (gap == interval) stays well inside the window at every allowed divisor. Refusing a
+// configuration that is safe for both of the common cases would cost more than it protects.
+func warnIfCadenceOutrunsStaleness(interval, averageBlockTime time.Duration, chainID, apiInterface string) {
+	window := chainstate.StalenessWindow(averageBlockTime)
+	worstCaseGap := time.Duration(chaintracker.DefaultMaxRelaySkipsBeforePoll+1) * interval
+	if worstCaseGap <= window {
+		return
+	}
+	utils.LavaFormatWarning("poll cadence can outrun the staleness window when the traffic gate skips", nil,
+		utils.LogAttr("chainID", chainID),
+		utils.LogAttr("apiInterface", apiInterface),
+		utils.LogAttr("pollInterval", interval),
+		utils.LogAttr("maxRelaySkips", chaintracker.DefaultMaxRelaySkipsBeforePoll),
+		utils.LogAttr("worstCaseGapBetweenPolls", worstCaseGap),
+		utils.LogAttr("stalenessWindow", window),
+		utils.LogAttr("impact", "an endpoint that stops serving relays right after the gate skips can read stale: no consensus vote, sync scoring off, probe scores it not-alive"),
+		utils.LogAttr("note", "an idle endpoint is unaffected (its gap is one interval); a served endpoint is refreshed by relay harvest"),
+	)
 }

--- a/protocol/endpointstate/poll_cadence_test.go
+++ b/protocol/endpointstate/poll_cadence_test.go
@@ -2,6 +2,7 @@ package endpointstate
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -17,11 +18,14 @@ import (
 func TestResolvePollDivisor(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
-		provided int
-		want     int
+		provided float64
+		want     float64
 	}{
 		{name: "absent (0) takes the built-in default", provided: 0, want: DefaultPollDivisor},
-		{name: "1 is the slowest supported cadence: one poll per block time", provided: 1, want: 1},
+		{name: "1 is one poll per block time", provided: 1, want: 1},
+		{name: "the lower bound is inclusive: one poll per four block times", provided: MinPollDivisor, want: MinPollDivisor},
+		{name: "a fractional value between the bounds is kept as given", provided: 0.5, want: 0.5},
+		{name: "below the range reverts, it does not clamp to Min", provided: 0.1, want: DefaultPollDivisor},
 		{name: "the default may be passed explicitly", provided: DefaultPollDivisor, want: DefaultPollDivisor},
 		{name: "the upper bound is inclusive", provided: MaxPollDivisor, want: MaxPollDivisor},
 		{name: "above the range reverts, it does not clamp to Max", provided: MaxPollDivisor + 1, want: DefaultPollDivisor},
@@ -29,6 +33,11 @@ func TestResolvePollDivisor(t *testing.T) {
 		// A negative divisor would produce a negative interval, which time.NewTimer fires
 		// immediately on — a hot loop against the upstream. It must never reach the tracker.
 		{name: "negative reverts", provided: -1, want: DefaultPollDivisor},
+		// NaN fails every ordinary comparison, so without an explicit check it would pass the
+		// range test and make the interval NaN — which time.Duration renders as a huge negative,
+		// i.e. a timer that fires immediately and hot-loops the upstream.
+		{name: "NaN reverts", provided: math.NaN(), want: DefaultPollDivisor},
+		{name: "+Inf reverts", provided: math.Inf(1), want: DefaultPollDivisor},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.want, resolvePollDivisor(tc.provided, "ETH1", spectypes.APIInterfaceJsonRPC))
@@ -43,7 +52,7 @@ func TestResolveFlatPollInterval(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
 		avgBlockTime time.Duration
-		divisor      int
+		divisor      float64
 		want         time.Duration
 	}{
 		{name: "ethereum at the default divisor", avgBlockTime: 12 * time.Second, divisor: DefaultPollDivisor, want: 6 * time.Second},
@@ -65,13 +74,17 @@ func TestNewEndpointMonitor_ResolvesFlatPollInterval(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
 		avgBlockTime time.Duration
-		divisor      int
+		divisor      float64
 		want         time.Duration
 	}{
 		{name: "default divisor", avgBlockTime: 12 * time.Second, divisor: 0, want: 6 * time.Second},
 		{name: "divisor 1", avgBlockTime: 12 * time.Second, divisor: 1, want: 12 * time.Second},
 		{name: "rejected divisor falls back to the default cadence", avgBlockTime: 12 * time.Second, divisor: 99, want: 6 * time.Second},
 		{name: "spec omits average_block_time: divides the floored default", avgBlockTime: 0, divisor: 1, want: DefaultAverageBlockTime},
+		// The point of the fractional low end: an interval LONGER than the chain's block time.
+		{name: "divisor 0.25 gives four block times", avgBlockTime: 12 * time.Second, divisor: 0.25, want: 48 * time.Second},
+		{name: "divisor 0.5 gives two block times", avgBlockTime: 12 * time.Second, divisor: 0.5, want: 24 * time.Second},
+		{name: "a fast chain stays sub-second at the slowest divisor", avgBlockTime: 400 * time.Millisecond, divisor: 0.25, want: 1600 * time.Millisecond},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
@@ -103,11 +116,12 @@ func TestNewEndpointMonitor_ResolvesFlatPollInterval(t *testing.T) {
 func TestEndpointMonitor_PollDivisor_ReachesLiveTracker(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
-		divisor int
+		divisor float64
 		want    time.Duration
 	}{
 		{name: "default divisor gives half the block time", divisor: 0, want: 30 * time.Second},
 		{name: "divisor 1 gives a full block time", divisor: 1, want: time.Minute},
+		{name: "divisor 0.25 gives four block times", divisor: 0.25, want: 4 * time.Minute},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/protocol/endpointstate/traffic_gate_test.go
+++ b/protocol/endpointstate/traffic_gate_test.go
@@ -176,7 +176,7 @@ func TestEndpointMonitor_SolanaTrafficGate_SuppressesUpstreamPoll(t *testing.T) 
 	}()
 
 	// Run across many flat-poll ticks (~600ms / 50ms ≈ 12 ticks). With the gate engaged the
-	// tracker forces only ~1 real poll per (defaultMaxRelaySkipsBeforePoll+1)=5 ticks, plus a
+	// tracker forces only ~1 real poll per (DefaultMaxRelaySkipsBeforePoll+1)=5 ticks, plus a
 	// couple of init polls. Without the gate wired it would poll on every tick (≥10).
 	time.Sleep(600 * time.Millisecond)
 	close(stop)

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -3127,7 +3127,7 @@ rpcsmartrouter smartrouter_examples/smartrouter_eth.yml --cache-be "127.0.0.1:77
 	// correct across every chain this process serves (each divides its own spec block time).
 	// Validation lives in endpointstate so config.yml and embedded servers get it too.
 	// Process-wide in the same sense as the flag above.
-	cmdRPCSmartRouter.Flags().Int(endpointstate.PollDivisorFlagName, 0, fmt.Sprintf("polling-relief: per-endpoint chain tracker polls every avgBlockTime/divisor (default %d). Set 1 to halve tracker request volume. Allowed [%d,%d]; out-of-range reverts to default. Applies to EVERY chain this process serves.", endpointstate.DefaultPollDivisor, endpointstate.MinPollDivisor, endpointstate.MaxPollDivisor))
+	cmdRPCSmartRouter.Flags().Float64(endpointstate.PollDivisorFlagName, 0, fmt.Sprintf("polling-relief: per-endpoint chain tracker polls every avgBlockTime/divisor (default %g). Below 1 polls SLOWER than the chain produces blocks — %g is one poll per four block times, the largest relief available. Allowed [%g,%g]; out-of-range reverts to default. Applies to EVERY chain this process serves.", endpointstate.DefaultPollDivisor, endpointstate.MinPollDivisor, endpointstate.MinPollDivisor, endpointstate.MaxPollDivisor))
 	cmdRPCSmartRouter.Flags().Var(&strategyFlag, "strategy", fmt.Sprintf("the strategy to use to pick providers (%s)", strings.Join(strategyNames, "|")))
 	defaultWeightedConfig := provideroptimizer.DefaultWeightedSelectorConfig()
 	cmdRPCSmartRouter.Flags().Float64(common.ProviderOptimizerAvailabilityWeight, defaultWeightedConfig.AvailabilityWeight, "weight assigned to provider availability when computing selection scores")

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -231,7 +231,10 @@ func (rpcss *RPCSmartRouterServer) ServeRPCRequests(
 		// Dedicated-poll cadence, read from viper for the same reason as the flag above (an
 		// embedded server with no flags bound gets 0, which IS the default). endpointstate
 		// validates the value and reverts an out-of-range one.
-		PollIntervalDivisor: viper.GetInt(endpointstate.PollDivisorFlagName),
+		// GetFloat64, not GetInt: the divisor is fractional at the low end, and GetInt would
+		// truncate 0.25 to 0 — which is the "unset" sentinel, so an operator asking for the
+		// largest relief would silently receive the default instead.
+		PollIntervalDivisor: viper.GetFloat64(endpointstate.PollDivisorFlagName),
 		// Feed every positive poll/relay block into the per-chain tip (cheap monotonic write)
 		// and mirror the resulting guarded tip into the router-wide latest-block gauge (MAG-2629).
 		OnTipObservation: rpcss.onTipObservation,


### PR DESCRIPTION
#Closes MAG-2985

Jira ticket: MAG-2985

## Why

`--chain-tracker-poll-divisor` was capped at `1`, so the slowest reachable cadence was **one poll per block time**.

That floor was justified by an argument that does not survive checking: `chainstate.StalenessWindow` = `max(10 × avgBlockTime, 2s)` **does not move with this knob**. The knob moves how long a tip can go unrefreshed — the *other* side of that comparison. At one poll per block time we were sitting an order of magnitude inside a window we were said to be approaching.

## What

Range widened to **[0.25, 8]**. At `0.25` the tracker polls once per four block times — 8× less than the built-in cadence, 4× less than the old floor.

Measured requests/min per endpoint:

| chain | default | old floor (1) | **0.25** |
|---|---|---|---|
| Aptos | 600 | 300 | **75** |
| Solana | 300 | 150 | **37.5** |
| Base | 60 | 30 | **7.5** |
| Ethereum | 9.2 | 4.6 | **1.2** |

## Float, end to end — and the two traps in it

The value is fractional, so the flag is `Float64`, the viper read is `GetFloat64`, the config field is `float64`, and the division changed **shape**, not just type:

```go
// before — time.Duration(0.25) truncates to 0, then divides by zero
averageBlockTime / time.Duration(divisor)
// after
time.Duration(float64(averageBlockTime) / divisor)
```

`GetInt` was the quieter hazard: it truncates `0.25` to `0`, which is the **"unset" sentinel** — so an operator asking for the largest relief would have silently received the *default*. Silent, and in the wrong direction.

`NaN` and `+Inf` are now rejected explicitly. NaN fails every ordinary comparison, so it would pass a range check and make the interval NaN, which `time.Duration` renders as a large negative — a timer that fires immediately and hot-loops the upstream.

## What the low end does not change, and the one seam it opens

The staleness window is unaffected, and both common cases stay well inside it:

- **Idle endpoint** — refreshed only by its own poll, so the gap *is* the interval: 4 × `avgBlockTime` at `0.25`, against a 10× window.
- **Served endpoint** — refreshed by relay harvest regardless of cadence.

The exposure is the seam: an endpoint that trips the traffic gate and then goes quiet is refreshed by neither, and the worst-case gap becomes `(skips+1) × interval` — 20 × `avgBlockTime` at `0.25`.

That is a property of the **product** of this knob and the gate's skip budget, not of either alone — which is exactly why a range check on either one cannot catch it. So `warnIfCadenceOutrunsStaleness` reports it once per chain at startup:

```
WRN poll cadence can outrun the staleness window when the traffic gate skips
    pollInterval=60s  worstCaseGapBetweenPolls=5m0s  stalenessWindow=2m30s  maxRelaySkips=4
    impact="an endpoint that stops serving relays right after the gate skips can read stale:
            no consensus vote, sync scoring off, probe scores it not-alive"
    note="an idle endpoint is unaffected (its gap is one interval); a served endpoint is
          refreshed by relay harvest"
```

It **warns rather than rejects**, deliberately: a configuration that is safe for both common cases should not be refused because of a seam. `chaintracker.DefaultMaxRelaySkipsBeforePoll` is exported so the check reads the real budget instead of duplicating the number.

## Verification

Against a **real node** (LAVA, 15s blocks), one endpoint, no relay traffic:

| run | `PollIntervalMs` | polls in 60s | staleness warning |
|---|---|---|---|
| default (divisor 2) | 7500 | 6 | — |
| `--chain-tracker-poll-divisor=0.25` | **60000** | **1** | **fired** |

`15000/0.25 = 60000ms` exactly, and one poll per minute. This also proves the float threads through all four conversions: had any been missed, `0.25` would have become `0` and the interval would have read 7500.

Tests extended for the fractional range: inclusive lower bound, a mid-range fractional value, below-range **reverting rather than clamping**, negative, NaN, +Inf, and end-to-end derivation at `0.25` / `0.5` including on a sub-second chain.

`go build ./...` clean, `go vet` clean, all 25 protocol packages pass.

## Note for review

The old `MinPollDivisor` comment asserted the floor of 1 was load-bearing. That reasoning is corrected in this PR rather than preserved — it conflated the fixed staleness window with the variable it is compared against.
