### PR TITLE
fix(smart-router): validate the cross-validation config before the router boots (MAG-3022)

### DIFF
--- a/protocol/rpcsmartrouter/cross_validation_policy.go
+++ b/protocol/rpcsmartrouter/cross_validation_policy.go
@@ -124,6 +124,29 @@ func NewCrossValidationPolicyResolver(cfg CrossValidationConfig) (*CrossValidati
 	return r, nil
 }
 
+// PreflightValidateCrossValidationConfig runs the context-free half of cross-validation config
+// validation — everything decidable from the config text alone: the enabled/forbid-caller-cv
+// contradiction, missing chain-id/api-interface/method, duplicate policies, and out-of-range bounds.
+//
+// This exists to run at process start, before the router boots anything (MAG-3022). The same parse and
+// resolver construction happen again per endpoint inside ServeRPCRequests, which is where the resolver
+// the relay path uses is actually built — but by then the router has dialed every provider and logged
+// that it is listening, so a config error there surfaces as a crash loop from an apparently-started
+// router. Rejecting the config here costs a few milliseconds and one extra parse, and means a
+// contradictory policy never gets that far.
+//
+// The checks that need spec or provider context (the stateful-write guard, the min-groups capacity
+// bound) cannot move here — they need a chainParser and registered providers. They stay in
+// validateCrossValidationStartup.
+func PreflightValidateCrossValidationConfig(v *viper.Viper) error {
+	cfg, err := ParseCrossValidationConfig(v)
+	if err != nil {
+		return err
+	}
+	_, err = NewCrossValidationPolicyResolver(cfg)
+	return err
+}
+
 // HasPolicies reports whether any policy is configured (used to keep the no-policy path identical to today).
 func (r *CrossValidationPolicyResolver) HasPolicies() bool {
 	return r != nil && len(r.policies) > 0

--- a/protocol/rpcsmartrouter/cross_validation_policy_test.go
+++ b/protocol/rpcsmartrouter/cross_validation_policy_test.go
@@ -306,6 +306,75 @@ func TestParseCrossValidationConfig_RejectsNonInteger(t *testing.T) {
 	}
 }
 
+// TestPreflightValidateCrossValidationConfig covers the context-free config gate that runs at process
+// start, before the router boots anything (MAG-3022). The contradiction it catches was already rejected
+// by NewCrossValidationPolicyResolver, but only from inside ServeRPCRequests — after every provider had
+// been dialed and after the router had logged "RPCSmartRouter Listening". These cases pin the rejection
+// to the preflight entry point, which is what makes the ordering structural rather than something you
+// have to read the logs to confirm.
+func TestPreflightValidateCrossValidationConfig(t *testing.T) {
+	preflight := func(t *testing.T, yamlBody string) error {
+		t.Helper()
+		v := viper.New()
+		v.SetConfigType("yaml")
+		require.NoError(t, v.ReadConfig(strings.NewReader(yamlBody)))
+		return PreflightValidateCrossValidationConfig(v)
+	}
+
+	const policyHeader = "cross-validation:\n" +
+		"  policies:\n" +
+		"    - chain-id: ETH1\n" +
+		"      api-interface: jsonrpc\n" +
+		"      method: eth_feeHistory\n"
+
+	t.Run("enabled + forbid-caller-cv is rejected before boot", func(t *testing.T) {
+		// The exact shape from the MAG-3022 report.
+		err := preflight(t, policyHeader+"      enabled: true\n      forbid-caller-cv: true\n")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mutually exclusive")
+		assert.Contains(t, err.Error(), "ETH1/jsonrpc/eth_feeHistory",
+			"the error must name the offending policy so an operator can find it without a debugger")
+	})
+
+	t.Run("either knob alone is accepted", func(t *testing.T) {
+		require.NoError(t, preflight(t, policyHeader+"      enabled: true\n"))
+		require.NoError(t, preflight(t, policyHeader+"      forbid-caller-cv: true\n"))
+	})
+
+	t.Run("no cross-validation key at all is accepted", func(t *testing.T) {
+		// The overwhelmingly common config. Preflight must be a no-op for it.
+		require.NoError(t, preflight(t, "direct-rpc:\n  - name: x\n"))
+	})
+
+	t.Run("the other context-free errors are caught too", func(t *testing.T) {
+		for _, tc := range []struct {
+			desc, body, wantSubstring string
+		}{
+			{
+				desc:          "missing method",
+				body:          "cross-validation:\n  policies:\n    - chain-id: ETH1\n      api-interface: jsonrpc\n",
+				wantSubstring: "must set chain-id, api-interface, and method",
+			},
+			{
+				desc:          "duplicate policy",
+				body:          policyHeader + "      enabled: true\n" + policyHeader[len("cross-validation:\n  policies:\n"):] + "      enabled: true\n",
+				wantSubstring: "duplicate cross-validation policy",
+			},
+			{
+				desc:          "non-integer knob",
+				body:          policyHeader + "      enabled: true\n      agreement-threshold: 2.5\n",
+				wantSubstring: "cross-validation",
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				err := preflight(t, tc.body)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantSubstring)
+			})
+		}
+	})
+}
+
 // TestValidateCrossValidationStartup covers the startup guards: the stateful-write guard (with a real
 // parser and the fail-closed path when the parser cannot classify) and the min-groups capacity bound.
 func TestValidateCrossValidationStartup(t *testing.T) {

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -2695,7 +2695,6 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	// relay + poll observations, with strict-majority consensus), constructed inside
 	// ServeRPCRequests. No single-node tip, no fire-and-forget poller per pod.
 
-	utils.LavaFormatInfo("RPCSmartRouter Listening", utils.Attribute{Key: "endpoints", Value: rpcEndpoint.String()})
 	// Convert smartRouterIdentifier string to empty sdk.AccAddress for smart router
 	err = rpcSmartRouterServer.ServeRPCRequests(ctx, rpcEndpoint, chainParser, sessionManager, options.cache, rpcSmartRouterMetrics, relaysMonitor, options.cmdFlags, options.stateShare, wsSubscriptionManager, smartRouterMetricsManager)
 	if err != nil {
@@ -2703,6 +2702,17 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 		errCh <- err
 		return err
 	}
+
+	// Logged AFTER ServeRPCRequests returns, not before it (MAG-3022). Everything ServeRPCRequests
+	// validates synchronously — the cross-validation startup guards, the chain listener construction —
+	// happens before this line now, so the message is only written once the endpoint has actually been
+	// brought up. Previously it was written first, which meant any synchronous failure inside
+	// ServeRPCRequests produced a router that announced itself and then exited.
+	//
+	// Not a bind confirmation: ServeRPCRequests starts the listener with `go chainListener.Serve(...)`,
+	// so the socket may still be a moment away. It does mean the endpoint was accepted and serving is
+	// underway, which is what the line is read as.
+	utils.LavaFormatInfo("RPCSmartRouter Listening", utils.Attribute{Key: "endpoints", Value: rpcEndpoint.String()})
 
 	// Store server reference for per-endpoint ChainTracker cleanup on epoch updates
 	rpsr.mu.Lock()
@@ -2848,6 +2858,16 @@ rpcsmartrouter smartrouter_examples/smartrouter_eth.yml --cache-be "127.0.0.1:77
 			rpcEndpoints, err = ParseEndpoints(viper.GetViper())
 			if err != nil || len(rpcEndpoints) == 0 {
 				return utils.LavaFormatError("invalid endpoints definition", err)
+			}
+
+			// Reject a self-contradictory cross-validation config here, alongside the endpoints check,
+			// rather than per-endpoint inside ServeRPCRequests (MAG-3022). Both are pure config-shape
+			// checks and both are decidable from viper alone. Doing it here means the process exits
+			// before the metrics port binds, before any provider is dialed, and before the router logs
+			// that it is listening — so a bad config is a clean startup error instead of a crash loop
+			// from a router that has already announced itself.
+			if err := PreflightValidateCrossValidationConfig(viper.GetViper()); err != nil {
+				return utils.LavaFormatError("invalid cross-validation configuration", err)
 			}
 
 			// Smart router doesn't need blockchain chain ID


### PR DESCRIPTION
# Description

A self-contradictory per-method cross-validation policy — one setting both `enabled` and `forbid-caller-cv` — was rejected correctly, but only from inside `ServeRPCRequests`. By then the router had validated every provider, dialed each one, reset its blocked-provider list, and logged `RPCSmartRouter Listening`. The failure landed one line after the announce, so a bad config produced a crash loop from a router that had already presented itself as up.

## Jira ticket

Jira ticket: MAG-3022

---

## What changed

Split the validation along the line the code already suggests.

**The context-free half moves to `RunE`.** The `enabled`/`forbid-caller-cv` contradiction, missing `chain-id`/`api-interface`/`method`, duplicate policies, and out-of-range bounds are all decidable from viper alone. New `PreflightValidateCrossValidationConfig` runs next to the existing endpoints check — before the metrics port binds, before any provider is dialed, before the announce.

**The context-dependent half stays put.** The stateful-write guard needs a `chainParser`; the min-groups capacity bound needs registered providers. `validateCrossValidationStartup` cannot move and doesn't.

**`RPCSmartRouter Listening` moves below the `ServeRPCRequests` error check.** That covers the context-dependent half without relocating it, since those guards run synchronously inside `ServeRPCRequests`. The line is still not a bind confirmation — the listener starts via `go chainListener.Serve(...)` — but it no longer precedes the checks that can reject the endpoint. Commented as such.

No behavior change for a valid config: the preflight is the same parse and the same resolver construction `ServeRPCRequests` already performs. Configs with no `cross-validation:` key are a no-op.

## Files to review

- `protocol/rpcsmartrouter/cross_validation_policy.go` — the new preflight function.
- `protocol/rpcsmartrouter/rpcsmartrouter.go` — the `RunE` call site and the log move.

## Verification

Real boot with the exact config shape from the ticket:

```
BEFORE (main, 17 lines)                 AFTER (5 lines)
  ...                                     INF Process Started
  INF prometheus endpoint listening       INF RPCSmartRouter started
      Listen Address=0.0.0.0:7779         INF read config file successfully
  INF RPCSmartRouter identifier           ERR invalid cross-validation configuration
  INF setting up endpoints length=1           ...mutually exclusive...
  ERR no static spec paths...
```

After: exits ~0.4 ms after reading config, before `Running Smart Router`, before the metrics manager exists.

Caveat on the before-run: the minimal repro config has no static spec paths, so on `main` it died on that instead of reaching the CV error — it does not reproduce the ticket's exact six-line sequence. It does show the metrics port binding while the router is nowhere near serving, which is the subject of MAG-3045.

Tests: `TestPreflightValidateCrossValidationConfig` (4 subtests, including the exact MAG-3022 shape and the no-policy no-op). Full `protocol/rpcsmartrouter` package passes, `go vet` clean.

## Not in scope

MAG-3022 asked for a test asserting the listening line does not precede the policy error, read from pod logs. That is not assertable under our testing rules and a deploy test would be filtered out of both nightly lanes by `and not slow`. Hoisting the validation makes the ordering structural instead — the unit test covers the rejection at the preflight entry point, and there is no longer a path where the announce can come first.

MAG-3045 covers the other half of the reported symptom: the readiness probe reads `/metrics`, so a router that cannot serve still reports Ready and a failed deploy evicts the last working pod. That is a chart change and is not addressed here. This PR makes the log line honest; it does not make the pod state honest.

---

## Author Checklist

I have...

* [x] read the [contribution guide](https://github.com/magma-Devs/smart-router/blob/main/CONTRIBUTING.md)
* [x] included the correct type prefix in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change — n/a, not breaking; a config already rejected at startup is now rejected earlier
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests
* [x] updated the relevant documentation or specification, including comments for documenting Go code
* [ ] confirmed all CI checks have passed — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)