### PR TITLE
ci: CVE-scan the published image, on the PR that changes it

### DIFF
--- a/.github/workflows/image-cve-scan.yml
+++ b/.github/workflows/image-cve-scan.yml
@@ -1,0 +1,126 @@
+name: Image CVE scan
+
+# Scans the image THIS repo publishes, built from the PR that changes it.
+#
+# The fleet repo (smart-router-infrastructure) scans images too, but that runs
+# against what a tenant is already serving — by which point a vulnerable image
+# has been built, pushed to GHCR, pinned in a cluster.yaml and rolled out. That
+# check is the right one for UPSTREAM images nobody here builds; this is the
+# right layer for ours.
+#
+# The published image is distroless + one static Go binary, so in practice the
+# whole CVE surface is this module graph. grype reads the module list embedded
+# in the binary, which is why the image is scanned rather than go.sum: it
+# reports what actually shipped, including anything the build pulled in that
+# the manifest does not obviously name.
+#
+# The first fleet-wide scan put this image at ZERO Critical and ZERO High — the
+# cleanest thing running on the fleet. This exists to keep it that way, not
+# because it is currently failing.
+#
+# Two triggers, because they catch different things:
+#   pull_request — a NEW vulnerability introduced by this change
+#   schedule     — one DISCLOSED after the merge, against the same build
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "07 4 * * 1" # Mondays, 04:07 UTC
+  workflow_dispatch:
+    inputs:
+      fail_on:
+        description: "Severity that fails the run"
+        required: false
+        default: "critical"
+        type: choice
+        options: [critical, high]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: image-cve-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: The published image has no Critical CVEs
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      # Dockerfile.ci consumes a prebuilt binary from the build job, so the
+      # binary is built here the same way — static, netgo, stripped — rather
+      # than scanning a differently-produced artefact and hoping it matches.
+      - name: Build the binary the image ships
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/linux/amd64
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -tags netgo \
+            -ldflags '-w -s' -o artifacts/linux/amd64/smartrouter ./cmd/smartrouter
+          chmod +x artifacts/linux/amd64/smartrouter
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # Single-arch and loaded, not pushed: a multi-arch build cannot be loaded
+      # into the local daemon, and the module graph does not differ by arch.
+      - name: Build the image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile.ci
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: smart-router:scan
+
+      - name: Scan with grype
+        run: |
+          set -uo pipefail
+          FAIL_ON="${{ github.event.inputs.fail_on || 'critical' }}"
+
+          if ! docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+                 anchore/grype:latest docker:smart-router:scan -o json --quiet > /tmp/scan.json 2>/tmp/scan.err \
+             || [ ! -s /tmp/scan.json ]; then
+            # A scan that could not run must never read as "no vulnerabilities".
+            echo "::error::grype could not scan the image: $(tr '\n' ' ' < /tmp/scan.err | cut -c1-300)"
+            exit 1
+          fi
+
+          CRIT=$(jq '[.matches[]?|select(.vulnerability.severity=="Critical")]|length' /tmp/scan.json)
+          HIGH=$(jq '[.matches[]?|select(.vulnerability.severity=="High")]|length' /tmp/scan.json)
+          TOT=$(jq '[.matches[]?]|length' /tmp/scan.json)
+          echo "smart-router: ${CRIT} critical, ${HIGH} high, ${TOT} total"
+
+          {
+            echo "## smart-router image — ${CRIT} critical, ${HIGH} high, ${TOT} total"
+            echo
+            if [ "$CRIT" -gt 0 ] || [ "$HIGH" -gt 0 ]; then
+              echo '| severity | id | package | installed | fixed in |'
+              echo '|---|---|---|---|---|'
+              jq -r '.matches[]? | select(.vulnerability.severity=="Critical" or .vulnerability.severity=="High")
+                     | "| \(.vulnerability.severity) | \(.vulnerability.id) | \(.artifact.name) | \(.artifact.version) | \(.vulnerability.fix.versions[0] // "no fix") |"' \
+                /tmp/scan.json | sort -u
+            else
+              echo "No Critical or High findings."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          rc=0
+          if [ "$CRIT" -gt 0 ]; then
+            echo "::error::${CRIT} CRITICAL finding(s) — the job summary names the package and the version that fixes it"
+            rc=1
+          fi
+          if [ "$FAIL_ON" = "high" ] && [ "$HIGH" -gt 0 ]; then
+            echo "::error::${HIGH} HIGH finding(s), and fail_on=high"
+            rc=1
+          fi
+          exit $rc


### PR DESCRIPTION
#Closes MAG-3274

Jira ticket: MAG-3274

## Why here, and not only in the fleet repo

`smart-router-infrastructure` now scans images too — but that runs against **what a tenant is already serving**. By the time it speaks, a vulnerable image has been built, pushed to GHCR, pinned in a `cluster.yaml` and rolled out. That check is the right one for **upstream** images nobody here builds (RKE2's bundled manifests, cert-manager, Envoy); it is the wrong layer for ours.

**This image is currently the cleanest thing running on the fleet.** The first fleet-wide scan, across 24 images:

```
ghcr.io/magma-devs/smart-router:v1.4.0     0 Critical, 0 High   (4 findings, none above Medium)
```

For contrast, the same sweep put RKE2's own control-plane image at 5 Critical / 62 High, and the dashboard images at 2 and 1 Critical. So this workflow exists to **keep** a good position, not to fix a bad one — which is the cheapest time to add it.

## What it does

The published image is `distroless/static-debian12` plus one static Go binary, so in practice the entire CVE surface is this module graph. The binary is rebuilt here **exactly as the build job produces it** — `CGO_ENABLED=0`, `-tags netgo`, `-ldflags '-w -s'` — and the image assembled from `docker/Dockerfile.ci`, so what is scanned is what would ship rather than a lookalike.

Scanning the *image* rather than `go.sum` is deliberate: grype reads the module list embedded in the binary, so it reports what actually shipped, including anything the build pulled in that the manifest does not obviously name.

Single-arch and `load`ed rather than pushed — a multi-arch build cannot be loaded into the local daemon, and the module graph does not differ by arch.

Two triggers, because they catch different things:

- **`pull_request`** — a vulnerability *introduced* by a change, before it can be published
- **weekly `schedule`** — one *disclosed after* the merge, against the same build

The job summary lists severity, id, package, installed version and the fixed version, so the next step is visible without opening the log. A scan that could not run **fails** rather than reporting clean.

## Scope

Fails on Critical only. High is reported in the summary but does not block — a Go module advisory with no reachable call path should not stop a release, and a gate that blocks on 60 Highs is a gate people learn to bypass. `workflow_dispatch` takes `fail_on: high` when you want the stricter answer.