### PR TITLE
fix(lavasession): make the epoch's probe branch reachable again

### DIFF
--- a/protocol/lavasession/block_reason_test.go
+++ b/protocol/lavasession/block_reason_test.go
@@ -759,6 +759,56 @@ func TestBlockRecord_CarriedRecordTakesTheScopeItIsReBlockedIn(t *testing.T) {
 	require.Equal(t, uint32(1), row.Carries)
 }
 
+// epochPairing builds a single direct-RPC provider for the epoch-transition tests.
+//
+// usable decides whether probeDirectRPCEndpoints — the gate the epoch's release pass runs — passes
+// or fails. It is a routability check: at least one ENABLED endpoint carrying a connection object.
+//
+// Both shapes are genuinely direct-RPC (IsDirectRPC() is len(DirectConnections) > 0), which matters:
+// an endpoint with no DirectConnections at all is skipped one branch earlier, failing with "no
+// direct RPC endpoints found" — a misconfiguration, not the gate under test. Failing on the wrong
+// branch would still make these tests pass, while proving reachability through a provider shape
+// that cannot occur in a correctly configured deployment.
+func epochPairing(t *testing.T, address string, usable bool) map[uint64]*ConsumerSessionsWithProvider {
+	t.Helper()
+	// A connection object, not a live connection — NewDirectRPCConnection builds an HTTP client
+	// lazily and dials nothing, and the gate only asks whether one is present.
+	conn, err := NewDirectRPCConnection(context.Background(), common.NodeUrl{Url: "https://example.invalid:443/"}, 5, "")
+	require.NoError(t, err)
+	return map[uint64]*ConsumerSessionsWithProvider{
+		0: {
+			PublicLavaAddress: address,
+			Endpoints: []*Endpoint{{
+				NetworkAddress:    "https://example.invalid:443/",
+				Enabled:           usable, // an endpoint that is present but disabled fails the gate
+				DirectConnections: []DirectRPCConnection{conn},
+			}},
+			Sessions:        map[int64]*SingleConsumerSession{},
+			MaxComputeUnits: 200,
+			PairingEpoch:    firstEpochHeight,
+			StaticProvider:  true,
+		},
+	}
+}
+
+// awaitEpochReleasePass waits for the release pass to have run. It is spawned from a defer that
+// sleeps up to 500ms, and its own cleanup empties previousEpochBlockedProviders last.
+func awaitEpochReleasePass(t *testing.T, csm *ConsumerSessionManager) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		csm.lock.RLock()
+		defer csm.lock.RUnlock()
+		return len(csm.previousEpochBlockedProviders) == 0
+	}, 15*time.Second, 50*time.Millisecond, "the epoch release pass never ran")
+}
+
+// isValidAddress reports whether the provider is back in routing.
+func isValidAddress(csm *ConsumerSessionManager, address string) bool {
+	csm.lock.RLock()
+	defer csm.lock.RUnlock()
+	return slices.Contains(csm.validAddresses, address)
+}
+
 // The epoch re-blocks the previous epoch's blocked providers "to prevent known-bad providers from
 // getting a clean slate", then releases the ones it has no evidence against. It decided that by
 // asking csm.reportedProviders — but UpdateAllProviders empties that register in its body, while
@@ -768,28 +818,14 @@ func TestBlockRecord_CarriedRecordTakesTheScopeItIsReBlockedIn(t *testing.T) {
 // with no health check at all.
 //
 // The decision now reads the carried block record, which holds what the register held before it was
-// reset.
+// reset. That is equivalent by construction, not merely a reasonable snapshot: ReportProvider is
+// called from exactly two sites, both inside blockProvider, and every RemoveReport site also
+// unblocks the provider — so nothing can change a provider's report state while its block stands.
 //
-// Both cases are asserted, because "keep everything blocked" would pass a one-sided test while
-// being just as wrong as the bug. The provider's endpoint is deliberately unreachable so the two
-// branches have different outcomes: probe → stays blocked, no-probe → released regardless.
+// Both directions are asserted, because "keep everything blocked" would satisfy a one-sided test
+// while being just as wrong as the bug.
 func TestEpochTransition_ProbeIsRequiredOnlyForAReportedProvider(t *testing.T) {
-	// A direct-RPC provider with no usable connection. probeDirectRPCEndpoints is a routability
-	// gate, so it fails here — unlike the gRPC probe, which dials lazily and reports success
-	// against a dead address.
-	deadPairing := func() map[uint64]*ConsumerSessionsWithProvider {
-		return map[uint64]*ConsumerSessionsWithProvider{
-			0: {
-				PublicLavaAddress: "provider-unreachable",
-				Endpoints:         []*Endpoint{{NetworkAddress: "127.0.0.1:1", Enabled: true}},
-				Sessions:          map[int64]*SingleConsumerSession{},
-				MaxComputeUnits:   200,
-				PairingEpoch:      firstEpochHeight,
-				StaticProvider:    true,
-			},
-		}
-	}
-
+	const address = "provider-unreachable"
 	for _, tc := range []struct {
 		name           string
 		reportProvider bool
@@ -800,8 +836,8 @@ func TestEpochTransition_ProbeIsRequiredOnlyForAReportedProvider(t *testing.T) {
 		{
 			name: "reported provider must earn its way back", reportProvider: true, wantReported: true,
 			stillBlocked: true,
-			why: "it was reported, so the epoch owes it a probe — and the probe cannot pass against " +
-				"an unreachable endpoint. Releasing it anyway is the clean slate the re-block exists to prevent",
+			why: "it was reported, so the epoch owes it a probe — and the probe cannot pass while its " +
+				"only endpoint is disabled. Releasing it anyway is the clean slate the re-block exists to prevent",
 		},
 		{
 			name: "unreported provider is released without one", reportProvider: false, wantReported: false,
@@ -811,32 +847,88 @@ func TestEpochTransition_ProbeIsRequiredOnlyForAReportedProvider(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			csm := CreateConsumerSessionManager()
-			require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, deadPairing(), nil))
-			const address = "provider-unreachable"
+			require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, epochPairing(t, address, false), nil))
 
 			require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonAllEndpointsDisabled,
 				tc.reportProvider, csm.atomicReadCurrentEpoch(), MaxConsecutiveConnectionAttempts, 0, false, nil))
 			require.Equal(t, tc.wantReported, blockedRecord(t, csm, address).Reported)
-			require.NotContains(t, csm.validAddresses, address)
+			require.False(t, isValidAddress(csm, address))
 
-			// Roll the epoch: copies the block forward, re-blocks it, resets the reported register,
-			// and schedules the release pass.
-			require.NoError(t, csm.UpdateAllProviders(secondEpochHeight, deadPairing(), nil))
+			require.NoError(t, csm.UpdateAllProviders(secondEpochHeight, epochPairing(t, address, false), nil))
+			awaitEpochReleasePass(t, csm)
 
-			// That pass is a deferred goroutine that sleeps up to 500ms, so wait for it to have run.
-			require.Eventually(t, func() bool {
-				csm.lock.RLock()
-				defer csm.lock.RUnlock()
-				return len(csm.previousEpochBlockedProviders) == 0
-			}, 15*time.Second, 50*time.Millisecond, "the epoch release pass never ran")
-
-			csm.lock.RLock()
-			defer csm.lock.RUnlock()
-			if tc.stillBlocked {
-				require.NotContains(t, csm.validAddresses, address, tc.why)
-			} else {
-				require.Contains(t, csm.validAddresses, address, tc.why)
-			}
+			require.Equal(t, !tc.stillBlocked, isValidAddress(csm, address), tc.why)
 		})
 	}
+}
+
+// The other half of the gate: a reported provider that CAN pass its probe is released, through
+// ReleaseEpochProbe. Without this the fix is only shown to keep providers out, and the open question
+// on the PR — whether restoring the gate changes anything in production or locks providers out —
+// stays unfalsifiable.
+func TestEpochTransition_AReportedProviderThatPassesItsProbeIsReleased(t *testing.T) {
+	const address = "provider-healthy"
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, epochPairing(t, address, true), nil))
+
+	require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonAllEndpointsDisabled,
+		true, csm.atomicReadCurrentEpoch(), MaxConsecutiveConnectionAttempts, 0, false, nil))
+	require.True(t, blockedRecord(t, csm, address).Reported)
+	require.False(t, isValidAddress(csm, address))
+
+	require.NoError(t, csm.UpdateAllProviders(secondEpochHeight, epochPairing(t, address, true), nil))
+	awaitEpochReleasePass(t, csm)
+
+	require.True(t, isValidAddress(csm, address),
+		"the gate is a routability check, not a quarantine: a provider that can serve must come back")
+}
+
+// An unknown record must not be read as "never reported". That field decides whether a provider has
+// to prove itself, and its zero value would hand a free pass to exactly the case where we have lost
+// track of why the provider is out.
+func TestEpochTransition_AMissingRecordStillFacesTheProbe(t *testing.T) {
+	const address = "provider-record-lost"
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, epochPairing(t, address, false), nil))
+
+	require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonAllEndpointsDisabled,
+		true, csm.atomicReadCurrentEpoch(), MaxConsecutiveConnectionAttempts, 0, false, nil))
+
+	// Strand the block: the record is gone while the provider stays blocked. The store paths that
+	// could do this are fixed, so this is the defensive case — which is the one worth pinning,
+	// because a fail-open default is silent by definition.
+	csm.lock.Lock()
+	delete(csm.blockedProviderRecords, address)
+	csm.lock.Unlock()
+
+	require.NoError(t, csm.UpdateAllProviders(secondEpochHeight, epochPairing(t, address, false), nil))
+	awaitEpochReleasePass(t, csm)
+
+	require.False(t, isValidAddress(csm, address),
+		"an unknown block must fail closed — 'we do not know why it is out' is not evidence of health")
+}
+
+// Backups are the load-bearing exception the rewritten comment leans on: !isBackup short-circuits
+// ahead of the report check, so a backup's report state is never consulted and a backup always
+// faces the probe. Nothing asserted that.
+func TestEpochTransition_BackupAlwaysFacesTheProbeWhateverItsReportState(t *testing.T) {
+	const address = "backup-unreachable"
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight,
+		createNamedPairingList("regular-a"), epochPairing(t, address, false)))
+
+	// reportProvider=false: on the regular path this would mean "no evidence, release immediately".
+	require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonTooManyDeadSessions,
+		false, csm.atomicReadCurrentEpoch(), 0, 0, false, nil))
+	require.False(t, blockedRecord(t, csm, address).Reported)
+
+	require.NoError(t, csm.UpdateAllProviders(secondEpochHeight,
+		createNamedPairingList("regular-a"), epochPairing(t, address, false)))
+	awaitEpochReleasePass(t, csm)
+
+	csm.lock.RLock()
+	defer csm.lock.RUnlock()
+	_, stillBlocked := csm.blockedBackupProviders[address]
+	require.True(t, stillBlocked,
+		"a backup is routed to the probe regardless of report state, and this one cannot pass it")
 }

--- a/protocol/lavasession/block_reason_test.go
+++ b/protocol/lavasession/block_reason_test.go
@@ -932,3 +932,43 @@ func TestEpochTransition_BackupAlwaysFacesTheProbeWhateverItsReportState(t *test
 	require.True(t, stillBlocked,
 		"a backup is routed to the probe regardless of report state, and this one cannot pass it")
 }
+
+// The end-to-end consequence of the above: after two ordinary blocks in one epoch, the provider must
+// still face the probe.
+func TestEpochTransition_AProviderReportedByARepeatBlockStillFacesTheProbe(t *testing.T) {
+	const address = "provider-blocked-twice"
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, epochPairing(t, address, false), nil))
+	epoch := csm.atomicReadCurrentEpoch()
+
+	require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonTooManyDeadSessions,
+		false, epoch, 0, 0, false, nil))
+	require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonAllEndpointsDisabled,
+		true, epoch, MaxConsecutiveConnectionAttempts, 0, false, nil))
+
+	require.NoError(t, csm.UpdateAllProviders(secondEpochHeight, epochPairing(t, address, false), nil))
+	awaitEpochReleasePass(t, csm)
+
+	require.False(t, isValidAddress(csm, address),
+		"it was reported, so it owes a probe — a stale record here is a working bypass of the fix")
+}
+
+// The dead-session cap on its own is the other half, and it was untested in either direction. It is
+// released without a probe, and that is correct rather than a gap: the epoch rebuilds every session
+// object, so the blocklisted-session count that caused this block is already back at zero. There is
+// nothing left for a probe to find.
+func TestEpochTransition_DeadSessionCapIsReleasedWithoutAProbe(t *testing.T) {
+	const address = "provider-dead-sessions"
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, epochPairing(t, address, false), nil))
+
+	require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonTooManyDeadSessions,
+		false, csm.atomicReadCurrentEpoch(), 0, 0, false, nil))
+	require.False(t, blockedRecord(t, csm, address).Reported, "this path blocks quietly by design")
+
+	require.NoError(t, csm.UpdateAllProviders(secondEpochHeight, epochPairing(t, address, false), nil))
+	awaitEpochReleasePass(t, csm)
+
+	require.True(t, isValidAddress(csm, address),
+		"nothing was recorded against it, and the condition it was blocked on is reset by the epoch itself")
+}

--- a/protocol/lavasession/block_reason_test.go
+++ b/protocol/lavasession/block_reason_test.go
@@ -758,3 +758,85 @@ func TestBlockRecord_CarriedRecordTakesTheScopeItIsReBlockedIn(t *testing.T) {
 	require.Equal(t, "primary", row.Scope, "the only standing block is the regular one")
 	require.Equal(t, uint32(1), row.Carries)
 }
+
+// The epoch re-blocks the previous epoch's blocked providers "to prevent known-bad providers from
+// getting a clean slate", then releases the ones it has no evidence against. It decided that by
+// asking csm.reportedProviders — but UpdateAllProviders empties that register in its body, while
+// this pass runs from a defer that sleeps first. Every non-backup therefore looked unreported, took
+// the immediate-unblock branch, and the comprehensive-probe branch was unreachable for regular
+// providers: a provider that failed every request for a full epoch was rehabilitated at the tick
+// with no health check at all.
+//
+// The decision now reads the carried block record, which holds what the register held before it was
+// reset.
+//
+// Both cases are asserted, because "keep everything blocked" would pass a one-sided test while
+// being just as wrong as the bug. The provider's endpoint is deliberately unreachable so the two
+// branches have different outcomes: probe → stays blocked, no-probe → released regardless.
+func TestEpochTransition_ProbeIsRequiredOnlyForAReportedProvider(t *testing.T) {
+	// A direct-RPC provider with no usable connection. probeDirectRPCEndpoints is a routability
+	// gate, so it fails here — unlike the gRPC probe, which dials lazily and reports success
+	// against a dead address.
+	deadPairing := func() map[uint64]*ConsumerSessionsWithProvider {
+		return map[uint64]*ConsumerSessionsWithProvider{
+			0: {
+				PublicLavaAddress: "provider-unreachable",
+				Endpoints:         []*Endpoint{{NetworkAddress: "127.0.0.1:1", Enabled: true}},
+				Sessions:          map[int64]*SingleConsumerSession{},
+				MaxComputeUnits:   200,
+				PairingEpoch:      firstEpochHeight,
+				StaticProvider:    true,
+			},
+		}
+	}
+
+	for _, tc := range []struct {
+		name           string
+		reportProvider bool
+		wantReported   bool
+		stillBlocked   bool
+		why            string
+	}{
+		{
+			name: "reported provider must earn its way back", reportProvider: true, wantReported: true,
+			stillBlocked: true,
+			why: "it was reported, so the epoch owes it a probe — and the probe cannot pass against " +
+				"an unreachable endpoint. Releasing it anyway is the clean slate the re-block exists to prevent",
+		},
+		{
+			name: "unreported provider is released without one", reportProvider: false, wantReported: false,
+			stillBlocked: false,
+			why:          "nothing was ever recorded against it, so there is no evidence to answer for",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			csm := CreateConsumerSessionManager()
+			require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, deadPairing(), nil))
+			const address = "provider-unreachable"
+
+			require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonAllEndpointsDisabled,
+				tc.reportProvider, csm.atomicReadCurrentEpoch(), MaxConsecutiveConnectionAttempts, 0, false, nil))
+			require.Equal(t, tc.wantReported, blockedRecord(t, csm, address).Reported)
+			require.NotContains(t, csm.validAddresses, address)
+
+			// Roll the epoch: copies the block forward, re-blocks it, resets the reported register,
+			// and schedules the release pass.
+			require.NoError(t, csm.UpdateAllProviders(secondEpochHeight, deadPairing(), nil))
+
+			// That pass is a deferred goroutine that sleeps up to 500ms, so wait for it to have run.
+			require.Eventually(t, func() bool {
+				csm.lock.RLock()
+				defer csm.lock.RUnlock()
+				return len(csm.previousEpochBlockedProviders) == 0
+			}, 15*time.Second, 50*time.Millisecond, "the epoch release pass never ran")
+
+			csm.lock.RLock()
+			defer csm.lock.RUnlock()
+			if tc.stillBlocked {
+				require.NotContains(t, csm.validAddresses, address, tc.why)
+			} else {
+				require.Contains(t, csm.validAddresses, address, tc.why)
+			}
+		})
+	}
+}

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -3014,7 +3014,7 @@ func (csm *ConsumerSessionManager) checkAndUnblockHealthyReBlockedProviders(ctx 
 	// First pass: Identify which re-blocked providers had successful probes
 	providersNeedingComprehensiveProbe := make(map[string]reBlockedProviderInfo)
 
-	for blockedAddr := range csm.previousEpochBlockedProviders {
+	for blockedAddr, carried := range csm.previousEpochBlockedProviders {
 		cswp, exists := csm.pairing[blockedAddr]
 		isBackup := false
 		if !exists {
@@ -3028,16 +3028,23 @@ func (csm *ConsumerSessionManager) checkAndUnblockHealthyReBlockedProviders(ctx 
 		// A backup ALWAYS takes the comprehensive-probe branch: !isBackup short-circuits, so a
 		// backup's report state is never consulted at all. That is deliberate — report state is
 		// only meaningful as a health signal for a provider we actually have evidence about, and
-		// a backup that was never selected has none. Falling through to !IsReported for it would
-		// read "absent from reportedProviders" as "healthy" and unblock it with no real check.
+		// a backup that was never selected has none. Falling through to "not reported" for it would
+		// read that as "healthy" and unblock it with no real check.
 		//
-		// Note a backup CAN legitimately appear in reportedProviders: blockProvider's
-		// AddressIndexWasNotFoundError branch marks blockedBackupProviders and then falls through
-		// to the reportProvider block below it. That is irrelevant here precisely because the
-		// short-circuit means we never look.
-		if !isBackup && !csm.reportedProviders.IsReported(blockedAddr) {
-			// Non-backup provider whose probe succeeded (it wasn't added to reportedProviders).
-			// Unblock immediately.
+		// The report state comes from the CARRIED BLOCK RECORD, not from csm.reportedProviders.
+		// The live register cannot answer this question at an epoch transition: UpdateAllProviders
+		// calls reportedProviders.Reset() in its body, while this pass runs from a defer that
+		// sleeps first — so the register is always already empty by the time we get here. Reading
+		// it made every non-backup look unreported, sent all of them down the immediate-unblock
+		// branch, and left this else-branch unreachable for regular providers. The whole point of
+		// re-blocking them ("prevents known-bad providers from getting a clean slate") was undone
+		// in the same tick.
+		//
+		// The record is the honest source: it holds whether the provider was reported at the moment
+		// it was blocked, which is exactly what the register held before the reset.
+		if !isBackup && !carried.Reported {
+			// Non-backup provider that was never reported — no evidence it is bad. Unblock
+			// immediately.
 			utils.LavaFormatInfo("Re-blocked provider's probe succeeded, immediately unblocking",
 				utils.Attribute{Key: "provider", Value: blockedAddr},
 				utils.Attribute{Key: "isBackup", Value: isBackup},

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -2632,14 +2632,25 @@ func (csm *ConsumerSessionManager) validateAndReturnBlockedProviderToValidAddres
 	// if we didn't find it, we might had two sessions in parallel and thats ok. the first one dealt with it we can just return
 }
 
-// blockRecordOrUnknownLocked returns a blocked provider's record, or a placeholder naming the epoch
-// carry-over when none is stored. The placeholder should be unreachable — every block writes a
-// record — so seeing it in a log means a block path forgot to. csm.lock must be held.
+// blockRecordOrUnknownLocked returns a blocked provider's record, or a placeholder when none is
+// stored. csm.lock must be held.
+//
+// The placeholder fails CLOSED: Reported is true, so an unknown block faces the epoch's probe rather
+// than being waved through. That field decides whether a re-blocked provider has to prove itself,
+// and its zero value would read as "never reported, no evidence against it, let it back in" — which
+// is precisely the free clean slate the re-block exists to prevent. When we do not know why a
+// provider is out, the safe answer is to make it prove itself, not to assume the best.
+//
+// Reaching this means a block path did not record a reason, which is a bug in that path rather than
+// a state to tolerate quietly — hence the warning.
 func (csm *ConsumerSessionManager) blockRecordOrUnknownLocked(providerAddress string) BlockRecord {
 	if record, ok := csm.blockedProviderRecords[providerAddress]; ok {
 		return record
 	}
-	return BlockRecord{Reason: BlockReasonPreviousEpoch, Since: time.Now()}
+	utils.LavaFormatWarning("blocked provider carried no block record at the epoch boundary", nil,
+		utils.LogAttr("address", providerAddress),
+	)
+	return BlockRecord{Reason: BlockReasonPreviousEpoch, Since: time.Now(), Reported: true}
 }
 
 // blockedTotalLocked is how many providers are out across both pools — the number an operator wants
@@ -3052,7 +3063,10 @@ func (csm *ConsumerSessionManager) checkAndUnblockHealthyReBlockedProviders(ctx 
 				utils.LogAttr("GUID", ctx),
 			)
 			csm.validateAndReturnBlockedProviderToValidAddressesListLocked(blockedAddr, ReleaseEpochNotReported)
-			csm.reportedProviders.RemoveReport(blockedAddr)
+			// No RemoveReport here. UpdateAllProviders resets the register in its body before this
+			// pass runs, so there has never been anything to remove — and this branch no longer
+			// consults it at all. Leaving the call in would suggest the register is meaningful on
+			// this path, which is the assumption that produced the bug above.
 		} else {
 			// Either a backup provider (always routed here by the short-circuit above),
 			// or a non-backup that was reported for relay failures.


### PR DESCRIPTION
Jira ticket: MAG-3190

> 📚 **Stacked on [#336](https://github.com/Magma-Devs/smart-router/pull/336)** (MAG-2599). It reads
> `BlockRecord.Reported`, which that PR introduces. **Merge #336 first.**
>
> Three commits, each with its own section below: `e24884b` (the fix), `7f618a6` (review round 1),
> `c802a43` (review round 2).

## The bug

The epoch re-blocks the previous epoch's blocked providers on purpose. The comment says why:

> `// This prevents known-bad providers from getting a clean slate at epoch transition`

A second pass then decides who to let back in:

```go
if !isBackup && !csm.reportedProviders.IsReported(blockedAddr) {
    // "Non-backup provider whose probe succeeded (it wasn't added to reportedProviders)."
    // Unblock immediately.
} else {
    // comprehensive probe with tryReconnect=true
}
```

It reads *"not in the reported register"* as *"this provider is fine"*.

**But `UpdateAllProviders` empties that register before the check runs.** `reportedProviders.Reset()`
is in the function body (`:502`); the release pass is a **deferred goroutine that sleeps up to 500ms
before spawning** (`:440-448`). A defer runs after the body, so the register is always already empty.

So every non-backup looked unreported, every one took the immediate-unblock branch, and **the
comprehensive-probe branch was unreachable for regular providers**. The re-block was undone in the
same tick that created it.

## What that meant

**A provider that failed every single request for a full epoch was rehabilitated at the next tick,
with no health check of any kind.** Every 15 minutes, regardless of behaviour.

It also caps FAILOVER-TASKS §2 and §3: any `bench-after` count or `cooldown` state would be wiped
every epoch. #328 stopped the bench being wiped *per relay*; this wiped it *per epoch*.

## Evidence

Live router, MAG-2599 rig, `--epoch-duration 90s`, prober parked. Both primaries driven into a real
block:

```
INF provider blocked  address=primary-a block_reason=all-endpoints-disabled
    detail=disconnections=50 reported=true second_chance=false valid_remaining=0

  … 55 seconds later, at the epoch tick …

INF blocked provider list released released_by=epoch-rebuild released=primary-a,primary-b count=2
INF provider released address=primary-a block_reason=all-endpoints-disabled
    blocked_for=54.886s released_by=epoch-not-reported scope=primary
INF provider released address=primary-b … released_by=epoch-not-reported scope=primary
```

Blocked with `reported=true`, released through the **not-reported** branch.

*(Those field names come from #336. Before it this was three lines naming neither the reason nor the
route, which is why it went unnoticed.)*

## What the fix actually covers

Reported by a reviewer, and worth stating precisely rather than leaving the opening claim to imply
more than the change delivers. The gate reaches providers that were **actually reported**:

| reason | at the epoch, after this PR |
|---|---|
| `all-endpoints-disabled` | **probe** — fixed here |
| `never-served-successfully`, 2nd offence | **probe** — fixed here |
| `never-served-successfully`, 1st offence | immediate release — it took the second chance instead of reporting |
| `too-many-dead-sessions` | immediate release — unchanged |
| `explicit-block-signal` via `BlockProviderError` | immediate release — unchanged (no production producer) |

The unchanged rows are defensible rather than a gap, and the reason is worth knowing: **the epoch
resets the conditions those blocks were made on.** `updateEpoch` builds fresh
`ConsumerSessionsWithProvider` objects every tick — explicitly, to stop sessions accumulating — so
the blocklisted-session count behind `too-many-dead-sessions` returns to zero, and it calls
`ResetHealth()` on every endpoint first, so the disabled endpoints behind `all-endpoints-disabled`
are re-enabled. There is nothing left for a probe to find.

### Where that reset argument stops applying

An earlier draft of this section concluded that the gate's production effect is "close to zero"
because the epoch clears the state it inspects. That holds for the epoch tick — **and only for it.**
`UpdateAllProviders` has four production callers, and every one of them runs the full carry →
re-block → release pass:

| caller | endpoint health reset first? |
|---|---|
| initial registration (`rpcsmartrouter.go:2668`) | n/a — nothing is blocked yet, the pass is a no-op |
| `updateEpoch` (`:3567`) | **yes** — `endpoint.ResetHealth()` on every endpoint, before the call |
| `retryFailedProviders` (`:3880`) | **no** |
| reset-pairing (`:4038`) | **no** |

The last two pass `currentEpoch`, so nothing is reset and the probe runs against endpoints that are
still disabled. There a reported provider genuinely **stays blocked** where it previously sailed
back in. So the honest statement is not "close to zero" — it is that the effect is close to zero on
the epoch path and real on the other two.

That is the intended behaviour rather than a regression: those endpoints cannot serve, and releasing
the provider only feeds it relays it will fail. It also cannot wedge a provider out, by three
independent routes:

- the next epoch tick's `ResetHealth()` re-enables the endpoints and the probe then passes;
- the prober restores it directly via `RestoreRecoveredProvider`;
- `resetValidAddresses` (`consumer_session_manager.go:1156`) dumps the **entire** blocked list the
  moment a request finds zero valid providers — the gate sits above a floor, so it cannot black out
  a chain.

## The fix

Read the **carried block record** instead of the live register.

`previousEpochBlockedProviders` already carries the full `BlockRecord` across the transition, and
`record.Reported` holds what the register held at the moment of the block — exactly what it held
before the reset. **No new state, and no ordering dependency across a goroutine boundary** (which is
what produced the bug).

That is **equivalent by construction**, not merely a reasonable snapshot, which answers the obvious
"a snapshot can go stale" objection: `ReportProvider` is called from exactly two sites, both inside
`blockProvider`, and every `RemoveReport` site also unblocks the provider — so no path can change a
provider's report state while its block stands.

Backups are unchanged: `!isBackup` short-circuits ahead of the check, so a backup's report state was
never consulted and still is not.

## Tests

`TestEpochTransition_ProbeIsRequiredOnlyForAReportedProvider`, asserting **both** directions —
"keep everything blocked" would satisfy a one-sided test while being just as wrong as the bug:

| | expectation |
|---|---|
| reported provider | must face the probe → stays blocked when it cannot pass |
| unreported provider | released without one → nothing was recorded against it |

It uses a **direct-RPC** provider with no usable connection, because `probeDirectRPCEndpoints` is a
real routability gate — the gRPC probe dials lazily and reports success against a dead address, so
the two branches would otherwise have the same outcome and the test would prove nothing.

**Verified to fail on the previous condition**, with the reported provider back in `validAddresses`.

`go build ./...`, `go vet ./...` clean · `gofmt` clean · full `go test ./...` green ·
`go test -race ./protocol/lavasession/` clean (it was not, until #336 fixed the package-level
`retrySecondChanceAfter` read).

## One thing worth a reviewer's opinion

This restores the *intended* behaviour, which means **a reported provider now actually has to pass a
probe at the epoch**. That is a real behaviour change: providers that used to sail back in will now
stay blocked when the probe fails.

`BLOCKING-TODAY.md` notes that for direct-RPC providers this probe is a **structural check** — does
the provider have at least one enabled endpoint with a connection object — with no network call, and
that endpoint health was reset moments earlier, so on the epoch path it will usually pass. On the
two callers that skip the reset it will not, which is where the change actually bites; see *Where
that reset argument stops applying* above. If a stricter gate is wanted, that is a separate
conversation about what the epoch probe should actually verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsVw3GRjz59spS7kWYjcaX

---

## Review round 1 (`7f618a6`)

**Fail closed on an unknown record.** The record is now the source of truth for "was this reported",
so its unknown-record fallback decides whether a provider must prove itself — and it left `Reported`
at the zero value, which reads as *"never reported, no evidence, let it in"*. That silently
reproduces the bug this PR fixes, in the one case where we have lost track of why a provider is out.
It now fails closed and warns. The store paths that could strand a record were closed on the base
branch, so this is defensive — which is why it is worth pinning, since a fail-open default is silent
by definition.

The blast radius is bounded: `blockRecordOrUnknownLocked` has exactly two callers, both in
`UpdateAllProviders`' carry loops, so the `Reported: true` placeholder cannot leak into any other
decision.

**The test fixture was not what its comment said.** `IsDirectRPC()` is `len(DirectConnections) > 0`
and the fixture set none, so the endpoint was skipped a branch earlier and the probe failed with
*"no direct RPC endpoints found"* — a misconfiguration — rather than on the routability gate. It now
carries a connection object and toggles `Enabled`, failing with *"no enabled direct RPC endpoints"*.

That also made the **pass case reachable**, which it was not before: the fixture could only fail, so
nothing covered a reported provider being *released* through `ReleaseEpochProbe` — the case that
decides whether restoring the gate is a no-op or locks providers out. Now covered.

**Three tests added**, each verified to fail against the behaviour it pins: an unknown record still
faces the probe; a provider that passes its probe is released; and a backup faces the probe whatever
its report state — the short-circuit the rewritten comment leans on, previously unasserted.

**Also dropped** the `RemoveReport` in the not-reported branch: the register is reset before this
pass runs, so on the epoch path there is nothing to remove, and the branch no longer reads it.
(Strictly, a same-epoch `UpdateAllProviders` can see a fresh report land in the 500ms window, since
the epoch guard in `blockProvider` does not fire when the epoch has not advanced. The entry is
cleared by the next `Reset()` and `ReconnectCandidates` only picks up `Errors == 0` entries, so
nothing depends on it.)

---

## Review round 2 (`c802a43`) — the epoch half of a fix that moved down

This round originally carried `refreshBlockOutcomeLocked`, the fix for a record that goes stale on a
repeat block. **That has moved to #336**, on a reviewer's argument I think is right: the harm it
causes is felt there, not here. A record claiming `Reported=false` while the register says true
inverts what `BlockRecord` documents, so an operator reads `/debug/provider-routing` and concludes
manual intervention is needed while the 30-second reconnect loop is already working on the provider
— and that is true whether or not this PR exists. Had #336 merged alone, the bug would have shipped.

What stays here is the epoch consequence, which is this PR's subject. **Two tests, no production
change:**

**A provider reported by a REPEAT block must still face the probe.** Two ordinary blocks in one
epoch reach it: a `too-many-dead-sessions` block, which does not report, then an
`all-endpoints-disabled` block, which does. With a stale record that provider takes the
immediate-unblock branch — a working bypass of the gate this PR restores, reachable without anything
exotic. This test only passes on top of #336, which is the sharpest available statement of why the
stack order matters.

**The dead-session cap on its own**, previously untested in either direction. It is released without
a probe, and that is correct rather than a gap: the epoch rebuilds every session object, so the
blocklisted-session count that caused the block is already back at zero. There is nothing left for a
probe to find. This pins the `too-many-dead-sessions` row of the table above, which until now was
asserted only in prose.
