### PR TITLE
fix(smart-router): retry stateful/batch relays on a rate limit, 503 when fully capped

### DIFF
--- a/docs/RATE-LIMIT-HOLDOFF.md
+++ b/docs/RATE-LIMIT-HOLDOFF.md
@@ -26,10 +26,13 @@ another registry, and tests use `NewRegistry` or the jitter-free `NewRegistryWit
   reclaimed lazily on the next recorded 429 anywhere in the registry.
 - **Internal only.** The registry and the Retry-After values drive internal retry and
   scheduling decisions. Nothing here is surfaced to the customer.
-- **A rate limit is safe to retry, always.** The upstream refused before executing
-  anything, so the retry policy retries a stateful relay or a batch when every failure so
-  far was a rate limit — the one exception to "never retry a possibly-executed write".
-  The normal retry limits still bound it.
+- **A rate limit is safe to retry once the attempt has completed.** The upstream refused
+  before executing anything, so the retry policy retries a stateful relay or a batch when
+  every failure so far was a rate limit — the one exception to "never retry a
+  possibly-executed write". The normal retry limits still bound it. The exception does not
+  extend to a ticker hedge: that fires on a timer with a relay still in flight, and an
+  in-flight attempt may already have broadcast, so a hedged stateful relay or batch stops
+  exactly as before.
 - **A fully capped chain answers 503.** When every attempt was refused for rate, the
   client gets 503 Service Unavailable — temporarily unservable, not broken — with no
   Retry-After (that stays internal). Any other failure mix keeps its usual shape.

--- a/docs/RATE-LIMIT-HOLDOFF.md
+++ b/docs/RATE-LIMIT-HOLDOFF.md
@@ -26,6 +26,13 @@ another registry, and tests use `NewRegistry` or the jitter-free `NewRegistryWit
   reclaimed lazily on the next recorded 429 anywhere in the registry.
 - **Internal only.** The registry and the Retry-After values drive internal retry and
   scheduling decisions. Nothing here is surfaced to the customer.
+- **A rate limit is safe to retry, always.** The upstream refused before executing
+  anything, so the retry policy retries a stateful relay or a batch when every failure so
+  far was a rate limit — the one exception to "never retry a possibly-executed write".
+  The normal retry limits still bound it.
+- **A fully capped chain answers 503.** When every attempt was refused for rate, the
+  client gets 503 Service Unavailable — temporarily unservable, not broken — with no
+  Retry-After (that stays internal). Any other failure mix keeps its usual shape.
 
 ## Query APIs
 
@@ -50,6 +57,7 @@ off" means on its path. This table is the catalog; add a row when wiring a new c
 | Chain tracker / endpoint poller | The poll backoff takes the upstream's Retry-After as a floor instead of guessing with the fail-count doubling | 429 poll responses | live |
 | WS subscriptions (`direct_ws_subscription_manager.go`) | A rate-limited connect/subscribe is held off instead of scored (no availability sample), selection skips held endpoints while something ready remains, and the pool's reconnect ladder is floored by the dial's Retry-After. Keyed per WS URL — no provider name exists on this path, so vendor-tier escalation does not apply | 429 handshakes and subscribe failures | live |
 | WS / gRPC transports | Recognition first: a 429 on the WS upgrade or a corroborated gRPC rate limit produces the typed sentinel these consumers key on | handshake / metadata 429s | live |
+| gRPC streaming subscriptions (`direct_grpc_subscription_manager.go`) | Selection skips held-off endpoints while something ready remains; the full tier stays when nothing is | (reads only — the relay path records) | live |
 
 ## Metrics
 

--- a/protocol/relaycore/interfaces.go
+++ b/protocol/relaycore/interfaces.go
@@ -69,11 +69,15 @@ type ResultsSummary struct {
 	NodeErrors                int
 	SpecialNodeErrors         int
 	ProtocolErrors            int
-	HasNonRetryableNodeError  bool  // any node error with IsNonRetryable flag (umbrella — THE RETRY GATE)
-	HasUnsupportedMethod      bool  // subset of non-retryable, for caching decisions and zero-CU
-	HasPermanentProtocolError bool  // any non-retryable protocol error (excluding epoch mismatch)
-	HasEpochMismatch          bool  // any protocol error is epoch mismatch
-	HashErr                   error // hash computation error (nil = hash OK)
+	HasNonRetryableNodeError  bool // any node error with IsNonRetryable flag (umbrella — THE RETRY GATE)
+	HasUnsupportedMethod      bool // subset of non-retryable, for caching decisions and zero-CU
+	HasPermanentProtocolError bool // any non-retryable protocol error (excluding epoch mismatch)
+	HasEpochMismatch          bool // any protocol error is epoch mismatch
+	// OnlyRateLimited is true when at least one attempt failed and every failure so far was
+	// an upstream rate limit — the one failure that is safe to retry even for a stateful
+	// relay or a batch, because the upstream refused before executing anything.
+	OnlyRateLimited bool
+	HashErr         error // hash computation error (nil = hash OK)
 }
 
 // Action represents the post-relay decision action.

--- a/protocol/relaycore/rate_limit_failure_test.go
+++ b/protocol/relaycore/rate_limit_failure_test.go
@@ -1,0 +1,80 @@
+package relaycore
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/chainlib"
+	"github.com/magma-Devs/smart-router/protocol/chainlib/extensionslib"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func newTwoProviderProcessor(t *testing.T) (*RelayProcessor, *lavasession.UsedProviders, func()) {
+	t.Helper()
+	ctx := context.Background()
+	serverHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	chainParser, _, _, closeServer, _, err := chainlib.CreateChainLibMocks(ctx, "LAVA", spectypes.APIInterfaceRest, serverHandler, nil, "../../", nil)
+	require.NoError(t, err)
+	chainMsg, err := chainParser.ParseMsg("/cosmos/base/tendermint/v1beta1/blocks/17", nil, http.MethodGet, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+	require.NoError(t, err)
+	protocolMessage := chainlib.NewProtocolMessage(chainMsg, nil, nil, "dapp", "123.11")
+	usedProviders := lavasession.NewUsedProviders(nil)
+	rp := NewRelayProcessor(ctx, nil, RelayProcessorMetrics, RelayProcessorMetrics, RelayRetriesManagerInstance, newMockRelayStateMachine(protocolMessage, usedProviders))
+
+	lockCtx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	defer cancel()
+	require.Nil(t, usedProviders.TryLockSelection(lockCtx))
+	usedProviders.AddUsed(lavasession.ConsumerSessionsMap{"lava@a": &lavasession.SessionInfo{}, "lava@b": &lavasession.SessionInfo{}}, nil)
+	closer := func() {
+		if closeServer != nil {
+			closeServer()
+		}
+	}
+	return rp, usedProviders, closer
+}
+
+// Every attempt refused for rate: the chain is temporarily unservable, not broken — the
+// client gets 503, and the policy summary says the failures were only rate limits.
+func TestProcessingResult_AllRateLimitedIs503(t *testing.T) {
+	rp, _, closer := newTwoProviderProcessor(t)
+	defer closer()
+
+	go SendProtocolError(rp, "lava@a", time.Millisecond, common.RateLimited(errors.New("HTTP 429"), 30*time.Second))
+	go SendProtocolError(rp, "lava@b", 2*time.Millisecond, common.RateLimited(errors.New("HTTP 429"), 0))
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_ = rp.WaitForResults(ctx)
+
+	summary := rp.GetResultsSummary()
+	require.True(t, summary.OnlyRateLimited)
+	require.False(t, summary.HasPermanentProtocolError, "a typed 429 must stay retryable")
+
+	result, err := rp.ProcessingResult()
+	require.Error(t, err)
+	require.Equal(t, http.StatusServiceUnavailable, result.StatusCode)
+}
+
+// Mixed failures keep today's shape — the best error's own result, status untouched (the
+// listener applies its default) — and the summary does not claim only-rate-limited.
+func TestProcessingResult_MixedFailuresUnchanged(t *testing.T) {
+	rp, _, closer := newTwoProviderProcessor(t)
+	defer closer()
+
+	go SendProtocolError(rp, "lava@a", time.Millisecond, common.RateLimited(errors.New("HTTP 429"), 0))
+	go SendProtocolError(rp, "lava@b", 2*time.Millisecond, errors.New("connection refused"))
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_ = rp.WaitForResults(ctx)
+
+	require.False(t, rp.GetResultsSummary().OnlyRateLimited)
+	result, err := rp.ProcessingResult()
+	require.Error(t, err)
+	require.NotEqual(t, http.StatusServiceUnavailable, result.StatusCode, "only an all-rate-limited failure is 503")
+	require.Equal(t, 0, result.StatusCode, "the protocol error's own result is returned as before")
+}

--- a/protocol/relaycore/rate_limit_failure_test.go
+++ b/protocol/relaycore/rate_limit_failure_test.go
@@ -39,6 +39,20 @@ func newTwoProviderProcessor(t *testing.T) (*RelayProcessor, *lavasession.UsedPr
 	return rp, usedProviders, closer
 }
 
+// startBatch opens a new selection batch of the given providers, so a follow-up
+// WaitForResults expects exactly their responses — the shape of a retry round.
+func startBatch(t *testing.T, usedProviders *lavasession.UsedProviders, providers ...string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	require.Nil(t, usedProviders.TryLockSelection(ctx))
+	sessions := lavasession.ConsumerSessionsMap{}
+	for _, provider := range providers {
+		sessions[provider] = &lavasession.SessionInfo{}
+	}
+	usedProviders.AddUsed(sessions, nil)
+}
+
 // Every attempt refused for rate: the chain is temporarily unservable, not broken — the
 // client gets 503, and the policy summary says the failures were only rate limits.
 func TestProcessingResult_AllRateLimitedIs503(t *testing.T) {
@@ -77,4 +91,36 @@ func TestProcessingResult_MixedFailuresUnchanged(t *testing.T) {
 	require.Error(t, err)
 	require.NotEqual(t, http.StatusServiceUnavailable, result.StatusCode, "only an all-rate-limited failure is 503")
 	require.Equal(t, 0, result.StatusCode, "the protocol error's own result is returned as before")
+}
+
+// The 503 is stamped on a copy, never on the stored result. sendRelayWithRetries reuses one
+// processor and calls ProcessingResult() per iteration, so an all-429 iteration must not
+// leave a 503 behind for a later, mixed one to inherit.
+func TestProcessingResult_RateLimited503DoesNotStick(t *testing.T) {
+	rp, usedProviders, closer := newTwoProviderProcessor(t)
+	defer closer()
+
+	// Iteration 1: every failure is a rate limit.
+	go SendProtocolError(rp, "lava@a", time.Millisecond, common.RateLimited(errors.New("HTTP 429"), 0))
+	go SendProtocolError(rp, "lava@b", 2*time.Millisecond, common.RateLimited(errors.New("HTTP 429"), 0))
+	firstCtx, cancelFirst := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancelFirst()
+	_ = rp.WaitForResults(firstCtx)
+
+	result, err := rp.ProcessingResult()
+	require.Error(t, err)
+	require.Equal(t, http.StatusServiceUnavailable, result.StatusCode)
+
+	// Iteration 2: the retry lands on an endpoint that is down rather than capped, so the
+	// chain is no longer merely unservable and the 429 result must report its own status.
+	startBatch(t, usedProviders, "lava@c")
+	go SendProtocolError(rp, "lava@c", time.Millisecond, errors.New("connection refused"))
+	secondCtx, cancelSecond := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancelSecond()
+	_ = rp.WaitForResults(secondCtx)
+
+	require.False(t, rp.GetResultsSummary().OnlyRateLimited)
+	result, err = rp.ProcessingResult()
+	require.Error(t, err)
+	require.Equal(t, 0, result.StatusCode, "the earlier 503 must not have been stamped onto the stored result")
 }

--- a/protocol/relaycore/relay_processor.go
+++ b/protocol/relaycore/relay_processor.go
@@ -455,6 +455,7 @@ func (rp *RelayProcessor) GetResultsSummary() ResultsSummary {
 		HasUnsupportedMethod:      hasUnsupportedMethod,
 		HasPermanentProtocolError: hasPermanentProtocolError,
 		HasEpochMismatch:          hasEpochMismatch,
+		OnlyRateLimited:           rp.onlyRateLimitedLocked(),
 		HashErr:                   hashErr,
 	}
 }
@@ -1229,6 +1230,27 @@ func (rp *RelayProcessor) processNonCrossValidationResult(
 	return rp.buildFailureResult(nodeErrorCount, protocolErrorCount)
 }
 
+// onlyRateLimitedLocked reports whether at least one attempt failed and every failure was an
+// upstream rate limit — a typed 429 protocol error, or a node error the classifier flagged
+// IsRateLimited. Caller must hold rp.lock.
+func (rp *RelayProcessor) onlyRateLimitedLocked() bool {
+	_, nodeErrorResults, protocolErrorResults := rp.GetResultsData()
+	failures := 0
+	for _, result := range nodeErrorResults {
+		failures++
+		if !result.IsRateLimited {
+			return false
+		}
+	}
+	for _, protocolError := range protocolErrorResults {
+		failures++
+		if !errors.Is(protocolError.GetError(), common.StatusCodeError429) {
+			return false
+		}
+	}
+	return failures > 0
+}
+
 // buildFailureResult constructs an error result when no consensus can be reached. It returns the best
 // node/protocol error's own RelayResult, whose ProviderInfo.ProviderAddress is a SINGLE provider — the
 // source of the error body being returned. It must never be a comma-joined list: packing the whole
@@ -1257,6 +1279,13 @@ func (rp *RelayProcessor) buildFailureResult(
 		if protocolErr.Response != nil {
 			returnedResult = &protocolErr.Response.RelayResult
 		}
+	}
+
+	// Every attempt was refused for rate: the chain is temporarily unservable, not broken.
+	// 503 is the honest status and what well-behaved clients back off on; no Retry-After
+	// is surfaced — the hold-off registry owns that, internally.
+	if rp.onlyRateLimitedLocked() {
+		returnedResult.StatusCode = http.StatusServiceUnavailable
 	}
 
 	// Log with classified error code for metrics/observability

--- a/protocol/relaycore/relay_processor.go
+++ b/protocol/relaycore/relay_processor.go
@@ -455,7 +455,7 @@ func (rp *RelayProcessor) GetResultsSummary() ResultsSummary {
 		HasUnsupportedMethod:      hasUnsupportedMethod,
 		HasPermanentProtocolError: hasPermanentProtocolError,
 		HasEpochMismatch:          hasEpochMismatch,
-		OnlyRateLimited:           rp.onlyRateLimitedLocked(),
+		OnlyRateLimited:           onlyRateLimited(nodeErrorResults, protocolErrorResults),
 		HashErr:                   hashErr,
 	}
 }
@@ -1153,7 +1153,7 @@ func (rp *RelayProcessor) ProcessingResult() (returnedResult *common.RelayResult
 	case Stateful, Stateless:
 		// Stateful (fan-out, no retries) and Stateless (sequential retries) differ only in the state
 		// machine; result selection here is identical for both.
-		return rp.processNonCrossValidationResult(successResults, nodeErrors, successResultsCount, nodeErrorCount, protocolErrorCount)
+		return rp.processNonCrossValidationResult(successResults, nodeErrors, protocolErrors)
 
 	default:
 		return nil, utils.LavaFormatError("unknown selection mode", nil, utils.LogAttr("selection", rp.selection))
@@ -1212,43 +1212,47 @@ func (rp *RelayProcessor) processCrossValidationResult(
 // difference lives in the state machine, not here.)
 func (rp *RelayProcessor) processNonCrossValidationResult(
 	successResults, nodeErrors []common.RelayResult,
-	successResultsCount, nodeErrorCount, protocolErrorCount int,
+	protocolErrors []RelayError,
 ) (*common.RelayResult, error) {
 	// Return first success if available
-	if successResultsCount > 0 {
+	if len(successResults) > 0 {
 		result := successResults[0]
 		return &result, nil
 	}
 
 	// No successes, return first node error if available
-	if nodeErrorCount > 0 {
+	if len(nodeErrors) > 0 {
 		result := nodeErrors[0]
 		return &result, nil
 	}
 
 	// No node responses at all - build a failure result from the best node/protocol error.
-	return rp.buildFailureResult(nodeErrorCount, protocolErrorCount)
+	return rp.buildFailureResult(nodeErrors, protocolErrors)
 }
 
-// onlyRateLimitedLocked reports whether at least one attempt failed and every failure was an
+// onlyRateLimited reports whether at least one attempt failed and every failure was an
 // upstream rate limit — a typed 429 protocol error, or a node error the classifier flagged
-// IsRateLimited. Caller must hold rp.lock.
-func (rp *RelayProcessor) onlyRateLimitedLocked() bool {
-	_, nodeErrorResults, protocolErrorResults := rp.GetResultsData()
-	failures := 0
+// IsRateLimited.
+//
+// Pure over the slices handed to it: it takes no lock of its own, and it does not depend on
+// rp.lock. Callers pass the results they already read via GetResultsData, which snapshots
+// them under the results manager's own rm.lock — a different mutex from rp.lock, and the one
+// that actually guards this memory.
+func onlyRateLimited(nodeErrorResults []common.RelayResult, protocolErrorResults []RelayError) bool {
+	if len(nodeErrorResults)+len(protocolErrorResults) == 0 {
+		return false
+	}
 	for _, result := range nodeErrorResults {
-		failures++
 		if !result.IsRateLimited {
 			return false
 		}
 	}
 	for _, protocolError := range protocolErrorResults {
-		failures++
 		if !errors.Is(protocolError.GetError(), common.StatusCodeError429) {
 			return false
 		}
 	}
-	return failures > 0
+	return true
 }
 
 // buildFailureResult constructs an error result when no consensus can be reached. It returns the best
@@ -1258,13 +1262,13 @@ func (rp *RelayProcessor) onlyRateLimitedLocked() bool {
 // append it after the per-attempt names, so on the all-transport-errors path Lava-Provider-Address
 // listed ~2x the providers and disagreed with Lava-Retries (MAG-2351).
 func (rp *RelayProcessor) buildFailureResult(
-	nodeErrorCount, protocolErrorCount int,
+	nodeErrors []common.RelayResult, protocolErrors []RelayError,
 ) (*common.RelayResult, error) {
 	returnedResult := &common.RelayResult{StatusCode: http.StatusInternalServerError}
 	var processingError error
 
 	var bestLavaError *common.LavaError
-	if nodeErrorCount > 0 {
+	if len(nodeErrors) > 0 {
 		// Prefer node errors over protocol errors
 		nodeErr := rp.GetBestNodeErrorMessageForUser()
 		processingError = nodeErr.Err
@@ -1272,7 +1276,7 @@ func (rp *RelayProcessor) buildFailureResult(
 		if nodeErr.Response != nil {
 			returnedResult = &nodeErr.Response.RelayResult
 		}
-	} else if protocolErrorCount > 0 {
+	} else if len(protocolErrors) > 0 {
 		protocolErr := rp.GetBestProtocolErrorMessageForUser()
 		processingError = protocolErr.Err
 		bestLavaError = protocolErr.LavaError
@@ -1284,8 +1288,14 @@ func (rp *RelayProcessor) buildFailureResult(
 	// Every attempt was refused for rate: the chain is temporarily unservable, not broken.
 	// 503 is the honest status and what well-behaved clients back off on; no Retry-After
 	// is surfaced — the hold-off registry owns that, internally.
-	if rp.onlyRateLimitedLocked() {
-		returnedResult.StatusCode = http.StatusServiceUnavailable
+	if onlyRateLimited(nodeErrors, protocolErrors) {
+		// Copy before stamping: returnedResult aliases the STORED RelayResult (the two
+		// assignments above take its address), and this runs under a read lock holding
+		// nothing of rm.lock. Mutating in place would write shared state without the write
+		// lock and make the 503 permanent for every later ProcessingResult call.
+		stamped := *returnedResult
+		stamped.StatusCode = http.StatusServiceUnavailable
+		returnedResult = &stamped
 	}
 
 	// Log with classified error code for metrics/observability

--- a/protocol/relaypolicy/policy.go
+++ b/protocol/relaypolicy/policy.go
@@ -23,7 +23,11 @@ func (p *Policy) Decide(input DecisionInput) DecisionOutput {
 	if input.Selection == relaycore.CrossValidation {
 		return DecisionOutput{Action: Stop, Reason: "CrossValidation"}
 	}
-	if input.Selection == relaycore.Stateful {
+	// A stateful relay is not retried because a possibly-executed write must not run
+	// twice. A rate limit is the one failure that concern does not cover: the upstream
+	// refused before executing anything, so the retry lands on a different endpoint
+	// with nothing at risk. The limit checks below still bound it.
+	if input.Selection == relaycore.Stateful && !input.Summary.OnlyRateLimited {
 		return DecisionOutput{Action: Stop, Reason: "Stateful"}
 	}
 
@@ -41,7 +45,8 @@ func (p *Policy) Decide(input DecisionInput) DecisionOutput {
 	if input.AttemptNumber >= p.config.MaxRetries {
 		return DecisionOutput{Action: Stop, Reason: "MaxRetriesReached"}
 	}
-	if input.IsBatch && p.config.DisableBatchRetry {
+	// Same reasoning for batches: a rate-limited batch executed nothing.
+	if input.IsBatch && p.config.DisableBatchRetry && !input.Summary.OnlyRateLimited {
 		return DecisionOutput{Action: Stop, Reason: "BatchDisabled"}
 	}
 

--- a/protocol/relaypolicy/policy.go
+++ b/protocol/relaypolicy/policy.go
@@ -27,7 +27,13 @@ func (p *Policy) Decide(input DecisionInput) DecisionOutput {
 	// twice. A rate limit is the one failure that concern does not cover: the upstream
 	// refused before executing anything, so the retry lands on a different endpoint
 	// with nothing at risk. The limit checks below still bound it.
-	if input.Selection == relaycore.Stateful && !input.Summary.OnlyRateLimited {
+	//
+	// That is a claim about attempts that have COMPLETED, and only the gotResults path
+	// guarantees it — the ticker fires on a timer with a relay still in flight, which may
+	// already have broadcast. So the carve-out does not extend to a hedge.
+	rateLimitRetrySafe := input.Summary.OnlyRateLimited && !input.IsTickerHedge
+
+	if input.Selection == relaycore.Stateful && !rateLimitRetrySafe {
 		return DecisionOutput{Action: Stop, Reason: "Stateful"}
 	}
 
@@ -45,8 +51,9 @@ func (p *Policy) Decide(input DecisionInput) DecisionOutput {
 	if input.AttemptNumber >= p.config.MaxRetries {
 		return DecisionOutput{Action: Stop, Reason: "MaxRetriesReached"}
 	}
-	// Same reasoning for batches: a rate-limited batch executed nothing.
-	if input.IsBatch && p.config.DisableBatchRetry && !input.Summary.OnlyRateLimited {
+	// Same reasoning for batches: a rate-limited batch executed nothing — and the same
+	// in-flight caveat, since a batch can carry an eth_sendRawTransaction.
+	if input.IsBatch && p.config.DisableBatchRetry && !rateLimitRetrySafe {
 		return DecisionOutput{Action: Stop, Reason: "BatchDisabled"}
 	}
 

--- a/protocol/relaypolicy/policy_rate_limit_test.go
+++ b/protocol/relaypolicy/policy_rate_limit_test.go
@@ -36,3 +36,38 @@ func TestDecide_OnlyRateLimitedRetriesStatefulAndBatch(t *testing.T) {
 		require.Equal(t, "ErrorToleranceExceeded", out.Reason)
 	})
 }
+
+// The carve-out is a claim about attempts that have COMPLETED. A ticker hedge fires on a
+// timer with a relay still in flight — one that may already have broadcast — so
+// OnlyRateLimited says nothing about it and the carve-out must not extend there.
+func TestDecide_TickerHedgeKeepsTheStatefulAndBatchStops(t *testing.T) {
+	policy := NewPolicy(PolicyConfig{MaxRetries: 10, RelayRetryLimit: 2, SendRelayAttempts: 3, DisableBatchRetry: true})
+
+	t.Run("stateful stops on a hedge even when every failure was a rate limit", func(t *testing.T) {
+		out := policy.Decide(DecisionInput{
+			Selection:     relaycore.Stateful,
+			IsTickerHedge: true,
+			Summary:       ResultsSummary{ProtocolErrors: 1, OnlyRateLimited: true},
+		})
+		require.Equal(t, Stop, out.Action)
+		require.Equal(t, "Stateful", out.Reason)
+	})
+	t.Run("batch stops on a hedge even when every failure was a rate limit", func(t *testing.T) {
+		out := policy.Decide(DecisionInput{
+			Selection:     relaycore.Stateless,
+			IsBatch:       true,
+			IsTickerHedge: true,
+			Summary:       ResultsSummary{ProtocolErrors: 1, OnlyRateLimited: true},
+		})
+		require.Equal(t, Stop, out.Action)
+		require.Equal(t, "BatchDisabled", out.Reason)
+	})
+	t.Run("a stateless non-batch hedge is unaffected", func(t *testing.T) {
+		out := policy.Decide(DecisionInput{
+			Selection:     relaycore.Stateless,
+			IsTickerHedge: true,
+			Summary:       ResultsSummary{ProtocolErrors: 1, OnlyRateLimited: true},
+		})
+		require.Equal(t, Retry, out.Action)
+	})
+}

--- a/protocol/relaypolicy/policy_rate_limit_test.go
+++ b/protocol/relaypolicy/policy_rate_limit_test.go
@@ -1,0 +1,38 @@
+package relaypolicy
+
+import (
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/relaycore"
+	"github.com/stretchr/testify/require"
+)
+
+// A rate limit is the one failure safe to retry for a stateful relay or a batch: the
+// upstream refused before executing anything, so a retry elsewhere risks nothing.
+func TestDecide_OnlyRateLimitedRetriesStatefulAndBatch(t *testing.T) {
+	policy := NewPolicy(PolicyConfig{MaxRetries: 10, RelayRetryLimit: 2, SendRelayAttempts: 3, DisableBatchRetry: true})
+
+	t.Run("stateful retries when every failure was a rate limit", func(t *testing.T) {
+		out := policy.Decide(DecisionInput{Selection: relaycore.Stateful, Summary: ResultsSummary{ProtocolErrors: 1, OnlyRateLimited: true}})
+		require.Equal(t, Retry, out.Action)
+	})
+	t.Run("stateful still stops on any other failure", func(t *testing.T) {
+		out := policy.Decide(DecisionInput{Selection: relaycore.Stateful, Summary: ResultsSummary{ProtocolErrors: 1}})
+		require.Equal(t, Stop, out.Action)
+		require.Equal(t, "Stateful", out.Reason)
+	})
+	t.Run("batch retries when every failure was a rate limit", func(t *testing.T) {
+		out := policy.Decide(DecisionInput{Selection: relaycore.Stateless, IsBatch: true, Summary: ResultsSummary{ProtocolErrors: 1, OnlyRateLimited: true}})
+		require.Equal(t, Retry, out.Action)
+	})
+	t.Run("batch still stops on any other failure", func(t *testing.T) {
+		out := policy.Decide(DecisionInput{Selection: relaycore.Stateless, IsBatch: true, Summary: ResultsSummary{NodeErrors: 1}})
+		require.Equal(t, Stop, out.Action)
+		require.Equal(t, "BatchDisabled", out.Reason)
+	})
+	t.Run("the limit checks still bound a rate-limited stateful relay", func(t *testing.T) {
+		out := policy.Decide(DecisionInput{Selection: relaycore.Stateful, Summary: ResultsSummary{ProtocolErrors: 3, OnlyRateLimited: true}})
+		require.Equal(t, Stop, out.Action)
+		require.Equal(t, "ErrorToleranceExceeded", out.Reason)
+	})
+}

--- a/protocol/rpcsmartrouter/direct_grpc_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_grpc_subscription_manager.go
@@ -1102,6 +1102,13 @@ func (dgm *DirectGRPCSubscriptionManager) selectFromTier(ctx context.Context, ti
 		return nil, fmt.Errorf("tier is empty")
 	}
 
+	// Rate-limit hold-off: prefer endpoints that are not currently held off after a 429.
+	// Only narrows the tier when something ready remains — a subscription must still be
+	// served when every endpoint is held off, so the full tier stays in that case.
+	if ready := notHeldOff(tier); len(ready) > 0 && len(ready) < len(tier) {
+		tier = ready
+	}
+
 	// Single endpoint or no optimizer: first-non-ignored.
 	if len(tier) == 1 || dgm.optimizer == nil {
 		for _, ep := range tier {

--- a/protocol/rpcsmartrouter/grpc_rate_limit_select_test.go
+++ b/protocol/rpcsmartrouter/grpc_rate_limit_select_test.go
@@ -24,5 +24,5 @@ func TestGRPCSelectFromTier_SkipsHeldOffEndpoints(t *testing.T) {
 	reg.RecordRateLimit("grpc-b.example:443", "grpc-b.example:443", time.Minute)
 	ep, err = dgm.selectFromTier(context.Background(), tier, nil, nil)
 	require.NoError(t, err)
-	require.NotNil(t, ep, "with everything held off the tier still serves")
+	require.Equal(t, "grpc-a.example:443", ep.Url, "with everything held off the full tier stays, so the first endpoint serves")
 }

--- a/protocol/rpcsmartrouter/grpc_rate_limit_select_test.go
+++ b/protocol/rpcsmartrouter/grpc_rate_limit_select_test.go
@@ -1,0 +1,28 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// gRPC streaming subscriptions consult the same hold-off as ws: held-off endpoints are
+// skipped while something ready remains, and the full tier stays when nothing is.
+func TestGRPCSelectFromTier_SkipsHeldOffEndpoints(t *testing.T) {
+	reg := withFreshRelayHoldoff(t)
+	dgm := &DirectGRPCSubscriptionManager{} // no optimizer: first-non-ignored selection
+	tier := []*common.NodeUrl{{Url: "grpc-a.example:443"}, {Url: "grpc-b.example:443"}}
+
+	reg.RecordRateLimit("grpc-a.example:443", "grpc-a.example:443", time.Minute)
+	ep, err := dgm.selectFromTier(context.Background(), tier, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, "grpc-b.example:443", ep.Url)
+
+	reg.RecordRateLimit("grpc-b.example:443", "grpc-b.example:443", time.Minute)
+	ep, err = dgm.selectFromTier(context.Background(), tier, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, ep, "with everything held off the tier still serves")
+}


### PR DESCRIPTION
#Closes MAG-2987

Jira ticket: MAG-2987

Follow-up to the 429/Retry-After stack (umbrella MAG-2910): the three places a rate limit was still handled as a generic failure.

## Why

A 429 means the upstream refused *before executing anything*. That property was not being used:

1. **Stateful relays and batches failed outright.** `relaypolicy` stops retrying them because a possibly-executed write must not run twice — the one concern a 429 does not raise. A tx broadcast or a JSON-RPC batch landing on a capped vendor failed to the customer, even though a second endpoint would have served it and selection already knew to avoid the first.
2. **A fully capped chain surfaced as 500.** `buildFailureResult` returned the best error's own result, rendered as 500 — "the router broke" — when the truth is "temporarily unservable".
3. **gRPC streaming subscriptions ignored the hold-off.** Selection ran over every URL; the ws manager got the filter in PR #320 (ws subscriptions hold off a rate-limited endpoint).

## What changed

- `ResultsSummary.OnlyRateLimited` — true when at least one attempt failed and every failure was a typed 429 protocol error or a node error the classifier flagged `IsRateLimited`. Computed by `onlyRateLimited`, a pure predicate over the error slices the caller already holds: it takes no lock of its own, and both callers (`GetResultsSummary` and `buildFailureResult`) pass results snapshotted under the results manager's `rm.lock` — a different mutex from `rp.lock`.
- `relaypolicy.Decide`: stateful and batch relays **retry** when `OnlyRateLimited` — but only on the `gotResults` path. `OnlyRateLimited` describes attempts that have *completed*; a ticker hedge fires on a timer with a relay still in flight, one that may already have broadcast, so `rateLimitRetrySafe = OnlyRateLimited && !IsTickerHedge` and a hedged stateful/batch relay stops exactly as before. Any other failure stops as before, and the limit checks (`MaxRetries`, `RelayRetryLimit`) still bound the retry.
- `buildFailureResult`: all failures rate-limited → **503**, stamped on a *copy* of the result (the local aliases the stored `RelayResult`, and this runs under a read lock that holds nothing of `rm.lock`). No Retry-After is surfaced (unchanged decision — the registry owns it internally). Any other failure mix keeps its shape.
- `DirectGRPCSubscriptionManager.selectFromTier` reuses `notHeldOff`: skips held-off endpoints while something ready remains; the full tier stays when nothing is.
- `docs/RATE-LIMIT-HOLDOFF.md`: two new semantics bullets + the gRPC-subscriptions consumer row.

## How to verify

```
go build ./...
go test ./protocol/relaypolicy/ -run TestDecide_ -v
go test ./protocol/relaycore/ -run 'TestProcessingResult_' -v
go test ./protocol/rpcsmartrouter/ -run TestGRPCSelectFromTier -v
go test ./protocol/relaycore/ ./protocol/relaypolicy/ ./protocol/rpcsmartrouter/
```

The relaycore tests drive a real `RelayProcessor` (LAVA REST mocks). Two providers both answering typed 429s → summary `OnlyRateLimited`, `HasPermanentProtocolError` false (a typed 429 stays retryable), `ProcessingResult` 503; a 429 + a connection-refused → not only-rate-limited, status untouched; and a two-round case in the `sendRelayWithRetries` shape — all-429 round asserts 503, then a connection-refused arrives in a second batch and `ProcessingResult` must report `0`, not the earlier 503.

The relaypolicy tests cover both directions of the carve-out: stateful/batch retry when every failure was a rate limit, and stateful/batch stop on a ticker hedge under the same summary (with a stateless-non-batch hedge as the control).

---

*Description refreshed after the review round (2026-08-24): the `OnlyRateLimited`, `Decide` and `buildFailureResult` bullets described the pre-review implementation. Known follow-up, deliberately not in this PR: **MAG-3066** — the hold-off narrowing in `selectFromTier` can strand a tier whose ready endpoints are all ignored, in the WS manager as well as this gRPC copy, so it wants fixing in both at once.*
