### PR TITLE
fix(chainlib): admit a provider serving only an add-on collection (MAG-3296)

### DIFF
--- a/protocol/chainlib/base_chain_parser.go
+++ b/protocol/chainlib/base_chain_parser.go
@@ -349,6 +349,62 @@ func (bcp *BaseChainParser) GetParsingByTag(tag spectypes.FUNCTION_TAG) (parsing
 	return val.Parsing, val.ApiCollection, ok
 }
 
+// GetParsingByTagForCollection resolves a tagged parse directive for a node that
+// serves specific add-on collections, falling back to GetParsingByTag's answer
+// when the node declares no add-ons or none of its collections carries the tag.
+//
+// MAG-3296: taggedApis holds exactly ONE directive per tag — the first collection
+// to declare it, which for a spec written base-first is the base collection. So
+// GetParsingByTag answers "the base collection's directive" no matter who is
+// asking. That is wrong for a spec whose add-on is a DISJOINT api surface rather
+// than a superset of the base one: Acala serves Substrate in the base collection
+// and EVM in an `evm` add-on, and an EVM-only node cannot answer the base
+// collection's chain_getHeader at all. Probing it with one gets -32601 and, on
+// the admission path, costs the provider its place outright.
+//
+// Add-ons are tried in the order the node declares them, so a node's own
+// preference decides between two collections that both carry the tag. The
+// connection type comes from the base answer, because the tag is served over the
+// same transport whichever collection defines it — this is a keyed lookup rather
+// than a scan of apiCollections, which is a map and would iterate randomly.
+//
+// `addons` may contain extension names too (callers pass NodeUrl.Addons, which
+// mixes both). An extension name matches no collection's AddOn, so it is skipped
+// rather than needing to be separated out first.
+func (bcp *BaseChainParser) GetParsingByTagForCollection(tag spectypes.FUNCTION_TAG, addons []string, internalPath string) (parsing *spectypes.ParseDirective, apiCollection *spectypes.ApiCollection, existed bool) {
+	bcp.rwLock.RLock()
+	defer bcp.rwLock.RUnlock()
+
+	base, baseExisted := bcp.taggedApis[tag]
+	if baseExisted {
+		parsing, apiCollection, existed = base.Parsing, base.ApiCollection, true
+	}
+	if len(addons) == 0 || !baseExisted {
+		return parsing, apiCollection, existed
+	}
+
+	for _, addon := range addons {
+		if addon == "" {
+			continue // the base collection, which is already the fallback
+		}
+		collection, ok := bcp.apiCollections[CollectionKey{
+			ConnectionType: base.ApiCollection.CollectionData.Type,
+			InternalPath:   internalPath,
+			Addon:          addon,
+		}]
+		if !ok || !collection.Enabled {
+			continue
+		}
+		for _, directive := range collection.ParseDirectives {
+			if directive.FunctionTag == tag {
+				return directive, collection, true
+			}
+		}
+	}
+
+	return parsing, apiCollection, existed
+}
+
 func (bcp *BaseChainParser) IsTagInCollection(tag spectypes.FUNCTION_TAG, collectionKey CollectionKey) bool {
 	bcp.rwLock.RLock()
 	defer bcp.rwLock.RUnlock()

--- a/protocol/chainlib/base_chain_parser.go
+++ b/protocol/chainlib/base_chain_parser.go
@@ -371,24 +371,37 @@ func (bcp *BaseChainParser) GetParsingByTag(tag spectypes.FUNCTION_TAG) (parsing
 // `addons` may contain extension names too (callers pass NodeUrl.Addons, which
 // mixes both). An extension name matches no collection's AddOn, so it is skipped
 // rather than needing to be separated out first.
-func (bcp *BaseChainParser) GetParsingByTagForCollection(tag spectypes.FUNCTION_TAG, addons []string, internalPath string) (parsing *spectypes.ParseDirective, apiCollection *spectypes.ApiCollection, existed bool) {
+//
+// allowBaseFallback is the caller's ServesBaseCollection(): false means the node
+// serves ONLY its add-on collections, and the tagged fallback is then refused
+// rather than handing back a directive that node cannot answer.
+func (bcp *BaseChainParser) GetParsingByTagForCollection(tag spectypes.FUNCTION_TAG, addons []string, internalPath string, allowBaseFallback bool) (parsing *spectypes.ParseDirective, apiCollection *spectypes.ApiCollection, existed bool) {
 	bcp.rwLock.RLock()
 	defer bcp.rwLock.RUnlock()
 
-	base, baseExisted := bcp.taggedApis[tag]
-	if baseExisted {
-		parsing, apiCollection, existed = base.Parsing, base.ApiCollection, true
+	// `tagged`, not `base`: taggedApis is first-wins in SPEC-FILE order, so for a
+	// spec that lists an add-on collection before the base one this entry is the
+	// add-on's. The name must not assert an invariant the map does not enforce.
+	tagged, taggedExisted := bcp.taggedApis[tag]
+	if taggedExisted {
+		parsing, apiCollection, existed = tagged.Parsing, tagged.ApiCollection, true
 	}
-	if len(addons) == 0 || !baseExisted {
+	if len(addons) == 0 || !taggedExisted {
+		// taggedApis is populated from EVERY enabled collection, so a tag missing
+		// from it is declared nowhere and searching the add-on collections cannot
+		// find it either.
+		if !taggedExisted {
+			return nil, nil, false
+		}
 		return parsing, apiCollection, existed
 	}
 
 	for _, addon := range addons {
 		if addon == "" {
-			continue // the base collection, which is already the fallback
+			continue // the base collection, which is the fallback below
 		}
 		collection, ok := bcp.apiCollections[CollectionKey{
-			ConnectionType: base.ApiCollection.CollectionData.Type,
+			ConnectionType: tagged.ApiCollection.CollectionData.Type,
 			InternalPath:   internalPath,
 			Addon:          addon,
 		}]
@@ -402,6 +415,16 @@ func (bcp *BaseChainParser) GetParsingByTagForCollection(tag spectypes.FUNCTION_
 		}
 	}
 
+	if !allowBaseFallback {
+		// The caller serves only its add-on collections, and none of them declares
+		// this tag. Falling back would hand it the one directive the operator said
+		// the node cannot answer — reinstating the very probe standalone-addons
+		// opted out of, quietly. The keyed lookup above misses whenever a spec
+		// declares the add-on collection only at the root and the url carries an
+		// internal path, so this is reachable the moment a spec combines a disjoint
+		// add-on with internal paths.
+		return nil, nil, false
+	}
 	return parsing, apiCollection, existed
 }
 

--- a/protocol/chainlib/base_chain_parser.go
+++ b/protocol/chainlib/base_chain_parser.go
@@ -629,6 +629,18 @@ func (apip *BaseChainParser) getApiCollection(connectionType, internalPath, addo
 	return api, nil
 }
 
+// findParseDirectiveByTag returns a collection's own directive for a tag, or nil
+// when it declares none. Used to resolve what a tag-referencing verification
+// borrows, so it borrows from the collection it belongs to.
+func findParseDirectiveByTag(apiCollection *spectypes.ApiCollection, tag spectypes.FUNCTION_TAG) *spectypes.ParseDirective {
+	for _, directive := range apiCollection.ParseDirectives {
+		if directive.FunctionTag == tag {
+			return directive
+		}
+	}
+	return nil
+}
+
 func getServiceApis(
 	spec spectypes.Spec,
 	rpcInterface string,
@@ -740,8 +752,26 @@ func getServiceApis(
 			}
 			for _, verification := range apiCollection.Verifications {
 				if verification.ParseDirective.FunctionTag != spectypes.FUNCTION_TAG_VERIFICATION {
-					if _, ok := taggedApis[verification.ParseDirective.FunctionTag]; ok {
-						verification.ParseDirective = taggedApis[verification.ParseDirective.FunctionTag].Parsing
+					// A verification that names a tag instead of carrying its own
+					// template borrows a directive. Take the one from ITS OWN
+					// collection first (MAG-3296): taggedApis holds a single
+					// directive per tag — the first collection to declare it — so
+					// borrowing from there gave every collection the base one.
+					// Acala's `evm` pruning verification names GET_EARLIEST_BLOCK
+					// and was rewritten to probe with the base collection's
+					// Substrate chain_getBlockHash, which the EVM node it was
+					// meant to check cannot answer.
+					//
+					// taggedApis stays the fallback, so a collection that borrows a
+					// tag it does not itself declare still resolves exactly as before.
+					borrowed := findParseDirectiveByTag(apiCollection, verification.ParseDirective.FunctionTag)
+					if borrowed == nil {
+						if container, ok := taggedApis[verification.ParseDirective.FunctionTag]; ok {
+							borrowed = container.Parsing
+						}
+					}
+					if borrowed != nil {
+						verification.ParseDirective = borrowed
 					} else {
 						utils.LavaFormatError("Bad verification definition", fmt.Errorf("verification function tag is not defined in the collections parse directives"), utils.LogAttr("function_tag", verification.ParseDirective.FunctionTag))
 						continue

--- a/protocol/chainlib/base_chain_parser_addon_tag_test.go
+++ b/protocol/chainlib/base_chain_parser_addon_tag_test.go
@@ -1,0 +1,226 @@
+package chainlib
+
+import (
+	"testing"
+
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// MAG-3296. A spec whose add-on is a DISJOINT api surface rather than a superset
+// of the base one: Acala serves Substrate in the base collection and EVM in an
+// `evm` add-on, and the two have no method in common. `txpool` is the ordinary
+// shape for contrast — a real add-on (ASTAR has one) that declares no tagged
+// directives of its own and is meant to inherit the base collection's.
+func acalaShapedParser(t *testing.T) (parser *BaseChainParser, base, evm *spectypes.ApiCollection) {
+	t.Helper()
+
+	collectionData := func(addon, internalPath string) spectypes.CollectionData {
+		return spectypes.CollectionData{
+			ApiInterface: spectypes.APIInterfaceJsonRPC,
+			InternalPath: internalPath,
+			Type:         "POST",
+			AddOn:        addon,
+		}
+	}
+
+	base = &spectypes.ApiCollection{
+		Enabled:        true,
+		CollectionData: collectionData("", ""),
+		ParseDirectives: []*spectypes.ParseDirective{
+			{FunctionTag: spectypes.FUNCTION_TAG_GET_BLOCKNUM, ApiName: "chain_getHeader"},
+		},
+	}
+	evm = &spectypes.ApiCollection{
+		Enabled:        true,
+		CollectionData: collectionData("evm", ""),
+		ParseDirectives: []*spectypes.ParseDirective{
+			{FunctionTag: spectypes.FUNCTION_TAG_GET_BLOCKNUM, ApiName: "eth_blockNumber"},
+			{FunctionTag: spectypes.FUNCTION_TAG_GET_BLOCK_BY_NUM, ApiName: "eth_getBlockByNumber"},
+		},
+	}
+	txpool := &spectypes.ApiCollection{
+		Enabled:        true,
+		CollectionData: collectionData("txpool", ""),
+	}
+	disabled := &spectypes.ApiCollection{
+		Enabled:        false,
+		CollectionData: collectionData("disabled", ""),
+		ParseDirectives: []*spectypes.ParseDirective{
+			{FunctionTag: spectypes.FUNCTION_TAG_GET_BLOCKNUM, ApiName: "never_reached"},
+		},
+	}
+	otherPath := &spectypes.ApiCollection{
+		Enabled:        true,
+		CollectionData: collectionData("evm", "/v2"),
+		ParseDirectives: []*spectypes.ParseDirective{
+			{FunctionTag: spectypes.FUNCTION_TAG_GET_BLOCKNUM, ApiName: "v2_blockNumber"},
+		},
+	}
+
+	collections := map[CollectionKey]*spectypes.ApiCollection{}
+	for _, collection := range []*spectypes.ApiCollection{base, evm, txpool, disabled, otherPath} {
+		collections[CollectionKey{
+			ConnectionType: collection.CollectionData.Type,
+			InternalPath:   collection.CollectionData.InternalPath,
+			Addon:          collection.CollectionData.AddOn,
+		}] = collection
+	}
+
+	return &BaseChainParser{
+		apiCollections: collections,
+		// taggedApis holds one entry per tag — the first collection to declare it.
+		// For a spec written base-first that is the base collection, which is the
+		// whole of the bug this resolver exists to route around.
+		taggedApis: map[spectypes.FUNCTION_TAG]TaggedContainer{
+			spectypes.FUNCTION_TAG_GET_BLOCKNUM: {
+				Parsing:       base.ParseDirectives[0],
+				ApiCollection: base,
+			},
+		},
+	}, base, evm
+}
+
+func TestGetParsingByTagForCollection(t *testing.T) {
+	parser, base, evm := acalaShapedParser(t)
+
+	// The unscoped lookup answers "base" for everyone. Pinned because it is the
+	// behaviour every other caller still relies on, and the reason the scoped
+	// lookup had to be added rather than the old one changed.
+	parsing, collection, ok := parser.GetParsingByTag(spectypes.FUNCTION_TAG_GET_BLOCKNUM)
+	require.True(t, ok)
+	require.Equal(t, "chain_getHeader", parsing.ApiName)
+	require.Same(t, base, collection)
+
+	for _, tc := range []struct {
+		name         string
+		addons       []string
+		internalPath string
+		wantApiName  string
+		wantExisted  bool
+	}{
+		{
+			name:        "no addons falls back to the base collection",
+			addons:      nil,
+			wantApiName: "chain_getHeader",
+			wantExisted: true,
+		},
+		{
+			name:        "an evm-only node is probed with the evm collection's directive",
+			addons:      []string{"evm"},
+			wantApiName: "eth_blockNumber",
+			wantExisted: true,
+		},
+		{
+			name:        "an addon that declares no directive inherits the base one",
+			addons:      []string{"txpool"},
+			wantApiName: "chain_getHeader",
+			wantExisted: true,
+		},
+		{
+			name:        "an addon with no collection at all inherits the base one",
+			addons:      []string{"archive"},
+			wantApiName: "chain_getHeader",
+			wantExisted: true,
+		},
+		{
+			name:        "an extension name mixed in with the addons is skipped, not matched",
+			addons:      []string{"debug", "trace", "evm"},
+			wantApiName: "eth_blockNumber",
+			wantExisted: true,
+		},
+		{
+			name:        "a disabled collection is not a source of directives",
+			addons:      []string{"disabled"},
+			wantApiName: "chain_getHeader",
+			wantExisted: true,
+		},
+		{
+			name:        "the empty addon means the base collection and is not re-searched",
+			addons:      []string{""},
+			wantApiName: "chain_getHeader",
+			wantExisted: true,
+		},
+		{
+			name:         "an internal path scopes the lookup to that path's collection",
+			addons:       []string{"evm"},
+			internalPath: "/v2",
+			wantApiName:  "v2_blockNumber",
+			wantExisted:  true,
+		},
+		{
+			name:         "an addon on an internal path the spec does not define inherits the base one",
+			addons:       []string{"evm"},
+			internalPath: "/nope",
+			wantApiName:  "chain_getHeader",
+			wantExisted:  true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parsing, _, existed := parser.GetParsingByTagForCollection(
+				spectypes.FUNCTION_TAG_GET_BLOCKNUM, tc.addons, tc.internalPath)
+			require.Equal(t, tc.wantExisted, existed)
+			require.NotNil(t, parsing)
+			require.Equal(t, tc.wantApiName, parsing.ApiName)
+		})
+	}
+
+	t.Run("the resolved collection is returned alongside the directive", func(t *testing.T) {
+		_, collection, ok := parser.GetParsingByTagForCollection(
+			spectypes.FUNCTION_TAG_GET_BLOCKNUM, []string{"evm"}, "")
+		require.True(t, ok)
+		require.Same(t, evm, collection,
+			"the caller crafts the probe from CollectionData, so it must be the add-on's")
+	})
+
+	t.Run("a tag no collection declares stays absent", func(t *testing.T) {
+		// GET_BLOCK_BY_NUM is declared by the evm collection but has no taggedApis
+		// entry, so there is no base answer to fall back to. Reporting it as found
+		// would hand callers a directive the base surface cannot serve.
+		_, _, existed := parser.GetParsingByTagForCollection(
+			spectypes.FUNCTION_TAG_GET_BLOCK_BY_NUM, []string{"evm"}, "")
+		require.False(t, existed)
+	})
+
+	t.Run("resolution is deterministic across calls", func(t *testing.T) {
+		// apiCollections is a map. A scan of it would iterate randomly and could
+		// return a different collection per call, which reads downstream as a node
+		// whose tip source flaps.
+		for i := 0; i < 200; i++ {
+			parsing, _, ok := parser.GetParsingByTagForCollection(
+				spectypes.FUNCTION_TAG_GET_BLOCKNUM, []string{"txpool", "evm"}, "")
+			require.True(t, ok)
+			require.Equal(t, "eth_blockNumber", parsing.ApiName)
+		}
+	})
+}
+
+// TestGetParsingByTagForCollection_AddonOrderIsTheNodesOwn asserts the node's
+// declaration order decides between two add-on collections that both carry the
+// tag, rather than map order deciding for it.
+func TestGetParsingByTagForCollection_AddonOrderIsTheNodesOwn(t *testing.T) {
+	parser, _, _ := acalaShapedParser(t)
+
+	second := &spectypes.ApiCollection{
+		Enabled: true,
+		CollectionData: spectypes.CollectionData{
+			ApiInterface: spectypes.APIInterfaceJsonRPC,
+			Type:         "POST",
+			AddOn:        "other",
+		},
+		ParseDirectives: []*spectypes.ParseDirective{
+			{FunctionTag: spectypes.FUNCTION_TAG_GET_BLOCKNUM, ApiName: "other_blockNumber"},
+		},
+	}
+	parser.apiCollections[CollectionKey{ConnectionType: "POST", Addon: "other"}] = second
+
+	parsing, _, ok := parser.GetParsingByTagForCollection(
+		spectypes.FUNCTION_TAG_GET_BLOCKNUM, []string{"evm", "other"}, "")
+	require.True(t, ok)
+	require.Equal(t, "eth_blockNumber", parsing.ApiName)
+
+	parsing, _, ok = parser.GetParsingByTagForCollection(
+		spectypes.FUNCTION_TAG_GET_BLOCKNUM, []string{"other", "evm"}, "")
+	require.True(t, ok)
+	require.Equal(t, "other_blockNumber", parsing.ApiName)
+}

--- a/protocol/chainlib/base_chain_parser_addon_tag_test.go
+++ b/protocol/chainlib/base_chain_parser_addon_tag_test.go
@@ -158,7 +158,7 @@ func TestGetParsingByTagForCollection(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			parsing, _, existed := parser.GetParsingByTagForCollection(
-				spectypes.FUNCTION_TAG_GET_BLOCKNUM, tc.addons, tc.internalPath)
+				spectypes.FUNCTION_TAG_GET_BLOCKNUM, tc.addons, tc.internalPath, true)
 			require.Equal(t, tc.wantExisted, existed)
 			require.NotNil(t, parsing)
 			require.Equal(t, tc.wantApiName, parsing.ApiName)
@@ -167,19 +167,42 @@ func TestGetParsingByTagForCollection(t *testing.T) {
 
 	t.Run("the resolved collection is returned alongside the directive", func(t *testing.T) {
 		_, collection, ok := parser.GetParsingByTagForCollection(
-			spectypes.FUNCTION_TAG_GET_BLOCKNUM, []string{"evm"}, "")
+			spectypes.FUNCTION_TAG_GET_BLOCKNUM, []string{"evm"}, "", true)
 		require.True(t, ok)
 		require.Same(t, evm, collection,
 			"the caller crafts the probe from CollectionData, so it must be the add-on's")
 	})
 
 	t.Run("a tag no collection declares stays absent", func(t *testing.T) {
-		// GET_BLOCK_BY_NUM is declared by the evm collection but has no taggedApis
-		// entry, so there is no base answer to fall back to. Reporting it as found
-		// would hand callers a directive the base surface cannot serve.
+		// getServiceApis populates taggedApis from EVERY enabled collection, so a
+		// tag missing from it is declared nowhere and the add-on search cannot find
+		// it either. GET_EARLIEST_BLOCK is that tag here — no collection in this
+		// fixture declares one.
 		_, _, existed := parser.GetParsingByTagForCollection(
-			spectypes.FUNCTION_TAG_GET_BLOCK_BY_NUM, []string{"evm"}, "")
+			spectypes.FUNCTION_TAG_GET_EARLIEST_BLOCK, []string{"evm"}, "", true)
 		require.False(t, existed)
+	})
+
+	t.Run("a standalone url is not handed the fallback it opted out of", func(t *testing.T) {
+		// The evm collection declares GET_BLOCKNUM at the root, so a root url
+		// resolves normally even with the fallback refused.
+		parsing, _, ok := parser.GetParsingByTagForCollection(
+			spectypes.FUNCTION_TAG_GET_BLOCKNUM, []string{"evm"}, "", false)
+		require.True(t, ok)
+		require.Equal(t, "eth_blockNumber", parsing.ApiName)
+
+		// On an internal path the spec does not define the add-on collection at,
+		// the keyed lookup misses. For an ordinary url the base directive is the
+		// right answer; for one that serves ONLY its add-ons it is the very probe
+		// the operator said the node cannot answer, so it must fail loudly instead.
+		_, _, okOrdinary := parser.GetParsingByTagForCollection(
+			spectypes.FUNCTION_TAG_GET_BLOCKNUM, []string{"evm"}, "/nope", true)
+		require.True(t, okOrdinary, "an ordinary url still inherits the base directive")
+
+		_, _, okStandalone := parser.GetParsingByTagForCollection(
+			spectypes.FUNCTION_TAG_GET_BLOCKNUM, []string{"evm"}, "/nope", false)
+		require.False(t, okStandalone,
+			"a standalone url must not be handed the base collection's directive")
 	})
 
 	t.Run("resolution is deterministic across calls", func(t *testing.T) {
@@ -188,7 +211,7 @@ func TestGetParsingByTagForCollection(t *testing.T) {
 		// whose tip source flaps.
 		for i := 0; i < 200; i++ {
 			parsing, _, ok := parser.GetParsingByTagForCollection(
-				spectypes.FUNCTION_TAG_GET_BLOCKNUM, []string{"txpool", "evm"}, "")
+				spectypes.FUNCTION_TAG_GET_BLOCKNUM, []string{"txpool", "evm"}, "", true)
 			require.True(t, ok)
 			require.Equal(t, "eth_blockNumber", parsing.ApiName)
 		}
@@ -215,12 +238,12 @@ func TestGetParsingByTagForCollection_AddonOrderIsTheNodesOwn(t *testing.T) {
 	parser.apiCollections[CollectionKey{ConnectionType: "POST", Addon: "other"}] = second
 
 	parsing, _, ok := parser.GetParsingByTagForCollection(
-		spectypes.FUNCTION_TAG_GET_BLOCKNUM, []string{"evm", "other"}, "")
+		spectypes.FUNCTION_TAG_GET_BLOCKNUM, []string{"evm", "other"}, "", true)
 	require.True(t, ok)
 	require.Equal(t, "eth_blockNumber", parsing.ApiName)
 
 	parsing, _, ok = parser.GetParsingByTagForCollection(
-		spectypes.FUNCTION_TAG_GET_BLOCKNUM, []string{"other", "evm"}, "")
+		spectypes.FUNCTION_TAG_GET_BLOCKNUM, []string{"other", "evm"}, "", true)
 	require.True(t, ok)
 	require.Equal(t, "other_blockNumber", parsing.ApiName)
 }

--- a/protocol/chainlib/base_chain_parser_addon_tag_test.go
+++ b/protocol/chainlib/base_chain_parser_addon_tag_test.go
@@ -224,3 +224,82 @@ func TestGetParsingByTagForCollection_AddonOrderIsTheNodesOwn(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "other_blockNumber", parsing.ApiName)
 }
+
+// TestVerificationBorrowsItsOwnCollectionsDirective is the MAG-3296 defect in its
+// third location. A verification that names a function tag instead of carrying its
+// own template borrows a directive, and it used to borrow from taggedApis — which
+// holds one directive per tag, the base collection's.
+//
+// The shape is Acala's, verbatim from aca.json: the `evm` collection's `pruning`
+// verification is declared as nothing but `{"function_tag": "GET_EARLIEST_BLOCK"}`,
+// so it borrowed the base collection's Substrate chain_getBlockHash and probed an
+// EVM node with a method that node does not implement.
+func TestVerificationBorrowsItsOwnCollectionsDirective(t *testing.T) {
+	collectionData := func(addon string) spectypes.CollectionData {
+		return spectypes.CollectionData{
+			ApiInterface: spectypes.APIInterfaceJsonRPC,
+			Type:         "POST",
+			AddOn:        addon,
+		}
+	}
+
+	spec := spectypes.Spec{
+		Index:   "ACA",
+		Enabled: true,
+		ApiCollections: []*spectypes.ApiCollection{
+			{
+				Enabled:        true,
+				CollectionData: collectionData(""),
+				ParseDirectives: []*spectypes.ParseDirective{
+					{FunctionTag: spectypes.FUNCTION_TAG_GET_EARLIEST_BLOCK, ApiName: "chain_getBlockHash"},
+					{FunctionTag: spectypes.FUNCTION_TAG_GET_BLOCKNUM, ApiName: "chain_getHeader"},
+				},
+				Verifications: []*spectypes.Verification{{
+					Name:           "pruning",
+					ParseDirective: &spectypes.ParseDirective{FunctionTag: spectypes.FUNCTION_TAG_GET_EARLIEST_BLOCK},
+					Values:         []*spectypes.ParseValue{{LatestDistance: 7200}},
+				}},
+			},
+			{
+				Enabled:        true,
+				CollectionData: collectionData("evm"),
+				ParseDirectives: []*spectypes.ParseDirective{
+					{FunctionTag: spectypes.FUNCTION_TAG_GET_EARLIEST_BLOCK, ApiName: "eth_getBlockByNumber"},
+					{FunctionTag: spectypes.FUNCTION_TAG_GET_BLOCKNUM, ApiName: "eth_blockNumber"},
+				},
+				Verifications: []*spectypes.Verification{{
+					Name:           "pruning",
+					ParseDirective: &spectypes.ParseDirective{FunctionTag: spectypes.FUNCTION_TAG_GET_EARLIEST_BLOCK},
+					Values:         []*spectypes.ParseValue{{LatestDistance: 7200}},
+				}},
+			},
+			{
+				// Borrows a tag it does not declare itself, which is the ordinary
+				// case and must keep resolving through taggedApis as before.
+				Enabled:        true,
+				CollectionData: collectionData("txpool"),
+				Verifications: []*spectypes.Verification{{
+					Name:           "pruning",
+					ParseDirective: &spectypes.ParseDirective{FunctionTag: spectypes.FUNCTION_TAG_GET_EARLIEST_BLOCK},
+					Values:         []*spectypes.ParseValue{{LatestDistance: 7200}},
+				}},
+			},
+		},
+	}
+
+	_, _, _, _, _, verifications := getServiceApis(spec, spectypes.APIInterfaceJsonRPC)
+
+	directiveFor := func(addon string) string {
+		containers, ok := verifications[VerificationKey{Addon: addon}][""]
+		require.True(t, ok, "expected a verification for addon %q", addon)
+		require.Len(t, containers, 1)
+		return containers[0].ParseDirective.ApiName
+	}
+
+	require.Equal(t, "eth_getBlockByNumber", directiveFor("evm"),
+		"the evm verification must probe with the evm collection's directive")
+	require.Equal(t, "chain_getBlockHash", directiveFor(""),
+		"the base verification is unchanged")
+	require.Equal(t, "chain_getBlockHash", directiveFor("txpool"),
+		"a collection that declares no directive for the tag still inherits the base one")
+}

--- a/protocol/chainlib/chain_fetcher.go
+++ b/protocol/chainlib/chain_fetcher.go
@@ -145,7 +145,10 @@ func (cf *ChainFetcher) Validate(ctx context.Context) error {
 		var latestBlock int64
 		if needsLatestBlock(url, verifications) {
 			for attempts := 0; attempts < 3; attempts++ {
-				latestBlock, err = cf.FetchLatestBlockNum(ctx)
+				// Probe the head with THIS url's collections. Using the base
+				// collection's directive for every node is what excluded a
+				// provider serving only a disjoint add-on surface (MAG-3296).
+				latestBlock, err = cf.FetchLatestBlockNumForCollection(ctx, url.Addons, url.InternalPath)
 				if stopValidateRetries(err) {
 					break
 				}
@@ -230,7 +233,9 @@ func (cf *ChainFetcher) ValidateCollect(ctx context.Context) []NodeURLValidation
 		var latestBlock int64
 		if needsLatestBlock(url, verifications) {
 			for attempts := 0; attempts < 3; attempts++ {
-				latestBlock, err = cf.FetchLatestBlockNum(ctx)
+				// Same collection-aware probe as Validate, so `smartrouter health`
+				// reports the head a node can actually serve (MAG-3296).
+				latestBlock, err = cf.FetchLatestBlockNumForCollection(ctx, url.Addons, url.InternalPath)
 				if stopValidateRetries(err) {
 					break
 				}
@@ -505,8 +510,25 @@ func (cf *ChainFetcher) CustomMessage(ctx context.Context, path string, data []b
 	return reply.RelayReply.Data, nil
 }
 
+// FetchLatestBlockNum probes the chain head using the base collection's
+// GET_BLOCKNUM directive. Callers that know which collections the node actually
+// serves should use FetchLatestBlockNumForCollection instead — see MAG-3296.
 func (cf *ChainFetcher) FetchLatestBlockNum(ctx context.Context) (int64, error) {
-	parsing, apiCollection, ok := cf.chainParser.GetParsingByTag(spectypes.FUNCTION_TAG_GET_BLOCKNUM)
+	return cf.FetchLatestBlockNumForCollection(ctx, nil, "")
+}
+
+// FetchLatestBlockNumForCollection probes the chain head with the GET_BLOCKNUM
+// directive of the collection this node URL actually serves.
+//
+// MAG-3296: this used to be the base collection's directive for every node,
+// which excluded any provider whose add-on is a disjoint api surface rather than
+// a superset — an EVM-only Acala node answers the `evm` collection's
+// eth_blockNumber and cannot answer the base collection's Substrate
+// chain_getHeader at all. On the admission path a failed head probe returns
+// before a single verification runs, so such a provider was dropped without ever
+// being asked the questions it could answer.
+func (cf *ChainFetcher) FetchLatestBlockNumForCollection(ctx context.Context, addons []string, internalPath string) (int64, error) {
+	parsing, apiCollection, ok := cf.chainParser.GetParsingByTagForCollection(spectypes.FUNCTION_TAG_GET_BLOCKNUM, addons, internalPath)
 	tagName := spectypes.FUNCTION_TAG_GET_BLOCKNUM.String()
 	if !ok {
 		return spectypes.NOT_APPLICABLE, utils.LavaFormatError(tagName+" tag function not found", nil, []utils.Attribute{{Key: "chainID", Value: cf.endpoint.ChainID}, {Key: "APIInterface", Value: cf.endpoint.ApiInterface}}...)

--- a/protocol/chainlib/chain_fetcher.go
+++ b/protocol/chainlib/chain_fetcher.go
@@ -101,6 +101,42 @@ func skipVerification(url common.NodeUrl, name string) bool {
 	return SkipAllVerifications || url.ShouldSkipVerification(name)
 }
 
+// verificationsForNodeUrl drops the base collection's verifications for a url that
+// has opted out of serving it (NodeUrl.StandaloneAddons).
+//
+// GetVerifications always adds the empty addon to whatever a url declares, so an
+// add-on node runs the base collection's verifications too. That is right when the
+// add-on EXTENDS the base surface and wrong when it REPLACES it: Acala's base
+// chain-id verification fires a Substrate chain_getBlockHash, which an EVM-only
+// node answers with -32601, and an omitted severity in a spec means Fail — so one
+// inherited verification excluded the provider (MAG-3296).
+//
+// This runs BEFORE needsLatestBlock for the same reason the skip filter does: a
+// verification that is not going to run must not drag a head probe out to the
+// upstream on its way past.
+//
+// Filtering here rather than inside GetVerifications keeps the parser's signature
+// free of node-url concerns — and dropping Addon=="" containers afterwards is
+// exactly equivalent to never having appended the empty addon.
+func verificationsForNodeUrl(url common.NodeUrl, verifications []VerificationContainer) []VerificationContainer {
+	if url.ServesBaseCollection() {
+		return verifications
+	}
+	kept := make([]VerificationContainer, 0, len(verifications))
+	for _, verification := range verifications {
+		if verification.Addon == "" {
+			utils.LavaFormatDebug("skipping base-collection verification for a standalone-addons url",
+				utils.LogAttr("verification", verification.Name),
+				utils.LogAttr("url", url.UrlStr()),
+				utils.LogAttr("addons", url.Addons),
+			)
+			continue
+		}
+		kept = append(kept, verification)
+	}
+	return kept
+}
+
 // needsLatestBlock reports whether any verification that will ACTUALLY RUN for this
 // node-url depends on the chain head, and therefore whether Validate has to spend a
 // FetchLatestBlockNum relay against the upstream before verifying.
@@ -138,6 +174,7 @@ func (cf *ChainFetcher) Validate(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		verifications = verificationsForNodeUrl(url, verifications)
 		if len(verifications) == 0 {
 			utils.LavaFormatWarning("no verifications for url", nil, utils.LogAttr("url", url.String()))
 		}
@@ -229,6 +266,7 @@ func (cf *ChainFetcher) ValidateCollect(ctx context.Context) []NodeURLValidation
 			results = append(results, nodeResult)
 			continue
 		}
+		verifications = verificationsForNodeUrl(url, verifications)
 
 		var latestBlock int64
 		if needsLatestBlock(url, verifications) {

--- a/protocol/chainlib/chain_fetcher.go
+++ b/protocol/chainlib/chain_fetcher.go
@@ -185,7 +185,7 @@ func (cf *ChainFetcher) Validate(ctx context.Context) error {
 				// Probe the head with THIS url's collections. Using the base
 				// collection's directive for every node is what excluded a
 				// provider serving only a disjoint add-on surface (MAG-3296).
-				latestBlock, err = cf.FetchLatestBlockNumForCollection(ctx, url.Addons, url.InternalPath)
+				latestBlock, err = cf.FetchLatestBlockNumForCollection(ctx, url.Addons, url.InternalPath, url.ServesBaseCollection())
 				if stopValidateRetries(err) {
 					break
 				}
@@ -273,7 +273,7 @@ func (cf *ChainFetcher) ValidateCollect(ctx context.Context) []NodeURLValidation
 			for attempts := 0; attempts < 3; attempts++ {
 				// Same collection-aware probe as Validate, so `smartrouter health`
 				// reports the head a node can actually serve (MAG-3296).
-				latestBlock, err = cf.FetchLatestBlockNumForCollection(ctx, url.Addons, url.InternalPath)
+				latestBlock, err = cf.FetchLatestBlockNumForCollection(ctx, url.Addons, url.InternalPath, url.ServesBaseCollection())
 				if stopValidateRetries(err) {
 					break
 				}
@@ -552,7 +552,7 @@ func (cf *ChainFetcher) CustomMessage(ctx context.Context, path string, data []b
 // GET_BLOCKNUM directive. Callers that know which collections the node actually
 // serves should use FetchLatestBlockNumForCollection instead — see MAG-3296.
 func (cf *ChainFetcher) FetchLatestBlockNum(ctx context.Context) (int64, error) {
-	return cf.FetchLatestBlockNumForCollection(ctx, nil, "")
+	return cf.FetchLatestBlockNumForCollection(ctx, nil, "", true)
 }
 
 // FetchLatestBlockNumForCollection probes the chain head with the GET_BLOCKNUM
@@ -565,8 +565,8 @@ func (cf *ChainFetcher) FetchLatestBlockNum(ctx context.Context) (int64, error) 
 // chain_getHeader at all. On the admission path a failed head probe returns
 // before a single verification runs, so such a provider was dropped without ever
 // being asked the questions it could answer.
-func (cf *ChainFetcher) FetchLatestBlockNumForCollection(ctx context.Context, addons []string, internalPath string) (int64, error) {
-	parsing, apiCollection, ok := cf.chainParser.GetParsingByTagForCollection(spectypes.FUNCTION_TAG_GET_BLOCKNUM, addons, internalPath)
+func (cf *ChainFetcher) FetchLatestBlockNumForCollection(ctx context.Context, addons []string, internalPath string, allowBaseFallback bool) (int64, error) {
+	parsing, apiCollection, ok := cf.chainParser.GetParsingByTagForCollection(spectypes.FUNCTION_TAG_GET_BLOCKNUM, addons, internalPath, allowBaseFallback)
 	tagName := spectypes.FUNCTION_TAG_GET_BLOCKNUM.String()
 	if !ok {
 		return spectypes.NOT_APPLICABLE, utils.LavaFormatError(tagName+" tag function not found", nil, []utils.Attribute{{Key: "chainID", Value: cf.endpoint.ChainID}, {Key: "APIInterface", Value: cf.endpoint.ApiInterface}}...)

--- a/protocol/chainlib/chain_fetcher_addon_probe_test.go
+++ b/protocol/chainlib/chain_fetcher_addon_probe_test.go
@@ -97,3 +97,79 @@ func TestFetchLatestBlockNumKeepsBaseCollectionSemantics(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, int64(spectypes.NOT_APPLICABLE), block)
 }
+
+// acalaVerifications is the set GetVerifications returns for a node declaring
+// addons ["evm"] and no archive extension, taken from aca.json (lava-specs #121).
+// The base entry is the one that excluded an EVM-only provider: it fires a
+// Substrate chain_getBlockHash, and an omitted severity in a spec means Fail.
+func acalaVerifications() []VerificationContainer {
+	return []VerificationContainer{
+		{ // base collection, inherited by every node
+			Name:            "chain-id",
+			Value:           "0xfc41b9bd8ef8fe53d58c7ea67c794c7ec9a73daf05e6d54b14ff6342c99ba64c",
+			VerificationKey: VerificationKey{Addon: ""},
+		},
+		{ // evm collection
+			Name:            "chain-id",
+			Value:           "0x313",
+			VerificationKey: VerificationKey{Addon: "evm"},
+		},
+		{ // evm collection, head-dependent
+			Name:            "pruning",
+			LatestDistance:  7200,
+			VerificationKey: VerificationKey{Addon: "evm"},
+		},
+	}
+}
+
+func TestVerificationsForNodeUrl(t *testing.T) {
+	t.Run("a standalone-addons url does not answer for the base collection", func(t *testing.T) {
+		url := common.NodeUrl{
+			Url:              "https://eth-rpc-acala.aca-api.network",
+			Addons:           []string{"evm"},
+			StandaloneAddons: true,
+		}
+
+		kept := verificationsForNodeUrl(url, acalaVerifications())
+
+		require.Len(t, kept, 2)
+		for _, verification := range kept {
+			require.Equal(t, "evm", verification.Addon)
+		}
+		// The check that actually validates an Acala EVM node survives. Skipping
+		// by name could not do this — both collections name theirs "chain-id",
+		// and ShouldSkipVerification matches on the name alone.
+		require.Equal(t, "0x313", kept[0].Value)
+	})
+
+	t.Run("the default is unchanged for every existing deployment", func(t *testing.T) {
+		url := common.NodeUrl{Url: "https://archive.example.com", Addons: []string{"archive"}}
+		require.Len(t, verificationsForNodeUrl(url, acalaVerifications()), 3,
+			"an add-on that extends the base surface still inherits its verifications")
+	})
+
+	t.Run("the flag is ignored on a url declaring no addons", func(t *testing.T) {
+		url := common.NodeUrl{Url: "https://plain.example.com", StandaloneAddons: true}
+		require.Len(t, verificationsForNodeUrl(url, acalaVerifications()), 3,
+			"there would be nothing left to serve")
+	})
+}
+
+// TestStandaloneAddonsUrlSkipsTheHeadProbeItCannotAnswer pins the ordering: the
+// base-collection filter runs before needsLatestBlock, so an inherited
+// verification that is not going to run cannot drag a head probe out to the
+// upstream on its way past. Same lesson as the skip-verifications filter.
+func TestStandaloneAddonsUrlSkipsTheHeadProbeItCannotAnswer(t *testing.T) {
+	base := []VerificationContainer{{
+		Name:            "pruning",
+		LatestDistance:  100,
+		VerificationKey: VerificationKey{Addon: ""},
+	}}
+
+	standalone := common.NodeUrl{Addons: []string{"evm"}, StandaloneAddons: true}
+	require.False(t, needsLatestBlock(standalone, verificationsForNodeUrl(standalone, base)),
+		"the only head-dependent verification belongs to a collection this url does not serve")
+
+	inheriting := common.NodeUrl{Addons: []string{"evm"}}
+	require.True(t, needsLatestBlock(inheriting, verificationsForNodeUrl(inheriting, base)))
+}

--- a/protocol/chainlib/chain_fetcher_addon_probe_test.go
+++ b/protocol/chainlib/chain_fetcher_addon_probe_test.go
@@ -63,7 +63,7 @@ func TestValidateProbesHeadWithTheUrlsOwnCollections(t *testing.T) {
 			// lookup. Returning "not found" ends Validate here, which is all this
 			// test needs — the call itself is the subject.
 			parser.EXPECT().
-				GetParsingByTagForCollection(spectypes.FUNCTION_TAG_GET_BLOCKNUM, tc.addons, tc.internalPath).
+				GetParsingByTagForCollection(spectypes.FUNCTION_TAG_GET_BLOCKNUM, tc.addons, tc.internalPath, true).
 				Return(nil, nil, false).
 				MinTimes(1)
 
@@ -85,7 +85,7 @@ func TestFetchLatestBlockNumKeepsBaseCollectionSemantics(t *testing.T) {
 
 	parser := NewMockChainParser(ctrl)
 	parser.EXPECT().
-		GetParsingByTagForCollection(spectypes.FUNCTION_TAG_GET_BLOCKNUM, nil, "").
+		GetParsingByTagForCollection(spectypes.FUNCTION_TAG_GET_BLOCKNUM, nil, "", true).
 		Return(nil, nil, false)
 
 	fetcher := &ChainFetcher{

--- a/protocol/chainlib/chain_fetcher_addon_probe_test.go
+++ b/protocol/chainlib/chain_fetcher_addon_probe_test.go
@@ -1,0 +1,99 @@
+package chainlib
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// headDependentVerification is a verification that cannot be evaluated without the
+// chain head, which is what makes Validate spend a head probe before verifying.
+func headDependentVerification(name string) VerificationContainer {
+	return VerificationContainer{
+		Name:           name,
+		LatestDistance: 100,
+		Severity:       spectypes.ParseValue_Fail,
+	}
+}
+
+// TestValidateProbesHeadWithTheUrlsOwnCollections is the MAG-3296 assertion at the
+// level the bug was reported from: admission must ask for the head using the
+// directives of the collections THIS node url serves.
+//
+// It stops at the lookup — the mock reports the tag as absent, so the probe fails
+// and Validate returns — because the argument passed to the lookup is the whole
+// defect. Before the fix, admission asked GetParsingByTag, which cannot be told
+// which node is asking and answers with the base collection for all of them.
+func TestValidateProbesHeadWithTheUrlsOwnCollections(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		addons       []string
+		internalPath string
+	}{
+		{name: "an evm-only node", addons: []string{"evm"}},
+		{name: "a node declaring several addons", addons: []string{"evm", "archive"}},
+		{name: "a node on an internal path", addons: []string{"evm"}, internalPath: "/v2"},
+		{name: "a plain node with no addons", addons: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			parser := NewMockChainParser(ctrl)
+			endpoint := &lavasession.RPCProviderEndpoint{
+				ChainID:      "ACA",
+				ApiInterface: spectypes.APIInterfaceJsonRPC,
+				NodeUrls: []common.NodeUrl{{
+					Url:          "https://eth-rpc-acala.aca-api.network",
+					Addons:       tc.addons,
+					InternalPath: tc.internalPath,
+				}},
+			}
+
+			parser.EXPECT().
+				GetVerifications(tc.addons, tc.internalPath, spectypes.APIInterfaceJsonRPC).
+				Return([]VerificationContainer{headDependentVerification("pruning")}, nil)
+
+			// The assertion: scoped to this url's collections, never the unscoped
+			// lookup. Returning "not found" ends Validate here, which is all this
+			// test needs — the call itself is the subject.
+			parser.EXPECT().
+				GetParsingByTagForCollection(spectypes.FUNCTION_TAG_GET_BLOCKNUM, tc.addons, tc.internalPath).
+				Return(nil, nil, false).
+				MinTimes(1)
+
+			fetcher := &ChainFetcher{endpoint: endpoint, chainParser: parser}
+
+			err := fetcher.Validate(context.Background())
+			require.Error(t, err, "a node whose head cannot be resolved still fails admission")
+		})
+	}
+}
+
+// TestFetchLatestBlockNumKeepsBaseCollectionSemantics pins the unscoped entry
+// point. It is on the chaintracker's fetcher interface and has no node url to
+// scope by, so it must keep asking for the base collection's directive — which
+// GetParsingByTagForCollection returns for an empty addon set.
+func TestFetchLatestBlockNumKeepsBaseCollectionSemantics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	parser := NewMockChainParser(ctrl)
+	parser.EXPECT().
+		GetParsingByTagForCollection(spectypes.FUNCTION_TAG_GET_BLOCKNUM, nil, "").
+		Return(nil, nil, false)
+
+	fetcher := &ChainFetcher{
+		endpoint:    &lavasession.RPCProviderEndpoint{ChainID: "ACA", ApiInterface: spectypes.APIInterfaceJsonRPC},
+		chainParser: parser,
+	}
+
+	block, err := fetcher.FetchLatestBlockNum(context.Background())
+	require.Error(t, err)
+	require.Equal(t, int64(spectypes.NOT_APPLICABLE), block)
+}

--- a/protocol/chainlib/chainlib.go
+++ b/protocol/chainlib/chainlib.go
@@ -68,7 +68,7 @@ type ChainParser interface {
 	SetSpec(spec spectypes.Spec)
 	ChainBlockStats() (allowedBlockLagForQosSync int64, averageBlockTime time.Duration, blockDistanceForFinalizedData, blocksInFinalizationProof uint32)
 	GetParsingByTag(tag spectypes.FUNCTION_TAG) (parsing *spectypes.ParseDirective, apiCollection *spectypes.ApiCollection, existed bool)
-	GetParsingByTagForCollection(tag spectypes.FUNCTION_TAG, addons []string, internalPath string) (parsing *spectypes.ParseDirective, apiCollection *spectypes.ApiCollection, existed bool)
+	GetParsingByTagForCollection(tag spectypes.FUNCTION_TAG, addons []string, internalPath string, allowBaseFallback bool) (parsing *spectypes.ParseDirective, apiCollection *spectypes.ApiCollection, existed bool)
 	IsTagInCollection(tag spectypes.FUNCTION_TAG, collectionKey CollectionKey) bool
 	GetAllInternalPaths() []string
 	IsInternalPathEnabled(internalPath string, apiInterface string, addon string) bool

--- a/protocol/chainlib/chainlib.go
+++ b/protocol/chainlib/chainlib.go
@@ -68,6 +68,7 @@ type ChainParser interface {
 	SetSpec(spec spectypes.Spec)
 	ChainBlockStats() (allowedBlockLagForQosSync int64, averageBlockTime time.Duration, blockDistanceForFinalizedData, blocksInFinalizationProof uint32)
 	GetParsingByTag(tag spectypes.FUNCTION_TAG) (parsing *spectypes.ParseDirective, apiCollection *spectypes.ApiCollection, existed bool)
+	GetParsingByTagForCollection(tag spectypes.FUNCTION_TAG, addons []string, internalPath string) (parsing *spectypes.ParseDirective, apiCollection *spectypes.ApiCollection, existed bool)
 	IsTagInCollection(tag spectypes.FUNCTION_TAG, collectionKey CollectionKey) bool
 	GetAllInternalPaths() []string
 	IsInternalPathEnabled(internalPath string, apiInterface string, addon string) bool

--- a/protocol/chainlib/chainlib_mock.go
+++ b/protocol/chainlib/chainlib_mock.go
@@ -165,9 +165,9 @@ func (mr *MockChainParserMockRecorder) GetParsingByTag(tag interface{}) *gomock.
 }
 
 // GetParsingByTagForCollection mocks base method.
-func (m *MockChainParser) GetParsingByTagForCollection(tag spec.FUNCTION_TAG, addons []string, internalPath string) (*spec.ParseDirective, *spec.ApiCollection, bool) {
+func (m *MockChainParser) GetParsingByTagForCollection(tag spec.FUNCTION_TAG, addons []string, internalPath string, allowBaseFallback bool) (*spec.ParseDirective, *spec.ApiCollection, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetParsingByTagForCollection", tag, addons, internalPath)
+	ret := m.ctrl.Call(m, "GetParsingByTagForCollection", tag, addons, internalPath, allowBaseFallback)
 	ret0, _ := ret[0].(*spec.ParseDirective)
 	ret1, _ := ret[1].(*spec.ApiCollection)
 	ret2, _ := ret[2].(bool)
@@ -175,9 +175,9 @@ func (m *MockChainParser) GetParsingByTagForCollection(tag spec.FUNCTION_TAG, ad
 }
 
 // GetParsingByTagForCollection indicates an expected call of GetParsingByTagForCollection.
-func (mr *MockChainParserMockRecorder) GetParsingByTagForCollection(tag, addons, internalPath interface{}) *gomock.Call {
+func (mr *MockChainParserMockRecorder) GetParsingByTagForCollection(tag, addons, internalPath, allowBaseFallback interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParsingByTagForCollection", reflect.TypeOf((*MockChainParser)(nil).GetParsingByTagForCollection), tag, addons, internalPath)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParsingByTagForCollection", reflect.TypeOf((*MockChainParser)(nil).GetParsingByTagForCollection), tag, addons, internalPath, allowBaseFallback)
 }
 
 // GetUniqueName mocks base method.

--- a/protocol/chainlib/chainlib_mock.go
+++ b/protocol/chainlib/chainlib_mock.go
@@ -164,6 +164,22 @@ func (mr *MockChainParserMockRecorder) GetParsingByTag(tag interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParsingByTag", reflect.TypeOf((*MockChainParser)(nil).GetParsingByTag), tag)
 }
 
+// GetParsingByTagForCollection mocks base method.
+func (m *MockChainParser) GetParsingByTagForCollection(tag spec.FUNCTION_TAG, addons []string, internalPath string) (*spec.ParseDirective, *spec.ApiCollection, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetParsingByTagForCollection", tag, addons, internalPath)
+	ret0, _ := ret[0].(*spec.ParseDirective)
+	ret1, _ := ret[1].(*spec.ApiCollection)
+	ret2, _ := ret[2].(bool)
+	return ret0, ret1, ret2
+}
+
+// GetParsingByTagForCollection indicates an expected call of GetParsingByTagForCollection.
+func (mr *MockChainParserMockRecorder) GetParsingByTagForCollection(tag, addons, internalPath interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParsingByTagForCollection", reflect.TypeOf((*MockChainParser)(nil).GetParsingByTagForCollection), tag, addons, internalPath)
+}
+
 // GetUniqueName mocks base method.
 func (m *MockChainParser) GetUniqueName() string {
 	m.ctrl.T.Helper()

--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -121,6 +121,27 @@ type NodeUrl struct {
 	Addons            []string      `yaml:"addons,omitempty" json:"addons,omitempty" mapstructure:"addons"`
 	SkipVerifications []string      `yaml:"skip-verifications,omitempty" json:"skip-verifications,omitempty" mapstructure:"skip-verifications"`
 	Methods           []string      `yaml:"methods,omitempty" json:"methods,omitempty" mapstructure:"methods"`
+	// StandaloneAddons declares that this url serves ONLY the collections its
+	// `addons` name, instead of those plus the spec's base collection.
+	//
+	// It exists because a spec's add-on can mean either of two things and the
+	// spec model cannot tell them apart. Usually an add-on EXTENDS the base
+	// surface — an archive node still answers everything a full node does — and
+	// inheriting the base collection's verifications is right. But Acala,
+	// Litentry/Heima and peaq use an add-on as a DISJOINT surface: Substrate in
+	// the base collection, EVM in an `evm` add-on, served by different
+	// infrastructure with no method in common. There, inheriting the base
+	// collection asks the node to be something it never claimed to be, and the
+	// resulting failure costs the provider its place (MAG-3296).
+	//
+	// Default false, so every existing deployment keeps inheriting. Only an
+	// operator knows which of the two a given url is, which is why this is
+	// configuration and not inference — until the spec model can say it, at
+	// which point this becomes redundant rather than wrong.
+	//
+	// Ignored on a url that declares no addons: there would be nothing left to
+	// serve.
+	StandaloneAddons bool `yaml:"standalone-addons,omitempty" json:"standalone-addons,omitempty" mapstructure:"standalone-addons"`
 	// GrpcConfig holds gRPC-specific configuration for direct gRPC connections (smart router)
 	GrpcConfig GrpcConfig `yaml:"grpc-config,omitempty" json:"grpc-config,omitempty" mapstructure:"grpc-config"`
 }
@@ -142,6 +163,13 @@ const SkipVerificationsWildcard = "*"
 func (nurl NodeUrl) ShouldSkipVerification(name string) bool {
 	return slices.Contains(nurl.SkipVerifications, SkipVerificationsWildcard) ||
 		slices.Contains(nurl.SkipVerifications, name)
+}
+
+// ServesBaseCollection reports whether this url answers for the spec's base
+// collection in addition to whatever its addons name. True for every url that
+// has not opted out — see StandaloneAddons.
+func (nurl NodeUrl) ServesBaseCollection() bool {
+	return !nurl.StandaloneAddons || len(nurl.Addons) == 0
 }
 
 type ChainMessageGetApiInterface interface {

--- a/protocol/endpointstate/endpoint_poller.go
+++ b/protocol/endpointstate/endpoint_poller.go
@@ -140,7 +140,7 @@ func (ecf *EndpointPoller) FetchLatestBlockNum(ctx context.Context) (blockNum in
 		ecf.ObserveLatestBlockPoll(blockNum, pollLatency, err)
 	}()
 
-	parsing, apiCollection, ok := ecf.chainParser.GetParsingByTagForCollection(spectypes.FUNCTION_TAG_GET_BLOCKNUM, ecf.collectionAddons(), ecf.endpoint.InternalPath)
+	parsing, apiCollection, ok := ecf.chainParser.GetParsingByTagForCollection(spectypes.FUNCTION_TAG_GET_BLOCKNUM, ecf.collectionAddons(), ecf.endpoint.InternalPath, ecf.endpoint.ServesBaseCollection())
 	tagName := spectypes.FUNCTION_TAG_GET_BLOCKNUM.String()
 	if !ok {
 		return spectypes.NOT_APPLICABLE, utils.LavaFormatError(tagName+" tag function not found", nil,
@@ -231,7 +231,7 @@ func (ecf *EndpointPoller) FetchLatestBlockNum(ctx context.Context) (blockNum in
 // This handles both propagation delays (the latest slot data hasn't reached the
 // node yet) and skipped slots (Solana occasionally produces no block for a slot).
 func (ecf *EndpointPoller) FetchBlockHashByNum(ctx context.Context, blockNum int64) (string, error) {
-	parsing, apiCollection, ok := ecf.chainParser.GetParsingByTagForCollection(spectypes.FUNCTION_TAG_GET_BLOCK_BY_NUM, ecf.collectionAddons(), ecf.endpoint.InternalPath)
+	parsing, apiCollection, ok := ecf.chainParser.GetParsingByTagForCollection(spectypes.FUNCTION_TAG_GET_BLOCK_BY_NUM, ecf.collectionAddons(), ecf.endpoint.InternalPath, ecf.endpoint.ServesBaseCollection())
 	tagName := spectypes.FUNCTION_TAG_GET_BLOCK_BY_NUM.String()
 	if !ok {
 		return "", utils.LavaFormatError(tagName+" tag function not found", nil,

--- a/protocol/endpointstate/endpoint_poller.go
+++ b/protocol/endpointstate/endpoint_poller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
 	"sync/atomic"
 	"time"
 
@@ -105,6 +106,27 @@ func (ecf *EndpointPoller) hydrateGrpcChainMessage(chainMessage chainlib.ChainMe
 	return chainlib.HydrateGrpcResponseParsing(chainMessage, methodDesc)
 }
 
+// collectionAddons returns this endpoint's declared add-ons, so the head poll and
+// the fork check ask for the directives of the collection the node actually serves
+// rather than the base collection's (MAG-3296).
+//
+// Sorted, because Endpoint.Addons is a map and an unsorted range would let two
+// polls of the same endpoint pick different collections when a node declares more
+// than one add-on carrying the tag. Which collection wins matters less than it
+// being the same one every time — an alternating tip source reads as a flapping
+// node.
+func (ecf *EndpointPoller) collectionAddons() []string {
+	if ecf.endpoint == nil || len(ecf.endpoint.Addons) == 0 {
+		return nil
+	}
+	addons := make([]string, 0, len(ecf.endpoint.Addons))
+	for addon := range ecf.endpoint.Addons {
+		addons = append(addons, addon)
+	}
+	sort.Strings(addons)
+	return addons
+}
+
 // FetchLatestBlockNum fetches the latest block number from the endpoint.
 // Uses spec-driven parsing to support any chain type (EVM, Tendermint, REST, etc.).
 func (ecf *EndpointPoller) FetchLatestBlockNum(ctx context.Context) (blockNum int64, err error) {
@@ -118,7 +140,7 @@ func (ecf *EndpointPoller) FetchLatestBlockNum(ctx context.Context) (blockNum in
 		ecf.ObserveLatestBlockPoll(blockNum, pollLatency, err)
 	}()
 
-	parsing, apiCollection, ok := ecf.chainParser.GetParsingByTag(spectypes.FUNCTION_TAG_GET_BLOCKNUM)
+	parsing, apiCollection, ok := ecf.chainParser.GetParsingByTagForCollection(spectypes.FUNCTION_TAG_GET_BLOCKNUM, ecf.collectionAddons(), ecf.endpoint.InternalPath)
 	tagName := spectypes.FUNCTION_TAG_GET_BLOCKNUM.String()
 	if !ok {
 		return spectypes.NOT_APPLICABLE, utils.LavaFormatError(tagName+" tag function not found", nil,
@@ -209,7 +231,7 @@ func (ecf *EndpointPoller) FetchLatestBlockNum(ctx context.Context) (blockNum in
 // This handles both propagation delays (the latest slot data hasn't reached the
 // node yet) and skipped slots (Solana occasionally produces no block for a slot).
 func (ecf *EndpointPoller) FetchBlockHashByNum(ctx context.Context, blockNum int64) (string, error) {
-	parsing, apiCollection, ok := ecf.chainParser.GetParsingByTag(spectypes.FUNCTION_TAG_GET_BLOCK_BY_NUM)
+	parsing, apiCollection, ok := ecf.chainParser.GetParsingByTagForCollection(spectypes.FUNCTION_TAG_GET_BLOCK_BY_NUM, ecf.collectionAddons(), ecf.endpoint.InternalPath)
 	tagName := spectypes.FUNCTION_TAG_GET_BLOCK_BY_NUM.String()
 	if !ok {
 		return "", utils.LavaFormatError(tagName+" tag function not found", nil,

--- a/protocol/endpointstate/endpoint_poller_addons_test.go
+++ b/protocol/endpointstate/endpoint_poller_addons_test.go
@@ -1,0 +1,46 @@
+package endpointstate
+
+import (
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCollectionAddonsIsSortedAndStable covers the input the head poll and the
+// fork check hand to the collection-scoped directive lookup (MAG-3296).
+//
+// Endpoint.Addons is a map, so ranging it directly would order differently per
+// call. Where a node declares two add-ons that both carry GET_BLOCKNUM, that
+// would let consecutive polls of the SAME endpoint read the head from different
+// collections — which surfaces as an endpoint whose tip jumps rather than as a
+// configuration problem anyone could see.
+func TestCollectionAddonsIsSortedAndStable(t *testing.T) {
+	poller := &EndpointPoller{
+		endpoint: &lavasession.Endpoint{
+			Addons: map[string]struct{}{
+				"evm":     {},
+				"archive": {},
+				"txpool":  {},
+			},
+		},
+	}
+
+	want := []string{"archive", "evm", "txpool"}
+	for i := 0; i < 200; i++ {
+		require.Equal(t, want, poller.collectionAddons())
+	}
+}
+
+func TestCollectionAddonsEmptyCases(t *testing.T) {
+	t.Run("no addons", func(t *testing.T) {
+		poller := &EndpointPoller{endpoint: &lavasession.Endpoint{}}
+		require.Nil(t, poller.collectionAddons(),
+			"an empty set must resolve to the base collection, not to no collection")
+	})
+
+	t.Run("nil endpoint", func(t *testing.T) {
+		poller := &EndpointPoller{}
+		require.Nil(t, poller.collectionAddons())
+	})
+}

--- a/protocol/lavasession/consumer_types.go
+++ b/protocol/lavasession/consumer_types.go
@@ -225,6 +225,12 @@ type Endpoint struct {
 	relayProbeAttempts uint64
 	Addons             map[string]struct{}
 	Extensions         map[string]struct{}
+	// StandaloneAddons mirrors common.NodeUrl.StandaloneAddons: this endpoint
+	// serves ONLY the collections its Addons name, not those plus the base one.
+	// Set for a url whose add-on REPLACES the base api surface rather than
+	// extending it — Acala's `evm` against a Substrate base. It keeps
+	// base-collection traffic off an endpoint that cannot answer it (MAG-3296).
+	StandaloneAddons bool
 	// InternalPath is the spec collection this endpoint's url serves — "/v2",
 	// "/P", or "" for the root. It mirrors the chain router's own per-path
 	// proxies (chainlib/chain_router.go): a node-url declaring `internal-path`
@@ -311,8 +317,23 @@ func (e *Endpoint) IsProviderRelay() bool {
 	return len(e.Connections) > 0
 }
 
+// ServesBaseCollection reports whether this endpoint answers for the spec's base
+// collection as well as its add-ons. Mirrors common.NodeUrl.ServesBaseCollection,
+// from which it is populated. See StandaloneAddons.
+func (e *Endpoint) ServesBaseCollection() bool {
+	return !e.StandaloneAddons || len(e.Addons) == 0
+}
+
 func (e *Endpoint) CheckSupportForServices(addon string, extensions []string) (supported bool) {
-	if addon != "" {
+	if addon == "" {
+		// The base collection is not automatically everybody's. An endpoint whose
+		// add-ons REPLACE the base surface rather than extending it cannot serve a
+		// base-collection request at all — routing one to an EVM-only Acala node
+		// gets a -32601 the client reads as a verdict on its request (MAG-3296).
+		if !e.ServesBaseCollection() {
+			return false
+		}
+	} else {
 		if _, ok := e.Addons[addon]; !ok {
 			return false
 		}
@@ -839,7 +860,15 @@ func (cswp *ConsumerSessionsWithProvider) IsSupportingAddon(addon string) bool {
 	cswp.Lock.RLock()
 	defer cswp.Lock.RUnlock()
 	if addon == "" {
-		return true
+		// Not unconditionally true: a provider every one of whose endpoints has
+		// opted out of the base collection cannot serve a base-collection request
+		// (MAG-3296). A provider with any ordinary endpoint still can.
+		for _, endpoint := range cswp.Endpoints {
+			if endpoint.ServesBaseCollection() {
+				return true
+			}
+		}
+		return false
 	}
 	for _, endpoint := range cswp.Endpoints {
 		if _, ok := endpoint.Addons[addon]; ok {

--- a/protocol/lavasession/standalone_addons_routing_test.go
+++ b/protocol/lavasession/standalone_addons_routing_test.go
@@ -81,3 +81,36 @@ func TestIsSupportingAddon_StandaloneAddons(t *testing.T) {
 		require.True(t, cswp.IsSupportingExtensions([]string{"evm"}, context.Background()))
 	})
 }
+
+// TestStandaloneAddonsOnAnExtensionOnlyUrlServesNothing pins WHY the boot path
+// downgrades standalone-addons on a url that names no add-on collection.
+//
+// Endpoint.Addons and Endpoint.Extensions are both populated from the same raw
+// config list, which mixes the two. So for `addons: ["archive"],
+// standalone-addons: true` the endpoint would be eligible for nothing at all:
+// extension traffic carries addon "" with the extension in a separate slice, and
+// the base check fails before the extension loop is ever reached. Admission
+// passes — there are no verifications to fail — so a config typo yields a
+// silently dead endpoint. rpcsmartrouter.go downgrades the flag and warns.
+func TestStandaloneAddonsOnAnExtensionOnlyUrlServesNothing(t *testing.T) {
+	extensionOnly := &Endpoint{
+		NetworkAddress:   "https://archive.example.com",
+		Enabled:          true,
+		Addons:           map[string]struct{}{"archive": {}},
+		Extensions:       map[string]struct{}{"archive": {}},
+		StandaloneAddons: true,
+	}
+
+	require.False(t, extensionOnly.CheckSupportForServices("", []string{"archive"}),
+		"archive traffic carries addon \"\", so the opt-out refuses it")
+	require.False(t, extensionOnly.CheckSupportForServices("", nil),
+		"and plain traffic too — the endpoint would serve nothing")
+
+	// Which is why the flag is downgraded before the endpoint is built. Same
+	// endpoint without it serves both, which is the behaviour an operator who
+	// wrote `addons: [archive]` expects.
+	downgraded := *extensionOnly
+	downgraded.StandaloneAddons = false
+	require.True(t, downgraded.CheckSupportForServices("", []string{"archive"}))
+	require.True(t, downgraded.CheckSupportForServices("", nil))
+}

--- a/protocol/lavasession/standalone_addons_routing_test.go
+++ b/protocol/lavasession/standalone_addons_routing_test.go
@@ -1,0 +1,83 @@
+package lavasession
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// MAG-3296, the routing half. Admitting a provider whose add-on REPLACES the base
+// api surface is only half the job: base-collection traffic must then stay off it.
+// Both eligibility checks used to treat addon "" as universally served, so an
+// EVM-only Acala endpoint was eligible for Substrate requests and answered -32601
+// — which the client reads as a verdict on its request rather than on routing.
+
+func standaloneEndpoint() *Endpoint {
+	return &Endpoint{
+		NetworkAddress:   "https://eth-rpc-acala.aca-api.network",
+		Enabled:          true,
+		Addons:           map[string]struct{}{"evm": {}},
+		Extensions:       map[string]struct{}{"evm": {}},
+		StandaloneAddons: true,
+	}
+}
+
+func baseEndpoint() *Endpoint {
+	return &Endpoint{
+		NetworkAddress: "https://acala-rpc.aca-api.network",
+		Enabled:        true,
+		Addons:         map[string]struct{}{},
+		Extensions:     map[string]struct{}{},
+	}
+}
+
+func TestEndpointCheckSupportForServices_StandaloneAddons(t *testing.T) {
+	standalone := standaloneEndpoint()
+	require.True(t, standalone.CheckSupportForServices("evm", nil),
+		"it serves the add-on it declares")
+	require.False(t, standalone.CheckSupportForServices("", nil),
+		"it must not be offered base-collection traffic it cannot answer")
+
+	base := baseEndpoint()
+	require.True(t, base.CheckSupportForServices("", nil),
+		"an ordinary endpoint still serves the base collection")
+	require.False(t, base.CheckSupportForServices("evm", nil))
+
+	// The default is unchanged: an add-on endpoint that has NOT opted out still
+	// answers for the base collection, which is right when the add-on extends it.
+	inheriting := standaloneEndpoint()
+	inheriting.StandaloneAddons = false
+	require.True(t, inheriting.CheckSupportForServices("", nil))
+
+	// The flag is inert without add-ons — there would be nothing left to serve.
+	empty := &Endpoint{StandaloneAddons: true, Addons: map[string]struct{}{}}
+	require.True(t, empty.CheckSupportForServices("", nil))
+}
+
+func TestIsSupportingAddon_StandaloneAddons(t *testing.T) {
+	t.Run("a provider with only standalone endpoints cannot serve base", func(t *testing.T) {
+		cswp := &ConsumerSessionsWithProvider{Endpoints: []*Endpoint{standaloneEndpoint()}}
+		require.True(t, cswp.IsSupportingAddon("evm"))
+		require.False(t, cswp.IsSupportingAddon(""))
+	})
+
+	t.Run("one ordinary endpoint is enough to serve base", func(t *testing.T) {
+		cswp := &ConsumerSessionsWithProvider{Endpoints: []*Endpoint{standaloneEndpoint(), baseEndpoint()}}
+		require.True(t, cswp.IsSupportingAddon(""))
+		require.True(t, cswp.IsSupportingAddon("evm"))
+	})
+
+	t.Run("the default is unchanged", func(t *testing.T) {
+		e := standaloneEndpoint()
+		e.StandaloneAddons = false
+		cswp := &ConsumerSessionsWithProvider{Endpoints: []*Endpoint{e}}
+		require.True(t, cswp.IsSupportingAddon(""), "every existing deployment keeps serving base")
+	})
+
+	// Extensions are a separate axis and must not be affected by the addon opt-out.
+	t.Run("extension support is untouched", func(t *testing.T) {
+		cswp := &ConsumerSessionsWithProvider{Endpoints: []*Endpoint{standaloneEndpoint()}}
+		require.True(t, cswp.IsSupportingExtensions([]string{"evm"}, context.Background()))
+	})
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -2434,6 +2434,30 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 					extensions[extension] = struct{}{}
 				}
 
+				// standalone-addons only means anything for a url that declares an
+				// actual add-on COLLECTION. Addons here is the raw config list, which
+				// mixes add-ons and extensions, and Endpoint.Addons/.Extensions are
+				// both populated from it above. So on a url whose entries are all
+				// extension names the opt-out would make the endpoint eligible for
+				// nothing at all: extension traffic carries addon "" with the
+				// extension in a separate slice, and CheckSupportForServices would
+				// fail the base check before reaching the extension loop. Admission
+				// passes (no verifications), and the endpoint silently serves no
+				// traffic — a config typo with no diagnostic.
+				standaloneAddons := url.StandaloneAddons
+				if standaloneAddons {
+					declaredAddons, _, sepErr := chainParser.SeparateAddonsExtensions(ctx, url.Addons)
+					if sepErr != nil || len(declaredAddons) == 0 {
+						utils.LavaFormatWarning("ignoring standalone-addons: url declares no add-on collection", sepErr,
+							utils.LogAttr("url", url.Url),
+							utils.LogAttr("addons", url.Addons),
+							utils.LogAttr("provider", provider.Name),
+							utils.LogAttr("hint", "standalone-addons names add-on collections; extension names belong in addons but do not opt a url out of the base collection"),
+						)
+						standaloneAddons = false
+					}
+				}
+
 				// Create DirectRPCConnection for smart router (direct mode)
 				// Use default parallel connections for HTTP connection pooling
 				// Pass ApiInterface for proper protocol detection (bare host:port → gRPC when interface is gRPC)
@@ -2465,8 +2489,9 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 					Extensions:     extensions,
 					// Carry the url's opt-out through, so session selection keeps
 					// base-collection traffic off an endpoint that only serves its
-					// add-ons (MAG-3296).
-					StandaloneAddons:  url.StandaloneAddons,
+					// add-ons (MAG-3296). Downgraded to false above for a url that
+					// names no add-on collection.
+					StandaloneAddons:  standaloneAddons,
 					InternalPath:      url.InternalPath,
 					Connections:       nil,
 					DirectConnections: []lavasession.DirectRPCConnection{directConn}, // Smart router uses direct RPC

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -2459,10 +2459,14 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 				createdConnections = append(createdConnections, directConn)
 
 				endpoint := &lavasession.Endpoint{
-					NetworkAddress:    url.Url,
-					Enabled:           true,
-					Addons:            extensions,
-					Extensions:        extensions,
+					NetworkAddress: url.Url,
+					Enabled:        true,
+					Addons:         extensions,
+					Extensions:     extensions,
+					// Carry the url's opt-out through, so session selection keeps
+					// base-collection traffic off an endpoint that only serves its
+					// add-ons (MAG-3296).
+					StandaloneAddons:  url.StandaloneAddons,
 					InternalPath:      url.InternalPath,
 					Connections:       nil,
 					DirectConnections: []lavasession.DirectRPCConnection{directConn}, // Smart router uses direct RPC

--- a/protocol/rpcsmartrouter/spec_reverifier.go
+++ b/protocol/rpcsmartrouter/spec_reverifier.go
@@ -538,7 +538,7 @@ func validateProvider(
 	chainParser chainlib.ChainParser,
 	timeout time.Duration,
 ) error {
-	routerEndpoint, verificationEndpoint := verificationEndpoints(provider)
+	routerEndpoint, fetcherEndpoint := verificationEndpoints(provider)
 
 	attemptCtx, attemptCancel := context.WithTimeout(ctx, timeout)
 	defer attemptCancel()
@@ -560,7 +560,7 @@ func validateProvider(
 	verificationFetcher := chainlib.NewChainFetcher(attemptCtx, &chainlib.ChainFetcherOptions{
 		ChainRouter: verificationRouter,
 		ChainParser: validationParser,
-		Endpoint:    verificationEndpoint,
+		Endpoint:    fetcherEndpoint,
 		Cache:       nil,
 	})
 

--- a/protocol/rpcsmartrouter/spec_reverifier.go
+++ b/protocol/rpcsmartrouter/spec_reverifier.go
@@ -496,30 +496,49 @@ func validateProviderTier(
 // It builds a fresh ChainRouter + ChainFetcher under a bounded attempt context
 // (so a hung upstream cannot stall a whole reconcile cycle), calls Validate,
 // and tears the temporary resources down regardless of outcome.
+// verificationEndpoints splits the two endpoints a validation attempt needs.
+//
+// The ROUTER one expands every add-on url into a with-addon and a without-addon
+// route, the same way startup PHASE 1 does, because chain_router.go requires both
+// for routing flexibility.
+//
+// The FETCHER one carries only the urls the provider actually declared. The
+// stripped copies are a routing artifact, not a claim the provider made, and
+// MAG-3296 is what validating them costs: it makes every add-on node answer for
+// the base collection as well. Where an add-on extends the base surface that is
+// merely redundant; where it REPLACES it — Acala's `evm` against a Substrate base
+// — the stripped copy asks a question the node cannot answer. Validate returns on
+// the first failing url, so the copy's verdict became the provider's verdict and
+// an EVM-only node was dropped for failing to be a Substrate node.
+func verificationEndpoints(provider *lavasession.RPCStaticProviderEndpoint) (routerEndpoint, fetcherEndpoint *lavasession.RPCProviderEndpoint) {
+	routedNodeUrls := make([]common.NodeUrl, 0, len(provider.NodeUrls)*2)
+	for _, nodeUrl := range provider.NodeUrls {
+		routedNodeUrls = append(routedNodeUrls, nodeUrl)
+		if len(nodeUrl.Addons) > 0 {
+			noAddonUrl := nodeUrl
+			noAddonUrl.Addons = []string{}
+			routedNodeUrls = append(routedNodeUrls, noAddonUrl)
+		}
+	}
+
+	newEndpoint := func(nodeUrls []common.NodeUrl) *lavasession.RPCProviderEndpoint {
+		return &lavasession.RPCProviderEndpoint{
+			NetworkAddress: provider.NetworkAddress,
+			ChainID:        provider.ChainID,
+			ApiInterface:   provider.ApiInterface,
+			NodeUrls:       nodeUrls,
+		}
+	}
+	return newEndpoint(routedNodeUrls), newEndpoint(provider.NodeUrls)
+}
+
 func validateProvider(
 	ctx context.Context,
 	provider *lavasession.RPCStaticProviderEndpoint,
 	chainParser chainlib.ChainParser,
 	timeout time.Duration,
 ) error {
-	// Expand addon URLs the same way startup PHASE 1 does — chain_router.go
-	// requires both with-addon and without-addon routes for routing flexibility.
-	verificationNodeUrls := make([]common.NodeUrl, 0, len(provider.NodeUrls)*2)
-	for _, nodeUrl := range provider.NodeUrls {
-		verificationNodeUrls = append(verificationNodeUrls, nodeUrl)
-		if len(nodeUrl.Addons) > 0 {
-			noAddonUrl := nodeUrl
-			noAddonUrl.Addons = []string{}
-			verificationNodeUrls = append(verificationNodeUrls, noAddonUrl)
-		}
-	}
-
-	verificationEndpoint := &lavasession.RPCProviderEndpoint{
-		NetworkAddress: provider.NetworkAddress,
-		ChainID:        provider.ChainID,
-		ApiInterface:   provider.ApiInterface,
-		NodeUrls:       verificationNodeUrls,
-	}
+	routerEndpoint, verificationEndpoint := verificationEndpoints(provider)
 
 	attemptCtx, attemptCancel := context.WithTimeout(ctx, timeout)
 	defer attemptCancel()
@@ -533,7 +552,7 @@ func validateProvider(
 	validationParser := chainlib.CloneChainParserForValidation(chainParser)
 
 	parallelConnections := uint(lavasession.DefaultMaximumStreamsOverASingleConnection)
-	verificationRouter, err := chainlib.GetChainRouter(attemptCtx, parallelConnections, verificationEndpoint, validationParser)
+	verificationRouter, err := chainlib.GetChainRouter(attemptCtx, parallelConnections, routerEndpoint, validationParser)
 	if err != nil {
 		return err
 	}

--- a/protocol/rpcsmartrouter/spec_reverifier_addon_urls_test.go
+++ b/protocol/rpcsmartrouter/spec_reverifier_addon_urls_test.go
@@ -1,0 +1,71 @@
+package rpcsmartrouter
+
+import (
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVerificationEndpointsDoNotValidateStrippedCopies is the MAG-3296 half that
+// lives in the re-verifier: an add-on node url is duplicated with its add-ons
+// stripped so the chain router has both routes, and that copy used to be
+// validated too. For a disjoint add-on surface — Acala's EVM against a Substrate
+// base — the copy asks the node to be something it never claimed to be, and
+// Validate returns on the first failing url, so the copy failed the provider.
+func TestVerificationEndpointsDoNotValidateStrippedCopies(t *testing.T) {
+	provider := &lavasession.RPCStaticProviderEndpoint{
+		NetworkAddress: lavasession.NetworkAddressData{Address: "acala-evm:443"},
+		ChainID:        "ACA",
+		ApiInterface:   "jsonrpc",
+		NodeUrls: []common.NodeUrl{
+			{Url: "https://eth-rpc-acala.aca-api.network", Addons: []string{"evm"}},
+			{Url: "https://plain.example.com"},
+		},
+	}
+
+	routerEndpoint, fetcherEndpoint := verificationEndpoints(provider)
+
+	// The router still gets both routes for the add-on url — that expansion is
+	// what chain_router.go needs and is not what this fix changes.
+	require.Len(t, routerEndpoint.NodeUrls, 3)
+	require.Equal(t, []string{"evm"}, routerEndpoint.NodeUrls[0].Addons)
+	require.Empty(t, routerEndpoint.NodeUrls[1].Addons,
+		"the stripped copy is still routed")
+	require.Equal(t, "https://eth-rpc-acala.aca-api.network", routerEndpoint.NodeUrls[1].Url)
+
+	// The fetcher validates only what the provider declared.
+	require.Len(t, fetcherEndpoint.NodeUrls, 2)
+	require.Equal(t, provider.NodeUrls, fetcherEndpoint.NodeUrls)
+	for _, url := range fetcherEndpoint.NodeUrls {
+		if url.Url == "https://eth-rpc-acala.aca-api.network" {
+			require.Equal(t, []string{"evm"}, url.Addons,
+				"the declared url keeps its add-ons, so its collections resolve")
+		}
+	}
+
+	// Identity is preserved on both, since the two differ only in node urls.
+	for _, endpoint := range []*lavasession.RPCProviderEndpoint{routerEndpoint, fetcherEndpoint} {
+		require.Equal(t, provider.NetworkAddress, endpoint.NetworkAddress)
+		require.Equal(t, provider.ChainID, endpoint.ChainID)
+		require.Equal(t, provider.ApiInterface, endpoint.ApiInterface)
+	}
+}
+
+// TestVerificationEndpointsWithoutAddonsAreIdentical pins that a provider with no
+// add-ons is unaffected — nothing is expanded, so nothing is dropped either.
+func TestVerificationEndpointsWithoutAddonsAreIdentical(t *testing.T) {
+	provider := &lavasession.RPCStaticProviderEndpoint{
+		ChainID:      "ETH1",
+		ApiInterface: "jsonrpc",
+		NodeUrls: []common.NodeUrl{
+			{Url: "https://a.example.com"},
+			{Url: "https://b.example.com"},
+		},
+	}
+
+	routerEndpoint, fetcherEndpoint := verificationEndpoints(provider)
+	require.Equal(t, provider.NodeUrls, routerEndpoint.NodeUrls)
+	require.Equal(t, provider.NodeUrls, fetcherEndpoint.NodeUrls)
+}

--- a/protocol/rpcsmartrouter/standalone_addons_config_test.go
+++ b/protocol/rpcsmartrouter/standalone_addons_config_test.go
@@ -1,0 +1,53 @@
+package rpcsmartrouter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStandaloneAddonsParsesFromConfig proves the MAG-3296 flag survives the real
+// config path — viper.UnmarshalKey into []*RPCStaticProviderEndpoint, the same
+// call the router boots through. A field whose mapstructure tag did not match
+// would decode as false and drop the provider with no error anywhere, so this is
+// the assertion that makes the flag usable rather than merely present.
+func TestStandaloneAddonsParsesFromConfig(t *testing.T) {
+	const config = `
+endpoints:
+  - chain-id: ACA
+    api-interface: jsonrpc
+    name: acala-evm
+    network-address:
+      address: 127.0.0.1:2201
+    node-urls:
+      - url: https://eth-rpc-acala.aca-api.network
+        addons: ["evm"]
+        standalone-addons: true
+        skip-verifications: ["pruning"]
+      - url: https://substrate.example.com
+`
+
+	v := viper.New()
+	v.SetConfigType("yaml")
+	require.NoError(t, v.ReadConfig(strings.NewReader(config)))
+
+	endpoints, err := ParseStaticProviderEndpoints(v, "endpoints")
+	require.NoError(t, err)
+	require.Len(t, endpoints, 1)
+	require.Len(t, endpoints[0].NodeUrls, 2)
+
+	evmUrl := endpoints[0].NodeUrls[0]
+	require.True(t, evmUrl.StandaloneAddons, "standalone-addons must survive config load")
+	require.Equal(t, []string{"evm"}, evmUrl.Addons)
+	require.False(t, evmUrl.ServesBaseCollection(),
+		"an EVM-only Acala url must not answer for the Substrate base collection")
+	// The neighbouring field is asserted too, so a tag-name regression on either
+	// one shows up here rather than as a provider that silently fails admission.
+	require.True(t, evmUrl.ShouldSkipVerification("pruning"))
+
+	plainUrl := endpoints[0].NodeUrls[1]
+	require.False(t, plainUrl.StandaloneAddons, "the default is unchanged")
+	require.True(t, plainUrl.ServesBaseCollection())
+}


### PR DESCRIPTION
# Description

A provider serving only an add-on collection could not be admitted. Acala splits its two api surfaces across collections — Substrate in the base one, EVM in an `evm` add-on — and an EVM-only node was excluded outright at admission, before a single one of the verifications it *could* pass had run. Not Acala-specific: Litentry/Heima (`lit.json`) and peaq (`peaq.json`) carry the same two-collection shape.

The ticket inferred the cause from observed behaviour and asked for it to be confirmed against the source. It is confirmed, and there were **five** gates rather than one. Gates 1-3 are the same root cause in different places; gates 4 and 5 are the same modelling assumption on the verification and routing sides.

`taggedApis` holds exactly **one** parse directive per function tag — the first collection to declare it, which for a spec written base-first is the base collection. So `GetParsingByTag` answers *"the base collection's directive"* no matter who is asking.

| | Gate | Fix |
|---|---|---|
| 1 | Both head probes went through `GetParsingByTag`, so every node was asked the base collection's `GET_BLOCKNUM`. An EVM-only Acala node cannot answer `chain_getHeader`, returns `-32601`, and `Validate` returns on a failed head probe **before** reaching the verification loop. | `GetParsingByTagForCollection` resolves from the collections a node actually serves, falling back to the base answer when it declares no add-ons or none carries the tag — so nothing changes for any existing chain. Wired into `ChainFetcher`'s probe (admission + `smartrouter health`) **and** `EndpointPoller`'s (live per-endpoint tip + fork check). |
| 2 | The re-verifier validated the addon-stripped URL copies it creates for the chain router, asking an EVM-only node to be a Substrate node. `Validate` returns on the first failing url, so the copy's verdict was the provider's verdict. | The expanded list goes to the router only; the fetcher validates the urls the provider actually declared. |
| 3 | A verification that names a tag instead of carrying its own template borrowed its directive from `taggedApis`. Acala's `evm` `pruning` is declared as nothing but `{"function_tag": "GET_EARLIEST_BLOCK"}`, so the one check meant to validate an EVM node's history was rewritten into a Substrate call. | Borrow from the verification's own collection first, `taggedApis` as fallback so the ordinary case (e.g. ASTAR's `txpool`) resolves exactly as before. |
| 4 | `GetVerifications` appends the empty addon unconditionally, so every node runs the base collection's verifications too. Acala's base `chain-id` fires `chain_getBlockHash` at an EVM node. **Every `severity` in `aca.json` is omitted and an omitted severity is `Fail`** (`ParseValue_Fail = 0`), so one inherited verification excluded the provider. | New per-node-url `standalone-addons: true`. |
| 5 | Admitting the provider was only half the job. `CheckSupportForServices` filtered only on a non-empty addon and `IsSupportingAddon` returned true outright for `""`, so an EVM-only endpoint became eligible for **Substrate** traffic and answered `-32601` — which a client reads as a verdict on its request. Found by running a mixed deployment against a router built from this branch. | `Endpoint` carries the url's opt-out; both checks ask `ServesBaseCollection()`. A provider still serves base while **one** of its endpoints is ordinary. |

**Why gate 4 needed a config flag rather than existing config.** `skip-verifications` cannot express the exception: it matches on the verification **name alone**, and both Acala collections name theirs `chain-id`, so suppressing the Substrate check also suppresses the `evm` `0x313` one — the only check that actually validates the node. `standalone-addons: true` says "this url serves only the collections its `addons` name". Default false, so every existing deployment is untouched; ignored on a url with no addons. An add-on can mean *extends the base surface* (archive) or *replaces it* (Acala/Litentry/peaq) and the spec model cannot currently tell them apart — only an operator knows which a given url is. When the spec model can say it, this flag becomes redundant rather than wrong.

The gate-4 filter runs **before** `needsLatestBlock`, for the same reason the `skip-verifications` filter already does: a verification that is not going to run must not drag a head probe out to the upstream on its way past.

### The result, traced against the real `aca.json` (lava-specs #121)

A node configured `addons: ["evm"], standalone-addons: true` runs `evm` `chain-id` (`eth_chainId` → `0x313`) and `evm` `pruning` (`eth_getBlockByNumber` at head−7200), probes its head with `eth_blockNumber`, and is admitted. The base Substrate `chain-id` is dropped rather than failed.

### Most critical to review

- `protocol/chainlib/base_chain_parser.go` — `GetParsingByTagForCollection` (add-ons tried in the node's own declaration order; a keyed lookup, not a scan of `apiCollections`, which is a map and would iterate randomly), and the verification-borrow change.
- `protocol/common/endpoints.go` — the `standalone-addons` field and `ServesBaseCollection()`.
- `protocol/chainlib/chain_fetcher.go` — `verificationsForNodeUrl` and its placement relative to `needsLatestBlock`.

### Scope — what this does not cover

- **Relay routing for a mixed Substrate + EVM-only deployment is not traced.** Admission and tip polling are verified end to end; whether base-collection traffic can be routed to an admitted EVM-only endpoint is not. `GetChainRouter` constructs fine (`populateRequiredForAddon` recurses over extensions only and never requires a base-addon route), but that is a different question from relay selection.
- Admission stays all-or-nothing per provider rather than per collection.


### Verified live against the real upstreams

Built from this branch (`docker/Dockerfile`) and run against `aca.json` from lava-specs #121, with `ghcr.io/magma-devs/smart-router:main` — the image the spec pipeline itself boots — as the control. Same spec dir, same config, one variable at a time.

**Isolated EVM-only provider** (`eth-rpc-acala.aca-api.network`, `addons: ["evm"]`):

| Run | Log signature | Outcome |
|---|---|---|
| `:main` control | `chain_getHeader` ×30, `GET_BLOCKNUM Failed` ×30, `failed to fetch latest block number` ×6 | `excluding from provider list` |
| this branch, **no** flag | head probe silent; `chain_getBlockHash` ×36, `invalid Verification on provider startup` ×12 | `excluding from provider list` |
| this branch, `standalone-addons: true` | `skipping base-collection verification` ×2 | **admitted, serving** |

The middle row is the point: gates 1-3 move the failure off the head probe entirely, and what is left is exactly the inherited base `chain-id` that gate 4 addresses.

**Mixed deployment** — one router, a Substrate provider and the EVM-only provider:

| Request | `:main` control | this branch |
|---|---|---|
| `eth_chainId` | `No Providers For Addon {addon:evm}` | `0x313` |
| `eth_blockNumber` | `No Providers For Addon {addon:evm}` | `0xb571cb` |
| `chain_getHeader` | real Substrate header | real Substrate header |
| `system_chain` | `"Acala"` | `"Acala"` |

Both surfaces served from one listener, 0 exclusions. This is the run that found gate 5: before that commit, `chain_getHeader` on this branch returned `-32601` because Substrate traffic was reaching the EVM endpoint.

**One residual, non-fatal and not fixed here.** `RPCSmartRouterServer.craftRelay` builds the startup warm-up relay from the base collection too, so a disjoint-addon provider logs a handful of `-32601` node errors at boot. Measured: a one-time burst, stable across 60s, provider never excluded, tip polling correct and advancing. It is the same root cause and wants the per-collection admission work the ticket calls step 3 — worth its own ticket rather than growing this PR.

### Tests

Each fix has a guard **verified by breaking it**, not by watching it pass:
- reverting the `Validate` call site makes the probe test fail with `GetParsingByTagForCollection([GET_BLOCKNUM [] ])` where `[evm]` was expected;
- reverting the verification borrow makes the evm directive resolve to `chain_getBlockHash`.

Also covered: determinism across 200 calls and add-on declaration order (the map-iteration hazard that would otherwise have been the follow-up bug), disabled collections, internal paths, extension names mixed into `addons`, and a config round-trip through `viper.UnmarshalKey` — a mapstructure tag that did not match would decode as false and drop the provider with no error anywhere.

`go build ./...` clean; full `./protocol/...` suite green.

### Two things worth flagging

- `ServesBaseCollection()` guards on `len(Addons) == 0`, but `Addons` mixes addons and extensions — so `standalone-addons: true` on a url whose `addons` are all extension names drops every verification. Visible rather than silent: the filter sits above the existing `no verifications for url` warning.
- `chainlib_mock.go` carries `DO NOT EDIT`; a MockGen regeneration reproduces the hand-added `GetParsingByTagForCollection` verbatim now that the interface declares it.

## Jira ticket

Jira ticket: MAG-3296

---

## Author Checklist

I have...

* [x] read the [contribution guide](https://github.com/magma-Devs/smart-router/blob/main/CONTRIBUTING.md)
* [x] included the correct type prefix in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change — n/a; `ChainParser` gains a method (implementors updated, mock included), config field is additive and defaults to today's behaviour
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests
* [x] updated the relevant documentation or specification, including comments for documenting Go code
* [ ] confirmed all CI checks have passed — pending first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHyKbFQzzmj9e1bE9yKRa
