### PR TITLE
fix(chainlib): stop a whole-body null reply from ending the router process (MAG-3077)

### DIFF
--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -220,6 +220,18 @@ func checkUTXOResponseAndFixReply(chainID string, replyData []byte) []byte {
 	// Try single response first
 	var jsonMsg *rpcclient.JsonrpcMessage
 	if err := json.Unmarshal(replyData, &jsonMsg); err == nil {
+		// MAG-3077: err == nil does NOT imply jsonMsg != nil. The target is a *pointer*,
+		// and JSON `null` is a legal value for one, so a reply body of `null` unmarshals
+		// as (nil pointer, nil error) — the one input that reaches here non-convertible.
+		// Every other scalar body (`5`, `true`, `"s"`) fails to unmarshal into the struct
+		// and takes the batch path below instead. Dereferencing the nil in
+		// convertToUTXOResponse panicked, and with no recover middleware on the fiber
+		// request path that ended the process for every in-flight caller, not just this
+		// relay. Hand the node's bytes back unchanged, as this function already does for
+		// every other body it cannot convert.
+		if jsonMsg == nil {
+			return replyData
+		}
 		if marshaledRes, err := json.Marshal(convertToUTXOResponse(jsonMsg)); err == nil {
 			return marshaledRes
 		}
@@ -248,6 +260,14 @@ func checkUTXOResponseAndFixReply(chainID string, replyData []byte) []byte {
 // includes the "error" field (even when null). The relay pipeline may add "jsonrpc":"2.0"
 // and strip null errors during response reconstruction — this undoes those changes.
 func convertToUTXOResponse(msg *rpcclient.JsonrpcMessage) *rpcclient.BTCResponse {
+	if msg == nil {
+		// Unreachable from both current call sites: the single-response path filters nil
+		// above, and the batch path passes &jsonMsgs[i], which is never nil. Kept so the
+		// helper is total on its own signature rather than relying on a caller invariant —
+		// the caller-side guard is the real fix, this only bounds a future third caller to
+		// an empty response instead of a process exit.
+		return &rpcclient.BTCResponse{}
+	}
 	return &rpcclient.BTCResponse{
 		// Omit Version: UTXO-family nodes use JSON-RPC 1.0 which doesn't include the "jsonrpc" field.
 		// The relay pipeline may inject "2.0" during reconstruction; leaving Version empty strips it

--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -204,8 +204,36 @@ func drainHTTPThenWS(ctx context.Context, app *fiber.App, wg *sync.WaitGroup, na
 	return httpErr
 }
 
+// utxoFamilyChainIDs is the set of chain ids whose reply bodies need the JSON-RPC 1.0
+// fixup below. Membership is not a judgement call: it is exactly "the chain's spec
+// transitively imports BTC", which is what makes the node a Bitcoin Core derivative
+// speaking JSON-RPC 1.0. Resolved against the lava-specs catalog (255 specs), 14 enabled
+// specs reach BTC through their imports chain, and all 14 are listed here.
+//
+// MAG-3077: six of them — BTCT4, BTCS, DASH, DASHT, ZCASH, ZCASHT — were missing, so
+// those chains took the non-UTXO path and returned bodies with "jsonrpc":"2.0" injected
+// and a null "error" stripped. That is precisely the mangling checkUTXOResponseAndFixReply
+// exists to undo, and it breaks Bitcoin-derived clients that read resp["error"]
+// unconditionally.
+//
+// MONERO/MONEROT are deliberately absent and are not an oversight: monero.json declares no
+// imports and monerod speaks JSON-RPC 2.0, so it needs no 1.0 fixup. Lookup is
+// case-sensitive because spec indexes are upper-case by construction.
+//
+// A new BTC-derived spec must be added here. TestIsUTXOFamily pins the membership so that
+// stays a deliberate edit rather than silent drift.
+var utxoFamilyChainIDs = map[string]struct{}{
+	"BTC": {}, "BTCT": {}, "BTCT4": {}, "BTCS": {}, // btc.json
+	"LTC": {}, "LTCT": {}, // litecoin.json -> BTC
+	"DOGE": {}, "DOGET": {}, // doge.json     -> BTC
+	"BCH": {}, "BCHT": {}, // bch.json      -> BTC
+	"DASH": {}, "DASHT": {}, // dash.json     -> BTC
+	"ZCASH": {}, "ZCASHT": {}, // zcash.json    -> BTC
+}
+
 func isUTXOFamily(chainID string) bool {
-	return chainID == "BTC" || chainID == "BTCT" || chainID == "LTC" || chainID == "LTCT" || chainID == "DOGE" || chainID == "DOGET" || chainID == "BCH" || chainID == "BCHT"
+	_, ok := utxoFamilyChainIDs[chainID]
+	return ok
 }
 
 // checkUTXOResponseAndFixReply returns the reply body for UTXO-family chains after

--- a/protocol/chainlib/common_test.go
+++ b/protocol/chainlib/common_test.go
@@ -510,6 +510,10 @@ func TestGetServiceApis(t *testing.T) {
 	}
 }
 
+// utxoFamilyChainIDsForTest lists every chain ID isUTXOFamily accepts, so the null-body
+// regression below is asserted against all of them rather than a hand-picked sample.
+var utxoFamilyChainIDsForTest = []string{"BTC", "BTCT", "LTC", "LTCT", "DOGE", "DOGET", "BCH", "BCHT"}
+
 func TestCheckUTXOResponseAndFixReply(t *testing.T) {
 	t.Run("single_response_preserves_error_null", func(t *testing.T) {
 		// BTC-family nodes return "error":null; the relay pipeline uses omitempty which strips it
@@ -571,6 +575,54 @@ func TestCheckUTXOResponseAndFixReply(t *testing.T) {
 		require.NoError(t, json.Unmarshal(result, &parsed))
 		errorField := parsed["error"]
 		require.NotNil(t, errorField, "error field must be preserved when not null")
+	})
+
+	// MAG-3077: a whole-body `null` unmarshals into a *JsonrpcMessage as (nil, nil error),
+	// and dereferencing that nil ended the router process — no recover middleware sits on
+	// the fiber request path, so one bad reply dropped every concurrent caller. Every
+	// pre-existing case in this suite used null only as a *field* value ("error":null),
+	// which is why none of them caught it.
+	t.Run("whole_body_null_is_returned_unchanged", func(t *testing.T) {
+		for _, chainID := range utxoFamilyChainIDsForTest {
+			t.Run(chainID, func(t *testing.T) {
+				require.NotPanics(t, func() {
+					result := checkUTXOResponseAndFixReply(chainID, []byte("null"))
+					require.Equal(t, "null", string(result),
+						"an unconvertible body must pass through untouched, not be replaced by a synthesized response")
+				})
+			})
+		}
+	})
+
+	t.Run("whole_body_null_with_surrounding_whitespace", func(t *testing.T) {
+		// The decoder skips leading/trailing whitespace, so this takes the same
+		// (nil, nil) path as a bare `null` rather than failing to unmarshal.
+		input := "  null\n"
+		require.NotPanics(t, func() {
+			result := checkUTXOResponseAndFixReply("BTC", []byte(input))
+			require.Equal(t, input, string(result))
+		})
+	})
+
+	t.Run("batch_with_null_element_does_not_panic", func(t *testing.T) {
+		// The batch branch converts &jsonMsgs[i], which is never nil, so a null element
+		// decodes to a zero-value message instead of panicking. Pinned so the single and
+		// batch branches cannot diverge on this input if either is refactored.
+		require.NotPanics(t, func() {
+			result := checkUTXOResponseAndFixReply("BTC", []byte(`[null]`))
+			var parsed []map[string]interface{}
+			require.NoError(t, json.Unmarshal(result, &parsed))
+			require.Len(t, parsed, 1)
+		})
+	})
+
+	t.Run("non_utxo_chain_null_body_passthrough", func(t *testing.T) {
+		// Control: non-UTXO chains never entered the conversion branch, which is why this
+		// only ever crashed Bitcoin-family routers.
+		require.NotPanics(t, func() {
+			result := checkUTXOResponseAndFixReply("ETH1", []byte("null"))
+			require.Equal(t, "null", string(result))
+		})
 	})
 }
 

--- a/protocol/chainlib/common_test.go
+++ b/protocol/chainlib/common_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -510,9 +511,53 @@ func TestGetServiceApis(t *testing.T) {
 	}
 }
 
-// utxoFamilyChainIDsForTest lists every chain ID isUTXOFamily accepts, so the null-body
-// regression below is asserted against all of them rather than a hand-picked sample.
-var utxoFamilyChainIDsForTest = []string{"BTC", "BTCT", "LTC", "LTCT", "DOGE", "DOGET", "BCH", "BCHT"}
+// utxoFamilyChainIDsForTest lists every chain id isUTXOFamily accepts. Derived from the
+// production set rather than restated, so the null-body regression below cannot silently
+// stop covering a chain that gets added later. TestIsUTXOFamily pins what that set is
+// allowed to contain.
+var utxoFamilyChainIDsForTest = func() []string {
+	ids := make([]string, 0, len(utxoFamilyChainIDs))
+	for id := range utxoFamilyChainIDs {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}()
+
+func TestIsUTXOFamily(t *testing.T) {
+	// Membership is exactly "the chain's spec transitively imports BTC", which is what makes
+	// the node a Bitcoin Core derivative speaking JSON-RPC 1.0. Resolved against the
+	// lava-specs catalog (255 specs): these 14 enabled specs reach BTC via imports, and
+	// nothing else does (MAG-3077).
+	btcDerived := []string{
+		"BTC", "BTCT", "BTCT4", "BTCS", // btc.json
+		"LTC", "LTCT", // litecoin.json -> BTC
+		"DOGE", "DOGET", // doge.json     -> BTC
+		"BCH", "BCHT", // bch.json      -> BTC
+		"DASH", "DASHT", // dash.json     -> BTC
+		"ZCASH", "ZCASHT", // zcash.json    -> BTC
+	}
+	for _, chainID := range btcDerived {
+		require.True(t, isUTXOFamily(chainID),
+			"%s derives from the BTC spec and needs the JSON-RPC 1.0 fixup", chainID)
+	}
+	require.Len(t, utxoFamilyChainIDs, len(btcDerived),
+		"the UTXO set must hold exactly the BTC-derived chains — adding one that is not, or "+
+			"dropping one that is, changes response formatting on a live chain")
+
+	notBTCDerived := map[string]string{
+		"MONERO":  "monero.json declares no imports and monerod speaks JSON-RPC 2.0",
+		"MONEROT": "inherits MONERO, not BTC",
+		"ETH1":    "EVM chains are JSON-RPC 2.0",
+		"SOLANA":  "not a Bitcoin Core derivative",
+		"btc":     "spec indexes are upper-case; the lookup is deliberately case-sensitive",
+		"BTC1":    "not a real index — a prefix match must not be enough",
+		"":        "an empty chain id must never take the UTXO path",
+	}
+	for chainID, why := range notBTCDerived {
+		require.False(t, isUTXOFamily(chainID), "%q must not take the UTXO path: %s", chainID, why)
+	}
+}
 
 func TestCheckUTXOResponseAndFixReply(t *testing.T) {
 	t.Run("single_response_preserves_error_null", func(t *testing.T) {


### PR DESCRIPTION
# Description

A Bitcoin-family node answering with the body `null` ended the router process. Every caller on that router lost service until it restarted — no auth, and nothing unusual from the client.

**Most critical file to review:** `protocol/chainlib/common.go`.

## The crash (commit 1)

`checkUTXOResponseAndFixReply` unmarshals into a `*rpcclient.JsonrpcMessage`. The target is a **pointer**, and JSON `null` is a legal value for one, so a body of `null` decodes as `(nil pointer, nil error)` — `err == nil` never implied a usable message. `convertToUTXOResponse` then read `msg.ID` off that nil.

Nothing catches it. Fiber v2.52's only core `recover()` is in `internal/schema` (request binding) and fasthttp v1.51's only one is in `Response.writeBodyStream`; neither is on the handler path. The panic unwound the connection goroutine and took the process with it, dropping **every concurrent relay**, not just the offending one.

`null` is the sole trigger. Every other scalar body (`5`, `true`, `"s"`) fails to unmarshal into the struct and falls through to the batch branch, and the batch branch converts `&jsonMsgs[i]`, which is never nil.

I confirmed the body actually reaches that line rather than assuming it:

| Step | Behaviour |
|---|---|
| `direct_rpc_relay.go:483` | admits it — `json.Valid("null")` is `true` |
| `CheckResponseError` → `checkJsonrpcEnvelope:102` | flags it: *"missing both 'result' and 'error' fields"* → `IsNodeError=true` |
| `IsNodeError` handling | drives session scoring (`shouldFailSessionForResult`) and a response header (`rpcsmartrouter_server.go:4721`) — **never a returned error** |
| `jsonRPC.go:496` | sees `err == nil`, falls to `:539`, calls the conversion → panic |

On a multi-endpoint router the node-error retry masks this unless the `null`-returning endpoint is the one whose reply is returned; a single-endpoint router panics on the first request.

**Fix:** return the node's bytes unchanged, matching what the function already does at `:227`/`:244` for every other body it cannot convert. `convertToUTXOResponse` also gets a nil guard so it is total on its own signature — following the convention `shouldFailSessionForResult` already uses, and explicitly documented as unreachable from both present call sites.

## The allowlist (commit 2 — separable)

The ticket flagged `BTCS` as an open question. Resolving the imports graph across the whole lava-specs catalog (255 specs) gives the answer and more: **14** enabled specs transitively import `BTC`, and `isUTXOFamily` listed **8**.

Missing: `BTCT4`, `BTCS`, `DASH`, `DASHT`, `ZCASH`, `ZCASHT`.

Those six took the non-UTXO path, so their replies went back with `"jsonrpc":"2.0"` injected and a null `"error"` stripped — exactly the mangling this function exists to undo, and it breaks Bitcoin-derived clients that read `resp["error"]` unconditionally. So this commit fixes a live correctness bug, not just a latent one.

`MONERO`/`MONEROT` stay out, now documented as deliberate rather than accidental: `monero.json` declares no imports and `monerod` speaks JSON-RPC 2.0.

Membership is now a set with the rule (*"the spec transitively imports BTC"*) written at the definition, pinned by `TestIsUTXOFamily` — including a length assertion, since adding a chain that does not belong changes response formatting on a live chain just as much as omitting one that does.

> **Note on ordering / risk:** this commit *widens* the null-body blast radius from 8 chains to 14, which is why it lands **after** the guard that fixes it. It is also the only commit here with a behaviour change on live chains (response formatting for those six), so if you would rather ship the crash fix alone, drop `1fe390f` and the first commit stands on its own.

## Test evidence

CI on this repo does not run `go test` (the gate is build/lint/govulncheck/Jira), so green checks say nothing about these tests. Run locally from a **clean `git worktree` checkout of the pushed sha**, not the working directory:

```
go build ./...                    BUILD OK
go test ./protocol/chainlib/...   all packages ok
gofmt -l <changed files>          clean
golangci-lint run                 4 findings in these files, all identical to the
                                  origin/main baseline — zero new issues
```

The new cases were validated by reverting both guards and re-running: `whole_body_null_is_returned_unchanged` fails with `Panic value: runtime error: invalid memory address or nil pointer dereference` on every UTXO chain. The five pre-existing subtests all used `null` as a *field* value (`"error":null`) and never as the whole body, which is why none of them caught this.

New coverage: whole-body `null` across all 14 chain ids (derived from the production set, so it cannot stop covering a chain added later), the `  null\n` whitespace variant, a `[null]` batch element, a non-UTXO control, and `TestIsUTXOFamily`.

## Jira ticket

Jira ticket: MAG-3077

## Follow-up, not in this PR

- **No panic boundary on the request path.** This is one nil deref among many possible ones; any handler panic anywhere takes the pod down. `fiber/middleware/recover` with a `StackTraceHandler` logging via `utils.LavaFormatError` would cap this whole class at "one 500 plus an alert". Worth its own ticket — it carries its own risk of masking real bugs in tests.
- **`ValidateNilResponse` is dead.** It returns `nil` unconditionally, and both call sites pass `string(replyMsg.Result)` — the parsed result field, not the raw body — so re-enabling it would not have caught this. `InvalidResponses` (`common.go:44`) is now referenced only from the commented-out code inside it.
- **`[null]` batch mangling.** Returns `[{"error":null,"result":null}]` rather than panicking. Pinned by a test here so it cannot regress into a crash, but it is still a silent mangle.

---

## Author Checklist

I have...

* [x] read the [contribution guide](https://github.com/magma-Devs/smart-router/blob/main/CONTRIBUTING.md)
* [x] included the correct type prefix in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change — n/a, no API change. Commit 2 changes response *formatting* for six chains, toward the JSON-RPC 1.0 shape those clients already expect.
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests — unit; validated by reverting the fix. No integration lane exists for UTXO chains.
* [x] updated the relevant documentation or specification, including comments for documenting Go code — the UTXO membership rule and the `null` decode hazard are now documented at their definitions.
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

I have...

* [ ] confirmed the correct type prefix in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
