### PR TITLE
feat(observability): explain provider exclusion at INFO

### DIFF
--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -1377,7 +1377,7 @@ func (csm *ConsumerSessionManager) filterRateLimitedProviders(ctx context.Contex
 		return validAddresses
 	}
 	if readyChoosable > 0 {
-		utils.LavaFormatDebug("rate-limit hold-off: skipping held-off providers",
+		utils.LavaFormatInfo("rate-limit hold-off: skipping held-off providers",
 			utils.LogAttr("held", heldCount),
 			utils.LogAttr("ready", readyChoosable),
 			utils.LogAttr("GUID", ctx),
@@ -1387,7 +1387,7 @@ func (csm *ConsumerSessionManager) filterRateLimitedProviders(ctx context.Contex
 	if soonest == "" {
 		return ready // every held candidate is also ignored this request — nothing to add
 	}
-	utils.LavaFormatDebug("rate-limit hold-off: every candidate held off, keeping the soonest to expire",
+	utils.LavaFormatWarning("rate-limit hold-off: every candidate held off, keeping the soonest to expire", nil,
 		utils.LogAttr("provider", soonest),
 		utils.LogAttr("readyAt", soonestAt),
 		utils.LogAttr("GUID", ctx),
@@ -1500,7 +1500,7 @@ func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context
 			}
 		}
 		if validAddressesLength-ignoredProvidersListLength <= 0 {
-			utils.LavaFormatDebug("Pairing list empty", utils.Attribute{Key: "Provider list", Value: validAddresses}, utils.Attribute{Key: "IgnoredProviderList", Value: ignoredProvidersList}, utils.Attribute{Key: "addon", Value: addon}, utils.Attribute{Key: "extensions", Value: extensions}, utils.LogAttr("GUID", ctx))
+			utils.LavaFormatInfo("Pairing list empty", utils.Attribute{Key: "Provider list", Value: validAddresses}, utils.Attribute{Key: "IgnoredProviderList", Value: ignoredProvidersList}, utils.Attribute{Key: "addon", Value: addon}, utils.Attribute{Key: "extensions", Value: extensions}, utils.LogAttr("GUID", ctx))
 			err = PairingListEmptyError
 			return addresses, err
 		}
@@ -1606,7 +1606,7 @@ func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context
 
 	// make sure we have at least 1 valid provider
 	if len(providers) == 0 || providers[0] == "" {
-		utils.LavaFormatDebug("No providers returned by the optimizer", utils.Attribute{Key: "Provider list", Value: validAddresses}, utils.Attribute{Key: "IgnoredProviderList", Value: ignoredProvidersList}, utils.LogAttr("GUID", ctx))
+		utils.LavaFormatInfo("No providers returned by the optimizer", utils.Attribute{Key: "Provider list", Value: validAddresses}, utils.Attribute{Key: "IgnoredProviderList", Value: ignoredProvidersList}, utils.LogAttr("GUID", ctx))
 		err = PairingListEmptyError
 		return addresses, err
 	}
@@ -2198,7 +2198,7 @@ func (csm *ConsumerSessionManager) OnSessionFailure(consumerSession *SingleConsu
 	allowSecondChance := false
 	// if this session failed more than MaximumNumberOfFailuresAllowedPerConsumerSession times or session went out of sync we block it.
 	if len(consumerSession.ConsecutiveErrors) > MaximumNumberOfFailuresAllowedPerConsumerSession || IsSessionSyncLoss(errorReceived) {
-		utils.LavaFormatDebug("Blocking consumer session",
+		utils.LavaFormatInfo("Blocking consumer session",
 			utils.LogAttr("ConsecutiveErrors", consumerSession.ConsecutiveErrors),
 			utils.LogAttr("errorsCount", consumerSession.errorsCount),
 			utils.LogAttr("id", consumerSession.SessionId),
@@ -2502,7 +2502,7 @@ func (csm *ConsumerSessionManager) GenerateReconnectCallback(consumerSessionsWit
 		ctx := utils.WithUniqueIdentifier(context.Background(), utils.GenerateUniqueIdentifier()) // unique identifier for retries
 		_, providerAddress, err := csm.probeProvider(ctx, consumerSessionsWithProvider, csm.atomicReadCurrentEpoch(), true)
 		if err == nil {
-			utils.LavaFormatDebug("Reconnecting provider succeeded returning provider to valid addresses list", utils.LogAttr("provider", providerAddress))
+			utils.LavaFormatInfo("Reconnecting provider succeeded returning provider to valid addresses list", utils.LogAttr("provider", providerAddress))
 			// csm.pairing and csm.backupProviders are built from separate inputs by
 			// UpdateAllProviders with no dedup, so a provider address can legitimately
 			// appear in both. The old "if backup else primary" branching silently dropped

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -1500,7 +1500,7 @@ func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context
 			}
 		}
 		if validAddressesLength-ignoredProvidersListLength <= 0 {
-			utils.LavaFormatInfo("Pairing list empty", utils.Attribute{Key: "Provider list", Value: validAddresses}, utils.Attribute{Key: "IgnoredProviderList", Value: ignoredProvidersList}, utils.Attribute{Key: "addon", Value: addon}, utils.Attribute{Key: "extensions", Value: extensions}, utils.LogAttr("GUID", ctx))
+			utils.LavaFormatDebug("Pairing list empty", utils.Attribute{Key: "Provider list", Value: validAddresses}, utils.Attribute{Key: "IgnoredProviderList", Value: ignoredProvidersList}, utils.Attribute{Key: "addon", Value: addon}, utils.Attribute{Key: "extensions", Value: extensions}, utils.LogAttr("GUID", ctx))
 			err = PairingListEmptyError
 			return addresses, err
 		}

--- a/protocol/relaycore/consistency_config.go
+++ b/protocol/relaycore/consistency_config.go
@@ -95,7 +95,7 @@ func NewConsistencyValidationConfig(
 		MaxWaitTime:          maxWaitTime,
 	}
 
-	utils.LavaFormatDebug("created consistency validation config",
+	utils.LavaFormatInfo("created consistency validation config",
 		utils.LogAttr("endpointLagThreshold", config.EndpointLagThreshold),
 		utils.LogAttr("maxWaitTime", config.MaxWaitTime),
 		utils.LogAttr("blockLagForQosSync", blockLagForQosSync),

--- a/protocol/relaycore/interfaces.go
+++ b/protocol/relaycore/interfaces.go
@@ -88,6 +88,19 @@ const (
 	ActionStop
 )
 
+// String makes Action readable in logs. Without it the retry decision line renders the
+// bare iota — every entry read "action=0", which is worse than not logging it at all.
+func (a Action) String() string {
+	switch a {
+	case ActionRetry:
+		return "retry"
+	case ActionStop:
+		return "stop"
+	default:
+		return "unknown"
+	}
+}
+
 // SendResult represents the pre-relay send result decision.
 type SendResult int
 

--- a/protocol/relaycore/unified_relay_state_machine.go
+++ b/protocol/relaycore/unified_relay_state_machine.go
@@ -384,7 +384,15 @@ func (sm *UnifiedRelayStateMachine) GetRelayTaskChannel() (chan RelayStateSendIn
 
 				nodeErrors := numberOfNodeErrorsAtomic.Load()
 				output := sm.policy.Decide(sm.buildDecisionInput(nodeErrors, false))
-				utils.LavaFormatDebug("[StateMachine] policy.Decide",
+				// A retry is the exceptional path — the common case is a single attempt that
+				// stops — and it is the one an operator needs in order to explain a slow or
+				// multi-provider relay from production INFO logs. Log those at INFO; leave the
+				// ordinary Stop at DEBUG so steady-state traffic stays quiet.
+				logDecision := utils.LavaFormatDebug
+				if output.Action != ActionStop {
+					logDecision = utils.LavaFormatInfo
+				}
+				logDecision("[StateMachine] policy.Decide",
 					utils.LogAttr("GUID", sm.ctx),
 					utils.LogAttr("action", output.Action),
 					utils.LogAttr("reason", output.Reason),

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2241,10 +2241,21 @@ func (rpcss *RPCSmartRouterServer) filterEndpointsByConsistency(
 		)
 		if err != nil {
 			// Endpoint is too far behind - add to failed sessions
+			// lag + threshold are what an operator actually needs here, and they were being
+			// dropped: ValidateEndpointCapability logs them at DEBUG and this caller discards
+			// its err. Recompute them rather than promote the inner line as well — one INFO
+			// line per rejected endpoint, carrying the endpoint identity the inner line lacks.
+			lag := chainTip - endpointLatest
+			threshold := int64(0)
+			if rpcss.consistencyConfig != nil {
+				threshold = rpcss.consistencyConfig.EndpointLagThreshold
+			}
 			utils.LavaFormatInfo("skipping endpoint due to consistency check",
 				utils.LogAttr("endpoint", endpointAddress),
 				utils.LogAttr("endpointLatest", endpointLatest),
 				utils.LogAttr("chainTip", chainTip),
+				utils.LogAttr("lag", lag),
+				utils.LogAttr("threshold", threshold),
 				// Report which source produced the value: the store wins whenever it holds a
 				// positive tip (prefer-store), else the poll atomic is the bootstrap fallback.
 				utils.LogAttr("source", func() string {
@@ -2266,16 +2277,22 @@ func (rpcss *RPCSmartRouterServer) filterEndpointsByConsistency(
 
 	// If ALL endpoints failed validation, return error to trigger retry
 	if len(validSessions) == 0 && skippedCount > 0 {
-		utils.LavaFormatWarning("all endpoints failed consistency pre-validation, triggering retry", nil,
+		utils.LavaFormatDebug("all endpoints failed consistency pre-validation, triggering retry",
 			utils.LogAttr("totalEndpoints", len(sessions)),
 			utils.LogAttr("skippedCount", skippedCount),
 			utils.LogAttr("chainTip", chainTip),
 			utils.LogAttr("GUID", ctx),
 		)
+		// The error below carries the same sentinel and is visible at every level, so this
+		// stays at DEBUG rather than WARN — two records of one event made anything counting
+		// the sentinel double-count it. skippedCount and GUID moved onto the error so the
+		// single surviving line still carries them.
 		return nil, failedSessions, utils.LavaFormatError("all endpoints failed consistency pre-validation",
 			lavasession.ConsistencyPreValidationError,
 			utils.LogAttr("totalEndpoints", len(sessions)),
+			utils.LogAttr("skippedCount", skippedCount),
 			utils.LogAttr("chainTip", chainTip),
+			utils.LogAttr("GUID", ctx),
 		)
 	}
 

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -1950,7 +1950,16 @@ func (rpcss *RPCSmartRouterServer) sendRelayToDirectEndpoints(
 			// Handle response
 			if err != nil {
 				tracing.RecordError(provSpan, err)
-				utils.LavaFormatDebug("direct RPC relay failed in goroutine",
+				// A relay WE cancelled is not an endpoint failure: on a stateful broadcast the
+				// first answer cancels the rest, so promoting this unconditionally would emit
+				// N-1 INFO lines per request for endpoints that did nothing wrong — the same
+				// mis-attribution MAG-2648 removed from scoring. Keep those at DEBUG; a genuine
+				// endpoint failure is the exceptional path an operator needs at INFO.
+				logRelayFailure := utils.LavaFormatInfo
+				if isClientCancel {
+					logRelayFailure = utils.LavaFormatDebug
+				}
+				logRelayFailure("direct RPC relay failed in goroutine",
 					utils.LogAttr("endpoint", endpointAddress),
 					utils.LogAttr("error", err.Error()),
 					utils.LogAttr("latency", relayLatency),
@@ -2018,7 +2027,7 @@ func (rpcss *RPCSmartRouterServer) sendRelayToDirectEndpoints(
 				if releaseErr == nil {
 					releaseErr = fmt.Errorf("upstream rate-limited the relay (HTTP %d)", statusCode)
 				}
-				utils.LavaFormatDebug("relay rate-limited by upstream, holding endpoint off",
+				utils.LavaFormatInfo("relay rate-limited by upstream, holding endpoint off",
 					utils.LogAttr("endpoint", endpointAddress),
 					utils.LogAttr("holdoff", heldFor.String()),
 					utils.LogAttr("GUID", goroutineCtx),
@@ -2210,7 +2219,7 @@ func (rpcss *RPCSmartRouterServer) filterEndpointsByConsistency(
 			if rpcss.endpointChainTrackerManager != nil && endpointURL != "" {
 				trackerState, trackerLastError, _ = rpcss.endpointChainTrackerManager.GetTrackerState(endpointURL)
 			}
-			utils.LavaFormatDebug("skipping consistency validation because endpoint latest block is unknown",
+			utils.LavaFormatInfo("skipping consistency validation because endpoint latest block is unknown",
 				utils.LogAttr("endpoint", endpointAddress),
 				utils.LogAttr("endpointURL", endpointURL),
 				utils.LogAttr("chainTip", chainTip),
@@ -2232,7 +2241,7 @@ func (rpcss *RPCSmartRouterServer) filterEndpointsByConsistency(
 		)
 		if err != nil {
 			// Endpoint is too far behind - add to failed sessions
-			utils.LavaFormatDebug("skipping endpoint due to consistency check",
+			utils.LavaFormatInfo("skipping endpoint due to consistency check",
 				utils.LogAttr("endpoint", endpointAddress),
 				utils.LogAttr("endpointLatest", endpointLatest),
 				utils.LogAttr("chainTip", chainTip),
@@ -2257,7 +2266,7 @@ func (rpcss *RPCSmartRouterServer) filterEndpointsByConsistency(
 
 	// If ALL endpoints failed validation, return error to trigger retry
 	if len(validSessions) == 0 && skippedCount > 0 {
-		utils.LavaFormatDebug("all endpoints failed consistency pre-validation, triggering retry",
+		utils.LavaFormatWarning("all endpoints failed consistency pre-validation, triggering retry", nil,
 			utils.LogAttr("totalEndpoints", len(sessions)),
 			utils.LogAttr("skippedCount", skippedCount),
 			utils.LogAttr("chainTip", chainTip),
@@ -2271,7 +2280,7 @@ func (rpcss *RPCSmartRouterServer) filterEndpointsByConsistency(
 	}
 
 	if skippedCount > 0 {
-		utils.LavaFormatDebug("filtered endpoints by consistency",
+		utils.LavaFormatInfo("filtered endpoints by consistency",
 			utils.LogAttr("totalEndpoints", len(sessions)),
 			utils.LogAttr("validEndpoints", len(validSessions)),
 			utils.LogAttr("skippedCount", skippedCount),


### PR DESCRIPTION
#Closes MAG-3123
Jira ticket: MAG-3123

## Why

Every reason a provider was excluded from a relay sat at DEBUG. A production router at
`--log-level info` could show that a request failed, but never why. The gk8 consistency
case and the dfns/polygon 429 case both had to be re-run at debug after the fact.

Measured on the real polygon pod capture in `agent_docs/bug-reports/polygin-investigation`:
999 INFO lines over 92 relays — ~11 per relay, of which 2 carried information. INFO was
loud and uninformative at once. This PR changes what INFO *says*; a follow-up can delete
the narration that makes up the rest.

## What changed

Severity only — **no log message text changed**, so nothing that greps on text is affected.
The one exception is the consistency line, which gained `lag` and `threshold`.

| Area | Line | Was | Now |
|---|---|---|---|
| Consistency | `skipping endpoint due to consistency check` (+`lag`, +`threshold`) | DEBUG | INFO |
| | `skipping consistency validation … block unknown` | DEBUG | INFO |
| | `filtered endpoints by consistency` | DEBUG | INFO |
| | `created consistency validation config` (once per chain, startup) | DEBUG | INFO |
| Hold-off | `rate-limit hold-off: skipping held-off providers` | DEBUG | INFO |
| | `every candidate held off` | DEBUG | **WARN** |
| Session | `Blocking consumer session` | DEBUG | INFO |
| | `Reconnecting provider succeeded …` | DEBUG | INFO |
| Selection | `No providers returned by the optimizer` | DEBUG | INFO |
| Relay | `relay rate-limited by upstream, holding endpoint off` | DEBUG | INFO |
| | `direct RPC relay failed in goroutine` | DEBUG | INFO (conditional) |
| State machine | `policy.Decide` | DEBUG | INFO on retry only |

Plus `relaycore.Action` gained a `String()`, so the decision line reads `action=retry`
instead of `action=0`.

## Two conditional promotions

- **`direct RPC relay failed in goroutine`** stays DEBUG when the failure is a cancellation
  we caused. On a stateful broadcast the first answer cancels the rest, so a flat promotion
  would emit N-1 INFO lines per request blaming endpoints that did nothing wrong — the
  mis-attribution MAG-2648 removed from scoring. Reuses the existing `isClientCancel`.
- **`policy.Decide`** logs at INFO only on a retry; the common single-attempt stop stays DEBUG.

## Reviewed and corrected before submission

An adversarial pass found four defects in the first commit; `263bb4b` fixes all four.
Recording them because three were **measured**, not argued:

1. `action=0` — `Action` had no `String()`, so every added line printed the bare iota.
2. The consistency line **discarded the error carrying `lag`/`threshold`** — the two numbers
   the incident report asked for. Recomputed at the call site.
3. `Pairing list empty` is **not** once per relay: **3.8 per relay** across 28 GUIDs in
   `debugging/logs/SR_LAVA_OFF.log`, worst during the outage it was meant to explain.
   Reverted to DEBUG.
4. `all endpoints failed consistency pre-validation` was emitted **twice** (WARN + ERROR,
   six lines apart). WARN back to DEBUG; its unique attrs moved onto the ERROR.

## How to verify

Add a temporary `TestMain` calling `utils.SetGlobalLoggingLevel("info")`, then:

```bash
go test ./protocol/rpcsmartrouter/ -run 'TestLiar_SingleProviderSelfHeals' -count=1 -v
```

Before (main) — one line, no cause:
```
ERR all endpoints failed consistency pre-validation chainTip=20100000 totalEndpoints=1
```

After — which endpoint, its block, the tip, how far behind, and the limit:
```
INF skipping endpoint due to consistency check endpoint=http://solo:8545 endpointLatest=1000 \
    chainTip=20100000 lag=20099000 threshold=10 source=endpointtip_store
ERR all endpoints failed consistency pre-validation skippedCount=1 totalEndpoints=1 \
    chainTip=20100000 GUID=
```

```bash
make lint    # go vet ./...   — clean
make test    # go test ./... -count=1  — exit 0, 34 packages ok, 0 FAIL
```

## Known limitations — please read

- **The Helm chart default is `warn`, not `info`** (`values.yaml: log.level: warn`). Ten of
  these promotions are to INFO, so **customers on chart defaults will see none of them**.
  Magma's own pods do run at info — the polygon capture is 999 `"level":"info"` lines — so
  this lands for us. Deciding whether the chart default should change is out of scope here.
- **No test pins these levels.** Nothing stops a future change from silently demoting them.
- **This changes the default for self-hosted operators** (`SR_LOG_LEVEL:-info` in compose).
  On a chain with a chronically-lagging endpoint, expect ~1 extra INFO line per relay per
  failing endpoint. Measured customer traffic is ~1.3–1.5 relays/sec, so a few lines/sec in
  the degraded case and zero in steady state.
- **One new WARN is alertable.** `every candidate held off` will appear in WARN-level
  alerting. Intended — it means the chain is not serving — but it is a behaviour change.
- Hold-off logging is partly redundant with `smartrouter_rate_limit_holdoffs_total`
  (`METRICS.md:292-305`); kept because the metric has no GUID for per-request correlation.
- **Not addressed:** `EnableDebugLogBuffer` cannot capture below the global log level —
  `utils/lavalog.go:487` early-returns before the ring-buffer sink, despite its doc claiming
  it "captures EVERYTHING". Fixing that gate would give per-request DEBUG forensics via
  `/debug/logs` at zero steady-state cost, and is the better long-term answer than this PR.
- **Not addressed:** `request_id` correlation — 252 sites log `GUID`, 23 log `request_id`,
  none on the selection path, so `/debug/logs?request_id=` finds almost nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ES82b8aH1E9jj8zRWerT8h
