### PR TITLE
fix(rpcsmartrouter): unsubscribe with the method the client called (MAG-3297)

### DIFF
--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
@@ -912,8 +912,9 @@ func (dwsm *DirectWSSubscriptionManager) Unsubscribe(
 	// Only call upstream when we're the last client (single client on this subscription)
 	lastClient := len(activeSub.connectedClients) == 1
 
-	// Derive unsubscribe method: eth_subscribe -> eth_unsubscribe, subscribe -> unsubscribe
-	unsubscribeMethod := getUnsubscribeMethod(subscribeMethod)
+	// The method to call upstream is the one the client actually invoked, not one
+	// derived from the subscribe method. See resolveUnsubscribeMethod.
+	unsubscribeMethod := resolveUnsubscribeMethod(protocolMessage, subscribeMethod)
 	requestID := extractRequestID(protocolMessage.RelayPrivateData().Data)
 
 	var unsubscribeParams interface{}
@@ -981,8 +982,42 @@ func (dwsm *DirectWSSubscriptionManager) Unsubscribe(
 	return nodeResp, nil
 }
 
+// resolveUnsubscribeMethod returns the method name to call upstream to tear a
+// subscription down.
+//
+// It is the name the client actually invoked. The spec pairs every SUBSCRIBE
+// parse directive with an UNSUBSCRIBE one carrying its own api_name, and the
+// caller has already matched this message against those directives by name
+// (consumer_websocket_manager.go dispatches here only when the message resolved
+// to an UNSUBSCRIBE tag), so the api name on the message IS the spec's
+// unsubscribe method. Nothing needs deriving.
+//
+// MAG-3297: it used to be derived from the subscribe method by string surgery,
+// which only ever worked for the two shapes getUnsubscribeMethod hardcodes.
+// Every Substrate pair falls through those to the "unsubscribe" fallback —
+// chain_subscribeNewHeads, state_subscribeStorage, subscribe_newHead and
+// chainHead_v1_follow are none of them "<x>_subscribe" — so the router called a
+// method the node does not have and forwarded its -32601 to the client. Several
+// pairs are not derivable by any string rule at all: chainHead_v1_follow tears
+// down with chainHead_v1_unfollow, author_submitAndWatchExtrinsic with
+// author_unwatchExtrinsic.
+//
+// getUnsubscribeMethod remains the fallback for a message with no api attached,
+// which a spec-resolved message never is.
+func resolveUnsubscribeMethod(protocolMessage chainlib.ProtocolMessage, subscribeMethod string) string {
+	if protocolMessage != nil {
+		if api := protocolMessage.GetApi(); api != nil && api.Name != "" {
+			return api.Name
+		}
+	}
+	return getUnsubscribeMethod(subscribeMethod)
+}
+
 // getUnsubscribeMethod derives the unsubscribe method from the subscribe method.
 // eth_subscribe -> eth_unsubscribe, subscribe -> unsubscribe
+//
+// Only reachable when the incoming message carries no api name; prefer
+// resolveUnsubscribeMethod, which uses the method the client invoked.
 func getUnsubscribeMethod(subscribeMethod string) string {
 	if subscribeMethod == "eth_subscribe" {
 		return "eth_unsubscribe"

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1002,11 +1003,20 @@ func (dwsm *DirectWSSubscriptionManager) Unsubscribe(
 // down with chainHead_v1_unfollow, author_submitAndWatchExtrinsic with
 // author_unwatchExtrinsic.
 //
-// getUnsubscribeMethod remains the fallback for a message with no api attached,
-// which a spec-resolved message never is.
+// The DefaultApiName guard is the one that matters. A method the spec does not
+// declare still gets an api, synthesised with Name "Default-<method>"
+// (base_chain_parser.go defaultApiContainer), and sending that upstream would be
+// a method no node has. It is unreachable from the single current caller — a
+// "Default-" name matches no directive's ApiName, so such a message is never
+// classified UNSUBSCRIBE and never arrives here — but the guard belongs to this
+// function rather than to its caller's invariant, since the doc above invites
+// future callers.
+//
+// getUnsubscribeMethod remains the fallback for those shapes.
 func resolveUnsubscribeMethod(protocolMessage chainlib.ProtocolMessage, subscribeMethod string) string {
 	if protocolMessage != nil {
-		if api := protocolMessage.GetApi(); api != nil && api.Name != "" {
+		if api := protocolMessage.GetApi(); api != nil && api.Name != "" &&
+			!strings.HasPrefix(api.Name, chainlib.DefaultApiName) {
 			return api.Name
 		}
 	}

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
@@ -30,6 +30,7 @@ type mockSubscriptionServer struct {
 	server          *httptest.Server
 	upgrader        websocket.Upgrader
 	subscriptions   map[string]chan struct{} // subscription ID -> close channel
+	observedMethods []string                 // every JSON-RPC method the server was actually asked for
 	lock            sync.RWMutex
 	writeMu         sync.Mutex // serializes conn.WriteMessage — gorilla requires a single concurrent writer
 	messageInterval time.Duration
@@ -78,30 +79,19 @@ func (ms *mockSubscriptionServer) handleWS(w http.ResponseWriter, r *http.Reques
 			continue
 		}
 
-		// Handle subscription requests
-		if strings.HasSuffix(req.Method, "_subscribe") || strings.HasPrefix(req.Method, "eth_subscribe") {
-			subID := ms.createSubscription()
+		ms.recordMethod(req.Method)
 
-			// Send subscription confirmation
-			response := map[string]interface{}{
-				"jsonrpc": "2.0",
-				"id":      req.ID,
-				"result":  subID,
-			}
-			respBytes, _ := json.Marshal(response)
-			ms.safeWriteMessage(conn, websocket.TextMessage, respBytes)
-
-			// Start sending subscription messages
-			go ms.sendSubscriptionMessages(conn, subID)
-		} else if strings.HasSuffix(req.Method, "_unsubscribe") || strings.HasPrefix(req.Method, "eth_unsubscribe") {
-			// Get subscription ID from params
-			params, ok := req.Params.([]interface{})
-			if ok && len(params) > 0 {
-				if subID, ok := params[0].(string); ok {
-					ms.closeSubscription(subID)
-				}
-			}
-
+		// Classify by whether the caller handed us a LIVE subscription id, never by
+		// the method name. This harness used to gate on "_subscribe"/"_unsubscribe"
+		// suffixes, which is the same assumption that produced MAG-3297: it could
+		// not serve a chain_subscribeNewHeads / chain_unsubscribeNewHeads pair at
+		// all, so no test here could have caught the bug.
+		//
+		// Everything gets a reply. Dropping an unrecognised method would make a
+		// regression hang out the router's 10s CallContext timeout instead of
+		// failing fast.
+		if subID, ok := firstStringParam(req.Params); ok && ms.hasSubscription(subID) {
+			ms.closeSubscription(subID)
 			response := map[string]interface{}{
 				"jsonrpc": "2.0",
 				"id":      req.ID,
@@ -109,8 +99,52 @@ func (ms *mockSubscriptionServer) handleWS(w http.ResponseWriter, r *http.Reques
 			}
 			respBytes, _ := json.Marshal(response)
 			ms.safeWriteMessage(conn, websocket.TextMessage, respBytes)
+			continue
 		}
+
+		subID := ms.createSubscription()
+		response := map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      req.ID,
+			"result":  subID,
+		}
+		respBytes, _ := json.Marshal(response)
+		ms.safeWriteMessage(conn, websocket.TextMessage, respBytes)
+		go ms.sendSubscriptionMessages(conn, subID)
 	}
+}
+
+// firstStringParam returns params[0] when it is a string, which is the shape every
+// unsubscribe in every spec uses to name the subscription being torn down.
+func firstStringParam(params interface{}) (string, bool) {
+	list, ok := params.([]interface{})
+	if !ok || len(list) == 0 {
+		return "", false
+	}
+	s, ok := list[0].(string)
+	return s, ok
+}
+
+func (ms *mockSubscriptionServer) recordMethod(method string) {
+	ms.lock.Lock()
+	defer ms.lock.Unlock()
+	ms.observedMethods = append(ms.observedMethods, method)
+}
+
+// ObservedMethods returns the JSON-RPC methods the upstream was actually asked
+// for, which is the thing MAG-3297 got wrong and the only place a regression at
+// the CallContext call site is visible.
+func (ms *mockSubscriptionServer) ObservedMethods() []string {
+	ms.lock.RLock()
+	defer ms.lock.RUnlock()
+	return append([]string(nil), ms.observedMethods...)
+}
+
+func (ms *mockSubscriptionServer) hasSubscription(subID string) bool {
+	ms.lock.RLock()
+	defer ms.lock.RUnlock()
+	_, ok := ms.subscriptions[subID]
+	return ok
 }
 
 func (ms *mockSubscriptionServer) createSubscription() string {
@@ -2491,11 +2525,15 @@ func TestUnsubscribe_StillRejectsForeignSubscription(t *testing.T) {
 }
 
 // substrateUnsubscribePairs is the full SUBSCRIBE/UNSUBSCRIBE set declared by the
-// ASTAR spec's base collection, and the same shape Acala (aca.json) and Shiden
-// (sdn.json) carry. Every Substrate spec pairs by name, and none of the pairings
-// is a "<x>_subscribe" -> "<x>_unsubscribe" rewrite: three of them
-// (chainHead_v1_follow, author_submitAndWatchExtrinsic,
-// transactionWatch_v1_submitAndWatch) do not contain "subscribe" at all.
+// ASTAR spec's base collection, transcribed from lava-specs `astar.json` (already
+// merged on that repo's main); Acala (`aca.json`) and Shiden (`sdn.json`) carry
+// the same shape. The specs live in lava-specs, not under `specs/` here, so this
+// table cannot be validated in-repo — hence naming the file it came from.
+//
+// It is documentation of WHY no string rule could have worked, not coverage
+// breadth: every row drives the same one-line pass-through. The three rows that
+// carry the argument are chainHead_v1_follow, author_submitAndWatchExtrinsic and
+// transactionWatch_v1_submitAndWatch, which do not contain "subscribe" at all.
 var substrateUnsubscribePairs = []struct {
 	subscribe   string
 	unsubscribe string
@@ -2582,4 +2620,90 @@ func TestResolveUnsubscribeMethod_FallsBackWithoutApi(t *testing.T) {
 	t.Run("nil message", func(t *testing.T) {
 		assert.Equal(t, "eth_unsubscribe", resolveUnsubscribeMethod(nil, "eth_subscribe"))
 	})
+
+	// The one row here whose input the parser can actually hand you. A method the
+	// spec does not declare still gets an api, synthesised as "Default-<method>"
+	// (base_chain_parser.go defaultApiContainer). Sending that upstream would be a
+	// method no node implements, so it must not be preferred over the fallback.
+	//
+	// Unreachable from today's only caller — a "Default-" name matches no
+	// directive's ApiName, so the message is never classified UNSUBSCRIBE — but
+	// the guard belongs to this function, not to its caller's invariant.
+	t.Run("synthesised default api name", func(t *testing.T) {
+		pm := &mockWSProtocolMessage{method: chainlib.DefaultApiName + "chain_unsubscribeNewHeads"}
+		assert.Equal(t, "eth_unsubscribe", resolveUnsubscribeMethod(pm, "eth_subscribe"),
+			"a Default-prefixed name is not a wire method")
+	})
+}
+
+// TestEndToEnd_UnsubscribeSendsTheSpecMethodUpstream is the MAG-3297 regression
+// test at the level the bug lived: what the ROUTER SENDS UPSTREAM.
+//
+// The unit tests above pin resolveUnsubscribeMethod's return value, which does
+// not exercise the CallContext call site — reverting that one line back to
+// getUnsubscribeMethod would leave them all green. This one drives a real
+// WebSocket round trip and asserts the method the upstream was actually asked
+// for, which is the only place that regression is visible.
+//
+// It uses a Substrate pair on purpose. Before the fix the router derived the
+// teardown method from the subscribe method by string surgery, and
+// chain_subscribeNewHeads matches none of its rules, so it sent the literal
+// "unsubscribe" — which is what this asserts is absent.
+func TestEndToEnd_UnsubscribeSendsTheSpecMethodUpstream(t *testing.T) {
+	mockSrv := newMockSubscriptionServer()
+	mockSrv.messageInterval = 20 * time.Millisecond
+	defer mockSrv.Close()
+
+	nodeUrl := &common.NodeUrl{Url: mockSrv.URL()}
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc", "SDN", "jsonrpc",
+		[]*common.NodeUrl{nodeUrl},
+		nil, nil, nil,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const dappID, ip, wsUID = "dapp-sdn", "192.168.99.98", "ws-sdn"
+	subscribeBody, err := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0", "method": "chain_subscribeNewHeads", "params": []interface{}{}, "id": 1,
+	})
+	require.NoError(t, err)
+	subscribeMsg := &mockWSProtocolMessageWithRawData{
+		mockWSProtocolMessage: mockWSProtocolMessage{method: "chain_subscribeNewHeads", params: []interface{}{}},
+		rawData:               subscribeBody,
+	}
+
+	reply, _, err := manager.StartSubscription(ctx, subscribeMsg, dappID, ip, wsUID, nil)
+	require.NoError(t, err, "the subscribe half always worked, including before the fix")
+	require.NotNil(t, reply)
+
+	var subResp map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(reply.Data, &subResp))
+	var routerSubID string
+	require.NoError(t, json.Unmarshal(subResp["result"], &routerSubID))
+	require.NotEmpty(t, routerSubID)
+
+	unsubscribeBody, err := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0", "method": "chain_unsubscribeNewHeads", "params": []interface{}{routerSubID}, "id": 2,
+	})
+	require.NoError(t, err)
+	unsubscribeMsg := &mockWSProtocolMessageWithRawData{
+		mockWSProtocolMessage: mockWSProtocolMessage{
+			method: "chain_unsubscribeNewHeads",
+			params: []interface{}{routerSubID},
+		},
+		rawData: unsubscribeBody,
+	}
+
+	_, err = manager.Unsubscribe(ctx, unsubscribeMsg, dappID, ip, wsUID, nil)
+	require.NoError(t, err)
+
+	observed := mockSrv.ObservedMethods()
+	require.Contains(t, observed, "chain_subscribeNewHeads")
+	require.Contains(t, observed, "chain_unsubscribeNewHeads",
+		"the router must tear down with the spec's own unsubscribe method; observed=%v", observed)
+	require.NotContains(t, observed, "unsubscribe",
+		"the derivation fallback sent this literal method, which no Substrate node implements; observed=%v", observed)
 }

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
@@ -2489,3 +2489,97 @@ func TestUnsubscribe_StillRejectsForeignSubscription(t *testing.T) {
 	assert.Equal(t, common.SubscriptionNotFoundError, err,
 		"unrelated client must not be able to unsubscribe via upstream-id fallback")
 }
+
+// substrateUnsubscribePairs is the full SUBSCRIBE/UNSUBSCRIBE set declared by the
+// ASTAR spec's base collection, and the same shape Acala (aca.json) and Shiden
+// (sdn.json) carry. Every Substrate spec pairs by name, and none of the pairings
+// is a "<x>_subscribe" -> "<x>_unsubscribe" rewrite: three of them
+// (chainHead_v1_follow, author_submitAndWatchExtrinsic,
+// transactionWatch_v1_submitAndWatch) do not contain "subscribe" at all.
+var substrateUnsubscribePairs = []struct {
+	subscribe   string
+	unsubscribe string
+}{
+	{"author_submitAndWatchExtrinsic", "author_unwatchExtrinsic"},
+	{"chainHead_v1_follow", "chainHead_v1_unfollow"},
+	{"chain_subscribeAllHeads", "chain_unsubscribeAllHeads"},
+	{"chain_subscribeFinalisedHeads", "chain_unsubscribeFinalisedHeads"},
+	{"chain_subscribeFinalizedHeads", "chain_unsubscribeFinalizedHeads"},
+	{"chain_subscribeNewHead", "chain_unsubscribeNewHead"},
+	{"chain_subscribeNewHeads", "chain_unsubscribeNewHeads"},
+	{"chain_subscribeRuntimeVersion", "chain_unsubscribeRuntimeVersion"},
+	{"state_subscribeRuntimeVersion", "state_unsubscribeRuntimeVersion"},
+	{"state_subscribeStorage", "state_unsubscribeStorage"},
+	{"subscribe_newHead", "unsubscribe_newHead"},
+	{"transactionWatch_v1_submitAndWatch", "transactionWatch_v1_unwatch"},
+}
+
+// TestResolveUnsubscribeMethod_UsesClientMethodName asserts the method the router
+// sends UPSTREAM, which is the thing MAG-3297 got wrong. Asserting only that an
+// unsubscribe does not error would pass against a node that happens to accept the
+// generic "unsubscribe".
+func TestResolveUnsubscribeMethod_UsesClientMethodName(t *testing.T) {
+	for _, pair := range substrateUnsubscribePairs {
+		t.Run(pair.unsubscribe, func(t *testing.T) {
+			// The client calls the spec's unsubscribe method; the api resolved from
+			// the spec by name is what lands on the protocol message.
+			pm := &mockWSProtocolMessage{method: pair.unsubscribe}
+
+			got := resolveUnsubscribeMethod(pm, pair.subscribe)
+			assert.Equal(t, pair.unsubscribe, got,
+				"router must call upstream with the method the client invoked")
+
+			// MAG-3297 regression guard: deriving from the subscribe method cannot
+			// produce this name. If someone reinstates derivation here, the assertion
+			// above stops holding and this one says why.
+			assert.NotEqual(t, pair.unsubscribe, getUnsubscribeMethod(pair.subscribe),
+				"derivation is expected to be wrong for Substrate — it is why this fix exists")
+		})
+	}
+}
+
+// TestResolveUnsubscribeMethod_EthAndTendermintUnchanged pins the two shapes that
+// already worked, so the fix is not a behaviour change for them. eth_unsubscribe
+// working while every Substrate pair failed is what localised this bug.
+func TestResolveUnsubscribeMethod_EthAndTendermintUnchanged(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		subscribe   string
+		unsubscribe string
+	}{
+		{"evm", "eth_subscribe", "eth_unsubscribe"},
+		{"tendermint", "subscribe", "unsubscribe"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pm := &mockWSProtocolMessage{method: tc.unsubscribe}
+			assert.Equal(t, tc.unsubscribe, resolveUnsubscribeMethod(pm, tc.subscribe))
+			// These are the cases the old derivation hardcoded, so it agrees.
+			assert.Equal(t, tc.unsubscribe, getUnsubscribeMethod(tc.subscribe))
+		})
+	}
+}
+
+// mockWSProtocolMessageNoApi is a message that resolved to no spec api — the only
+// case the derivation fallback is still reachable from.
+type mockWSProtocolMessageNoApi struct {
+	mockWSProtocolMessage
+}
+
+func (m *mockWSProtocolMessageNoApi) GetApi() *spectypes.Api { return nil }
+
+func TestResolveUnsubscribeMethod_FallsBackWithoutApi(t *testing.T) {
+	t.Run("nil api", func(t *testing.T) {
+		pm := &mockWSProtocolMessageNoApi{mockWSProtocolMessage{method: "chain_unsubscribeNewHeads"}}
+		assert.Equal(t, "eth_unsubscribe", resolveUnsubscribeMethod(pm, "eth_subscribe"),
+			"with no api to read, fall back to derivation rather than sending an empty method")
+	})
+
+	t.Run("empty api name", func(t *testing.T) {
+		pm := &mockWSProtocolMessage{method: ""}
+		assert.Equal(t, "eth_unsubscribe", resolveUnsubscribeMethod(pm, "eth_subscribe"))
+	})
+
+	t.Run("nil message", func(t *testing.T) {
+		assert.Equal(t, "eth_unsubscribe", resolveUnsubscribeMethod(nil, "eth_subscribe"))
+	})
+}


### PR DESCRIPTION
# Description

Substrate `*_unsubscribe*` methods returned `-32601` through the router. The subscribe half worked and the unsubscribe half did not, on every Substrate spec — 12 methods on Acala, 10 of 12 on Shiden, and identically on **ASTAR, which is merged and live**.

**The ticket's hypothesis was that the router's `SUBSCRIBE`/`UNSUBSCRIBE` directive lookup keys on `function_tag` alone.** That turned out not to be the cause here. The dispatch path is correct: `GetParseDirective` (`chain_message_queries.go:23`) matches directives **by `ApiName`**, so `chain_unsubscribeNewHeads` is classified correctly and reaches the unsubscribe handler.

The actual cause is `getUnsubscribeMethod` (`direct_ws_subscription_manager.go`), which derived the upstream teardown method from the **subscribe** method by string surgery and never consulted the spec at all:

```go
if subscribeMethod == "eth_subscribe" { return "eth_unsubscribe" }
if subscribeMethod == "subscribe"     { return "unsubscribe" }
if <ends with "_subscribe">           { return <prefix> + "_unsubscribe" }
return "unsubscribe"          // ← everything Substrate lands here
```

All twelve of ASTAR's subscribe methods fall through to that last line — `chain_subscribeNewHeads`, `state_subscribeStorage`, `subscribe_newHead`, `chainHead_v1_follow` are none of them `<x>_subscribe`. So the router called the literal method `unsubscribe`, the node replied `-32601`, and that response was streamed back to the client verbatim. `eth_unsubscribe` worked only because it is one of the two hardcoded cases, which is exactly what made this look spec-shaped rather than code-shaped.

Three pairs are not derivable by any string rule: `chainHead_v1_follow` → `chainHead_v1_unfollow`, `author_submitAndWatchExtrinsic` → `author_unwatchExtrinsic`, `transactionWatch_v1_submitAndWatch` → `transactionWatch_v1_unwatch`.

**Nothing needs deriving.** The spec pairs each `SUBSCRIBE` directive with an `UNSUBSCRIBE` one carrying its own `api_name`, and `consumer_websocket_manager.go` reaches this path only after matching the incoming message against those directives by name — so the api on the message already *is* the spec's unsubscribe method. Use it. `getUnsubscribeMethod` stays as the fallback for a message with no api attached, which a spec-resolved message never is.

### Most critical to review

- `protocol/rpcsmartrouter/direct_ws_subscription_manager.go` — `resolveUnsubscribeMethod`, and the single call site it replaces (verified: `getUnsubscribeMethod` had no other callers repo-wide).

### Tests

The tests assert the method sent **upstream**, over the ASTAR base collection's full set of pairs. Asserting only that an unsubscribe does not error would pass against a node that happens to accept the generic `unsubscribe`. Each pair also carries a `NotEqual` against the old derivation, so the tests document why the fix exists and fail if anyone reinstates it. The eth and tendermint shapes are pinned as unchanged.

`go build ./...` clean; full `./protocol/...` suite green.

### Note for reviewers

This kills the falsifier proposed on the ticket — *"if a Substrate spec with exactly one unsubscribe pair works, that is strong support"*. Under this diagnosis that test **fails**: one pair or twelve, `chain_subscribeNewHeads` still hits the fallback. Not worth spending a spec on.

## Jira ticket

Jira ticket: MAG-3297

---

## Author Checklist

I have...

* [x] read the [contribution guide](https://github.com/magma-Devs/smart-router/blob/main/CONTRIBUTING.md)
* [x] included the correct type prefix in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change — n/a, no API or client breaking change
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests
* [x] updated the relevant documentation or specification, including comments for documenting Go code
* [ ] confirmed all CI checks have passed — pending first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHyKbFQzzmj9e1bE9yKRa
