### PR TITLE
docs(holdoff): mark the tracker and ws/gRPC consumer rows live

### DIFF
--- a/docs/RATE-LIMIT-HOLDOFF.md
+++ b/docs/RATE-LIMIT-HOLDOFF.md
@@ -47,9 +47,9 @@ off" means on its path. This table is the catalog; add a row when wiring a new c
 | Spec re-verification (`spec_reverifier.go`) | Skip the probe, return the rate-limit error so reconciliation stays inconclusive — membership unchanged, streak untouched — without spending a request | 429 from `Validate` | live |
 | Hot relay path (endpoint selection) | A rate-limited relay releases its session with no QoS sample in either direction, and selection prefers providers that are not held off; when every candidate is held off, the soonest-to-expire one stays in — the customer is never answered with a synthesized 429 | 429 relay results, both shapes (typed HTTP error, 2xx-body/gRPC classification) | live |
 | Recovery probe (`recovery_probe.go`) | Skip the replay while held off (verdict stays inconclusive), instead of burning replay-attempt budget on a vendor that said stop | 429 probe responses (Retry-After floor honoured) | live |
-| Chain tracker / endpoint poller | The poll backoff takes the upstream's Retry-After as a floor instead of guessing with the fail-count doubling | 429 poll responses | lands with MAG-2949 |
+| Chain tracker / endpoint poller | The poll backoff takes the upstream's Retry-After as a floor instead of guessing with the fail-count doubling | 429 poll responses | live |
 | WS subscriptions (`direct_ws_subscription_manager.go`) | A rate-limited connect/subscribe is held off instead of scored (no availability sample), selection skips held endpoints while something ready remains, and the pool's reconnect ladder is floored by the dial's Retry-After. Keyed per WS URL — no provider name exists on this path, so vendor-tier escalation does not apply | 429 handshakes and subscribe failures | live |
-| WS / gRPC transports | Recognition first: a 429 on the WS upgrade or a corroborated gRPC rate limit produces the typed sentinel these consumers key on | handshake / metadata 429s | lands with MAG-2949 |
+| WS / gRPC transports | Recognition first: a 429 on the WS upgrade or a corroborated gRPC rate limit produces the typed sentinel these consumers key on | handshake / metadata 429s | live |
 
 ## Metrics
 


### PR DESCRIPTION
#Closes MAG-2986

Jira ticket: MAG-2986

## Why

`docs/RATE-LIMIT-HOLDOFF.md`'s consumer table is the catalog a new hold-off consumer is told to update. Two rows — "Chain tracker / endpoint poller" and "WS / gRPC transports" — were written while MAG-2949 was in flight and still read "lands with MAG-2949". PR #318 in smart-router (recognize 429s on ws + gRPC, floor the tracker poll) merged on 2026-08-21, so both are live and the table misstated the shipped state.

## What changed

Two cells flipped to "live". Docs only.

## How to verify

`grep -c "lands with" docs/RATE-LIMIT-HOLDOFF.md` → 0.
