### PR TITLE
ci(lint): gate on golangci-lint at a pinned v2.13.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,17 +21,23 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
-      # golangci-lint is currently advisory on this repo: the fork is on
-      # Go 1.26 and earlier golangci-lint releases refuse to lint a newer
-      # toolchain than they were built with. Once a stable v2.x is pinned
-      # and known to produce a clean run against this codebase, drop the
-      # continue-on-error flags on the retries.
+      # golangci-lint GATES this repo: a finding fails the job.
+      #
+      # The version is pinned rather than tracking `latest` so that a linter
+      # release cannot change the finding set without a change here. The pin
+      # has a floor as well as a ceiling: golangci-lint refuses to lint a Go
+      # toolchain newer than the one it was built with, and this module is on
+      # go 1.26 — v2.13.1's release binary is built with go1.27.0, which is
+      # what makes it usable. Re-run the linter locally before moving the pin.
+      #
+      # The first two attempts are advisory so an install or network flake
+      # retries rather than failing the job; the third one decides.
       - name: Lint
         uses: golangci/golangci-lint-action@v9
         continue-on-error: true
         id: lint_first_try
         with:
-          version: latest
+          version: v2.13.1
           args: --config .golangci.yml -v
 
       - name: Lint Retry 1
@@ -40,20 +46,18 @@ jobs:
         continue-on-error: true
         id: lint_retry_1
         with:
-          version: latest
+          version: v2.13.1
           args: --config .golangci.yml -v
 
       - name: Lint Retry 2
         if: steps.lint_retry_1.outcome == 'failure'
         uses: golangci/golangci-lint-action@v9
-        continue-on-error: true
         id: lint_retry_2
         with:
-          version: latest
+          version: v2.13.1
           args: --config .golangci.yml -v
 
-  # Supply-chain vuln scan. Unlike golangci-lint above (advisory while the
-  # Go 1.26 toolchain outpaces stable linter releases), this job GATES: a
+  # Supply-chain vuln scan. Like golangci-lint above, this job GATES: a
   # known-vulnerable dependency or stdlib version should block the merge.
   # govulncheck is call-graph aware — it only flags advisories whose
   # vulnerable symbols are actually reachable from this codebase, so it


### PR DESCRIPTION
#Closes MAG-3317

Jira ticket: MAG-3317

## Summary

The `lint` job reported success no matter what golangci-lint found — every one of its three attempts carried `continue-on-error: true`. A green `lint` check meant only that the runner finished.

- Drops `continue-on-error` from the final attempt, so a genuine finding fails the job. The first two attempts keep it: they exist for install/network flakes, and a real finding will still be there on the third.
- Pins `version: v2.13.1` in place of `latest`, so a linter release cannot change the finding set without a change to this file.
- Rewrites the stale comment above the steps, and the `govulncheck` comment that described lint as the advisory counter-example.

**Why that pin.** The version is bounded on both sides. golangci-lint refuses to lint a Go toolchain newer than the one it was built with, and this module is on `go 1.26.6` — so the binary has to be built with go1.27 or later. The official `golangci-lint-2.13.1-linux-amd64` release binary is (`go version -m` → `go1.27.0`), which is what makes it usable here. Re-run the linter locally before moving the pin.

## Merge order — this PR is blocked on #342

Opened as a draft because the gate cannot go green on `main` yet. Measured with the pinned binary:

| Ref | `golangci-lint run --config .golangci.yml ./...` |
| --- | --- |
| `main` today | 79 issues — staticcheck 73, unconvert 3, nilnil 2, ineffassign 1 |
| #342 (`mag-3299`) | **0 issues** |

#342 carries the baseline clearance (MAG-3308). Until it merges, this branch's own `lint` check is red — correctly, which is the demonstration that the gate works. Once #342 is on `main`: rebase this branch, confirm `lint` goes green, mark ready.

Basing this on `mag-3299` instead would dodge the red check but also skip the evidence — `lint.yml` only triggers on PRs targeting `main`, so a stacked PR would run no lint job at all.

## Follow-up not included here

`lint` is not in the required-checks list on `main`'s branch protection ruleset, so this makes the check red on the PR page without hard-blocking the merge button. Adding it is an org-ruleset change rather than a repo change, so it isn't in this diff.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow parses; step matrix is advisory / advisory / gating, all three pinned to `v2.13.1`
- [x] Official `v2.13.1` release binary against `mag-3299` → `0 issues`
- [x] Official `v2.13.1` release binary against `main` → 79 issues, i.e. the gate does discriminate
- [x] `go version -m golangci-lint` → `go1.27.0`, satisfying the go 1.26 module floor
