### PR TITLE
fix(lavasession): make the epoch's probe branch reachable again (MAG-3190)

### DIFF
--- a/protocol/lavasession/block_reason_test.go
+++ b/protocol/lavasession/block_reason_test.go
@@ -759,6 +759,56 @@ func TestBlockRecord_CarriedRecordTakesTheScopeItIsReBlockedIn(t *testing.T) {
 	require.Equal(t, uint32(1), row.Carries)
 }
 
+// epochPairing builds a single direct-RPC provider for the epoch-transition tests.
+//
+// usable decides whether probeDirectRPCEndpoints — the gate the epoch's release pass runs — passes
+// or fails. It is a routability check: at least one ENABLED endpoint carrying a connection object.
+//
+// Both shapes are genuinely direct-RPC (IsDirectRPC() is len(DirectConnections) > 0), which matters:
+// an endpoint with no DirectConnections at all is skipped one branch earlier, failing with "no
+// direct RPC endpoints found" — a misconfiguration, not the gate under test. Failing on the wrong
+// branch would still make these tests pass, while proving reachability through a provider shape
+// that cannot occur in a correctly configured deployment.
+func epochPairing(t *testing.T, address string, usable bool) map[uint64]*ConsumerSessionsWithProvider {
+	t.Helper()
+	// A connection object, not a live connection — NewDirectRPCConnection builds an HTTP client
+	// lazily and dials nothing, and the gate only asks whether one is present.
+	conn, err := NewDirectRPCConnection(context.Background(), common.NodeUrl{Url: "https://example.invalid:443/"}, 5, "")
+	require.NoError(t, err)
+	return map[uint64]*ConsumerSessionsWithProvider{
+		0: {
+			PublicLavaAddress: address,
+			Endpoints: []*Endpoint{{
+				NetworkAddress:    "https://example.invalid:443/",
+				Enabled:           usable, // an endpoint that is present but disabled fails the gate
+				DirectConnections: []DirectRPCConnection{conn},
+			}},
+			Sessions:        map[int64]*SingleConsumerSession{},
+			MaxComputeUnits: 200,
+			PairingEpoch:    firstEpochHeight,
+			StaticProvider:  true,
+		},
+	}
+}
+
+// awaitEpochReleasePass waits for the release pass to have run. It is spawned from a defer that
+// sleeps up to 500ms, and its own cleanup empties previousEpochBlockedProviders last.
+func awaitEpochReleasePass(t *testing.T, csm *ConsumerSessionManager) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		csm.lock.RLock()
+		defer csm.lock.RUnlock()
+		return len(csm.previousEpochBlockedProviders) == 0
+	}, 15*time.Second, 50*time.Millisecond, "the epoch release pass never ran")
+}
+
+// isValidAddress reports whether the provider is back in routing.
+func isValidAddress(csm *ConsumerSessionManager, address string) bool {
+	csm.lock.RLock()
+	defer csm.lock.RUnlock()
+	return slices.Contains(csm.validAddresses, address)
+}
+
 // The epoch re-blocks the previous epoch's blocked providers "to prevent known-bad providers from
 // getting a clean slate", then releases the ones it has no evidence against. It decided that by
 // asking csm.reportedProviders — but UpdateAllProviders empties that register in its body, while
@@ -768,28 +818,14 @@ func TestBlockRecord_CarriedRecordTakesTheScopeItIsReBlockedIn(t *testing.T) {
 // with no health check at all.
 //
 // The decision now reads the carried block record, which holds what the register held before it was
-// reset.
+// reset. That is equivalent by construction, not merely a reasonable snapshot: ReportProvider is
+// called from exactly two sites, both inside blockProvider, and every RemoveReport site also
+// unblocks the provider — so nothing can change a provider's report state while its block stands.
 //
-// Both cases are asserted, because "keep everything blocked" would pass a one-sided test while
-// being just as wrong as the bug. The provider's endpoint is deliberately unreachable so the two
-// branches have different outcomes: probe → stays blocked, no-probe → released regardless.
+// Both directions are asserted, because "keep everything blocked" would satisfy a one-sided test
+// while being just as wrong as the bug.
 func TestEpochTransition_ProbeIsRequiredOnlyForAReportedProvider(t *testing.T) {
-	// A direct-RPC provider with no usable connection. probeDirectRPCEndpoints is a routability
-	// gate, so it fails here — unlike the gRPC probe, which dials lazily and reports success
-	// against a dead address.
-	deadPairing := func() map[uint64]*ConsumerSessionsWithProvider {
-		return map[uint64]*ConsumerSessionsWithProvider{
-			0: {
-				PublicLavaAddress: "provider-unreachable",
-				Endpoints:         []*Endpoint{{NetworkAddress: "127.0.0.1:1", Enabled: true}},
-				Sessions:          map[int64]*SingleConsumerSession{},
-				MaxComputeUnits:   200,
-				PairingEpoch:      firstEpochHeight,
-				StaticProvider:    true,
-			},
-		}
-	}
-
+	const address = "provider-unreachable"
 	for _, tc := range []struct {
 		name           string
 		reportProvider bool
@@ -800,8 +836,8 @@ func TestEpochTransition_ProbeIsRequiredOnlyForAReportedProvider(t *testing.T) {
 		{
 			name: "reported provider must earn its way back", reportProvider: true, wantReported: true,
 			stillBlocked: true,
-			why: "it was reported, so the epoch owes it a probe — and the probe cannot pass against " +
-				"an unreachable endpoint. Releasing it anyway is the clean slate the re-block exists to prevent",
+			why: "it was reported, so the epoch owes it a probe — and the probe cannot pass while its " +
+				"only endpoint is disabled. Releasing it anyway is the clean slate the re-block exists to prevent",
 		},
 		{
 			name: "unreported provider is released without one", reportProvider: false, wantReported: false,
@@ -811,32 +847,88 @@ func TestEpochTransition_ProbeIsRequiredOnlyForAReportedProvider(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			csm := CreateConsumerSessionManager()
-			require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, deadPairing(), nil))
-			const address = "provider-unreachable"
+			require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, epochPairing(t, address, false), nil))
 
 			require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonAllEndpointsDisabled,
 				tc.reportProvider, csm.atomicReadCurrentEpoch(), MaxConsecutiveConnectionAttempts, 0, false, nil))
 			require.Equal(t, tc.wantReported, blockedRecord(t, csm, address).Reported)
-			require.NotContains(t, csm.validAddresses, address)
+			require.False(t, isValidAddress(csm, address))
 
-			// Roll the epoch: copies the block forward, re-blocks it, resets the reported register,
-			// and schedules the release pass.
-			require.NoError(t, csm.UpdateAllProviders(secondEpochHeight, deadPairing(), nil))
+			require.NoError(t, csm.UpdateAllProviders(secondEpochHeight, epochPairing(t, address, false), nil))
+			awaitEpochReleasePass(t, csm)
 
-			// That pass is a deferred goroutine that sleeps up to 500ms, so wait for it to have run.
-			require.Eventually(t, func() bool {
-				csm.lock.RLock()
-				defer csm.lock.RUnlock()
-				return len(csm.previousEpochBlockedProviders) == 0
-			}, 15*time.Second, 50*time.Millisecond, "the epoch release pass never ran")
-
-			csm.lock.RLock()
-			defer csm.lock.RUnlock()
-			if tc.stillBlocked {
-				require.NotContains(t, csm.validAddresses, address, tc.why)
-			} else {
-				require.Contains(t, csm.validAddresses, address, tc.why)
-			}
+			require.Equal(t, !tc.stillBlocked, isValidAddress(csm, address), tc.why)
 		})
 	}
+}
+
+// The other half of the gate: a reported provider that CAN pass its probe is released, through
+// ReleaseEpochProbe. Without this the fix is only shown to keep providers out, and the open question
+// on the PR — whether restoring the gate changes anything in production or locks providers out —
+// stays unfalsifiable.
+func TestEpochTransition_AReportedProviderThatPassesItsProbeIsReleased(t *testing.T) {
+	const address = "provider-healthy"
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, epochPairing(t, address, true), nil))
+
+	require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonAllEndpointsDisabled,
+		true, csm.atomicReadCurrentEpoch(), MaxConsecutiveConnectionAttempts, 0, false, nil))
+	require.True(t, blockedRecord(t, csm, address).Reported)
+	require.False(t, isValidAddress(csm, address))
+
+	require.NoError(t, csm.UpdateAllProviders(secondEpochHeight, epochPairing(t, address, true), nil))
+	awaitEpochReleasePass(t, csm)
+
+	require.True(t, isValidAddress(csm, address),
+		"the gate is a routability check, not a quarantine: a provider that can serve must come back")
+}
+
+// An unknown record must not be read as "never reported". That field decides whether a provider has
+// to prove itself, and its zero value would hand a free pass to exactly the case where we have lost
+// track of why the provider is out.
+func TestEpochTransition_AMissingRecordStillFacesTheProbe(t *testing.T) {
+	const address = "provider-record-lost"
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, epochPairing(t, address, false), nil))
+
+	require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonAllEndpointsDisabled,
+		true, csm.atomicReadCurrentEpoch(), MaxConsecutiveConnectionAttempts, 0, false, nil))
+
+	// Strand the block: the record is gone while the provider stays blocked. The store paths that
+	// could do this are fixed, so this is the defensive case — which is the one worth pinning,
+	// because a fail-open default is silent by definition.
+	csm.lock.Lock()
+	delete(csm.blockedProviderRecords, address)
+	csm.lock.Unlock()
+
+	require.NoError(t, csm.UpdateAllProviders(secondEpochHeight, epochPairing(t, address, false), nil))
+	awaitEpochReleasePass(t, csm)
+
+	require.False(t, isValidAddress(csm, address),
+		"an unknown block must fail closed — 'we do not know why it is out' is not evidence of health")
+}
+
+// Backups are the load-bearing exception the rewritten comment leans on: !isBackup short-circuits
+// ahead of the report check, so a backup's report state is never consulted and a backup always
+// faces the probe. Nothing asserted that.
+func TestEpochTransition_BackupAlwaysFacesTheProbeWhateverItsReportState(t *testing.T) {
+	const address = "backup-unreachable"
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight,
+		createNamedPairingList("regular-a"), epochPairing(t, address, false)))
+
+	// reportProvider=false: on the regular path this would mean "no evidence, release immediately".
+	require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonTooManyDeadSessions,
+		false, csm.atomicReadCurrentEpoch(), 0, 0, false, nil))
+	require.False(t, blockedRecord(t, csm, address).Reported)
+
+	require.NoError(t, csm.UpdateAllProviders(secondEpochHeight,
+		createNamedPairingList("regular-a"), epochPairing(t, address, false)))
+	awaitEpochReleasePass(t, csm)
+
+	csm.lock.RLock()
+	defer csm.lock.RUnlock()
+	_, stillBlocked := csm.blockedBackupProviders[address]
+	require.True(t, stillBlocked,
+		"a backup is routed to the probe regardless of report state, and this one cannot pass it")
 }

--- a/protocol/lavasession/block_reason_test.go
+++ b/protocol/lavasession/block_reason_test.go
@@ -932,3 +932,43 @@ func TestEpochTransition_BackupAlwaysFacesTheProbeWhateverItsReportState(t *test
 	require.True(t, stillBlocked,
 		"a backup is routed to the probe regardless of report state, and this one cannot pass it")
 }
+
+// The end-to-end consequence of the above: after two ordinary blocks in one epoch, the provider must
+// still face the probe.
+func TestEpochTransition_AProviderReportedByARepeatBlockStillFacesTheProbe(t *testing.T) {
+	const address = "provider-blocked-twice"
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, epochPairing(t, address, false), nil))
+	epoch := csm.atomicReadCurrentEpoch()
+
+	require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonTooManyDeadSessions,
+		false, epoch, 0, 0, false, nil))
+	require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonAllEndpointsDisabled,
+		true, epoch, MaxConsecutiveConnectionAttempts, 0, false, nil))
+
+	require.NoError(t, csm.UpdateAllProviders(secondEpochHeight, epochPairing(t, address, false), nil))
+	awaitEpochReleasePass(t, csm)
+
+	require.False(t, isValidAddress(csm, address),
+		"it was reported, so it owes a probe — a stale record here is a working bypass of the fix")
+}
+
+// The dead-session cap on its own is the other half, and it was untested in either direction. It is
+// released without a probe, and that is correct rather than a gap: the epoch rebuilds every session
+// object, so the blocklisted-session count that caused this block is already back at zero. There is
+// nothing left for a probe to find.
+func TestEpochTransition_DeadSessionCapIsReleasedWithoutAProbe(t *testing.T) {
+	const address = "provider-dead-sessions"
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, epochPairing(t, address, false), nil))
+
+	require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonTooManyDeadSessions,
+		false, csm.atomicReadCurrentEpoch(), 0, 0, false, nil))
+	require.False(t, blockedRecord(t, csm, address).Reported, "this path blocks quietly by design")
+
+	require.NoError(t, csm.UpdateAllProviders(secondEpochHeight, epochPairing(t, address, false), nil))
+	awaitEpochReleasePass(t, csm)
+
+	require.True(t, isValidAddress(csm, address),
+		"nothing was recorded against it, and the condition it was blocked on is reset by the epoch itself")
+}

--- a/protocol/lavasession/block_reason_test.go
+++ b/protocol/lavasession/block_reason_test.go
@@ -758,3 +758,85 @@ func TestBlockRecord_CarriedRecordTakesTheScopeItIsReBlockedIn(t *testing.T) {
 	require.Equal(t, "primary", row.Scope, "the only standing block is the regular one")
 	require.Equal(t, uint32(1), row.Carries)
 }
+
+// The epoch re-blocks the previous epoch's blocked providers "to prevent known-bad providers from
+// getting a clean slate", then releases the ones it has no evidence against. It decided that by
+// asking csm.reportedProviders — but UpdateAllProviders empties that register in its body, while
+// this pass runs from a defer that sleeps first. Every non-backup therefore looked unreported, took
+// the immediate-unblock branch, and the comprehensive-probe branch was unreachable for regular
+// providers: a provider that failed every request for a full epoch was rehabilitated at the tick
+// with no health check at all.
+//
+// The decision now reads the carried block record, which holds what the register held before it was
+// reset.
+//
+// Both cases are asserted, because "keep everything blocked" would pass a one-sided test while
+// being just as wrong as the bug. The provider's endpoint is deliberately unreachable so the two
+// branches have different outcomes: probe → stays blocked, no-probe → released regardless.
+func TestEpochTransition_ProbeIsRequiredOnlyForAReportedProvider(t *testing.T) {
+	// A direct-RPC provider with no usable connection. probeDirectRPCEndpoints is a routability
+	// gate, so it fails here — unlike the gRPC probe, which dials lazily and reports success
+	// against a dead address.
+	deadPairing := func() map[uint64]*ConsumerSessionsWithProvider {
+		return map[uint64]*ConsumerSessionsWithProvider{
+			0: {
+				PublicLavaAddress: "provider-unreachable",
+				Endpoints:         []*Endpoint{{NetworkAddress: "127.0.0.1:1", Enabled: true}},
+				Sessions:          map[int64]*SingleConsumerSession{},
+				MaxComputeUnits:   200,
+				PairingEpoch:      firstEpochHeight,
+				StaticProvider:    true,
+			},
+		}
+	}
+
+	for _, tc := range []struct {
+		name           string
+		reportProvider bool
+		wantReported   bool
+		stillBlocked   bool
+		why            string
+	}{
+		{
+			name: "reported provider must earn its way back", reportProvider: true, wantReported: true,
+			stillBlocked: true,
+			why: "it was reported, so the epoch owes it a probe — and the probe cannot pass against " +
+				"an unreachable endpoint. Releasing it anyway is the clean slate the re-block exists to prevent",
+		},
+		{
+			name: "unreported provider is released without one", reportProvider: false, wantReported: false,
+			stillBlocked: false,
+			why:          "nothing was ever recorded against it, so there is no evidence to answer for",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			csm := CreateConsumerSessionManager()
+			require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, deadPairing(), nil))
+			const address = "provider-unreachable"
+
+			require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonAllEndpointsDisabled,
+				tc.reportProvider, csm.atomicReadCurrentEpoch(), MaxConsecutiveConnectionAttempts, 0, false, nil))
+			require.Equal(t, tc.wantReported, blockedRecord(t, csm, address).Reported)
+			require.NotContains(t, csm.validAddresses, address)
+
+			// Roll the epoch: copies the block forward, re-blocks it, resets the reported register,
+			// and schedules the release pass.
+			require.NoError(t, csm.UpdateAllProviders(secondEpochHeight, deadPairing(), nil))
+
+			// That pass is a deferred goroutine that sleeps up to 500ms, so wait for it to have run.
+			require.Eventually(t, func() bool {
+				csm.lock.RLock()
+				defer csm.lock.RUnlock()
+				return len(csm.previousEpochBlockedProviders) == 0
+			}, 15*time.Second, 50*time.Millisecond, "the epoch release pass never ran")
+
+			csm.lock.RLock()
+			defer csm.lock.RUnlock()
+			if tc.stillBlocked {
+				require.NotContains(t, csm.validAddresses, address, tc.why)
+			} else {
+				require.Contains(t, csm.validAddresses, address, tc.why)
+			}
+		})
+	}
+}

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -3014,7 +3014,7 @@ func (csm *ConsumerSessionManager) checkAndUnblockHealthyReBlockedProviders(ctx 
 	// First pass: Identify which re-blocked providers had successful probes
 	providersNeedingComprehensiveProbe := make(map[string]reBlockedProviderInfo)
 
-	for blockedAddr := range csm.previousEpochBlockedProviders {
+	for blockedAddr, carried := range csm.previousEpochBlockedProviders {
 		cswp, exists := csm.pairing[blockedAddr]
 		isBackup := false
 		if !exists {
@@ -3028,16 +3028,23 @@ func (csm *ConsumerSessionManager) checkAndUnblockHealthyReBlockedProviders(ctx 
 		// A backup ALWAYS takes the comprehensive-probe branch: !isBackup short-circuits, so a
 		// backup's report state is never consulted at all. That is deliberate — report state is
 		// only meaningful as a health signal for a provider we actually have evidence about, and
-		// a backup that was never selected has none. Falling through to !IsReported for it would
-		// read "absent from reportedProviders" as "healthy" and unblock it with no real check.
+		// a backup that was never selected has none. Falling through to "not reported" for it would
+		// read that as "healthy" and unblock it with no real check.
 		//
-		// Note a backup CAN legitimately appear in reportedProviders: blockProvider's
-		// AddressIndexWasNotFoundError branch marks blockedBackupProviders and then falls through
-		// to the reportProvider block below it. That is irrelevant here precisely because the
-		// short-circuit means we never look.
-		if !isBackup && !csm.reportedProviders.IsReported(blockedAddr) {
-			// Non-backup provider whose probe succeeded (it wasn't added to reportedProviders).
-			// Unblock immediately.
+		// The report state comes from the CARRIED BLOCK RECORD, not from csm.reportedProviders.
+		// The live register cannot answer this question at an epoch transition: UpdateAllProviders
+		// calls reportedProviders.Reset() in its body, while this pass runs from a defer that
+		// sleeps first — so the register is always already empty by the time we get here. Reading
+		// it made every non-backup look unreported, sent all of them down the immediate-unblock
+		// branch, and left this else-branch unreachable for regular providers. The whole point of
+		// re-blocking them ("prevents known-bad providers from getting a clean slate") was undone
+		// in the same tick.
+		//
+		// The record is the honest source: it holds whether the provider was reported at the moment
+		// it was blocked, which is exactly what the register held before the reset.
+		if !isBackup && !carried.Reported {
+			// Non-backup provider that was never reported — no evidence it is bad. Unblock
+			// immediately.
 			utils.LavaFormatInfo("Re-blocked provider's probe succeeded, immediately unblocking",
 				utils.Attribute{Key: "provider", Value: blockedAddr},
 				utils.Attribute{Key: "isBackup", Value: isBackup},

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -2632,14 +2632,25 @@ func (csm *ConsumerSessionManager) validateAndReturnBlockedProviderToValidAddres
 	// if we didn't find it, we might had two sessions in parallel and thats ok. the first one dealt with it we can just return
 }
 
-// blockRecordOrUnknownLocked returns a blocked provider's record, or a placeholder naming the epoch
-// carry-over when none is stored. The placeholder should be unreachable — every block writes a
-// record — so seeing it in a log means a block path forgot to. csm.lock must be held.
+// blockRecordOrUnknownLocked returns a blocked provider's record, or a placeholder when none is
+// stored. csm.lock must be held.
+//
+// The placeholder fails CLOSED: Reported is true, so an unknown block faces the epoch's probe rather
+// than being waved through. That field decides whether a re-blocked provider has to prove itself,
+// and its zero value would read as "never reported, no evidence against it, let it back in" — which
+// is precisely the free clean slate the re-block exists to prevent. When we do not know why a
+// provider is out, the safe answer is to make it prove itself, not to assume the best.
+//
+// Reaching this means a block path did not record a reason, which is a bug in that path rather than
+// a state to tolerate quietly — hence the warning.
 func (csm *ConsumerSessionManager) blockRecordOrUnknownLocked(providerAddress string) BlockRecord {
 	if record, ok := csm.blockedProviderRecords[providerAddress]; ok {
 		return record
 	}
-	return BlockRecord{Reason: BlockReasonPreviousEpoch, Since: time.Now()}
+	utils.LavaFormatWarning("blocked provider carried no block record at the epoch boundary", nil,
+		utils.LogAttr("address", providerAddress),
+	)
+	return BlockRecord{Reason: BlockReasonPreviousEpoch, Since: time.Now(), Reported: true}
 }
 
 // blockedTotalLocked is how many providers are out across both pools — the number an operator wants
@@ -3052,7 +3063,10 @@ func (csm *ConsumerSessionManager) checkAndUnblockHealthyReBlockedProviders(ctx 
 				utils.LogAttr("GUID", ctx),
 			)
 			csm.validateAndReturnBlockedProviderToValidAddressesListLocked(blockedAddr, ReleaseEpochNotReported)
-			csm.reportedProviders.RemoveReport(blockedAddr)
+			// No RemoveReport here. UpdateAllProviders resets the register in its body before this
+			// pass runs, so there has never been anything to remove — and this branch no longer
+			// consults it at all. Leaving the call in would suggest the register is meaningful on
+			// this path, which is the assumption that produced the bug above.
 		} else {
 			// Either a backup provider (always routed here by the short-circuit above),
 			// or a non-backup that was reported for relay failures.


### PR DESCRIPTION
Jira ticket: MAG-3190

## Why this exists again

**[#337](https://github.com/Magma-Devs/smart-router/pull/337) shows as MERGED, but its fix is not in
`main`.** This re-opens it against `main` directly. Same three commits, cherry-picked cleanly.

### What happened

#337 was stacked on #336, so its base was `feat/mag-2599-block-reason`, not `main`.

| | |
|---|---|
| #336 merged → `main` | `2026-08-27T14:41:34Z` |
| #337 merged → `feat/mag-2599-block-reason` | `2026-08-27T14:41:51Z` — **17s later** |

The base branch had already been merged to `main` seventeen seconds earlier, so #337 landed on a
branch nothing would read again. GitHub reports it MERGED — correctly, it *did* merge into its base
— but the commit is not an ancestor of `origin/main`.

Normally GitHub retargets a stacked PR to `main` when its base merges. Seventeen seconds was not
enough for that to take effect.

**Verified three ways:**

```
$ git show origin/main:protocol/lavasession/consumer_session_manager.go | grep carried.Reported
(nothing)

$ git show origin/main:protocol/lavasession/consumer_session_manager.go | grep "IsReported(blockedAddr)"
3038:  if !isBackup && !csm.reportedProviders.IsReported(blockedAddr) {   ← still the broken line

$ git branch -r --contains 6cedcb3e
origin/feat/mag-2599-block-reason      ← and nowhere else
```

## The bug, still live in `main`

At every epoch tick the router deliberately re-blocks the previous epoch's blocked providers, so
known-bad providers do not get a clean slate. A second pass then decides who to release: a
**reported** provider must pass a real probe first; an unreported one is released immediately.

**The reported-providers register is emptied before that check runs.** `UpdateAllProviders` calls
`reportedProviders.Reset()` in its body, while the release pass runs from a `defer` that sleeps
first. So every non-backup provider looks unreported, every one takes the immediate-unblock branch,
and the probe branch is unreachable.

**A provider that failed every single request for a full epoch is fully rehabilitated at the next
tick, with no health check of any kind.** The re-block that exists to prevent exactly that is undone
in the same tick.

## The fix

Read the report state from the **carried block record** rather than the live register. The record
holds what the register held at the moment of the block — which is the question being asked.

```diff
-   if !isBackup && !csm.reportedProviders.IsReported(blockedAddr) {
+   if !isBackup && !carried.Reported {
```

Plus, from the two follow-up commits: an unknown record **fails closed** (an unrecoverable record is
not evidence of health), and a provider reported by a *repeat* block still owes a probe — a stale
record there would be a working bypass of the fix.

## Found by black-box testing, not by reading the diff

This surfaced while validating §2 against a live router. With `--epoch-duration 40s`, a provider
whose record read `Reported: true` was released at the tick via:

```
released_by=epoch-not-reported
```

Reported true, released down the *not-reported* branch, no probe. That is the defect reproducing on
`main` today.

## Verification

- `go build ./...`, `go vet ./...` clean; **full `go test ./...` green**
- **The three new tests fail on `main` and pass here** — back-ported the test file onto `origin/main`
  and ran it:

```
--- FAIL: TestEpochTransition_ProbeIsRequiredOnlyForAReportedProvider
    it was reported, so the epoch owes it a probe — and the probe cannot pass while its only
    endpoint is disabled. Releasing it anyway is the clean slate the re-block exists to prevent
--- FAIL: TestEpochTransition_AMissingRecordStillFacesTheProbe
    an unknown block must fail closed
--- FAIL: TestEpochTransition_AProviderReportedByARepeatBlockStillFacesTheProbe
    a stale record here is a working bypass of the fix
```

## Worth checking beyond this PR

Nothing in the process caught this. CI was green, the PR was reviewed, the status said merged. It was
found only because a behavioural test looked wrong.

**If stacked PRs are used regularly, other changes may have been lost the same way** — the signature
is a PR whose merge time is within seconds of its base's merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VnZf2owXiRWzPUXpnTNoX
