### PR TITLE
fix(metrics): report the providers that are actually blocked

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -355,14 +355,34 @@ histogram_quantile(0.9,
 Expose otherwise black-box Consumer-Session-Manager state so integration tests can
 assert `/debug/reset-all` emptied each store (see MAG-1762). All drop to `0` after a reset.
 
+The two blocked-provider gauges are also operator-facing — they answer "how many providers
+went out, and which" — so read the alerting note under the table before building on them.
+
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
-| `smartrouter_csm_blocked_providers` | Gauge | `spec`, `apiInterface` | Providers currently blocked and receiving no traffic. **Non-zero means the chain is degraded.** Before v1.4.1 this reported the previous-epoch store instead and read 0 during outages. |
+| `smartrouter_csm_blocked_providers` | Gauge | `spec`, `apiInterface` | Providers currently blocked. **Non-zero means the chain is degraded** — but zero does not prove it is healthy; see the sampling note below. Previously this reported the previous-epoch store instead and read 0 during outages. |
 | `smartrouter_csm_previous_epoch_blocked_providers` | Gauge | `spec`, `apiInterface` | Size of the previous-epoch blocked-providers store (cross-epoch carry-over, briefly populated at an epoch boundary). This is what `smartrouter_csm_blocked_providers` reported before it was corrected. |
-| `smartrouter_csm_provider_blocked` | Gauge | `spec`, `apiInterface`, `provider`, `provider_endpoint` | Whether one specific provider is blocked (1=blocked, 0=serving) — which provider went out, versus how many. |
-| `smartrouter_csm_blocked_backup_providers` | Gauge | `spec`, `apiInterface` | Size of the blocked-backup-providers store. |
+| `smartrouter_csm_provider_blocked` | Gauge | `spec`, `apiInterface`, `provider_address` | Whether one specific provider is blocked (1=blocked, 0=serving) — which provider went out, versus how many. Labelled by provider name only: a node URL can embed an API key and must never reach a series. |
+| `smartrouter_csm_blocked_backup_providers` | Gauge | `spec`, `apiInterface` | Size of the blocked-backup-providers store. Backups are tracked here only — they never appear in `smartrouter_csm_provider_blocked`. |
 | `smartrouter_csm_sticky_sessions` | Gauge | `spec`, `apiInterface` | Live sticky-session affinities. |
 | `smartrouter_csm_reported_providers` | Gauge | `spec`, `apiInterface` | Size of the reported-providers register. |
+
+**Alert on the maximum over a window, not the instant value.** When every provider is blocked
+the failover cascade releases the whole blocked list so the pool has something left to serve
+from, which drains the count to `0` until the providers fail again. During a sustained total
+outage the gauge therefore sawtooths between `0` and the pool size rather than sitting high, and
+a rule that requires the value to stay non-zero `for: 30s` can sample the trough and miss it.
+
+```promql
+# a chain that has had providers blocked at any point in the last 5 minutes
+max_over_time(smartrouter_csm_blocked_providers[5m]) > 0
+
+# which provider — the same window, per provider
+max_over_time(smartrouter_csm_provider_blocked[5m]) > 0
+```
+
+For "is this chain serving at all", prefer `smartrouter_endpoint_serving_tier` (below): it is not
+drained by the release path, and `0` means dark unambiguously.
 
 #### Serving tier (availability)
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -357,7 +357,9 @@ assert `/debug/reset-all` emptied each store (see MAG-1762). All drop to `0` aft
 
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
-| `smartrouter_csm_blocked_providers` | Gauge | `spec`, `apiInterface` | Size of the previous-epoch blocked-providers store. |
+| `smartrouter_csm_blocked_providers` | Gauge | `spec`, `apiInterface` | Providers currently blocked and receiving no traffic. **Non-zero means the chain is degraded.** Before v1.4.1 this reported the previous-epoch store instead and read 0 during outages. |
+| `smartrouter_csm_previous_epoch_blocked_providers` | Gauge | `spec`, `apiInterface` | Size of the previous-epoch blocked-providers store (cross-epoch carry-over, briefly populated at an epoch boundary). This is what `smartrouter_csm_blocked_providers` reported before it was corrected. |
+| `smartrouter_csm_provider_blocked` | Gauge | `spec`, `apiInterface`, `provider`, `provider_endpoint` | Whether one specific provider is blocked (1=blocked, 0=serving) — which provider went out, versus how many. |
 | `smartrouter_csm_blocked_backup_providers` | Gauge | `spec`, `apiInterface` | Size of the blocked-backup-providers store. |
 | `smartrouter_csm_sticky_sessions` | Gauge | `spec`, `apiInterface` | Live sticky-session affinities. |
 | `smartrouter_csm_reported_providers` | Gauge | `spec`, `apiInterface` | Size of the reported-providers register. |

--- a/protocol/lavasession/blocked_providers_metric_test.go
+++ b/protocol/lavasession/blocked_providers_metric_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/magma-Devs/smart-router/protocol/metrics"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,14 +27,18 @@ func TestBlockedProvidersGauge_ReflectsARealBlock(t *testing.T) {
 	csm := createConsumerSessionManagerWithMetrics(rec)
 	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
 
+	// Capture both up front. blockProvider removes the address from validAddresses, so reading
+	// validAddresses[0] twice would silently mean two different providers.
+	first, second := csm.validAddresses[0], csm.validAddresses[1]
+
 	csm.publishStateSizes()
 	require.Equal(t, 0, rec.blockedProvidersCount(), "nothing blocked yet")
 
-	blockOneProvider(t, csm, csm.validAddresses[0])
+	blockOneProvider(t, csm, first)
 	csm.publishStateSizes()
 	require.Equal(t, 1, rec.blockedProvidersCount(), "a blocked provider must show in the gauge")
 
-	blockOneProvider(t, csm, csm.validAddresses[0])
+	blockOneProvider(t, csm, second)
 	csm.publishStateSizes()
 	require.Equal(t, 2, rec.blockedProvidersCount(), "the gauge tracks the size of the blocked list")
 
@@ -63,15 +66,39 @@ func TestBlockedProvidersGauge_ZeroedByResetBlockedProviders(t *testing.T) {
 		"ResetBlockedProviders clears the standing block, so the gauge must follow")
 }
 
-// The per-provider signal was an empty function body in the smart router, so no call site
-// published anything. Assert the real manager writes a value for both directions.
-func TestSetBlockedProvider_IsNotAStub(t *testing.T) {
-	m := metrics.NewSmartRouterMetricsManager(metrics.SmartRouterMetricsManagerOptions{})
-	if m == nil {
-		t.Skip("metrics manager unavailable in this environment")
+// The per-provider gauge must survive a wholesale drain of the blocked list.
+//
+// setValidAddressesToDefaultValue empties currentlyBlockedProviderAddresses in one move and
+// publishes nothing per provider. It runs on the pool-empty release — the last resort of the
+// failover cascade, i.e. exactly the all-providers-down case this metric exists for — and on
+// every epoch transition. Publishing only on the block/unblock edges therefore left every
+// series it emptied stuck at 1 for a provider that was back in rotation and serving fine, so
+// the aggregate count and the per-provider gauge disagreed on the dashboard.
+func TestPerProviderGauge_ClearedByThePoolEmptyRelease(t *testing.T) {
+	rec := &stateSizeRecorder{}
+	csm := createConsumerSessionManagerWithMetrics(rec)
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
+
+	// An all-providers-down outage: block every provider in the pairing.
+	for len(csm.validAddresses) > 0 {
+		blockOneProvider(t, csm, csm.validAddresses[0])
 	}
-	require.NotPanics(t, func() {
-		m.SetBlockedProvider("LAVA", "tendermintrpc", "provider-1", "http://127.0.0.1:1", true)
-		m.SetBlockedProvider("LAVA", "tendermintrpc", "provider-1", "http://127.0.0.1:1", false)
-	})
+	csm.publishStateSizes()
+
+	duringOutage := rec.providerBlockedSnapshot()
+	require.NotEmpty(t, duringOutage, "every provider should have been published")
+	for address, isBlocked := range duringOutage {
+		require.True(t, isBlocked, "%s must read blocked during the outage", address)
+	}
+
+	// The last resort of the failover cascade: release the whole blocked list so the pool has
+	// something left to serve from.
+	csm.resetValidAddresses("", nil)
+	csm.publishStateSizes()
+
+	require.Equal(t, 0, rec.blockedProvidersCount(), "the release drained the standing block")
+	for address, isBlocked := range rec.providerBlockedSnapshot() {
+		require.False(t, isBlocked,
+			"%s is back in rotation and serving, so its per-provider gauge must not still read blocked", address)
+	}
 }

--- a/protocol/lavasession/blocked_providers_metric_test.go
+++ b/protocol/lavasession/blocked_providers_metric_test.go
@@ -1,0 +1,77 @@
+package lavasession
+
+import (
+	"context"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/metrics"
+	"github.com/stretchr/testify/require"
+)
+
+// The blocked-providers gauge published len(previousEpochBlockedProviders) — the cross-epoch
+// carry-over set, which is populated at an epoch boundary and cleared moments later by the
+// re-block pass. So it read 0 while providers were blocked and serving no traffic, and an
+// all-providers-down outage looked identical to a healthy router on every dashboard.
+//
+// It now publishes len(currentlyBlockedProviderAddresses), the standing block. These tests pin
+// both halves so the two can never be confused again.
+
+// blockOneProvider blocks a provider the way the product does, rather than by writing the field.
+func blockOneProvider(t *testing.T, csm *ConsumerSessionManager, address string) {
+	t.Helper()
+	require.NoError(t, csm.blockProvider(context.Background(), address, false, csm.atomicReadCurrentEpoch(), 0, 0, false, nil))
+}
+
+// A blocked provider must be visible in the gauge. This is the test whose absence let the bug ship.
+func TestBlockedProvidersGauge_ReflectsARealBlock(t *testing.T) {
+	rec := &stateSizeRecorder{}
+	csm := createConsumerSessionManagerWithMetrics(rec)
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
+
+	csm.publishStateSizes()
+	require.Equal(t, 0, rec.blockedProvidersCount(), "nothing blocked yet")
+
+	blockOneProvider(t, csm, csm.validAddresses[0])
+	csm.publishStateSizes()
+	require.Equal(t, 1, rec.blockedProvidersCount(), "a blocked provider must show in the gauge")
+
+	blockOneProvider(t, csm, csm.validAddresses[0])
+	csm.publishStateSizes()
+	require.Equal(t, 2, rec.blockedProvidersCount(), "the gauge tracks the size of the blocked list")
+
+	// The previous-epoch carry-over set is a different thing and must not move with it.
+	require.Equal(t, 0, rec.prevEpochBlockedCount(), "blocking does not populate the cross-epoch set")
+}
+
+// ResetBlockedProviders is what /debug/reset-all uses to clear the standing block, so it must
+// drive the gauge back to zero. ResetTransientFailureState deliberately does not.
+func TestBlockedProvidersGauge_ZeroedByResetBlockedProviders(t *testing.T) {
+	rec := &stateSizeRecorder{}
+	csm := createConsumerSessionManagerWithMetrics(rec)
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
+
+	blockOneProvider(t, csm, csm.validAddresses[0])
+	csm.publishStateSizes()
+	require.Equal(t, 1, rec.blockedProvidersCount())
+
+	csm.ResetTransientFailureState()
+	require.Equal(t, 1, rec.blockedProvidersCount(),
+		"ResetTransientFailureState preserves the standing block by design, so the gauge must hold")
+
+	csm.ResetBlockedProviders()
+	require.Equal(t, 0, rec.blockedProvidersCount(),
+		"ResetBlockedProviders clears the standing block, so the gauge must follow")
+}
+
+// The per-provider signal was an empty function body in the smart router, so no call site
+// published anything. Assert the real manager writes a value for both directions.
+func TestSetBlockedProvider_IsNotAStub(t *testing.T) {
+	m := metrics.NewSmartRouterMetricsManager(metrics.SmartRouterMetricsManagerOptions{})
+	if m == nil {
+		t.Skip("metrics manager unavailable in this environment")
+	}
+	require.NotPanics(t, func() {
+		m.SetBlockedProvider("LAVA", "tendermintrpc", "provider-1", "http://127.0.0.1:1", true)
+		m.SetBlockedProvider("LAVA", "tendermintrpc", "provider-1", "http://127.0.0.1:1", false)
+	})
+}

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -2843,7 +2843,12 @@ func (csm *ConsumerSessionManager) publishStateSizes() {
 	}
 
 	csm.lock.RLock()
-	blockedCount := len(csm.previousEpochBlockedProviders)
+	// currentlyBlockedProviderAddresses is the standing block: these providers receive no traffic
+	// until they recover. previousEpochBlockedProviders is only the cross-epoch carry-over set,
+	// populated at an epoch boundary and cleared moments later by the re-block pass — publishing
+	// that as "blocked providers" reported 0 through entire outages.
+	blockedCount := len(csm.currentlyBlockedProviderAddresses)
+	prevEpochBlockedCount := len(csm.previousEpochBlockedProviders)
 	blockedBackupCount := len(csm.blockedBackupProviders)
 	csm.lock.RUnlock()
 
@@ -2858,6 +2863,7 @@ func (csm *ConsumerSessionManager) publishStateSizes() {
 	chainID := csm.rpcEndpoint.ChainID
 	apiInterface := csm.rpcEndpoint.ApiInterface
 	csm.consumerMetricsManager.SetCSMBlockedProvidersCount(chainID, apiInterface, blockedCount)
+	csm.consumerMetricsManager.SetCSMPreviousEpochBlockedProvidersCount(chainID, apiInterface, prevEpochBlockedCount)
 	csm.consumerMetricsManager.SetCSMBlockedBackupProvidersCount(chainID, apiInterface, blockedBackupCount)
 	csm.consumerMetricsManager.SetCSMStickySessionsCount(chainID, apiInterface, stickyCount)
 	csm.consumerMetricsManager.SetCSMReportedProvidersCount(chainID, apiInterface, reportedCount)

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -2850,6 +2850,23 @@ func (csm *ConsumerSessionManager) publishStateSizes() {
 	blockedCount := len(csm.currentlyBlockedProviderAddresses)
 	prevEpochBlockedCount := len(csm.previousEpochBlockedProviders)
 	blockedBackupCount := len(csm.blockedBackupProviders)
+
+	// Snapshot the per-provider blocked state for the whole pairing, not just the addresses that
+	// changed. The per-provider gauge MUST be level-triggered: the blocked list is also drained
+	// wholesale by setValidAddressesToDefaultValue — on every epoch transition, and on the
+	// pool-empty release in releaseBlockedProvidersIfPoolEmpty — and neither drain publishes
+	// anything per provider. Edge-triggered publishing alone therefore left every series it
+	// emptied stuck at 1 for a provider that was back in rotation and serving fine (MAG-3106).
+	// Republishing the full truth each tick makes the gauge self-correcting instead.
+	blockedSet := make(map[string]struct{}, blockedCount)
+	for _, address := range csm.currentlyBlockedProviderAddresses {
+		blockedSet[address] = struct{}{}
+	}
+	providerBlocked := make(map[string]bool, len(csm.pairing))
+	for address := range csm.pairing {
+		_, blocked := blockedSet[address]
+		providerBlocked[address] = blocked
+	}
 	csm.lock.RUnlock()
 
 	var stickyCount, reportedCount int
@@ -2867,6 +2884,11 @@ func (csm *ConsumerSessionManager) publishStateSizes() {
 	csm.consumerMetricsManager.SetCSMBlockedBackupProvidersCount(chainID, apiInterface, blockedBackupCount)
 	csm.consumerMetricsManager.SetCSMStickySessionsCount(chainID, apiInterface, stickyCount)
 	csm.consumerMetricsManager.SetCSMReportedProvidersCount(chainID, apiInterface, reportedCount)
+	// The endpoint argument is unused by the smart router (a node URL can carry an API key and
+	// must never become a label) but is fixed by the shared interface.
+	for address, blocked := range providerBlocked {
+		csm.consumerMetricsManager.SetBlockedProvider(chainID, apiInterface, address, "", blocked)
+	}
 }
 
 // startStateSizesPublisher kicks off the periodic gauge tick. Per-CSM

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -2776,6 +2776,7 @@ type stateSizeRecorder struct {
 	blockedBackup       int
 	stickySessionsCount int
 	reportedProviders   int
+	providerBlocked     map[string]bool
 }
 
 func (r *stateSizeRecorder) SetCSMPreviousEpochBlockedProvidersCount(_, _ string, c int) {
@@ -2806,6 +2807,26 @@ func (r *stateSizeRecorder) SetCSMReportedProvidersCount(_, _ string, c int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.reportedProviders = c
+}
+
+func (r *stateSizeRecorder) SetBlockedProvider(_, _, providerAddress, _ string, isBlocked bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.providerBlocked == nil {
+		r.providerBlocked = map[string]bool{}
+	}
+	r.providerBlocked[providerAddress] = isBlocked
+}
+
+// providerBlockedSnapshot returns the last value published for each provider.
+func (r *stateSizeRecorder) providerBlockedSnapshot() map[string]bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make(map[string]bool, len(r.providerBlocked))
+	for address, isBlocked := range r.providerBlocked {
+		out[address] = isBlocked
+	}
+	return out
 }
 
 func (r *stateSizeRecorder) blockedProvidersCount() int {

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -2772,9 +2772,16 @@ type stateSizeRecorder struct {
 	metrics.NoOpConsumerMetrics
 	mu                  sync.Mutex
 	blockedProviders    int
+	prevEpochBlocked    int
 	blockedBackup       int
 	stickySessionsCount int
 	reportedProviders   int
+}
+
+func (r *stateSizeRecorder) SetCSMPreviousEpochBlockedProvidersCount(_, _ string, c int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.prevEpochBlocked = c
 }
 
 func (r *stateSizeRecorder) SetCSMBlockedProvidersCount(_, _ string, c int) {
@@ -2801,6 +2808,18 @@ func (r *stateSizeRecorder) SetCSMReportedProvidersCount(_, _ string, c int) {
 	r.reportedProviders = c
 }
 
+func (r *stateSizeRecorder) blockedProvidersCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.blockedProviders
+}
+
+func (r *stateSizeRecorder) prevEpochBlockedCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.prevEpochBlocked
+}
+
 func (r *stateSizeRecorder) snapshot() (int, int, int, int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -2818,8 +2837,12 @@ func createConsumerSessionManagerWithMetrics(m metrics.ConsumerMetricsManagerInf
 
 // TestPublishStateSizes_PopulateThenReset verifies that publishStateSizes
 // reflects the current size of every observed store, and that
-// ResetTransientFailureState drives all four counts back to zero — the
+// ResetTransientFailureState drives the transient counts back to zero — the
 // post-condition integration tests assert against /metrics (MAG-1762).
+//
+// currentlyBlockedProviderAddresses is deliberately NOT zeroed here:
+// ResetTransientFailureState preserves it by design, and /debug/reset-all
+// clears it by also calling ResetBlockedProviders. See the sibling test below.
 func TestPublishStateSizes_PopulateThenReset(t *testing.T) {
 	rec := &stateSizeRecorder{}
 	csm := createConsumerSessionManagerWithMetrics(rec)
@@ -2835,7 +2858,8 @@ func TestPublishStateSizes_PopulateThenReset(t *testing.T) {
 
 	csm.publishStateSizes()
 	blocked, blockedBackup, sticky, reported := rec.snapshot()
-	require.Equal(t, 2, blocked, "previousEpochBlockedProviders count must equal map size")
+	require.Equal(t, 2, rec.prevEpochBlockedCount(), "previousEpochBlockedProviders count must equal map size")
+	require.Equal(t, 0, blocked, "no provider is blocked, so the blocked-providers gauge must read 0")
 	require.Equal(t, 1, blockedBackup, "blockedBackupProviders count must equal map size")
 	require.Equal(t, 3, sticky, "stickySessions count must equal store size")
 	require.Equal(t, 1, reported, "reportedProviders count must equal register size")
@@ -2843,7 +2867,8 @@ func TestPublishStateSizes_PopulateThenReset(t *testing.T) {
 	csm.ResetTransientFailureState()
 
 	blocked, blockedBackup, sticky, reported = rec.snapshot()
-	require.Equal(t, 0, blocked, "ResetTransientFailureState must zero previousEpochBlockedProviders gauge")
+	require.Equal(t, 0, rec.prevEpochBlockedCount(), "ResetTransientFailureState must zero previousEpochBlockedProviders gauge")
+	require.Equal(t, 0, blocked, "blocked-providers gauge stays 0 — nothing was blocked in this test")
 	require.Equal(t, 0, blockedBackup, "ResetTransientFailureState must zero blockedBackupProviders gauge")
 	require.Equal(t, 0, sticky, "ResetTransientFailureState must zero stickySessions gauge")
 	require.Equal(t, 0, reported, "ResetTransientFailureState must zero reportedProviders gauge")

--- a/protocol/metrics/blocked_provider_metric_test.go
+++ b/protocol/metrics/blocked_provider_metric_test.go
@@ -1,0 +1,90 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+var blockedProviderLabels = []string{"spec", "apiInterface", "provider_address"}
+
+func newSmartRouterForBlockedProviderTest() *SmartRouterMetricsManager {
+	return &SmartRouterMetricsManager{
+		csmProviderBlocked: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{Name: "t_sr_provider_blocked"}, blockedProviderLabels),
+	}
+}
+
+// SetBlockedProvider was an empty function body, so no call site published anything. Assert the
+// value in both directions — the previous test only asserted that the call did not panic, which
+// an empty body also satisfies, so it passed against the very stub it was named after.
+func TestSetBlockedProvider_PublishesBothDirections(t *testing.T) {
+	m := newSmartRouterForBlockedProviderTest()
+	g := m.csmProviderBlocked.WithLabelValues("LAVA", "tendermintrpc", "provider-1")
+
+	m.SetBlockedProvider("LAVA", "tendermintrpc", "provider-1", "http://127.0.0.1:1", true)
+	require.Equal(t, float64(1), testutil.ToFloat64(g), "a blocked provider must publish 1")
+
+	m.SetBlockedProvider("LAVA", "tendermintrpc", "provider-1", "http://127.0.0.1:1", false)
+	require.Equal(t, float64(0), testutil.ToFloat64(g), "a restored provider must publish 0")
+}
+
+// The node URL must never become a label: it can carry an API key in its path or query, and
+// docs/METRICS.md makes that a rule for every series. Two calls that differ ONLY by endpoint
+// must land on one series rather than creating a second one keyed by the URL.
+func TestSetBlockedProvider_DoesNotLabelByNodeURL(t *testing.T) {
+	m := newSmartRouterForBlockedProviderTest()
+
+	m.SetBlockedProvider("LAVA", "tendermintrpc", "provider-1", "https://node.example/v2/SECRET-KEY", true)
+	m.SetBlockedProvider("LAVA", "tendermintrpc", "provider-1", "https://node.example/v2/ROTATED-KEY", false)
+
+	require.Equal(t, 1, testutil.CollectAndCount(m.csmProviderBlocked),
+		"the endpoint must not be a label — a changed URL must not fork a second series")
+	require.Equal(t, float64(0),
+		testutil.ToFloat64(m.csmProviderBlocked.WithLabelValues("LAVA", "tendermintrpc", "provider-1")),
+		"the unblock must land on the same series as the block")
+}
+
+// ResetBlockedProvidersMetrics rebases the gauge onto a new pairing at an epoch transition.
+// A provider that was blocked and is no longer paired must not leave a series stuck at 1:
+// the unblock path only publishes for addresses still in the standing block list, so nothing
+// else can ever clear it.
+func TestResetBlockedProvidersMetrics_DropsProvidersNoLongerPaired(t *testing.T) {
+	m := newSmartRouterForBlockedProviderTest()
+	m.SetBlockedProvider("LAVA", "tendermintrpc", "stays", "", true)
+	m.SetBlockedProvider("LAVA", "tendermintrpc", "leaves", "", true)
+	require.Equal(t, 2, testutil.CollectAndCount(m.csmProviderBlocked))
+
+	m.ResetBlockedProvidersMetrics("LAVA", "tendermintrpc", map[string]string{"stays": "http://127.0.0.1:1"})
+
+	require.Equal(t, 1, testutil.CollectAndCount(m.csmProviderBlocked),
+		"the departed provider's series must be dropped, not frozen at 1")
+	require.Equal(t, float64(0),
+		testutil.ToFloat64(m.csmProviderBlocked.WithLabelValues("LAVA", "tendermintrpc", "stays")),
+		"a provider carried into the new pairing is seeded as serving")
+}
+
+// The rebase is scoped to one chain: a reset on one spec/apiInterface must not wipe another's.
+func TestResetBlockedProvidersMetrics_ScopedToOneChain(t *testing.T) {
+	m := newSmartRouterForBlockedProviderTest()
+	m.SetBlockedProvider("LAVA", "tendermintrpc", "provider-1", "", true)
+	m.SetBlockedProvider("ETH1", "jsonrpc", "provider-1", "", true)
+
+	m.ResetBlockedProvidersMetrics("LAVA", "tendermintrpc", map[string]string{})
+
+	require.Equal(t, 1, testutil.CollectAndCount(m.csmProviderBlocked))
+	require.Equal(t, float64(1),
+		testutil.ToFloat64(m.csmProviderBlocked.WithLabelValues("ETH1", "jsonrpc", "provider-1")),
+		"another chain's blocked provider must survive this chain's epoch rebase")
+}
+
+// Every setter on this manager is nil-safe: the constructor returns nil when metrics are disabled.
+func TestBlockedProviderMetrics_NilManagerIsSafe(t *testing.T) {
+	var m *SmartRouterMetricsManager
+	require.NotPanics(t, func() {
+		m.SetBlockedProvider("LAVA", "tendermintrpc", "provider-1", "", true)
+		m.ResetBlockedProvidersMetrics("LAVA", "tendermintrpc", map[string]string{"provider-1": ""})
+	})
+}

--- a/protocol/metrics/consumer_metrics_manager_inf.go
+++ b/protocol/metrics/consumer_metrics_manager_inf.go
@@ -45,6 +45,7 @@ func (NoOpConsumerMetrics) SetQOSMetrics(string, string, string, string, *pairin
 func (NoOpConsumerMetrics) ResetSessionRelatedMetrics()                                    {}
 func (NoOpConsumerMetrics) ResetBlockedProvidersMetrics(string, string, map[string]string) {}
 func (NoOpConsumerMetrics) SetCSMBlockedProvidersCount(string, string, int)                {}
+func (NoOpConsumerMetrics) SetCSMPreviousEpochBlockedProvidersCount(string, string, int)   {}
 func (NoOpConsumerMetrics) SetCSMBlockedBackupProvidersCount(string, string, int)          {}
 func (NoOpConsumerMetrics) SetCSMStickySessionsCount(string, string, int)                  {}
 func (NoOpConsumerMetrics) SetCSMReportedProvidersCount(string, string, int)               {}
@@ -106,9 +107,12 @@ type ConsumerMetricsManagerInf interface {
 
 	// --- CSM state-store sizes (ConsumerSessionManager) ---
 	// Gauges that expose the current size of black-box state stores so
-	// integration tests can verify /debug/reset-all actually emptied them.
-	// All four go to zero after ResetTransientFailureState (MAG-1762).
+	// integration tests can verify /debug/reset-all actually emptied them
+	// (MAG-1762). Note ResetTransientFailureState deliberately preserves
+	// currentlyBlockedProviderAddresses, so SetCSMBlockedProvidersCount is
+	// zeroed by ResetBlockedProviders — /debug/reset-all calls both.
 	SetCSMBlockedProvidersCount(chainId, apiInterface string, count int)
+	SetCSMPreviousEpochBlockedProvidersCount(chainId, apiInterface string, count int)
 	SetCSMBlockedBackupProvidersCount(chainId, apiInterface string, count int)
 	SetCSMStickySessionsCount(chainId, apiInterface string, count int)
 	SetCSMReportedProvidersCount(chainId, apiInterface string, count int)

--- a/protocol/metrics/smartrouter_metrics_manager.go
+++ b/protocol/metrics/smartrouter_metrics_manager.go
@@ -115,6 +115,8 @@ type SmartRouterMetricsManager struct {
 	// black-box internal state so integration tests can verify /debug/reset-all
 	// emptied each store. See MAG-1762.
 	csmBlockedProvidersCount       *prometheus.GaugeVec // smartrouter_csm_blocked_providers
+	csmPrevEpochBlockedProviders   *prometheus.GaugeVec // smartrouter_csm_previous_epoch_blocked_providers
+	csmProviderBlocked             *prometheus.GaugeVec // smartrouter_csm_provider_blocked
 	csmBlockedBackupProvidersCount *prometheus.GaugeVec // smartrouter_csm_blocked_backup_providers
 	endpointServingTier            *prometheus.GaugeVec // smartrouter_endpoint_serving_tier
 	csmStickySessionsCount         *prometheus.GaugeVec // smartrouter_csm_sticky_sessions
@@ -494,8 +496,16 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	csmStateLabels := []string{"spec", "apiInterface"}
 	csmBlockedProvidersCount := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "smartrouter_csm_blocked_providers",
-		Help: "Size of ConsumerSessionManager.previousEpochBlockedProviders (cross-epoch known-bad provider memory). Goes to 0 after /debug/reset-all.",
+		Help: "Number of providers currently blocked and receiving no traffic (ConsumerSessionManager.currentlyBlockedProviderAddresses). Non-zero means the chain is degraded. Goes to 0 after /debug/reset-all.",
 	}, csmStateLabels)
+	csmPrevEpochBlockedProviders := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "smartrouter_csm_previous_epoch_blocked_providers",
+		Help: "Size of ConsumerSessionManager.previousEpochBlockedProviders (cross-epoch known-bad provider memory, briefly populated at an epoch boundary and cleared once the re-block pass runs). Goes to 0 after /debug/reset-all. This is what smartrouter_csm_blocked_providers reported before the metric was corrected.",
+	}, csmStateLabels)
+	csmProviderBlocked := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "smartrouter_csm_provider_blocked",
+		Help: "Whether this specific provider is currently blocked (1=blocked, 0=serving). Companion to the smartrouter_csm_blocked_providers count, for identifying WHICH provider went out.",
+	}, []string{"spec", "apiInterface", "provider", "provider_endpoint"})
 	csmBlockedBackupProvidersCount := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "smartrouter_csm_blocked_backup_providers",
 		Help: "Size of ConsumerSessionManager.blockedBackupProviders (per-epoch backup-provider failure memory). Goes to 0 after /debug/reset-all.",
@@ -635,6 +645,8 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	cacheFailedTotalMetric = registerOrReuse(cacheFailedTotalMetric)
 	cacheLatencyHistogram = registerOrReuse(cacheLatencyHistogram)
 	csmBlockedProvidersCount = registerOrReuse(csmBlockedProvidersCount)
+	csmPrevEpochBlockedProviders = registerOrReuse(csmPrevEpochBlockedProviders)
+	csmProviderBlocked = registerOrReuse(csmProviderBlocked)
 	csmBlockedBackupProvidersCount = registerOrReuse(csmBlockedBackupProvidersCount)
 	csmStickySessionsCount = registerOrReuse(csmStickySessionsCount)
 	csmReportedProvidersCount = registerOrReuse(csmReportedProvidersCount)
@@ -730,6 +742,8 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 
 		// CSM state-store gauges
 		csmBlockedProvidersCount:       csmBlockedProvidersCount,
+		csmPrevEpochBlockedProviders:   csmPrevEpochBlockedProviders,
+		csmProviderBlocked:             csmProviderBlocked,
 		csmBlockedBackupProvidersCount: csmBlockedBackupProvidersCount,
 		csmStickySessionsCount:         csmStickySessionsCount,
 		csmReportedProvidersCount:      csmReportedProvidersCount,
@@ -1501,7 +1515,21 @@ func (m *SmartRouterMetricsManager) SetProviderSelected(chainId string, apiInter
 	}
 }
 
-func (m *SmartRouterMetricsManager) SetBlockedProvider(string, string, string, string, bool) {}
+// SetBlockedProvider publishes whether one specific provider is blocked. The aggregate count in
+// SetCSMBlockedProvidersCount says how many went out; this says which.
+//
+// Was an empty stub, so every blockProvider / restore call site published nothing and the smart
+// router had no per-provider blocked signal at all.
+func (m *SmartRouterMetricsManager) SetBlockedProvider(chainId, apiInterface, providerAddress, providerEndpoint string, isBlocked bool) {
+	if m == nil {
+		return
+	}
+	value := 0.0
+	if isBlocked {
+		value = 1.0
+	}
+	m.csmProviderBlocked.WithLabelValues(chainId, apiInterface, providerAddress, providerEndpoint).Set(value)
+}
 
 func (m *SmartRouterMetricsManager) SetQOSMetrics(chainId string, apiInterface string, _ string, _ string, _ *pairingtypes.QualityOfServiceReport, _ *pairingtypes.QualityOfServiceReport, _ int64, _ uint64, _ time.Duration, _ bool) {
 }
@@ -1511,13 +1539,24 @@ func (m *SmartRouterMetricsManager) ResetSessionRelatedMetrics() {}
 func (m *SmartRouterMetricsManager) ResetBlockedProvidersMetrics(string, string, map[string]string) {
 }
 
-// SetCSMBlockedProvidersCount publishes the size of csm.previousEpochBlockedProviders.
-// Used by integration tests to verify /debug/reset-all emptied the store (MAG-1762).
+// SetCSMBlockedProvidersCount publishes the number of providers currently blocked — the operator-
+// facing "is this chain degraded" signal, and the post-condition integration tests assert against
+// /metrics after /debug/reset-all (MAG-1762).
 func (m *SmartRouterMetricsManager) SetCSMBlockedProvidersCount(chainId, apiInterface string, count int) {
 	if m == nil {
 		return
 	}
 	m.csmBlockedProvidersCount.WithLabelValues(chainId, apiInterface).Set(float64(count))
+}
+
+// SetCSMPreviousEpochBlockedProvidersCount publishes the size of csm.previousEpochBlockedProviders,
+// the cross-epoch carry-over set. Split out from the gauge above, which now reports the thing its
+// name promises.
+func (m *SmartRouterMetricsManager) SetCSMPreviousEpochBlockedProvidersCount(chainId, apiInterface string, count int) {
+	if m == nil {
+		return
+	}
+	m.csmPrevEpochBlockedProviders.WithLabelValues(chainId, apiInterface).Set(float64(count))
 }
 
 // SetCSMBlockedBackupProvidersCount publishes the size of csm.blockedBackupProviders.

--- a/protocol/metrics/smartrouter_metrics_manager.go
+++ b/protocol/metrics/smartrouter_metrics_manager.go
@@ -504,8 +504,8 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 	}, csmStateLabels)
 	csmProviderBlocked := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "smartrouter_csm_provider_blocked",
-		Help: "Whether this specific provider is currently blocked (1=blocked, 0=serving). Companion to the smartrouter_csm_blocked_providers count, for identifying WHICH provider went out.",
-	}, []string{"spec", "apiInterface", "provider", "provider_endpoint"})
+		Help: "Whether this specific provider is currently blocked (1=blocked, 0=serving). Companion to the smartrouter_csm_blocked_providers count, for identifying WHICH provider went out. Republished in full on every state-size tick, so it converges even when the blocked list is drained wholesale.",
+	}, []string{"spec", "apiInterface", "provider_address"})
 	csmBlockedBackupProvidersCount := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "smartrouter_csm_blocked_backup_providers",
 		Help: "Size of ConsumerSessionManager.blockedBackupProviders (per-epoch backup-provider failure memory). Goes to 0 after /debug/reset-all.",
@@ -1520,7 +1520,20 @@ func (m *SmartRouterMetricsManager) SetProviderSelected(chainId string, apiInter
 //
 // Was an empty stub, so every blockProvider / restore call site published nothing and the smart
 // router had no per-provider blocked signal at all.
-func (m *SmartRouterMetricsManager) SetBlockedProvider(chainId, apiInterface, providerAddress, providerEndpoint string, isBlocked bool) {
+//
+// providerEndpoint is deliberately NOT a label, and the parameter is ignored. Two reasons:
+//
+//  1. It would be a credential leak. Callers pass Endpoints[0].NetworkAddress, which is the raw
+//     configured node URL — and node URLs embed API keys in their path or query. The relay path
+//     already labels by provider name for exactly this reason ("use provider name (configured
+//     name) instead of raw URL to avoid leaking API keys"), and docs/METRICS.md states the rule
+//     outright: a credential must never reach a Prometheus series.
+//  2. It would go stale. Blocking is a per-provider decision, but Endpoints[0] is one arbitrary
+//     endpoint of several. If that value changes between the block and the unblock, the 0 lands
+//     on a new series and the old one is orphaned at 1 forever.
+//
+// The signature keeps the parameter because it is fixed by ConsumerMetricsManagerInf.
+func (m *SmartRouterMetricsManager) SetBlockedProvider(chainId, apiInterface, providerAddress, _ string, isBlocked bool) {
 	if m == nil {
 		return
 	}
@@ -1528,7 +1541,7 @@ func (m *SmartRouterMetricsManager) SetBlockedProvider(chainId, apiInterface, pr
 	if isBlocked {
 		value = 1.0
 	}
-	m.csmProviderBlocked.WithLabelValues(chainId, apiInterface, providerAddress, providerEndpoint).Set(value)
+	m.csmProviderBlocked.WithLabelValues(chainId, apiInterface, providerAddress).Set(value)
 }
 
 func (m *SmartRouterMetricsManager) SetQOSMetrics(chainId string, apiInterface string, _ string, _ string, _ *pairingtypes.QualityOfServiceReport, _ *pairingtypes.QualityOfServiceReport, _ int64, _ uint64, _ time.Duration, _ bool) {
@@ -1536,7 +1549,25 @@ func (m *SmartRouterMetricsManager) SetQOSMetrics(chainId string, apiInterface s
 
 func (m *SmartRouterMetricsManager) ResetSessionRelatedMetrics() {}
 
-func (m *SmartRouterMetricsManager) ResetBlockedProvidersMetrics(string, string, map[string]string) {
+// ResetBlockedProvidersMetrics rebases the per-provider blocked gauge onto a new pairing.
+// UpdateAllProviders calls it on every epoch transition with the new epoch's provider set.
+//
+// Without this, a provider that was blocked and then dropped from the pairing leaves a series
+// stuck at 1 that nothing can ever clear: the unblock path only publishes for addresses it finds
+// in the standing block list, and that provider is no longer in it. Over many epochs those
+// phantoms accumulate — a slow cardinality leak that also reads as a permanent outage.
+//
+// Drop every series for this chain first, then seed 0 for each provider in the new pairing, so
+// providers that left are gone rather than frozen. A provider that the re-block pass immediately
+// re-blocks is corrected by the next publishStateSizes tick, which republishes the full truth.
+func (m *SmartRouterMetricsManager) ResetBlockedProvidersMetrics(chainId, apiInterface string, providerAddressToEndpoint map[string]string) {
+	if m == nil {
+		return
+	}
+	m.csmProviderBlocked.DeletePartialMatch(prometheus.Labels{"spec": chainId, "apiInterface": apiInterface})
+	for providerAddress := range providerAddressToEndpoint {
+		m.csmProviderBlocked.WithLabelValues(chainId, apiInterface, providerAddress).Set(0)
+	}
 }
 
 // SetCSMBlockedProvidersCount publishes the number of providers currently blocked — the operator-


### PR DESCRIPTION
Jira ticket: MAG-3106

## The bug

`smartrouter_csm_blocked_providers` reads **0 while providers are blocked and serving no traffic**. An all-providers-down outage looks identical to a healthy router on every dashboard and alert built on this metric.

Observed on a live router with two primaries deliberately failed until blocked:

```
$ curl -s http://127.0.0.1:7910/debug/provider-routing
[{"ValidAddresses":[],
  "CurrentlyBlockedProviderAddresses":["primary-a","primary-b"],
  "BlockedBackupProviders":[]}]

$ curl -s http://127.0.0.1:7810/metrics | grep csm_blocked
smartrouter_csm_blocked_providers{apiInterface="tendermintrpc",spec="LAVA"} 0
```

Two providers blocked, gauge reads 0. It never moved off 0 at any point during the session.

## Root cause

The gauge published `len(previousEpochBlockedProviders)` — the **cross-epoch carry-over set**, which `UpdateAllProviders` fills at an epoch boundary and `checkAndUnblockHealthyReBlockedProviders` empties moments later. It is near-always zero.

The standing block lives in **`currentlyBlockedProviderAddresses`** — the field `/debug/provider-routing` correctly reports.

The gauge's `Help` string was honest about this (*"Size of ConsumerSessionManager.previousEpochBlockedProviders"*); the **name** was not. It was built to verify a `/debug/reset-all` post-condition (MAG-1762) but is named as the blocked-provider count, so that is how it gets used.

## The change

**1. The gauge reports what its name promises.** `smartrouter_csm_blocked_providers` now publishes `len(currentlyBlockedProviderAddresses)`.

**2. Nothing is lost.** The previous-epoch size moves to its own `smartrouter_csm_previous_epoch_blocked_providers`, so the MAG-1762 signal survives under a name that says what it is.

The MAG-1762 post-condition also still holds on the corrected gauge: `ResetTransientFailureState` deliberately preserves the standing block (it is an epoch-boundary operation in lava-pairing mode), but `/debug/reset-all` **also** calls `ResetBlockedProviders`, which clears it and republishes. Verified by test.

**3. `SetBlockedProvider` is no longer an empty stub.**

```go
func (m *SmartRouterMetricsManager) SetBlockedProvider(string, string, string, string, bool) {}
```

`blockProvider` and the two restore paths call this on every block and unblock, and in the smart router **all three published nothing** — so there was no per-provider blocked signal at all, only the broken aggregate. It now writes `smartrouter_csm_provider_blocked{provider, provider_endpoint}`, so a dashboard can show *which* provider went out, not just how many.

## Tests

Four, in `protocol/lavasession/blocked_providers_metric_test.go`:

- a real block — driven through `blockProvider`, **not** by writing the field — shows in the gauge, and scales with the list
- blocking does not populate the cross-epoch set (the two can't be confused again)
- `ResetBlockedProviders` zeroes the gauge; `ResetTransientFailureState` deliberately does not
- `SetBlockedProvider` writes both directions without panicking

**They fail on the old code with `expected: 1, actual: 0`** — the exact production symptom. There was previously no coverage that could have caught this, because the only test set `previousEpochBlockedProviders` directly and asserted on it.

`TestPublishStateSizes_PopulateThenReset` is updated to the corrected semantics and now asserts on both gauges separately.

## Verification

`go build ./...`, `go vet ./...` clean · `gofmt` clean on changed files · full `go test ./...` green.

## Two decisions worth a reviewer's opinion

**I repointed the existing metric name rather than renaming it.** `smartrouter_csm_blocked_providers` keeps its name and starts meaning what it says. The alternative — rename it and give the correct value a new name — avoids changing an existing series but leaves the misleading name in place. In-repo the only reference was `docs/METRICS.md` (updated), but **if any external dashboard or automation depends on the old semantics, this is the line to push back on.**

**The per-provider gauge adds cardinality** — one series per provider per chain. Small for static direct-RPC configs, worth a glance if you run many providers. The alternative was deleting `SetBlockedProvider` from this manager's interface; I chose to implement it because three call sites already expect it to do something, and a silently-empty interface method is a trap for the next reader.

## Provenance

Found while integration-testing #328 (MAG-2599). **Pre-existing and unrelated to that PR** — reproduced identically on `origin/main`. That PR's description originally claimed this metric would start reflecting reality during an outage; it has since been corrected to point here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsVw3GRjz59spS7kWYjcaX

