### PR TITLE
fix(lavasession): release the blocked provider list only after backup fails (MAG-2599)

### DIFF
--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -911,17 +911,54 @@ func (csm *ConsumerSessionManager) cacheAddonAddresses(addon string, extensions 
 	return result
 }
 
+// releaseCouldServeThisRequest reports whether releasing the blocked list could hand THIS request a
+// provider it has not already tried. A release refills validAddresses from the whole pairing pool,
+// so the question is whether any of those providers is both absent from this request's ignored set
+// and able to serve the addon and extensions asked for.
+//
+// When the answer is no, releasing cannot rescue the request and only destroys standing state that
+// every other relay depends on. That happens whenever the pool empties *during* a request rather
+// than before it: each provider is blocked as it fails, and by the time the last one goes the
+// request has already tried them all.
+func (csm *ConsumerSessionManager) releaseCouldServeThisRequest(ignored map[string]struct{}, addon string, extensions []string, ctx context.Context) bool {
+	csm.lock.RLock()
+	defer csm.lock.RUnlock()
+
+	for _, address := range csm.pairingAddresses {
+		if _, alreadyTried := ignored[address]; alreadyTried {
+			continue
+		}
+		provider, ok := csm.pairing[address]
+		if !ok || provider == nil {
+			continue
+		}
+		if provider.IsSupportingAddon(addon) && provider.IsSupportingExtensions(extensions, ctx) {
+			return true
+		}
+	}
+	return false
+}
+
 // releaseBlockedProvidersIfPoolEmpty releases the standing blocked list and retries selection once,
 // as the last resort of the failover cascade.
 //
-// It is a no-op unless the valid pool is genuinely empty. That guard is the whole subtlety: the
-// errors that bring us here also cover "every valid address is already ignored by this request",
-// which is ordinary retry exhaustion, and releasing on that would let one retried relay wipe the
-// blocked list for every other relay in the process.
+// Two guards, and both matter. The pool must be genuinely empty: the errors that bring us here also
+// cover "every valid address is already ignored by this request", which is ordinary retry
+// exhaustion, and releasing on that would let one retried relay wipe the blocked list for every
+// other relay in the process. And the release must be able to help the request making it — see
+// releaseCouldServeThisRequest — because GetSessions runs this chain more than once per relay, so a
+// request whose providers are blocked one by one arrives here a second time with nothing left to
+// try. Releasing then leaves the pool looking healthy while nothing in it can serve.
 //
 // Returns ok=false when nothing was released, or when the retry after a release still found nothing.
 func (csm *ConsumerSessionManager) releaseBlockedProvidersIfPoolEmpty(ctx context.Context, wantedProviderNumber int, tempIgnoredProviders *ignoredProviders, cuNeededForSession uint64, requestedBlock int64, addon string, extensionNames []string, stateful uint32, virtualEpoch uint64, stickiness string, selectedProvider string, minGroups, perGroupTarget int) (SessionWithProviderMap, bool) {
 	if len(csm.cacheAddonAddresses(addon, extensionNames, ctx)) != 0 {
+		return nil, false
+	}
+
+	if !csm.releaseCouldServeThisRequest(tempIgnoredProviders.providers, addon, extensionNames, ctx) {
+		utils.LavaFormatDebug("every provider has already been tried by this request, leaving the blocked list standing",
+			utils.LogAttr("addon", addon), utils.LogAttr("extensions", extensionNames), utils.LogAttr("GUID", ctx))
 		return nil, false
 	}
 

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -911,27 +911,39 @@ func (csm *ConsumerSessionManager) cacheAddonAddresses(addon string, extensions 
 	return result
 }
 
-// validating we still have providers, otherwise reset valid addresses list
-// also caches validAddresses for an addon to save on compute
-func (csm *ConsumerSessionManager) validatePairingListNotEmpty(addon string, extensions []string, ctx context.Context) uint64 {
-	numberOfResets := csm.atomicReadNumberOfResets()
-	validAddresses := csm.cacheAddonAddresses(addon, extensions, ctx)
-	// currentlyBlockedProviderAddresses is intentionally not read here: this method holds no csm.lock,
-	// so reading the shared slice for a log attr races a concurrent writer (blockProvider / restore).
-	utils.LavaFormatInfo("VALIDATING PROVIDERS", utils.LogAttr("addon", addon), utils.LogAttr("extensions", extensions), utils.LogAttr("validAddressesCount", len(validAddresses)), utils.LogAttr("validAddresses", validAddresses), utils.LogAttr("GUID", ctx))
-	if len(validAddresses) == 0 {
-		utils.LavaFormatWarning("NO VALID PROVIDERS - TRIGGERING RESET", nil, utils.LogAttr("addon", addon), utils.LogAttr("extensions", extensions), utils.LogAttr("GUID", ctx))
-		numberOfResets = csm.resetValidAddresses(addon, extensions)
-		utils.LavaFormatInfo("RESET COMPLETED", utils.LogAttr("addon", addon), utils.LogAttr("extensions", extensions), utils.LogAttr("newValidAddressesCount", len(csm.cacheAddonAddresses(addon, extensions, ctx))), utils.LogAttr("GUID", ctx))
+// releaseBlockedProvidersIfPoolEmpty releases the standing blocked list and retries selection once,
+// as the last resort of the failover cascade.
+//
+// It is a no-op unless the valid pool is genuinely empty. That guard is the whole subtlety: the
+// errors that bring us here also cover "every valid address is already ignored by this request",
+// which is ordinary retry exhaustion, and releasing on that would let one retried relay wipe the
+// blocked list for every other relay in the process.
+//
+// Returns ok=false when nothing was released, or when the retry after a release still found nothing.
+func (csm *ConsumerSessionManager) releaseBlockedProvidersIfPoolEmpty(ctx context.Context, wantedProviderNumber int, tempIgnoredProviders *ignoredProviders, cuNeededForSession uint64, requestedBlock int64, addon string, extensionNames []string, stateful uint32, virtualEpoch uint64, stickiness string, selectedProvider string, minGroups, perGroupTarget int) (SessionWithProviderMap, bool) {
+	if len(csm.cacheAddonAddresses(addon, extensionNames, ctx)) != 0 {
+		return nil, false
 	}
-	return numberOfResets
+
+	utils.LavaFormatWarning("NO VALID PROVIDERS - TRIGGERING RESET", nil, utils.LogAttr("addon", addon), utils.LogAttr("extensions", extensionNames), utils.LogAttr("GUID", ctx))
+	csm.resetValidAddresses(addon, extensionNames)
+	utils.LavaFormatInfo("RESET COMPLETED", utils.LogAttr("addon", addon), utils.LogAttr("extensions", extensionNames), utils.LogAttr("newValidAddressesCount", len(csm.cacheAddonAddresses(addon, extensionNames, ctx))), utils.LogAttr("GUID", ctx))
+
+	sessionWithProviderMap, err := csm.getValidConsumerSessionsWithProvider(ctx, wantedProviderNumber, tempIgnoredProviders, cuNeededForSession, requestedBlock, addon, extensionNames, stateful, virtualEpoch, stickiness, selectedProvider, minGroups, perGroupTarget)
+	if err != nil {
+		return nil, false
+	}
+
+	utils.LavaFormatDebug("Successfully got session after releasing the blocked provider list", utils.LogAttr("GUID", ctx))
+	return sessionWithProviderMap, true
 }
 
 func (csm *ConsumerSessionManager) getSessionWithProviderOrError(ctx context.Context, wantedProviderNumber int, usedProviders UsedProvidersInf, tempIgnoredProviders *ignoredProviders, cuNeededForSession uint64, requestedBlock int64, addon string, extensionNames []string, stateful uint32, virtualEpoch uint64, stickiness string, selectedProvider string, minGroups, perGroupTarget int) (sessionWithProviderMap SessionWithProviderMap, err error) {
 	sessionWithProviderMap, err = csm.getValidConsumerSessionsWithProvider(ctx, wantedProviderNumber, tempIgnoredProviders, cuNeededForSession, requestedBlock, addon, extensionNames, stateful, virtualEpoch, stickiness, selectedProvider, minGroups, perGroupTarget)
 	if err != nil {
 		if errors.Is(err, PairingListEmptyError) {
-			// Emergency fallback chain: backup providers first, then blocked providers for maximum availability
+			// Emergency fallback chain, in order: backup providers, then releasing the standing
+			// blocked list, then the blocked providers themselves, for maximum availability.
 			if len(csm.backupProviders) > 0 {
 				utils.LavaFormatDebug("No regular providers available, trying backup providers", utils.LogAttr("GUID", ctx))
 				// try to get a session from the backup providers
@@ -941,8 +953,18 @@ func (csm *ConsumerSessionManager) getSessionWithProviderOrError(ctx context.Con
 					utils.LavaFormatDebug("Successfully got session from backup providers", utils.LogAttr("GUID", ctx))
 					return sessionWithProviderMap, nil
 				}
-				// backup providers failed, continue to blocked providers
-				utils.LavaFormatDebug("Backup providers failed, trying blocked providers", utils.LogAttr("error", err.Error()), utils.LogAttr("GUID", ctx))
+				// backup providers failed, continue to the standing-bench release
+				utils.LavaFormatDebug("Backup providers failed, releasing the blocked provider list", utils.LogAttr("error", err.Error()), utils.LogAttr("GUID", ctx))
+			}
+
+			// Every primary is blocked and backup could not serve either, so release the standing
+			// blocked list and give the primaries one more chance. This used to run at the top of
+			// every GetSessions, which refilled validAddresses before the backup tier was ever
+			// consulted — so backup was unreachable via this path, and the block never held for
+			// longer than a single request. Running it here is what lets "every primary is blocked"
+			// actually mean "serve backup".
+			if released, ok := csm.releaseBlockedProvidersIfPoolEmpty(ctx, wantedProviderNumber, tempIgnoredProviders, cuNeededForSession, requestedBlock, addon, extensionNames, stateful, virtualEpoch, stickiness, selectedProvider, minGroups, perGroupTarget); ok {
+				return released, nil
 			}
 
 			// try to recover a session from the currently blocked providers
@@ -953,6 +975,16 @@ func (csm *ConsumerSessionManager) getSessionWithProviderOrError(ctx context.Con
 				return nil, errOnRetry
 			}
 			utils.LavaFormatDebug("Successfully got session from blocked providers", utils.LogAttr("GUID", ctx))
+		} else if errors.Is(err, SelectedProviderUnavailableError) {
+			// A pinned request must never fall through to a provider the caller did not ask for, so
+			// neither the backup tier nor the blocked-provider walk applies here. But an empty pool
+			// still has to release the blocked list, exactly as the old top-of-GetSessions reset
+			// did: without this, lava-select-provider stops resolving the moment every provider is
+			// blocked, even though the pinned provider is sitting in that blocked list.
+			if released, ok := csm.releaseBlockedProvidersIfPoolEmpty(ctx, wantedProviderNumber, tempIgnoredProviders, cuNeededForSession, requestedBlock, addon, extensionNames, stateful, virtualEpoch, stickiness, selectedProvider, minGroups, perGroupTarget); ok {
+				return released, nil
+			}
+			return nil, err
 		} else {
 			return nil, err
 		}
@@ -1034,8 +1066,13 @@ func (csm *ConsumerSessionManager) GetSessions(ctx context.Context, wantedProvid
 		utils.LogAttr("originalExtensions", extensions),
 		utils.LogAttr("extensionNames", extensionNames),
 		utils.LogAttr("GUID", ctx))
-	// if pairing list is empty we reset the state.
-	numberOfResets := csm.validatePairingListNotEmpty(addon, extensionNames, ctx)
+	// Warm the addon/extension address cache for this router key. The empty-pool reset that used
+	// to run here has moved into getSessionWithProviderOrError, so it fires only once the backup
+	// tier has also been ruled out rather than before the tier is consulted at all.
+	validAddresses := csm.cacheAddonAddresses(addon, extensionNames, ctx)
+	// currentlyBlockedProviderAddresses is intentionally not read here: no csm.lock is held, so
+	// reading the shared slice for a log attr races a concurrent writer (blockProvider / restore).
+	utils.LavaFormatInfo("VALIDATING PROVIDERS", utils.LogAttr("addon", addon), utils.LogAttr("extensions", extensionNames), utils.LogAttr("validAddressesCount", len(validAddresses)), utils.LogAttr("validAddresses", validAddresses), utils.LogAttr("GUID", ctx))
 
 	// providers that we don't try to connect this iteration.
 	tempIgnoredProviders := &ignoredProviders{
@@ -1050,6 +1087,10 @@ func (csm *ConsumerSessionManager) GetSessions(ctx context.Context, wantedProvid
 		utils.LavaFormatTrace("GetSessions error", utils.LogAttr("error", err.Error()), utils.LogAttr("GUID", ctx))
 		return nil, err
 	}
+
+	// Scales the per-provider blocklisted-session allowance, so it is read after the cascade
+	// rather than before it: a last-resort release inside it has to be reflected here.
+	numberOfResets := csm.atomicReadNumberOfResets()
 
 	// Save how many sessions we are aiming to have
 	wantedSession := len(sessionWithProviderMap)

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -2518,11 +2518,23 @@ func TestCheckAndUnblock_BackupUnblockedWhenHealthy(t *testing.T) {
 	err = csm.UpdateAllProviders(secondEpochHeight, nil, backupListEpoch2)
 	require.NoError(t, err)
 
-	// Precondition: re-blocked after epoch transition (comes from the previousEpoch merge).
-	csm.lock.RLock()
-	_, reblocked := csm.blockedBackupProviders[backupAddr]
-	csm.lock.RUnlock()
-	require.True(t, reblocked, "backup should be re-blocked immediately after epoch transition")
+	// UpdateAllProviders schedules its own unblock pass on a randomised delay, and against this
+	// live listener that pass SUCCEEDS — so the re-blocked state the epoch merge produces cannot be
+	// observed from here without racing it. (The sibling
+	// TestUpdateAllProviders_BlockedBackupProviderPersistedAcrossEpoch pins that merge
+	// deterministically by pointing epoch 2 at a dead endpoint, which this test cannot do since a
+	// successful probe is the thing under test.) So let the background pass finish first, then set
+	// up the state this test is actually about, leaving the manual pass below the only actor on it.
+	require.Eventually(t, func() bool {
+		csm.lock.RLock()
+		defer csm.lock.RUnlock()
+		return len(csm.previousEpochBlockedProviders) == 0
+	}, 5*time.Second, 10*time.Millisecond, "background unblock pass spawned by UpdateAllProviders should have run")
+
+	csm.lock.Lock()
+	csm.blockedBackupProviders[backupAddr] = struct{}{}
+	csm.previousEpochBlockedProviders[backupAddr] = struct{}{}
+	csm.lock.Unlock()
 
 	// Run the unblock pass. Comprehensive probe against grpcListener should succeed → unblock.
 	csm.checkAndUnblockHealthyReBlockedProviders(context.Background(), secondEpochHeight)

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -163,8 +163,9 @@ func TestEndpointHealthRecovery(t *testing.T) {
 	// The fix: ResetEndpointHealth re-enables the endpoints, and that is the ONLY external
 	// ingredient recovery needs. ResetBlockedProviders alone just failed above; re-enabling the
 	// endpoints was the missing piece. The blocked-provider state then self-heals on the very next
-	// GetSessions: with validAddresses empty it runs validatePairingListNotEmpty → resetValidAddresses
-	// → setValidAddressesToDefaultValue, which clears the blocked list and refills validAddresses from
+	// GetSessions: with validAddresses empty, selection fails, no backup tier is configured, and the
+	// cascade's last resort runs releaseBlockedProvidersIfPoolEmpty → resetValidAddresses →
+	// setValidAddressesToDefaultValue, which clears the blocked list and refills validAddresses from
 	// the pairing pool, so the now-enabled endpoints get selected. No explicit ResetBlockedProviders
 	// is required here — which is exactly why /debug/reset-endpoint-health re-enables endpoints and
 	// nothing else.

--- a/protocol/lavasession/unbench_after_backup_test.go
+++ b/protocol/lavasession/unbench_after_backup_test.go
@@ -1,0 +1,191 @@
+package lavasession
+
+import (
+	"context"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// FAILOVER-TASKS section 5: the last-resort release of the blocked provider list must fire only
+// when primary AND backup are both exhausted.
+//
+// It used to run at the top of every GetSessions, keyed on the primary pool alone. That refilled
+// validAddresses before the backup tier was ever consulted, so the "every primary is blocked"
+// route to backup was unreachable, and the block never survived a single request — which is what
+// made per-provider blocking settings (bench-after, cooldown) impossible to build on top of.
+
+// mkProviderForBenchTest builds a provider whose single endpoint points at the package's test grpc
+// server, so a session can actually be established against it.
+func mkProviderForBenchTest(address string) *ConsumerSessionsWithProvider {
+	return &ConsumerSessionsWithProvider{
+		PublicLavaAddress: address,
+		Endpoints:         []*Endpoint{{NetworkAddress: grpcListener, Enabled: true, Connections: []*EndpointConnection{}}},
+		Sessions:          map[int64]*SingleConsumerSession{},
+		MaxComputeUnits:   200,
+		PairingEpoch:      firstEpochHeight,
+	}
+}
+
+// setupBenchTestCSM returns a manager with two primaries and, optionally, one backup.
+func setupBenchTestCSM(t *testing.T, withBackup bool) *ConsumerSessionManager {
+	t.Helper()
+	csm := CreateConsumerSessionManager()
+	primaries := map[uint64]*ConsumerSessionsWithProvider{
+		0: mkProviderForBenchTest("lava@primary0"),
+		1: mkProviderForBenchTest("lava@primary1"),
+	}
+	var backups map[uint64]*ConsumerSessionsWithProvider
+	if withBackup {
+		backups = map[uint64]*ConsumerSessionsWithProvider{0: mkProviderForBenchTest("lava@backup0")}
+	}
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, primaries, backups))
+	return csm
+}
+
+// blockEveryPrimary empties the valid-address pool the way repeated failures do, and records the
+// providers as blocked so the state under test is the real one rather than just an empty slice.
+func blockEveryPrimary(csm *ConsumerSessionManager) {
+	csm.lock.Lock()
+	defer csm.lock.Unlock()
+	csm.currentlyBlockedProviderAddresses = append([]string{}, csm.validAddresses...)
+	csm.validAddresses = []string{}
+	csm.addonAddresses = nil // drop the cached per-router-key view of the pool we just emptied
+}
+
+// The core section-5 change: with every primary blocked, the request is served by backup and the
+// block is left standing. Before the fix the top-of-GetSessions reset refilled the pool first, so
+// this served a primary that had just been blocked and backup never saw the traffic.
+func TestAllPrimariesBlocked_ServesBackupAndKeepsTheBlock(t *testing.T) {
+	ctx := context.Background()
+	csm := setupBenchTestCSM(t, true)
+	blockEveryPrimary(csm)
+
+	css, err := csm.GetSessions(ctx, 1, cuForFirstRequest, NewUsedProviders(nil), servicedBlockNumber, "", nil, common.NO_STATE, 0, "", "")
+	require.NoError(t, err)
+	require.Len(t, css, 1)
+
+	for providerAddress := range css {
+		require.Equal(t, "lava@backup0", providerAddress, "an all-primaries-blocked pool must be served by backup")
+	}
+
+	// The block has to survive the request, otherwise nothing can be built on top of it.
+	require.Equal(t, uint64(0), csm.numberOfResets, "serving from backup must not release the blocked provider list")
+	require.Empty(t, csm.validAddresses, "the primary pool must stay empty while backup is serving")
+	require.Len(t, csm.currentlyBlockedProviderAddresses, 2, "both primaries must stay blocked")
+}
+
+// Traffic returns to primary by itself once one recovers — there is no state to reset.
+func TestAllPrimariesBlocked_ReturnsToPrimaryOnRecovery(t *testing.T) {
+	ctx := context.Background()
+	csm := setupBenchTestCSM(t, true)
+	blockEveryPrimary(csm)
+
+	css, err := csm.GetSessions(ctx, 1, cuForFirstRequest, NewUsedProviders(nil), servicedBlockNumber, "", nil, common.NO_STATE, 0, "", "")
+	require.NoError(t, err)
+	for providerAddress := range css {
+		require.Equal(t, "lava@backup0", providerAddress)
+	}
+
+	// One primary recovers.
+	csm.lock.Lock()
+	csm.validAddresses = []string{"lava@primary0"}
+	csm.currentlyBlockedProviderAddresses = []string{"lava@primary1"}
+	csm.addonAddresses = nil
+	csm.lock.Unlock()
+
+	css, err = csm.GetSessions(ctx, 1, cuForFirstRequest, NewUsedProviders(nil), servicedBlockNumber, "", nil, common.NO_STATE, 0, "", "")
+	require.NoError(t, err)
+	for providerAddress := range css {
+		require.Equal(t, "lava@primary0", providerAddress, "traffic must return to primary on its own once one is healthy")
+	}
+	require.Equal(t, uint64(0), csm.numberOfResets, "recovery needs no reset")
+}
+
+// Step 3 of the section-5 order: when backup cannot serve either, the block is released so the
+// router keeps serving. This is the path that used to fire first; it must still fire last.
+func TestAllPrimariesBlocked_BackupUnusableStillReleasesTheBlock(t *testing.T) {
+	ctx := context.Background()
+	csm := setupBenchTestCSM(t, true)
+	blockEveryPrimary(csm)
+
+	// The backup tier exists but cannot serve.
+	csm.lock.Lock()
+	csm.blockedBackupProviders["lava@backup0"] = struct{}{}
+	csm.lock.Unlock()
+
+	css, err := csm.GetSessions(ctx, 1, cuForFirstRequest, NewUsedProviders(nil), servicedBlockNumber, "", nil, common.NO_STATE, 0, "", "")
+	require.NoError(t, err, "with nothing healthy anywhere the router must release the block and keep serving")
+	require.Len(t, css, 1)
+	for providerAddress := range css {
+		require.Contains(t, []string{"lava@primary0", "lava@primary1"}, providerAddress)
+	}
+	require.Equal(t, uint64(1), csm.numberOfResets, "exactly one release once primary and backup are both exhausted")
+	require.Len(t, csm.validAddresses, 2, "the release refills the primary pool")
+}
+
+// With no backup configured at all the behaviour is unchanged: the block is released as before.
+func TestAllPrimariesBlocked_NoBackupReleasesTheBlockAsBefore(t *testing.T) {
+	ctx := context.Background()
+	csm := setupBenchTestCSM(t, false)
+	blockEveryPrimary(csm)
+
+	css, err := csm.GetSessions(ctx, 1, cuForFirstRequest, NewUsedProviders(nil), servicedBlockNumber, "", nil, common.NO_STATE, 0, "", "")
+	require.NoError(t, err)
+	require.Len(t, css, 1)
+	require.Equal(t, uint64(1), csm.numberOfResets)
+	require.Len(t, csm.validAddresses, 2)
+}
+
+// The release is guarded on the pool being genuinely empty. "No pairings available" also covers
+// ordinary retry exhaustion — every healthy provider already tried by THIS request — and that must
+// not release anyone's block, or a single retried relay would wipe the state for every other one.
+func TestRetryExhaustion_DoesNotReleaseTheBlock(t *testing.T) {
+	ctx := context.Background()
+	csm := setupBenchTestCSM(t, false)
+
+	// The pool is full and healthy; this request has simply already used every provider in it.
+	usedProviders := NewUsedProviders(nil)
+	routerKey := NewRouterKey(nil)
+	usedProviders.AddUnwantedAddresses("lava@primary0", routerKey)
+	usedProviders.AddUnwantedAddresses("lava@primary1", routerKey)
+
+	_, err := csm.GetSessions(ctx, 1, cuForFirstRequest, usedProviders, servicedBlockNumber, "", nil, common.NO_STATE, 0, "", "")
+	require.Error(t, err, "a request that has exhausted its own retries has nowhere left to go")
+
+	require.Equal(t, uint64(0), csm.numberOfResets, "retry exhaustion must not release the blocked provider list")
+	require.Len(t, csm.validAddresses, 2, "the pool was never empty and must be untouched")
+}
+
+// A pinned request (lava-select-provider) resolves against validAddresses BEFORE the empty-pool
+// check, and fails with SelectedProviderUnavailableError rather than PairingListEmptyError. Moving
+// the release into the cascade therefore has to catch that error too, or pinning silently stops
+// working the moment every provider is blocked — the pinned provider is sitting in the blocked list.
+func TestPinnedProvider_EmptyPoolStillReleasesTheBlock(t *testing.T) {
+	ctx := context.Background()
+	csm := setupBenchTestCSM(t, false)
+	blockEveryPrimary(csm)
+
+	css, err := csm.GetSessions(ctx, 1, cuForFirstRequest, NewUsedProviders(nil), servicedBlockNumber, "", nil, common.NO_STATE, 0, "", "lava@primary0")
+	require.NoError(t, err, "a pinned provider must still be reachable when every provider is blocked")
+	require.Len(t, css, 1)
+	for providerAddress := range css {
+		require.Equal(t, "lava@primary0", providerAddress, "the pin must be honoured, not replaced")
+	}
+	require.Equal(t, uint64(1), csm.numberOfResets)
+}
+
+// The pinned path must not fall through to another provider: a pin exists precisely so the request
+// is never served by someone the caller did not ask for. With a healthy pool, an unknown pin is
+// still an error, and nobody's block is released.
+func TestPinnedProvider_UnknownNameWithHealthyPoolStillFails(t *testing.T) {
+	ctx := context.Background()
+	csm := setupBenchTestCSM(t, true)
+
+	_, err := csm.GetSessions(ctx, 1, cuForFirstRequest, NewUsedProviders(nil), servicedBlockNumber, "", nil, common.NO_STATE, 0, "", "lava@doesnotexist")
+	require.Error(t, err, "an unknown pin must fail rather than be silently replaced")
+	require.ErrorIs(t, err, SelectedProviderUnavailableError)
+	require.Equal(t, uint64(0), csm.numberOfResets, "a bad pin must not release anyone's block")
+	require.Len(t, csm.validAddresses, 2)
+}

--- a/protocol/lavasession/unbench_after_backup_test.go
+++ b/protocol/lavasession/unbench_after_backup_test.go
@@ -138,6 +138,43 @@ func TestAllPrimariesBlocked_NoBackupReleasesTheBlockAsBefore(t *testing.T) {
 	require.Len(t, csm.validAddresses, 2)
 }
 
+// GetSessions runs the failover chain more than once per relay — once up front, and again from the
+// "fetch more sessions" loop. So a relay whose providers are blocked one at a time as they fail
+// arrives at the release a SECOND time, by which point it has already tried all of them. Releasing
+// then cannot rescue the relay and only wipes the standing block, leaving the pool reading healthy
+// while nothing in it can serve — the exact opposite of what this change is for.
+//
+// This is the realistic shape of an outage: providers are blocked because their endpoints went
+// down, and the release does not re-enable endpoints (see HEALTH-STORE-PLAN.md), so every released
+// provider fails again immediately.
+func TestProvidersBlockedMidRelay_DoNotReleaseTheBlockAgain(t *testing.T) {
+	ctx := context.Background()
+	csm := setupBenchTestCSM(t, false)
+
+	// Endpoints are down underneath the providers, which is why they were blocked.
+	csm.lock.Lock()
+	for _, address := range csm.validAddresses {
+		for _, endpoint := range csm.pairing[address].Endpoints {
+			endpoint.Enabled = false
+		}
+	}
+	csm.lock.Unlock()
+	blockEveryPrimary(csm)
+
+	for relay := 1; relay <= 3; relay++ {
+		_, err := csm.GetSessions(ctx, 1, cuForFirstRequest, NewUsedProviders(nil), servicedBlockNumber, "", nil, common.NO_STATE, 0, "", "")
+		require.Error(t, err, "relay %d: nothing can serve, so the relay must fail", relay)
+
+		// The standing state has to keep telling the truth: these providers are blocked.
+		require.Empty(t, csm.validAddresses, "relay %d: the pool must not be left looking healthy", relay)
+		require.Len(t, csm.currentlyBlockedProviderAddresses, 2, "relay %d: both providers must stay blocked", relay)
+
+		// One release per relay, not two. numberOfResets scales the blocklisted-session allowance,
+		// so a double release loosens that cap twice as fast as it should.
+		require.Equal(t, uint64(relay), csm.numberOfResets, "relay %d: exactly one release per relay", relay)
+	}
+}
+
 // The release is guarded on the pool being genuinely empty. "No pairings available" also covers
 // ordinary retry exhaustion — every healthy provider already tried by THIS request — and that must
 // not release anyone's block, or a single retried relay would wipe the state for every other one.


### PR DESCRIPTION
Jira ticket: MAG-2599

Implements [FAILOVER-TASKS](../blob/main/agent_docs/bug-reports/failover/FAILOVER-TASKS.md) **section 5**: the last-resort "release every blocked provider" must fire only when primary *and* backup are both exhausted.

> **Note for the reviewer:** commit `d8373be`'s message opens with "WORK IN PROGRESS / Do not merge as-is". **That warning is stale.** It described a defect that the following commit, `7d2911d`, fixes and pins with a test. The branch carries no known defect. I left the sequence intact rather than rewrite history — happy to squash the two if you'd prefer a single commit.

---

## The bug

The router already had the right last resort *and* the right fallback chain. They were wired in the wrong order.

`getSessionWithProviderOrError` walks primary → backup → blocked-provider list, which is what sections 4 and 5 describe. But `GetSessions` called `validatePairingListNotEmpty` at the **top of every request**, and that refilled `validAddresses` the moment the primary pool went empty. So:

- by the time the chain ran, the pool was never empty
- `PairingListEmptyError` never fired from a standing-empty pool
- **the backup tier was unreachable through that path**
- "every primary is blocked" silently meant "serve a primary we just blocked"

And because it ran per request rather than once, the block never survived a single relay — the next request released it again. That is what makes `bench-after` and `cooldown` (sections 2 and 3) impossible to build today: any block they set is wiped by the next relay. **This change is their prerequisite.**

`validatePairingListNotEmpty` has not been touched since `22cbf32`, the initial implementation.

## The change

`validatePairingListNotEmpty` did two unrelated jobs. Job 1 — warming the addon address cache — stays at the top of `GetSessions`. Job 2 — the release — moves into the chain, after backup:

```
1. a healthy primary
2. no healthy primary            -> serve backup, block still standing
3. nothing healthy anywhere      -> release the block and keep serving
```

Traffic returns to primary by itself once one recovers; there is no state to unwind. `numberOfResets` is now read *after* the chain, since a release inside it has to reach the blocklisted-session allowance that scales with it.

### Two guards, both load-bearing

`releaseBlockedProvidersIfPoolEmpty` releases only when:

1. **the pool is genuinely empty** — `PairingListEmptyError` also covers "every valid address is already ignored by this request", which is ordinary retry exhaustion. Releasing on that would let one retried relay wipe the block for every other relay in the process.
2. **the release could help the request making it** (`releaseCouldServeThisRequest`) — `GetSessions` runs this chain more than once per relay, so a request whose providers are blocked one-by-one as they fail arrives a second time having already tried them all. Releasing then cannot rescue it and only wipes the standing block, leaving the pool reading healthy while nothing in it can serve.

Guard 2 is the fix in `7d2911d`. Without it, against providers whose endpoints are down — the realistic outage — this branch ended each relay with `valid=0 blocked=2` turned into `valid=2 blocked=0`, and grew `numberOfResets` twice as fast as `main`.

### Pinned providers

`getValidProviderAddresses` resolves a `lava-select-provider` pin **before** the empty-pool check and fails with `SelectedProviderUnavailableError`, not `PairingListEmptyError`. An earlier version of this change caught only the latter, which broke pinning whenever every provider was blocked. The chain now catches both.

The pinned path releases but never falls through to backup or the blocked-provider walk — a pin exists so the request is never served by someone the caller did not ask for. `SelectedProviderAlreadyFailedError` (added by `2debe75` on main) correctly does **not** release: the request has already tried that provider.

## Verification

- `go build ./...`, `go vet ./...` clean; `gofmt` clean on touched files
- full `go test ./...` green, multiple consecutive runs
- **Differential matrices against `main`**, since almost nothing here should change behaviour:
  - **pin matrix** — 9 `lava-select-provider` scenarios (healthy pin, blocked pin with others healthy, blocked pin with empty pool, unknown name, case-folded name, already-failed-this-request, no pin) × with and without a backup tier
  - **release-persistence matrix** — endpoints up and down, three relays each
  - Every row is **identical to `main`** except the one intended row: all-primaries-blocked with a backup configured, which now leaves the block standing instead of releasing it.

Two of the new tests fail on the pre-fix code: `GetSessions` hands back a just-blocked primary instead of the backup. `TestProvidersBlockedMidRelay_DoNotReleaseTheBlockAgain` fails without guard 2.

**Integration-tested against a live router** — full write-up in [this comment](https://github.com/Magma-Devs/smart-router/pull/328#issuecomment-5397521529). Headline: with both primaries blocked and backup healthy, **20 steady-state relays produce 20 releases on `main` and 0 on this branch**. Seven scenarios checked (backup serves, block holds, recovery, last-resort ordering, retry exhaustion, guard 2, and the pin hole below), each against `main` and against this branch under an identical rig.

## ⚠️ Behaviour change reviewers should weigh

**Backup providers now receive traffic in a case where they previously never did.** For a customer whose backup is the metered or paid tier, that is a cost change, not just a routing change. It is exactly what section 4 intends — but it lands before `spill-on` exists, so there is no way yet for a customer to say which failures may cross.

Operationally: `NO VALID PROVIDERS - TRIGGERING RESET` becomes much rarer and now appears *after* `[BackupProviders] Static providers exhausted`.

**What this does NOT change, contrary to an earlier version of this description:** in a direct-RPC deployment `main` does not actually route customer traffic to a dead primary. `GetSessions` hands one back, but the relay to it fails immediately (its endpoints are disabled) and the request reaches backup through the per-request ignored list. Measured: **both builds serve `backup-node`**. The defect this fixes is the churn — a wasted attempt on a known-bad provider per relay, `numberOfResets` incrementing per relay (which inflates `maximumBlockedSessionsAllowed`, since that scales with `numberOfResets+1`), and a standing block that never survives long enough for §2 `bench-after` / §3 `cooldown` to be built on it.

I also expected the blocked-provider metric to start reflecting reality during an outage. It does not: `smartrouter_csm_blocked_providers` reads `0` while `/debug/provider-routing` correctly shows two blocked providers. That is a pre-existing metric bug, unrelated to this PR, and is being tracked separately.

## Known hole in guard 2 (pre-existing behaviour, reproduced)

`releaseCouldServeThisRequest` asks *"is there any provider this request has not tried?"*. When `lava-select-provider` is set, only that one provider can ever serve the request, so the guard answers a question that does not apply. A pin naming a provider that does not exist passes the guard, releases **every** blocked provider, and then fails anyway.

Reproduced on a live router — same router, nothing changed between the two halves:

```
23 steady-state relays   ->  backup-node x23,  releases delta = 0
                             blocked=[primary-a, primary-b]   valid=[]

one relay with:
  -H 'lava-select-provider: does-not-exist'
                         ->  HTTP 500,        releases delta = 1
                             blocked=[]       valid=[primary-a, primary-b]
```

**This behaves identically on `main`, so it is not a regression from this PR** — but the guard added here is meant to prevent exactly this class of useless release and does not catch it. Tracked separately; happy to fold the fix in here instead if a reviewer prefers.

## Not fixed here, deliberately

- **The release does not re-enable endpoints.** Providers return to `validAddresses` with endpoints still disabled, get picked, and are re-blocked. Pre-existing, documented in `HEALTH-STORE-PLAN.md`. This change makes the release rarer, so it bites less often.
- **Pin semantics are asymmetric.** A pinned-but-blocked provider resolves only when *every* provider is blocked, because that is the only case where the release happens to put it back. Identical on `main`.

## Commits

| | |
|---|---|
| `f30ab22` | pre-existing test flake fix — unrelated to the feature, split out so it can be taken separately |
| `d8373be` | the section 5 change + tests (stale WIP warning in its message, see the note at top) |
| `7d2911d` | guard 2 — the double-release fix |

`f30ab22` addresses a race that reproduces on `main` roughly one full `go test ./...` run in three: `TestCheckAndUnblock_BackupUnblockedWhenHealthy` asserted state that `UpdateAllProviders`' own background probe is free to change first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsVw3GRjz59spS7kWYjcaX

