### PR TITLE
docs(cross-validation): state that a cap bounds caller strictness (MAG-3035)

### DIFF
--- a/docs/CROSS-VALIDATION.md
+++ b/docs/CROSS-VALIDATION.md
@@ -56,6 +56,33 @@ cross-validation:
       min-groups: 2              # the quorum must span both groups (publicnode + tenderly)
 ```
 
+### How caller headers compose with a policy
+
+Each numeric knob resolves as `clamp(caller, floor, cap)`. The scalar shorthand above
+(`agreement-threshold: 2`) means `{floor: 2}` — a **floor** is an operator *minimum* the
+caller may exceed, so on that policy a caller asking for a stricter quorum gets it. A **cap**
+is an operator *maximum*, and it bounds how strict a caller may ask to be: a request above the
+cap is clamped down to it, and a knob written with `floor == cap` is pinned to that value
+whatever the caller sends.
+
+```yaml
+      max-participants: { floor: 3, cap: 3 }     # pinned: a caller asking for 6 gets 3
+      agreement-threshold: { floor: 2, cap: 3 }  # caller may raise 2 -> 3, and no further
+```
+
+So the shorthand "a caller may make cross-validation stricter, never weaker" holds only **up
+to the configured cap**. The cap is the one mechanism by which the router validates less
+strictly than a caller asked, and it is an explicit operator decision — an operator who wants
+a method's fan-out pinned regardless of caller headers sets `floor == cap`, and one who wants
+the headers ignored outright sets `forbid-caller-cv: true`.
+
+With no policy for a method the caller's headers are the only authority, and any
+self-consistent shape is honored — including the degenerate `max-participants: 1` with
+`agreement-threshold: 1`, which returns `lava-cross-validation-status: success` after a
+single response because the requested quorum of one was met. Nothing is compared in that
+case; `…-all-providers` and `…-agreeing-providers` each list the one provider queried, so a
+client that needs real corroboration should read those lists rather than `status` alone.
+
 ## Worked examples
 
 Two bundled example configs demonstrate the full setup end to end:


### PR DESCRIPTION
# Description

Cross-validation edge-case testing (MAG-3035) flagged two behaviors as potentially misleading. Both are working as designed; the gap is that `docs/CROSS-VALIDATION.md` — the operator-facing setup guide — said only that caller headers and a policy *"compose as `clamp(caller, floor, cap)`"* and never spelled out what that means for a caller.

This adds a **"How caller headers compose with a policy"** section covering the two points raised:

1. **A cap bounds caller strictness.** The shorthand "a caller may make cross-validation stricter, never weaker" is incomplete: a `cap` is an operator *maximum* that clamps a stricter caller down, and `floor == cap` pins a knob outright. That is why a 6/6 caller against a policy with `max-participants: {floor: 3, cap: 3}` is validated 3/3. Already stated in `cross_validation_policy.go:19-23` (*"the only mechanism that can make the router validate less strictly than a caller asked, and it is an explicit, documented operator decision"*), pinned by `TestResolve` case *"cap overrides a stricter caller (the approved loosening)"*, and described in the in-package README — this is the operator page catching up.

2. **The no-policy caller path.** With no policy the caller's headers are the only authority and any self-consistent shape is honored, including a degenerate `max-participants: 1` / `agreement-threshold: 1`, which reports `status: success` after a single response because the quorum of one it asked for was met. No comparison happens there, so a client needing real corroboration should read `…-all-providers` / `…-agreeing-providers` rather than `status` alone.

Worth noting for reviewers, since the ticket claimed otherwise: **there is no code path where `max-participants: 1` disables cross-validation.** Under an enabled policy a caller's `1` is floored *up* to the operator's minimum (`cross_validation_policy.go:371-386`), pinned by the regression test *"caller-shrunk max-participants cannot disable operator min-groups diversity"*. The only knob that disables CV for a method is `forbid-caller-cv`.

Docs only — no behavior change, no code touched.

## Jira ticket

Jira ticket: MAG-3035

---

## Author Checklist

I have...

* [x] read the [contribution guide](https://github.com/magma-Devs/smart-router/blob/main/CONTRIBUTING.md)
* [x] included the correct type prefix in the PR title (`docs`)
* [x] confirmed `!` in the type prefix if API or client breaking change — n/a, docs only
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests — n/a, docs only; the behaviors described are already covered by `TestResolve` in `cross_validation_policy_test.go`
* [x] updated the relevant documentation or specification
* [ ] confirmed all CI checks have passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)