### PR TITLE
feat(observability): record WHY an endpoint was taken out of rotation

### DIFF
--- a/protocol/lavasession/consumer_types.go
+++ b/protocol/lavasession/consumer_types.go
@@ -186,6 +186,11 @@ type Endpoint struct {
 	// after this instant, so a poll that succeeded BEFORE the disable can never re-enable (F1).
 	// Cleared (zeroed) on every re-enable.
 	disabledAt time.Time
+	// disableReason is WHY the endpoint was taken out, captured on the same Enabled→false edge that
+	// stamps disabledAt and cleared alongside it on re-enable. The provider-level BlockReason cannot
+	// answer this: it reads `all-endpoints-disabled`, which is a count of endpoints rather than a
+	// cause. See EndpointDisableReason.
+	disableReason EndpointDisableReason
 	// lastRecoveryPoll is the LastSuccessfulPoll value already counted toward the hysteresis streak,
 	// so a probe cadence faster than the poll cadence cannot count one successful poll twice — only a
 	// strictly newer successful poll advances the streak (F1: "distinct post-disable polls").
@@ -275,8 +280,12 @@ func (e *Endpoint) IsEnabled() bool {
 // never observes a half-applied MarkUnhealthy / RecordProbeVerdict transition. DisabledAt and
 // LastRecoveryPoll are zero while the endpoint is enabled / has never disabled.
 type EndpointHealthSnapshot struct {
-	Enabled                  bool
-	DisabledAt               time.Time
+	Enabled    bool
+	DisabledAt time.Time
+	// DisableReason is WHY the endpoint was taken out, captured on the same transition as
+	// DisabledAt and empty while enabled. The provider-level BlockReason cannot answer this — it
+	// reads `all-endpoints-disabled`, a count rather than a cause.
+	DisableReason            EndpointDisableReason
 	ConsecutiveHealthyProbes uint64 // distinct post-disable successful polls counted toward F1 re-enable
 	LastRecoveryPoll         time.Time
 	// RelayProbeMethod is the read-only method recorded as this disable episode's failing relay
@@ -304,6 +313,7 @@ func (e *Endpoint) HealthSnapshot() EndpointHealthSnapshot {
 	return EndpointHealthSnapshot{
 		Enabled:                  e.Enabled,
 		DisabledAt:               e.disabledAt,
+		DisableReason:            e.disableReason,
 		ConsecutiveHealthyProbes: e.consecutiveHealthyProbes,
 		LastRecoveryPoll:         e.lastRecoveryPoll,
 		RelayProbeMethod:         e.relayProbeMethod,
@@ -371,6 +381,10 @@ func (e *Endpoint) clearRecoveryStreakLocked() {
 func (e *Endpoint) clearRecoveryTrackingLocked() {
 	e.clearRecoveryStreakLocked()
 	e.disabledAt = time.Time{}
+	// The reason describes the episode that just ended, so it is cleared with the timestamp it was
+	// captured alongside. An enabled endpoint carrying a stale reason would read, in
+	// /debug/endpoint-state, as an endpoint that is somehow both serving and disabled-because-of-X.
+	e.disableReason = ""
 	e.dropRelayProbeEvidenceLocked()
 }
 
@@ -439,9 +453,21 @@ func endpointApproachingDisable(wasEnabled, transitioned bool, refusals uint64) 
 	return wasEnabled && !transitioned && refusals+endpointDisableWarningWindow >= MaxConsecutiveConnectionAttempts
 }
 
-// MarkUnhealthy increments connection refusals and disables endpoint if threshold exceeded.
-func (e *Endpoint) MarkUnhealthy() {
-	e.markUnhealthyAt(time.Now())
+// MarkUnhealthy increments connection refusals and disables the endpoint if the threshold is
+// exceeded, recording WHY on the disable itself.
+//
+// reason is required. Every call site already holds it — the relay path has the classified error or
+// the HTTP status in hand at the moment it decides to call this — and passing "" is treated as a bug
+// (EndpointDisableUnspecified) rather than silently meaning "no reason".
+func (e *Endpoint) MarkUnhealthy(reason EndpointDisableReason) {
+	e.markUnhealthyAt(time.Now(), reason)
+}
+
+// DisableReason reports why the endpoint was last taken out of rotation. Empty while enabled.
+func (e *Endpoint) DisableReason() EndpointDisableReason {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.disableReason
 }
 
 // markUnhealthyAt is MarkUnhealthy with an injectable clock (tests drive the disable instant so they
@@ -449,7 +475,10 @@ func (e *Endpoint) MarkUnhealthy() {
 // Enabled→false transition (edge-triggered): a repeated MarkUnhealthy on an already-disabled endpoint
 // must NOT push disabledAt forward, or it would silently invalidate post-disable poll evidence the
 // prober has already accumulated (F1).
-func (e *Endpoint) markUnhealthyAt(at time.Time) {
+func (e *Endpoint) markUnhealthyAt(at time.Time, reason EndpointDisableReason) {
+	if reason == "" {
+		reason = EndpointDisableUnspecified
+	}
 	e.mu.Lock()
 	e.ConnectionRefusals++
 	wasEnabled := e.Enabled
@@ -458,6 +487,10 @@ func (e *Endpoint) markUnhealthyAt(at time.Time) {
 	if disabled && wasEnabled {
 		e.Enabled = false
 		e.disabledAt = at
+		// Edge-triggered with disabledAt, and for the same reason: the reason belongs to the failure
+		// that actually took the endpoint out. A later failure of a different kind against an
+		// already-disabled endpoint must not rewrite the record of why it went down.
+		e.disableReason = reason
 		e.clearRecoveryStreakLocked()
 		// If this disable follows a probe re-enable that no successful relay ever validated, the probe's
 		// grant was wasted (the endpoint answers cheap polls but fails real relays). Escalate the next
@@ -475,6 +508,7 @@ func (e *Endpoint) markUnhealthyAt(at time.Time) {
 	if transitioned {
 		utils.LavaFormatWarning("disabled unhealthy endpoint", nil,
 			utils.LogAttr("endpoint", addr),
+			utils.LogAttr("disable_reason", reason),
 			utils.LogAttr("refusals", refusals),
 			utils.LogAttr("is_direct_rpc", isDirect),
 		)

--- a/protocol/lavasession/consumer_types.go
+++ b/protocol/lavasession/consumer_types.go
@@ -463,11 +463,29 @@ func (e *Endpoint) MarkUnhealthy(reason EndpointDisableReason) {
 	e.markUnhealthyAt(time.Now(), reason)
 }
 
-// DisableReason reports why the endpoint was last taken out of rotation. Empty while enabled.
-func (e *Endpoint) DisableReason() EndpointDisableReason {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
-	return e.disableReason
+// disableLocked performs the Enabled→false transition and records the evidence that belongs to it:
+// the instant, the reason, and a cleared recovery streak. Caller must hold e.mu for writing and must
+// have already checked that the endpoint IS currently enabled — this is the edge, not a level.
+//
+// It exists so "every disable transition records disabledAt AND a reason" is an invariant of the
+// type rather than a property that each disabling caller has to remember. There are two such callers
+// (markUnhealthyAt on the relay path, and the dial-failure path in fetchEndpointConnectionFromConsumerSessionWithProvider),
+// and before this was extracted the second one stamped the timestamp but not the reason — producing
+// a snapshot that read {Enabled: false, DisabledAt: set, DisableReason: ""}, which the field docs
+// define as an enabled endpoint.
+func (e *Endpoint) disableLocked(at time.Time, reason EndpointDisableReason) {
+	if reason == "" {
+		// Unreachable on current callers — both pass a named constant. Kept so a future caller cannot
+		// introduce a silently empty reason, which would read as "enabled" in /debug/endpoint-state.
+		reason = EndpointDisableUnspecified
+	}
+	e.Enabled = false
+	e.disabledAt = at
+	// Edge-triggered with disabledAt, and for the same reason: the reason belongs to the failure that
+	// actually took the endpoint out. A later failure of a different kind against an already-disabled
+	// endpoint must not rewrite the record of why it went down.
+	e.disableReason = reason
+	e.clearRecoveryStreakLocked()
 }
 
 // markUnhealthyAt is MarkUnhealthy with an injectable clock (tests drive the disable instant so they
@@ -476,22 +494,13 @@ func (e *Endpoint) DisableReason() EndpointDisableReason {
 // must NOT push disabledAt forward, or it would silently invalidate post-disable poll evidence the
 // prober has already accumulated (F1).
 func (e *Endpoint) markUnhealthyAt(at time.Time, reason EndpointDisableReason) {
-	if reason == "" {
-		reason = EndpointDisableUnspecified
-	}
 	e.mu.Lock()
 	e.ConnectionRefusals++
 	wasEnabled := e.Enabled
 	disabled := e.ConnectionRefusals >= MaxConsecutiveConnectionAttempts
 	transitioned := false
 	if disabled && wasEnabled {
-		e.Enabled = false
-		e.disabledAt = at
-		// Edge-triggered with disabledAt, and for the same reason: the reason belongs to the failure
-		// that actually took the endpoint out. A later failure of a different kind against an
-		// already-disabled endpoint must not rewrite the record of why it went down.
-		e.disableReason = reason
-		e.clearRecoveryStreakLocked()
+		e.disableLocked(at, reason)
 		// If this disable follows a probe re-enable that no successful relay ever validated, the probe's
 		// grant was wasted (the endpoint answers cheap polls but fails real relays). Escalate the next
 		// re-enable's hysteresis to dampen the flap; the cap bounds how long it stays disabled.
@@ -502,13 +511,17 @@ func (e *Endpoint) markUnhealthyAt(at time.Time, reason EndpointDisableReason) {
 		transitioned = true
 	}
 	addr, refusals, isDirect := e.NetworkAddress, e.ConnectionRefusals, e.IsDirectRPC()
+	// Read back what was actually recorded rather than re-using the argument: disableLocked
+	// normalises an empty reason, and the log line must not disagree with /debug/endpoint-state
+	// about why this endpoint went down.
+	recordedReason := e.disableReason
 	approaching := endpointApproachingDisable(wasEnabled, transitioned, refusals)
 	e.mu.Unlock()
 
 	if transitioned {
 		utils.LavaFormatWarning("disabled unhealthy endpoint", nil,
 			utils.LogAttr("endpoint", addr),
-			utils.LogAttr("disable_reason", reason),
+			utils.LogAttr("disable_reason", recordedReason),
 			utils.LogAttr("refusals", refusals),
 			utils.LogAttr("is_direct_rpc", isDirect),
 		)
@@ -1395,19 +1408,24 @@ func (cswp *ConsumerSessionsWithProvider) fetchEndpointConnectionFromConsumerSes
 					)
 
 					if endpoint.ConnectionRefusals >= MaxConsecutiveConnectionAttempts {
-						// Edge-trigger disabledAt on the actual enabled→false transition, mirroring
+						// Edge-trigger the disable on the actual enabled→false transition, mirroring
 						// MarkUnhealthy (F1). This path disables only PROVIDER-RELAY endpoints (direct-RPC
 						// returns early above and is disabled solely via MarkUnhealthy), so it is inert for
-						// the prober's recovery today — but stamping here keeps "every disable transition
-						// records disabledAt" an invariant of the type, not a property of one caller.
+						// the prober's recovery today — but going through disableLocked keeps "every disable
+						// transition records disabledAt AND a reason" an invariant of the type, not a
+						// property of one caller.
+						//
+						// EndpointDisableUnreachable is this constant's definition: the dial itself failed,
+						// so nothing ever reached a node.
 						if endpoint.Enabled {
-							endpoint.Enabled = false
-							endpoint.disabledAt = time.Now()
-							endpoint.clearRecoveryStreakLocked()
+							endpoint.disableLocked(time.Now(), EndpointDisableUnreachable)
 						}
 						utils.LavaFormatWarning("disabling provider endpoint for the duration of current epoch.", nil,
 							utils.LogAttr("Endpoint", networkAddress),
 							utils.LogAttr("address", cswp.PublicLavaAddress),
+							// Read back rather than hardcoding, so this line cannot drift from what
+							// /debug/endpoint-state reports for the same endpoint.
+							utils.LogAttr("disable_reason", endpoint.disableReason),
 							utils.LogAttr("GUID", ctx),
 						)
 					}

--- a/protocol/lavasession/debug_snapshots_test.go
+++ b/protocol/lavasession/debug_snapshots_test.go
@@ -23,7 +23,7 @@ func TestEndpointHealthSnapshot_TracksDisableAndRecovery(t *testing.T) {
 	// Disable via the relay-path failure threshold; disabledAt is stamped edge-triggered.
 	t0 := time.Unix(1_700_000_000, 0)
 	e.ConnectionRefusals = MaxConsecutiveConnectionAttempts - 1
-	e.markUnhealthyAt(t0)
+	e.markUnhealthyAt(t0, EndpointDisableUnreachable)
 	s = e.HealthSnapshot()
 	require.False(t, s.Enabled)
 	require.Equal(t, t0, s.DisabledAt)

--- a/protocol/lavasession/direct_rpc_session_selection_test.go
+++ b/protocol/lavasession/direct_rpc_session_selection_test.go
@@ -230,7 +230,7 @@ func TestFetchEndpointConnection_DirectRPC_BackoffAndSelfHeal(t *testing.T) {
 	// (1) + (2a): one short of the threshold the endpoint is still enabled and is
 	// offered for relay despite the unreachable upstream.
 	for i := 0; i < MaxConsecutiveConnectionAttempts-1; i++ {
-		endpoint.MarkUnhealthy()
+		endpoint.MarkUnhealthy(EndpointDisableUnreachable)
 	}
 	require.True(t, endpoint.Enabled, "endpoint must stay enabled below the consecutive-failure threshold")
 	connected, endpoints, err := fetch()
@@ -240,7 +240,7 @@ func TestFetchEndpointConnection_DirectRPC_BackoffAndSelfHeal(t *testing.T) {
 
 	// (2b): crossing the threshold disables the endpoint; selection now skips it and
 	// reports the provider as fully disabled.
-	endpoint.MarkUnhealthy()
+	endpoint.MarkUnhealthy(EndpointDisableUnreachable)
 	require.False(t, endpoint.Enabled, "endpoint must back off after MaxConsecutiveConnectionAttempts consecutive failures")
 	connected, _, err = fetch()
 	require.ErrorIs(t, err, AllProviderEndpointsDisabledError)

--- a/protocol/lavasession/endpoint_disable_reason.go
+++ b/protocol/lavasession/endpoint_disable_reason.go
@@ -1,0 +1,70 @@
+package lavasession
+
+// EndpointDisableReason names WHY one endpoint URL was taken out of rotation.
+//
+// This is the endpoint-level counterpart to BlockReason, and it exists because BlockReason cannot
+// answer the question. A provider block reads `all-endpoints-disabled`, which is not a cause — it is
+// a COUNT. It says "every URL I have is off" and nothing about why any of them went off, so an
+// operator reading it learns only what the block itself already told them.
+//
+// The causes that matter are all one level down, and they lead to different actions:
+//
+//	unreachable        network, DNS, TLS, a firewall — the request never arrived
+//	node-error         the node answered, and the answer was its own failure
+//	http-server-error  the node answered 5xx
+//
+// Every one of those produced the identical line before this existed:
+//
+//	WRN disabled unhealthy endpoint endpoint=... refusals=50
+//
+// The strings are operator-facing — they appear in that log line and in /debug/endpoint-state — so
+// the same two rules as BlockReason apply: say what HAPPENED rather than which counter tripped, and
+// prefer adding a value over redefining one, since renaming breaks dashboards and log queries.
+type EndpointDisableReason string
+
+const (
+	// EndpointDisableUnreachable — the request never got an answer. Timeout, connection refused,
+	// DNS failure, TLS mismatch, connection reset. CategoryInternal in the error registry.
+	//
+	// Actionable as an infrastructure problem: the address, the network path, or the credentials
+	// needed to open the connection.
+	EndpointDisableUnreachable EndpointDisableReason = "unreachable"
+
+	// EndpointDisableNodeError — the node answered, and the answer was its own failure: an internal
+	// error, a bad gateway, not-ready-yet. CategoryExternal and retryable, with none of the
+	// not-at-fault subcategories.
+	//
+	// Actionable as a node problem: the process is up and reachable but cannot serve.
+	EndpointDisableNodeError EndpointDisableReason = "node-error"
+
+	// EndpointDisableServerError — the node answered with an HTTP 5xx, decided on the status alone
+	// without reading the body.
+	//
+	// Kept distinct from node-error even though both mean "it answered badly": this one carries no
+	// registry classification at all, so it is the case where we know least. Merging them would hide
+	// that.
+	EndpointDisableServerError EndpointDisableReason = "http-server-error"
+
+	// EndpointDisableUnspecified — an endpoint was disabled without naming a reason. This is a bug:
+	// every call site names one. It exists so a missing reason is visibly wrong rather than an empty
+	// string that reads like "no reason needed".
+	EndpointDisableUnspecified EndpointDisableReason = "unspecified"
+)
+
+// allEndpointDisableReasons is the shared backing array — a package-level var rather than a fresh
+// slice per call, matching AllBlockReasons.
+var allEndpointDisableReasons = []EndpointDisableReason{
+	EndpointDisableUnreachable,
+	EndpointDisableNodeError,
+	EndpointDisableServerError,
+	EndpointDisableUnspecified,
+}
+
+// AllEndpointDisableReasons lists every reason a disable can carry, so a per-reason gauge can
+// publish a zero for the ones not currently in use and stay self-correcting.
+//
+// Keep in sync with the constants above — a reason missing here is a series that never returns to 0
+// once it has fired. TestEndpointDisableReasons_ListCoversEveryDeclaredConstant guards that.
+//
+// The returned slice is shared; callers must not mutate it.
+func AllEndpointDisableReasons() []EndpointDisableReason { return allEndpointDisableReasons }

--- a/protocol/lavasession/endpoint_disable_reason.go
+++ b/protocol/lavasession/endpoint_disable_reason.go
@@ -20,6 +20,20 @@ package lavasession
 // The strings are operator-facing — they appear in that log line and in /debug/endpoint-state — so
 // the same two rules as BlockReason apply: say what HAPPENED rather than which counter tripped, and
 // prefer adding a value over redefining one, since renaming breaks dashboards and log queries.
+// MERGE NOTE — #340 (bench-after) adds a THIRD disable call site that this PR cannot see.
+//
+// #340 introduces a disable for a node error delivered inside an HTTP 200 — the freeze it exists to
+// fix — at rpcsmartrouter_server.go. Merging the two branches is a COMPILE ERROR, not a silent
+// mismatch ("not enough arguments in call to targetEndpoint.MarkUnhealthy"), plus four textual
+// conflicts in direct_rpc_session_selection_test.go and endpoint_probe_reenable_test.go where #340
+// changed the loop counter to uint64 and this branch added the reason argument — both changes are
+// needed, so take theirs and keep the uint64.
+//
+// That third site MUST pass EndpointDisableNodeError. It is the commonest shape of a dying node and
+// the whole point of FAILOVER-TASKS section 2; resolving the compile error with
+// EndpointDisableUnspecified would make it build while shipping section 2's main disable path with
+// no reason at all — defeating this file precisely where it matters most.
+
 type EndpointDisableReason string
 
 const (

--- a/protocol/lavasession/endpoint_disable_reason.go
+++ b/protocol/lavasession/endpoint_disable_reason.go
@@ -9,9 +9,8 @@ package lavasession
 //
 // The causes that matter are all one level down, and they lead to different actions:
 //
-//	unreachable        network, DNS, TLS, a firewall — the request never arrived
-//	node-error         the node answered, and the answer was its own failure
-//	http-server-error  the node answered 5xx
+//	unreachable  network, DNS, TLS, a firewall — the request never arrived
+//	node-error   the node answered, and the answer was its own failure
 //
 // Every one of those produced the identical line before this existed:
 //
@@ -20,7 +19,17 @@ package lavasession
 // The strings are operator-facing — they appear in that log line and in /debug/endpoint-state — so
 // the same two rules as BlockReason apply: say what HAPPENED rather than which counter tripped, and
 // prefer adding a value over redefining one, since renaming breaks dashboards and log queries.
-// MERGE NOTE — #340 (bench-after) adds a THIRD disable call site that this PR cannot see.
+//
+// The vocabulary is deliberately the registry's own Internal/External boundary and nothing else.
+// An earlier draft carried a third value, `http-server-error`, for the disable site that decides on
+// an HTTP status without reading the body. It was dropped before merge because it did not name a
+// KIND of fault: JSON-RPC wraps a 5xx into an HTTPStatusError that reaches the registry and lands on
+// node-error, while REST returns it as a status and reached the status branch — so one upstream 5xx
+// incident split into two reasons purely by which api-interface the customer had configured, and a
+// dashboard grouped by reason would have shown two half-incidents. Both sites now classify through
+// the registry, so the label describes the fault rather than the transport that carried it.
+//
+// MERGE NOTE — #340 (bench-after) adds a THIRD disable call site that this branch cannot see.
 //
 // #340 introduces a disable for a node error delivered inside an HTTP 200 — the freeze it exists to
 // fix — at rpcsmartrouter_server.go. Merging the two branches is a COMPILE ERROR, not a silent
@@ -42,26 +51,30 @@ const (
 	//
 	// Actionable as an infrastructure problem: the address, the network path, or the credentials
 	// needed to open the connection.
+	//
+	// KNOWN GAP (MAG-3563): DNS, TLS and EOF faults do NOT reach this value today. The shared
+	// classifier has no branch for *net.DNSError, x509 errors or io.EOF, so they fall through to
+	// LavaErrorUnknown — CategoryExternal — and are recorded as node-error despite no node having
+	// answered. Pinned by the KNOWN-WRONG rows in
+	// rpcsmartrouter/endpoint_disable_reason_mapping_test.go, which turn red when MAG-3563 lands.
 	EndpointDisableUnreachable EndpointDisableReason = "unreachable"
 
 	// EndpointDisableNodeError — the node answered, and the answer was its own failure: an internal
-	// error, a bad gateway, not-ready-yet. CategoryExternal and retryable, with none of the
-	// not-at-fault subcategories.
+	// error, a bad gateway, not-ready-yet, an HTTP 5xx. CategoryExternal and retryable, with none of
+	// the not-at-fault subcategories.
 	//
 	// Actionable as a node problem: the process is up and reachable but cannot serve.
 	EndpointDisableNodeError EndpointDisableReason = "node-error"
 
-	// EndpointDisableServerError — the node answered with an HTTP 5xx, decided on the status alone
-	// without reading the body.
-	//
-	// Kept distinct from node-error even though both mean "it answered badly": this one carries no
-	// registry classification at all, so it is the case where we know least. Merging them would hide
-	// that.
-	EndpointDisableServerError EndpointDisableReason = "http-server-error"
-
 	// EndpointDisableUnspecified — an endpoint was disabled without naming a reason. This is a bug:
 	// every call site names one. It exists so a missing reason is visibly wrong rather than an empty
 	// string that reads like "no reason needed".
+	//
+	// Unreachable by construction today — every call site passes a named constant, and the two
+	// normalisation guards that can produce it (markUnhealthyAt's empty check and
+	// endpointDisableReasonFor's nil check) are both dead on current callers. They are kept as
+	// invariant guards so a FUTURE call site cannot introduce a silently empty reason, and both are
+	// pinned by tests rather than left to be rediscovered.
 	EndpointDisableUnspecified EndpointDisableReason = "unspecified"
 )
 
@@ -70,15 +83,20 @@ const (
 var allEndpointDisableReasons = []EndpointDisableReason{
 	EndpointDisableUnreachable,
 	EndpointDisableNodeError,
-	EndpointDisableServerError,
 	EndpointDisableUnspecified,
 }
 
-// AllEndpointDisableReasons lists every reason a disable can carry, so a per-reason gauge can
-// publish a zero for the ones not currently in use and stay self-correcting.
+// AllEndpointDisableReasons lists every reason a disable can carry.
 //
-// Keep in sync with the constants above — a reason missing here is a series that never returns to 0
-// once it has fired. TestEndpointDisableReasons_ListCoversEveryDeclaredConstant guards that.
+// It has no production caller yet. It exists for a per-reason gauge that is NOT wired in this
+// change — smartrouter_csm_disabled_endpoints_by_reason, mirroring how AllBlockReasons feeds
+// smartrouter_csm_blocked_providers_by_reason — so that gauge can publish a zero for the reasons not
+// currently in use and stay self-correcting. Tracked in the PR's "Follow-up, not in this PR"
+// section. Until then it is used only by the coverage test below.
+//
+// Keep in sync with the constants above — a reason missing here would, once that gauge exists, be a
+// series that never returns to 0 after it has fired.
+// TestEndpointDisableReasons_ListCoversEveryDeclaredConstant guards that by scanning this file.
 //
 // The returned slice is shared; callers must not mutate it.
 func AllEndpointDisableReasons() []EndpointDisableReason { return allEndpointDisableReasons }

--- a/protocol/lavasession/endpoint_disable_reason_test.go
+++ b/protocol/lavasession/endpoint_disable_reason_test.go
@@ -1,0 +1,120 @@
+package lavasession
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func disabledEndpoint(t *testing.T, reason EndpointDisableReason) *Endpoint {
+	t.Helper()
+	e := &Endpoint{NetworkAddress: "http://reason-test", Enabled: true}
+	for i := uint64(0); i < MaxConsecutiveConnectionAttempts; i++ {
+		e.MarkUnhealthy(reason)
+	}
+	require.False(t, e.Enabled, "precondition: the endpoint must be disabled")
+	return e
+}
+
+// The reason has to survive on the endpoint, or the whole point is lost: the provider-level record
+// says `all-endpoints-disabled`, which is a count of endpoints rather than a cause.
+func TestEndpointDisableReason_IsRecorded(t *testing.T) {
+	for _, reason := range []EndpointDisableReason{
+		EndpointDisableUnreachable,
+		EndpointDisableNodeError,
+		EndpointDisableServerError,
+	} {
+		t.Run(string(reason), func(t *testing.T) {
+			e := disabledEndpoint(t, reason)
+			require.Equal(t, reason, e.DisableReason())
+			require.Equal(t, reason, e.HealthSnapshot().DisableReason,
+				"the snapshot feeds /debug/endpoint-state and must carry it too")
+		})
+	}
+}
+
+// An enabled endpoint must carry no reason. One that did would read, in /debug/endpoint-state, as
+// simultaneously serving and disabled-because-of-X.
+func TestEndpointDisableReason_EmptyWhileEnabled(t *testing.T) {
+	e := &Endpoint{NetworkAddress: "http://reason-test", Enabled: true}
+	require.Empty(t, e.DisableReason(), "never disabled")
+
+	// Below the threshold the counter moves but the endpoint stays up — still no reason.
+	e.MarkUnhealthy(EndpointDisableNodeError)
+	require.True(t, e.Enabled)
+	require.Empty(t, e.DisableReason(), "the reason belongs to a disable, not to a failure")
+}
+
+// Cleared on recovery, alongside the disable timestamp it was captured with.
+func TestEndpointDisableReason_ClearedOnReEnable(t *testing.T) {
+	e := disabledEndpoint(t, EndpointDisableNodeError)
+	require.Equal(t, EndpointDisableNodeError, e.DisableReason())
+
+	require.True(t, e.ResetHealth(), "a successful relay re-enables")
+	require.True(t, e.Enabled)
+	require.Empty(t, e.DisableReason(), "a serving endpoint must not carry a stale reason")
+	require.True(t, e.HealthSnapshot().DisabledAt.IsZero(), "and the timestamp goes with it")
+}
+
+// Edge-triggered, exactly like DisabledAt. The reason belongs to the failure that actually took the
+// endpoint out; a later failure of a different kind against an already-disabled endpoint must not
+// rewrite the record of why it went down.
+func TestEndpointDisableReason_NotRewrittenWhileDisabled(t *testing.T) {
+	e := disabledEndpoint(t, EndpointDisableUnreachable)
+	at := e.HealthSnapshot().DisabledAt
+
+	for i := 0; i < 5; i++ {
+		e.MarkUnhealthy(EndpointDisableServerError)
+	}
+
+	require.Equal(t, EndpointDisableUnreachable, e.DisableReason(),
+		"the reason must stay with the failure that did it")
+	require.Equal(t, at, e.HealthSnapshot().DisabledAt,
+		"and it must not push the disable instant forward either")
+}
+
+// A probe re-enable is a trial, so the endpoint returns with no reason — and the NEXT disable
+// records its own, which may well differ from the one that took it out the first time.
+func TestEndpointDisableReason_ProbeReEnableClearsThenRecordsAfresh(t *testing.T) {
+	e := disabledEndpoint(t, EndpointDisableUnreachable)
+
+	e.mu.Lock()
+	e.reenableFromProbeLocked()
+	e.mu.Unlock()
+	require.True(t, e.Enabled)
+	require.Empty(t, e.DisableReason(), "a probe-re-enabled endpoint carries no reason")
+
+	// It comes back on a trial budget, so a handful of failures re-disable it.
+	for i := uint64(0); i < probeReenableTrialBudget; i++ {
+		e.MarkUnhealthy(EndpointDisableNodeError)
+	}
+	require.False(t, e.Enabled)
+	require.Equal(t, EndpointDisableNodeError, e.DisableReason(),
+		"the second episode records its own cause, not the first one's")
+}
+
+// An empty reason is a bug at the call site, not a legitimate "no reason needed". It is recorded as
+// unspecified so it shows up rather than reading as an absent field.
+func TestEndpointDisableReason_EmptyBecomesUnspecified(t *testing.T) {
+	e := disabledEndpoint(t, "")
+	require.Equal(t, EndpointDisableUnspecified, e.DisableReason())
+}
+
+// Keep AllEndpointDisableReasons in step with the constants: a reason missing from the list is a
+// metric series that never returns to zero once it has fired.
+func TestEndpointDisableReasons_ListCoversEveryDeclaredConstant(t *testing.T) {
+	declared := []EndpointDisableReason{
+		EndpointDisableUnreachable,
+		EndpointDisableNodeError,
+		EndpointDisableServerError,
+		EndpointDisableUnspecified,
+	}
+	require.ElementsMatch(t, declared, AllEndpointDisableReasons())
+
+	seen := map[EndpointDisableReason]bool{}
+	for _, r := range AllEndpointDisableReasons() {
+		require.NotEmpty(t, r, "a reason string must never be empty — that is the unspecified marker")
+		require.False(t, seen[r], "duplicate reason %q", r)
+		seen[r] = true
+	}
+}

--- a/protocol/lavasession/endpoint_disable_reason_test.go
+++ b/protocol/lavasession/endpoint_disable_reason_test.go
@@ -8,15 +8,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// disabledEndpoint drives a fresh endpoint to disabled with the given reason. It delegates to
+// disableAtWithReason rather than repeating the threshold loop — the two used to be separate copies
+// of the same loop and their failure messages had already drifted apart.
 func disabledEndpoint(t *testing.T, reason EndpointDisableReason) *Endpoint {
 	t.Helper()
 	e := &Endpoint{NetworkAddress: "http://reason-test", Enabled: true}
-	for i := uint64(0); i < MaxConsecutiveConnectionAttempts; i++ {
-		e.MarkUnhealthy(reason)
-	}
-	require.False(t, e.Enabled, "precondition: the endpoint must be disabled")
+	disableAtWithReason(t, e, probeBase, reason)
 	return e
 }
+
+// reasonOf reads the recorded reason the way production does — through the snapshot, which is the
+// type's only synchronised read path and what feeds /debug/endpoint-state. There is deliberately no
+// per-field getter (the type has none for DisabledAt or ConsecutiveHealthyProbes either).
+func reasonOf(e *Endpoint) EndpointDisableReason { return e.HealthSnapshot().DisableReason }
 
 // The reason has to survive on the endpoint, or the whole point is lost: the provider-level record
 // says `all-endpoints-disabled`, which is a count of endpoints rather than a cause.
@@ -24,13 +29,11 @@ func TestEndpointDisableReason_IsRecorded(t *testing.T) {
 	for _, reason := range []EndpointDisableReason{
 		EndpointDisableUnreachable,
 		EndpointDisableNodeError,
-		EndpointDisableServerError,
 	} {
 		t.Run(string(reason), func(t *testing.T) {
 			e := disabledEndpoint(t, reason)
-			require.Equal(t, reason, e.DisableReason())
-			require.Equal(t, reason, e.HealthSnapshot().DisableReason,
-				"the snapshot feeds /debug/endpoint-state and must carry it too")
+			require.Equal(t, reason, reasonOf(e),
+				"the snapshot feeds /debug/endpoint-state and must carry it")
 		})
 	}
 }
@@ -39,22 +42,22 @@ func TestEndpointDisableReason_IsRecorded(t *testing.T) {
 // simultaneously serving and disabled-because-of-X.
 func TestEndpointDisableReason_EmptyWhileEnabled(t *testing.T) {
 	e := &Endpoint{NetworkAddress: "http://reason-test", Enabled: true}
-	require.Empty(t, e.DisableReason(), "never disabled")
+	require.Empty(t, reasonOf(e), "never disabled")
 
 	// Below the threshold the counter moves but the endpoint stays up — still no reason.
 	e.MarkUnhealthy(EndpointDisableNodeError)
 	require.True(t, e.Enabled)
-	require.Empty(t, e.DisableReason(), "the reason belongs to a disable, not to a failure")
+	require.Empty(t, reasonOf(e), "the reason belongs to a disable, not to a failure")
 }
 
 // Cleared on recovery, alongside the disable timestamp it was captured with.
 func TestEndpointDisableReason_ClearedOnReEnable(t *testing.T) {
 	e := disabledEndpoint(t, EndpointDisableNodeError)
-	require.Equal(t, EndpointDisableNodeError, e.DisableReason())
+	require.Equal(t, EndpointDisableNodeError, reasonOf(e))
 
 	require.True(t, e.ResetHealth(), "a successful relay re-enables")
 	require.True(t, e.Enabled)
-	require.Empty(t, e.DisableReason(), "a serving endpoint must not carry a stale reason")
+	require.Empty(t, reasonOf(e), "a serving endpoint must not carry a stale reason")
 	require.True(t, e.HealthSnapshot().DisabledAt.IsZero(), "and the timestamp goes with it")
 }
 
@@ -66,10 +69,10 @@ func TestEndpointDisableReason_NotRewrittenWhileDisabled(t *testing.T) {
 	at := e.HealthSnapshot().DisabledAt
 
 	for i := 0; i < 5; i++ {
-		e.MarkUnhealthy(EndpointDisableServerError)
+		e.MarkUnhealthy(EndpointDisableNodeError)
 	}
 
-	require.Equal(t, EndpointDisableUnreachable, e.DisableReason(),
+	require.Equal(t, EndpointDisableUnreachable, reasonOf(e),
 		"the reason must stay with the failure that did it")
 	require.Equal(t, at, e.HealthSnapshot().DisabledAt,
 		"and it must not push the disable instant forward either")
@@ -84,22 +87,45 @@ func TestEndpointDisableReason_ProbeReEnableClearsThenRecordsAfresh(t *testing.T
 	e.reenableFromProbeLocked()
 	e.mu.Unlock()
 	require.True(t, e.Enabled)
-	require.Empty(t, e.DisableReason(), "a probe-re-enabled endpoint carries no reason")
+	require.Empty(t, reasonOf(e), "a probe-re-enabled endpoint carries no reason")
 
 	// It comes back on a trial budget, so a handful of failures re-disable it.
 	for i := uint64(0); i < probeReenableTrialBudget; i++ {
 		e.MarkUnhealthy(EndpointDisableNodeError)
 	}
 	require.False(t, e.Enabled)
-	require.Equal(t, EndpointDisableNodeError, e.DisableReason(),
+	require.Equal(t, EndpointDisableNodeError, reasonOf(e),
 		"the second episode records its own cause, not the first one's")
 }
 
 // An empty reason is a bug at the call site, not a legitimate "no reason needed". It is recorded as
 // unspecified so it shows up rather than reading as an absent field.
+//
+// Unreachable from production — every call site passes a named constant — so this pins the guard
+// itself, which is the only thing standing between a future caller's mistake and a disabled endpoint
+// whose snapshot reads {Enabled: false, DisableReason: ""}, i.e. indistinguishable from enabled.
 func TestEndpointDisableReason_EmptyBecomesUnspecified(t *testing.T) {
 	e := disabledEndpoint(t, "")
-	require.Equal(t, EndpointDisableUnspecified, e.DisableReason())
+	require.Equal(t, EndpointDisableUnspecified, reasonOf(e))
+}
+
+// The dial-failure path disables the endpoint directly rather than through MarkUnhealthy, and it
+// used to stamp disabledAt without a reason — producing a snapshot that reads
+// {Enabled: false, DisabledAt: set, DisableReason: ""}, which the field docs define as enabled.
+// Both disable paths now go through disableLocked, so the invariant belongs to the type.
+func TestDisableLocked_RecordsBothTimestampAndReason(t *testing.T) {
+	e := &Endpoint{NetworkAddress: "http://reason-test", Enabled: true}
+
+	e.mu.Lock()
+	e.disableLocked(probeBase, EndpointDisableUnreachable)
+	e.mu.Unlock()
+
+	snap := e.HealthSnapshot()
+	require.False(t, snap.Enabled)
+	require.Equal(t, probeBase, snap.DisabledAt, "the instant is recorded")
+	require.Equal(t, EndpointDisableUnreachable, snap.DisableReason,
+		"and so is the reason — a disabled endpoint with an empty reason reads as enabled")
+	require.Zero(t, snap.ConsecutiveHealthyProbes, "the recovery streak starts fresh")
 }
 
 // Keep AllEndpointDisableReasons in step with the constants: a reason missing from the list is a

--- a/protocol/lavasession/endpoint_disable_reason_test.go
+++ b/protocol/lavasession/endpoint_disable_reason_test.go
@@ -1,6 +1,8 @@
 package lavasession
 
 import (
+	"os"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -102,19 +104,28 @@ func TestEndpointDisableReason_EmptyBecomesUnspecified(t *testing.T) {
 
 // Keep AllEndpointDisableReasons in step with the constants: a reason missing from the list is a
 // metric series that never returns to zero once it has fired.
+// Scans the source rather than comparing two hand-written lists. A hand-copied `declared` slice
+// cannot catch the failure this guards — a constant added to neither list would satisfy both sides
+// of the comparison and pass. Mirrors TestBlockReasons_ListCoversEveryDeclaredConstant, which reads
+// block_reason.go for exactly this reason.
 func TestEndpointDisableReasons_ListCoversEveryDeclaredConstant(t *testing.T) {
-	declared := []EndpointDisableReason{
-		EndpointDisableUnreachable,
-		EndpointDisableNodeError,
-		EndpointDisableServerError,
-		EndpointDisableUnspecified,
-	}
-	require.ElementsMatch(t, declared, AllEndpointDisableReasons())
+	source, err := os.ReadFile("endpoint_disable_reason.go")
+	require.NoError(t, err)
 
-	seen := map[EndpointDisableReason]bool{}
-	for _, r := range AllEndpointDisableReasons() {
-		require.NotEmpty(t, r, "a reason string must never be empty — that is the unspecified marker")
-		require.False(t, seen[r], "duplicate reason %q", r)
-		seen[r] = true
+	declared := regexp.MustCompile(`EndpointDisableReason\s*=\s*"([^"]+)"`).FindAllStringSubmatch(string(source), -1)
+	require.NotEmpty(t, declared, "the declarations must be findable, or this guard is silently useless")
+
+	listed := make(map[EndpointDisableReason]struct{}, len(AllEndpointDisableReasons()))
+	for _, reason := range AllEndpointDisableReasons() {
+		require.NotEmpty(t, reason, "a reason string must never be empty — that is the unspecified marker")
+		_, duplicate := listed[reason]
+		require.Falsef(t, duplicate, "duplicate reason %q in AllEndpointDisableReasons()", reason)
+		listed[reason] = struct{}{}
 	}
+	for _, match := range declared {
+		_, ok := listed[EndpointDisableReason(match[1])]
+		require.Truef(t, ok, "EndpointDisableReason %q is declared but missing from AllEndpointDisableReasons() — "+
+			"its gauge series would never return to 0", match[1])
+	}
+	require.Len(t, listed, len(declared), "AllEndpointDisableReasons() lists a reason that is not declared")
 }

--- a/protocol/lavasession/endpoint_probe_reenable_test.go
+++ b/protocol/lavasession/endpoint_probe_reenable_test.go
@@ -20,7 +20,7 @@ var probeBase = time.Unix(1_700_000_000, 0)
 func disableAt(t *testing.T, e *Endpoint, at time.Time) {
 	t.Helper()
 	for i := 0; i < MaxConsecutiveConnectionAttempts; i++ {
-		e.markUnhealthyAt(at)
+		e.markUnhealthyAt(at, EndpointDisableUnreachable)
 	}
 	require.False(t, e.Enabled, "endpoint must be disabled after the relay disable threshold")
 }
@@ -136,7 +136,7 @@ func TestRecordProbeVerdict_NeverTouchesEnabledEndpoint(t *testing.T) {
 	e := &Endpoint{NetworkAddress: "http://ep:8545", Enabled: true}
 
 	for i := 0; i < MaxConsecutiveConnectionAttempts-1; i++ {
-		e.markUnhealthyAt(probeBase)
+		e.markUnhealthyAt(probeBase, EndpointDisableUnreachable)
 	}
 	require.True(t, e.Enabled)
 
@@ -150,7 +150,7 @@ func TestRecordProbeVerdict_NeverTouchesEnabledEndpoint(t *testing.T) {
 	require.Equal(t, uint64(0), e.consecutiveHealthyProbes, "the hysteresis streak stays 0 while enabled")
 	e.mu.RUnlock()
 
-	e.markUnhealthyAt(probeBase)
+	e.markUnhealthyAt(probeBase, EndpointDisableUnreachable)
 	require.False(t, e.Enabled, "the relay path can still disable despite intervening healthy probes")
 }
 
@@ -171,11 +171,11 @@ func TestRecordProbeVerdict_TrialBudgetOnProbeReEnable(t *testing.T) {
 
 	// The trial tolerates budget-1 failures without re-disabling…
 	for i := uint64(0); i < probeReenableTrialBudget-1; i++ {
-		e.markUnhealthyAt(probeBase.Add(3 * time.Second))
+		e.markUnhealthyAt(probeBase.Add(3*time.Second), EndpointDisableUnreachable)
 	}
 	require.True(t, e.Enabled, "a re-enabled endpoint isn't one failure from disabling — the trial budget absorbs blips")
 	// …and the budget-th consecutive failure ends the trial.
-	e.markUnhealthyAt(probeBase.Add(3 * time.Second))
+	e.markUnhealthyAt(probeBase.Add(3*time.Second), EndpointDisableUnreachable)
 	require.False(t, e.Enabled, "a still-broken endpoint re-disables after the trial budget, not after another full threshold")
 
 	// A successful real relay during a trial restores the FULL consecutive-failure budget. The
@@ -186,10 +186,10 @@ func TestRecordProbeVerdict_TrialBudgetOnProbeReEnable(t *testing.T) {
 	require.True(t, healthyPoll(e, probeBase.Add(time.Duration(3+2*k)*time.Second), k))
 	require.True(t, e.ResetHealth(), "a successful relay validates the trial")
 	for i := 0; i < MaxConsecutiveConnectionAttempts-1; i++ {
-		e.markUnhealthyAt(probeBase.Add(6 * time.Second))
+		e.markUnhealthyAt(probeBase.Add(6*time.Second), EndpointDisableUnreachable)
 	}
 	require.True(t, e.Enabled, "after relay validation the endpoint has the full failure budget again")
-	e.markUnhealthyAt(probeBase.Add(6 * time.Second))
+	e.markUnhealthyAt(probeBase.Add(6*time.Second), EndpointDisableUnreachable)
 	require.False(t, e.Enabled)
 }
 
@@ -207,7 +207,7 @@ func TestRecordProbeVerdict_DisabledAtNotPushedForwardByRepeatedMarkUnhealthy(t 
 	// More relay failures arrive on the already-disabled endpoint at a LATER instant. If disabledAt
 	// were re-stamped to this later time, the prior post-disable poll would retroactively look
 	// pre-disable and the streak would be wasted.
-	e.markUnhealthyAt(probeBase.Add(100 * time.Second))
+	e.markUnhealthyAt(probeBase.Add(100*time.Second), EndpointDisableUnreachable)
 	e.mu.RLock()
 	require.Equal(t, probeBase, e.disabledAt, "disabledAt must not move on an already-disabled endpoint")
 	e.mu.RUnlock()
@@ -292,7 +292,7 @@ func TestResetHealth_GenuineRecoveryDoesNotEscalate(t *testing.T) {
 	require.True(t, healthyPoll(e, probeBase.Add(2*time.Second), k), "re-enabled by the probe")
 
 	// A real relay succeeds, validating the recovery (clears the probe-grant flag).
-	e.markUnhealthyAt(probeBase.Add(3 * time.Second)) // a partial failure raises refusals so ResetHealth acts
+	e.markUnhealthyAt(probeBase.Add(3*time.Second), EndpointDisableUnreachable) // a partial failure raises refusals so ResetHealth acts
 	require.True(t, e.ResetHealth())
 
 	// A later disable is a fresh first offense, not a flap — no escalation.

--- a/protocol/lavasession/endpoint_probe_reenable_test.go
+++ b/protocol/lavasession/endpoint_probe_reenable_test.go
@@ -17,12 +17,21 @@ var probeBase = time.Unix(1_700_000_000, 0)
 
 // disableAt drives an endpoint to the disabled state via the relay path at a fixed instant, so
 // disabledAt is deterministic (edge-triggered on the actual Enabled→false transition).
-func disableAt(t *testing.T, e *Endpoint, at time.Time) {
+//
+// The reason is a parameter because the disable-reason tests need to vary it; every other caller
+// wants "some disable happened" and passes EndpointDisableUnreachable via disableAtDefault.
+func disableAtWithReason(t *testing.T, e *Endpoint, at time.Time, reason EndpointDisableReason) {
 	t.Helper()
 	for i := 0; i < MaxConsecutiveConnectionAttempts; i++ {
-		e.markUnhealthyAt(at, EndpointDisableUnreachable)
+		e.markUnhealthyAt(at, reason)
 	}
 	require.False(t, e.Enabled, "endpoint must be disabled after the relay disable threshold")
+}
+
+// disableAt is disableAtWithReason for the tests that do not care which reason took the endpoint out.
+func disableAt(t *testing.T, e *Endpoint, at time.Time) {
+	t.Helper()
+	disableAtWithReason(t, e, at, EndpointDisableUnreachable)
 }
 
 // healthyPoll is a valid post-disable recovery verdict: a successful poll at pollTime, keeping up.

--- a/protocol/lavasession/restore_recovered_provider_test.go
+++ b/protocol/lavasession/restore_recovered_provider_test.go
@@ -162,7 +162,7 @@ func TestEndpointEnabled_NoRaceUnderConcurrentProbeAndRelay(t *testing.T) {
 			case <-stop:
 				return
 			default:
-				e.MarkUnhealthy()
+				e.MarkUnhealthy(EndpointDisableUnreachable)
 			}
 		}
 	}()

--- a/protocol/rpcsmartrouter/endpoint_disable_reason_mapping_test.go
+++ b/protocol/rpcsmartrouter/endpoint_disable_reason_mapping_test.go
@@ -60,7 +60,7 @@ func classifyThroughRelayPath(err error, transport common.TransportType) *common
 // the string-fallback table has no matching row, so those faults classify as LavaErrorUnknown —
 // which is CategoryExternal, and every External maps to node-error. That is a pre-existing gap in
 // the shared classifier (it predates the disable-reason work and is used by retry, QoS and backoff
-// as well), so it is fixed in its own ticket rather than here. See MAG-XXXX.
+// as well), so it is fixed in its own ticket rather than here. See MAG-3563.
 func TestEndpointDisableReasonFor_RealTransportFaults(t *testing.T) {
 	refused := syscall.ECONNREFUSED
 	cases := []struct {
@@ -68,7 +68,7 @@ func TestEndpointDisableReasonFor_RealTransportFaults(t *testing.T) {
 		err        error
 		transport  common.TransportType
 		want       lavasession.EndpointDisableReason
-		knownWrong lavasession.EndpointDisableReason // non-empty = what it SHOULD be once MAG-XXXX lands
+		knownWrong lavasession.EndpointDisableReason // non-empty = what it SHOULD be once MAG-3563 lands
 	}{
 		{
 			name: "connection refused", err: &net.OpError{Op: "dial", Net: "tcp", Err: &refused},

--- a/protocol/rpcsmartrouter/endpoint_disable_reason_mapping_test.go
+++ b/protocol/rpcsmartrouter/endpoint_disable_reason_mapping_test.go
@@ -1,0 +1,148 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"io"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/stretchr/testify/require"
+)
+
+// The reason recorded on a disable is only worth having if it is right, and nothing else pins the
+// mapping — the behavioural tests in lavasession pass a reason in and assert it comes back out, so
+// they would agree with any mapping at all, including an inverted one.
+func TestEndpointDisableReasonFor_MapsRegistryCategory(t *testing.T) {
+	t.Run("internal means the request never got an answer", func(t *testing.T) {
+		require.Equal(t, lavasession.EndpointDisableUnreachable,
+			endpointDisableReasonFor(common.LavaErrorConnectionRefused))
+		require.Equal(t, lavasession.EndpointDisableUnreachable,
+			endpointDisableReasonFor(common.LavaErrorConnectionTimeout))
+	})
+
+	t.Run("external means the node answered and the answer was its own failure", func(t *testing.T) {
+		require.Equal(t, common.CategoryExternal, common.LavaErrorNodeInternalError.Category,
+			"precondition: this fixture must be the External case")
+		require.Equal(t, lavasession.EndpointDisableNodeError,
+			endpointDisableReasonFor(common.LavaErrorNodeInternalError))
+	})
+
+	t.Run("nil is a bug, and must be visibly wrong rather than empty", func(t *testing.T) {
+		require.Equal(t, lavasession.EndpointDisableUnspecified, endpointDisableReasonFor(nil))
+	})
+}
+
+// classifyThroughRelayPath mirrors what the disable site actually runs
+// (rpcsmartrouter_server.go: classified = ClassifyError(DetectConnectionError(err), ...)), so this
+// table measures the reason a real fault produces rather than the reason a hand-built LavaError does.
+func classifyThroughRelayPath(err error, transport common.TransportType) *common.LavaError {
+	errorCode := 0
+	var httpErr *lavasession.HTTPStatusError
+	if errors.As(err, &httpErr) {
+		errorCode = httpErr.StatusCode
+	}
+	return common.ClassifyError(common.DetectConnectionError(err), common.ChainFamilyEVM, transport, errorCode, err.Error())
+}
+
+// Characterisation test: this pins what a real transport fault is labelled TODAY, end to end.
+//
+// Several rows below are marked KNOWN-WRONG. They are asserted as-is deliberately — the reason is
+// wrong for them today, and a test that asserted the desired value would fail on main and tell
+// nobody anything. Pinned here, the wrongness is visible in the source and this test turns red the
+// moment the classifier is fixed, which is the prompt to update the expectations.
+//
+// Cause: common.DetectConnectionError has no branch for *net.DNSError, x509 errors or io.EOF, and
+// the string-fallback table has no matching row, so those faults classify as LavaErrorUnknown —
+// which is CategoryExternal, and every External maps to node-error. That is a pre-existing gap in
+// the shared classifier (it predates the disable-reason work and is used by retry, QoS and backoff
+// as well), so it is fixed in its own ticket rather than here. See MAG-XXXX.
+func TestEndpointDisableReasonFor_RealTransportFaults(t *testing.T) {
+	refused := syscall.ECONNREFUSED
+	cases := []struct {
+		name       string
+		err        error
+		transport  common.TransportType
+		want       lavasession.EndpointDisableReason
+		knownWrong lavasession.EndpointDisableReason // non-empty = what it SHOULD be once MAG-XXXX lands
+	}{
+		{
+			name: "connection refused", err: &net.OpError{Op: "dial", Net: "tcp", Err: &refused},
+			transport: common.TransportJsonRPC, want: lavasession.EndpointDisableUnreachable,
+		},
+		{
+			name: "context deadline exceeded", err: context.DeadlineExceeded,
+			transport: common.TransportJsonRPC, want: lavasession.EndpointDisableUnreachable,
+		},
+		{
+			name: "connection reset (string fallback)", err: errors.New("read tcp: connection reset by peer"),
+			transport: common.TransportJsonRPC, want: lavasession.EndpointDisableUnreachable,
+		},
+		{
+			name: "node answered 500", err: &lavasession.HTTPStatusError{StatusCode: 500, Status: "500"},
+			transport: common.TransportJsonRPC, want: lavasession.EndpointDisableNodeError,
+		},
+		// ---- KNOWN-WRONG below: all of these are infrastructure faults, none reached the node ----
+		{
+			name: "DNS: no such host", knownWrong: lavasession.EndpointDisableUnreachable,
+			err:       &net.OpError{Op: "dial", Net: "tcp", Err: &net.DNSError{Err: "no such host", Name: "rpc.example", IsNotFound: true}},
+			transport: common.TransportJsonRPC, want: lavasession.EndpointDisableNodeError,
+		},
+		{
+			name: "TLS: unknown authority", knownWrong: lavasession.EndpointDisableUnreachable,
+			err:       &net.OpError{Op: "dial", Net: "tcp", Err: x509.UnknownAuthorityError{}},
+			transport: common.TransportJsonRPC, want: lavasession.EndpointDisableNodeError,
+		},
+		{
+			name: "TLS: certificate expired", knownWrong: lavasession.EndpointDisableUnreachable,
+			err:       &net.OpError{Op: "dial", Net: "tcp", Err: x509.CertificateInvalidError{Reason: x509.Expired}},
+			transport: common.TransportJsonRPC, want: lavasession.EndpointDisableNodeError,
+		},
+		{
+			name: "io.EOF", knownWrong: lavasession.EndpointDisableUnreachable,
+			err:       io.EOF,
+			transport: common.TransportJsonRPC, want: lavasession.EndpointDisableNodeError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			classified := classifyThroughRelayPath(tc.err, tc.transport)
+			require.NotNil(t, classified, "ClassifyError never returns nil, so the nil branch is unreachable in production")
+
+			atFault, _ := classifyEndpointHealth(classified, false)
+			require.True(t, atFault, "precondition: this fault must reach the disable site at all")
+
+			got := endpointDisableReasonFor(classified)
+			if tc.knownWrong != "" {
+				require.Equalf(t, tc.want, got,
+					"KNOWN-WRONG row changed: %q now reports %q. If the classifier was fixed, this row should "+
+						"become %q and the knownWrong marker removed.", tc.name, got, tc.knownWrong)
+				return
+			}
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// The two disable sites derive the reason by different mechanisms — site 1 through the registry,
+// site 2 from the raw HTTP status — so the same upstream 5xx is labelled differently depending on
+// which api-interface the customer configured. Pinned so the divergence is a decision on the record
+// rather than a surprise on a dashboard grouped by disable_reason.
+func TestEndpointDisableReason_FiveHundredDivergesByTransport(t *testing.T) {
+	viaJSONRPC := endpointDisableReasonFor(
+		classifyThroughRelayPath(&lavasession.HTTPStatusError{StatusCode: 503, Status: "503"}, common.TransportJsonRPC))
+
+	// REST never reaches endpointDisableReasonFor at all: sendRESTRelay returns (result, nil) with
+	// StatusCode set, so the status branch at the call site hardcodes this constant instead.
+	viaREST := lavasession.EndpointDisableServerError
+
+	require.Equal(t, lavasession.EndpointDisableNodeError, viaJSONRPC,
+		"a 5xx arrives at the JSON-RPC site already wrapped as an error, so it is classified by the registry")
+	require.NotEqual(t, viaJSONRPC, viaREST,
+		"documented divergence: one upstream 5xx incident splits into two reasons by api-interface")
+}

--- a/protocol/rpcsmartrouter/endpoint_disable_reason_mapping_test.go
+++ b/protocol/rpcsmartrouter/endpoint_disable_reason_mapping_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"net/http"
 	"syscall"
 	"testing"
 
@@ -129,20 +130,45 @@ func TestEndpointDisableReasonFor_RealTransportFaults(t *testing.T) {
 	}
 }
 
-// The two disable sites derive the reason by different mechanisms — site 1 through the registry,
-// site 2 from the raw HTTP status — so the same upstream 5xx is labelled differently depending on
-// which api-interface the customer configured. Pinned so the divergence is a decision on the record
-// rather than a surprise on a dashboard grouped by disable_reason.
-func TestEndpointDisableReason_FiveHundredDivergesByTransport(t *testing.T) {
-	viaJSONRPC := endpointDisableReasonFor(
-		classifyThroughRelayPath(&lavasession.HTTPStatusError{StatusCode: 503, Status: "503"}, common.TransportJsonRPC))
+// One upstream 5xx must produce ONE reason, whichever api-interface carried it.
+//
+// The two disable sites reach the status by different routes: JSON-RPC's sender wraps it into an
+// HTTPStatusError that arrives as an error, while REST returns (result, nil) with StatusCode set, so
+// it lands on the status branch instead. An earlier draft of this change let the second site name a
+// reason from the raw code (`http-server-error`), which split one incident into two reasons purely
+// by customer configuration — a dashboard grouped by disable_reason would have shown two
+// half-incidents and neither would have matched the outage. Both sites now classify through the
+// registry, so this pins the convergence rather than the divergence.
+func TestEndpointDisableReason_FiveHundredAgreesAcrossTransports(t *testing.T) {
+	for _, statusCode := range []int{500, 502, 503} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			// Site 1's route: the sender wrapped the status into an error.
+			viaJSONRPC := endpointDisableReasonFor(classifyThroughRelayPath(
+				&lavasession.HTTPStatusError{StatusCode: statusCode, Status: http.StatusText(statusCode)},
+				common.TransportJsonRPC))
 
-	// REST never reaches endpointDisableReasonFor at all: sendRESTRelay returns (result, nil) with
-	// StatusCode set, so the status branch at the call site hardcodes this constant instead.
-	viaREST := lavasession.EndpointDisableServerError
+			// Site 2's route: (result, nil) with StatusCode set, classified from the status alone.
+			// Mirrors the call in relayInnerDirect exactly — nil connection error, empty message.
+			viaREST := endpointDisableReasonFor(
+				common.ClassifyError(nil, common.ChainFamilyEVM, common.TransportREST, statusCode, ""))
 
-	require.Equal(t, lavasession.EndpointDisableNodeError, viaJSONRPC,
-		"a 5xx arrives at the JSON-RPC site already wrapped as an error, so it is classified by the registry")
-	require.NotEqual(t, viaJSONRPC, viaREST,
-		"documented divergence: one upstream 5xx incident splits into two reasons by api-interface")
+			require.Equal(t, lavasession.EndpointDisableNodeError, viaJSONRPC,
+				"a 5xx means the node answered and the answer was its own failure")
+			require.Equal(t, viaJSONRPC, viaREST,
+				"one upstream incident, one reason — the label must describe the fault, not the transport")
+		})
+	}
+}
+
+// 429 must never reach the disable path: a rate-limited endpoint is not an unhealthy one, and
+// benching it would remove capacity precisely when the upstream is asking for less load. Guarded
+// here because the enclosing status branch matches `>= 500 || == 429`, so the whole carve-out lives
+// in classifyHTTPStatus and nothing else pinned it.
+func TestClassifyHTTPStatus_RateLimitDoesNotDisable(t *testing.T) {
+	shouldMarkUnhealthy, needsBackoff := classifyHTTPStatus(http.StatusTooManyRequests)
+	require.False(t, shouldMarkUnhealthy, "a 429 must not disable the endpoint")
+	require.True(t, needsBackoff, "but it must still back off")
+
+	shouldMarkUnhealthy, _ = classifyHTTPStatus(http.StatusServiceUnavailable)
+	require.True(t, shouldMarkUnhealthy, "control: a 5xx does disable")
 }

--- a/protocol/rpcsmartrouter/error_mapper.go
+++ b/protocol/rpcsmartrouter/error_mapper.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/magma-Devs/smart-router/protocol/chainlib"
 	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
 )
 
 // extractLavaError extracts the *common.LavaError from a LavaWrappedError,
@@ -104,4 +105,23 @@ func classifyEndpointHealth(classified *common.LavaError, isClientCancellation b
 	default:
 		return false, false
 	}
+}
+
+// endpointDisableReasonFor maps a classified relay error to the reason recorded on the disable.
+//
+// It is only ever consulted once classifyEndpointHealth has already decided the endpoint is at
+// fault, so it does not repeat that judgement — it only names which KIND of fault, which is the
+// distinction the provider-level `all-endpoints-disabled` cannot express.
+//
+// The split is the registry's own category boundary: Internal means the request never got an answer,
+// External means the node answered and the answer was its own failure. Those lead an operator to
+// different places — the network path versus the node process.
+func endpointDisableReasonFor(classified *common.LavaError) lavasession.EndpointDisableReason {
+	if classified == nil {
+		return lavasession.EndpointDisableUnspecified
+	}
+	if classified.Category == common.CategoryInternal {
+		return lavasession.EndpointDisableUnreachable
+	}
+	return lavasession.EndpointDisableNodeError
 }

--- a/protocol/rpcsmartrouter/error_mapper.go
+++ b/protocol/rpcsmartrouter/error_mapper.go
@@ -109,15 +109,26 @@ func classifyEndpointHealth(classified *common.LavaError, isClientCancellation b
 
 // endpointDisableReasonFor maps a classified relay error to the reason recorded on the disable.
 //
-// It is only ever consulted once classifyEndpointHealth has already decided the endpoint is at
-// fault, so it does not repeat that judgement — it only names which KIND of fault, which is the
-// distinction the provider-level `all-endpoints-disabled` cannot express.
+// It is consulted once the endpoint has already been judged at fault — by classifyEndpointHealth on
+// the error path, or by classifyHTTPStatus on the status path — so it does not repeat that
+// judgement. It only names which KIND of fault, which is the distinction the provider-level
+// `all-endpoints-disabled` cannot express.
 //
 // The split is the registry's own category boundary: Internal means the request never got an answer,
 // External means the node answered and the answer was its own failure. Those lead an operator to
-// different places — the network path versus the node process.
+// different places — the network path versus the node process. Both disable sites route through
+// here, so one upstream fault gets one reason regardless of which api-interface carried it.
+//
+// KNOWN GAP (MAG-3563): DNS, TLS and EOF faults arrive here classified External and are therefore
+// reported as node-error, though no node answered. The gap is in the shared classifier, not this
+// mapping — see the KNOWN-WRONG rows in endpoint_disable_reason_mapping_test.go.
 func endpointDisableReasonFor(classified *common.LavaError) lavasession.EndpointDisableReason {
 	if classified == nil {
+		// Unreachable today: ClassifyError never returns nil (its Step 3 falls back to
+		// LavaErrorUnknown) and extractLavaError's nil result is replaced before reaching here. Kept
+		// as a guard so a future caller cannot silently record an empty reason, which would read as
+		// "enabled" in /debug/endpoint-state. Pinned by
+		// TestEndpointDisableReasonFor_MapsRegistryCategory.
 		return lavasession.EndpointDisableUnspecified
 	}
 	if classified.Category == common.CategoryInternal {

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -1615,6 +1615,7 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 						"NetworkAddress":           url,
 						"Enabled":                  health.Enabled,
 						"DisabledAt":               debugTimeRFC3339(health.DisabledAt),
+						"DisableReason":            string(health.DisableReason),
 						"ConsecutiveHealthyProbes": health.ConsecutiveHealthyProbes,
 						"ConsecutivePollFailures":  obs.ConsecutivePollFailures,
 						"LastSuccessfulPoll":       debugTimeRFC3339(obs.LastSuccessfulPoll),

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -4241,7 +4241,7 @@ func (rpcss *RPCSmartRouterServer) relayInnerDirect(
 		// the disable episode carries its replayable recovery evidence (MAG-2550).
 		if shouldMarkUnhealthy && targetEndpoint != nil {
 			rpcss.recordRelayProbeEvidence(targetEndpoint, chainMessage, originalRequestData, relayTimeout)
-			targetEndpoint.MarkUnhealthy()
+			targetEndpoint.MarkUnhealthy(endpointDisableReasonFor(classified))
 			rpcss.smartRouterEndpointMetrics.SetEndpointOverallHealth(rpcss.listenEndpoint.ChainID, rpcss.listenEndpoint.ApiInterface, endpointName, false)
 		}
 
@@ -4265,7 +4265,10 @@ func (rpcss *RPCSmartRouterServer) relayInnerDirect(
 
 		if shouldMarkUnhealthy && targetEndpoint != nil {
 			rpcss.recordRelayProbeEvidence(targetEndpoint, chainMessage, originalRequestData, relayTimeout)
-			targetEndpoint.MarkUnhealthy()
+			// Decided on the status alone, without reading the body — so this is the case where the
+			// registry has told us nothing, and it is named separately from node-error to keep that
+			// visible rather than merged away.
+			targetEndpoint.MarkUnhealthy(lavasession.EndpointDisableServerError)
 			rpcss.smartRouterEndpointMetrics.SetEndpointOverallHealth(rpcss.listenEndpoint.ChainID, rpcss.listenEndpoint.ApiInterface, endpointName, false)
 			utils.LavaFormatDebug("endpoint returned error status",
 				utils.LogAttr("status", statusCode),

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -4181,28 +4181,12 @@ func (rpcss *RPCSmartRouterServer) relayInnerDirect(
 		classified := extractLavaError(err)
 		if classified == nil {
 			// Fallback: derive transport and chain family, classify from scratch
-			transport := common.TransportJsonRPC
-			switch directConnection.GetProtocol() {
-			case lavasession.DirectRPCProtocolGRPC:
-				transport = common.TransportGRPC
-			case lavasession.DirectRPCProtocolHTTP, lavasession.DirectRPCProtocolHTTPS:
-				// HTTP could be JSON-RPC or REST — use the endpoint's API interface
-				if rpcss.listenEndpoint.ApiInterface == "rest" {
-					transport = common.TransportREST
-				}
-			}
-
-			// Resolve chain family for Tier 2 matchers
-			chainFamily := common.ChainFamily(-1)
-			if family, ok := common.GetChainFamily(rpcss.listenEndpoint.ChainID); ok {
-				chainFamily = family
-			}
-
 			errorCode := 0
 			if httpErr, ok := err.(*lavasession.HTTPStatusError); ok {
 				errorCode = httpErr.StatusCode
 			}
-			classified = common.ClassifyError(common.DetectConnectionError(err), chainFamily, transport, errorCode, err.Error())
+			classified = common.ClassifyError(common.DetectConnectionError(err),
+				rpcss.directRelayChainFamily(), rpcss.directRelayTransport(directConnection), errorCode, err.Error())
 		}
 
 		// PROTOCOL_CONTEXT_CANCELED is expected in two cases:
@@ -4265,10 +4249,15 @@ func (rpcss *RPCSmartRouterServer) relayInnerDirect(
 
 		if shouldMarkUnhealthy && targetEndpoint != nil {
 			rpcss.recordRelayProbeEvidence(targetEndpoint, chainMessage, originalRequestData, relayTimeout)
-			// Decided on the status alone, without reading the body — so this is the case where the
-			// registry has told us nothing, and it is named separately from node-error to keep that
-			// visible rather than merged away.
-			targetEndpoint.MarkUnhealthy(lavasession.EndpointDisableServerError)
+			// Classify the status through the registry rather than naming a reason from the raw code.
+			// This branch is reached when the sender returned (result, nil) with an error status —
+			// REST's shape. The JSON-RPC sender wraps the same status into an HTTPStatusError that
+			// reaches the site above and is classified there, so deciding locally here would label one
+			// upstream 5xx incident two different ways depending only on the customer's api-interface,
+			// and a dashboard grouped by disable_reason would show two half-incidents.
+			statusClassified := common.ClassifyError(nil,
+				rpcss.directRelayChainFamily(), rpcss.directRelayTransport(directConnection), statusCode, "")
+			targetEndpoint.MarkUnhealthy(endpointDisableReasonFor(statusClassified))
 			rpcss.smartRouterEndpointMetrics.SetEndpointOverallHealth(rpcss.listenEndpoint.ChainID, rpcss.listenEndpoint.ApiInterface, endpointName, false)
 			utils.LavaFormatDebug("endpoint returned error status",
 				utils.LogAttr("status", statusCode),
@@ -5171,6 +5160,34 @@ func metadataFromDirectiveHeaders(directiveHeaders map[string]string) []pairingt
 		metadata = append(metadata, pairingtypes.Metadata{Name: name, Value: value})
 	}
 	return metadata
+}
+
+// directRelayTransport resolves which registry transport a direct-RPC connection speaks, so an
+// error can be classified with the same Tier-2 matchers the sender would have used.
+//
+// Shared by the two disable sites in relayInnerDirect. It used to be inlined at the first of them
+// only, which is how the second site ended up deciding a reason from the raw HTTP status instead —
+// splitting one upstream 5xx incident into two disable reasons by api-interface.
+func (rpcss *RPCSmartRouterServer) directRelayTransport(directConnection lavasession.DirectRPCConnection) common.TransportType {
+	switch directConnection.GetProtocol() {
+	case lavasession.DirectRPCProtocolGRPC:
+		return common.TransportGRPC
+	case lavasession.DirectRPCProtocolHTTP, lavasession.DirectRPCProtocolHTTPS:
+		// HTTP could be JSON-RPC or REST — use the endpoint's API interface
+		if rpcss.listenEndpoint.ApiInterface == "rest" {
+			return common.TransportREST
+		}
+	}
+	return common.TransportJsonRPC
+}
+
+// directRelayChainFamily resolves the chain family for Tier 2 matchers, or ChainFamily(-1) when the
+// chain is not one the registry knows.
+func (rpcss *RPCSmartRouterServer) directRelayChainFamily() common.ChainFamily {
+	if family, ok := common.GetChainFamily(rpcss.listenEndpoint.ChainID); ok {
+		return family
+	}
+	return common.ChainFamily(-1)
 }
 
 // classifyHTTPStatus classifies an HTTP status code for endpoint health decisions.


### PR DESCRIPTION
## Jira ticket

Jira ticket: MAG-2599

---

## The problem

Every provider block reads `all-endpoints-disabled`. **That is not a cause — it is a count.** It says
"every URL I have is off" and nothing about why any of them went off, so an operator reading it
learns only what the block itself already told them.

The causes are one level down, and they lead an operator to different places:

| Cause | Where to look |
|---|---|
| **unreachable** — timeout, connection refused, DNS, TLS, reset | the network path, the address, the credentials |
| **node-error** — the node answered, and the answer was its own failure | the node process; it is up and reachable but cannot serve |
| **http-server-error** — it answered 5xx | same, but we know least — this branch never read the body |

Before this, all three produced the identical line:

```
WRN disabled unhealthy endpoint endpoint=http://... refusals=50
```

**The information was already at both call sites and was being thrown away.** The relay path holds
the classified error (`:4067`) or the HTTP status (`:4091`) at the exact moment it decides to
disable. This records it.

## What changes

`MarkUnhealthy` now takes a reason. It is stored on the endpoint next to `disabledAt`, and surfaced
as `disable_reason` on the WARN line and `DisableReason` in `/debug/endpoint-state`.

```
WRN disabled unhealthy endpoint endpoint=http://... disable_reason=node-error refusals=50
```

**Two properties are load-bearing and pinned by tests:**

- **Edge-triggered.** Captured on the same `Enabled→false` transition that stamps `disabledAt`. A
  later failure of a *different* kind against an already-disabled endpoint must not rewrite the
  record of why it went down.
- **Cleared on re-enable.** An enabled endpoint carrying a stale reason would read, in
  `/debug/endpoint-state`, as simultaneously serving and disabled-because-of-X.

`http-server-error` is kept distinct from `node-error` deliberately. Both mean "it answered badly",
but that branch decides on the status without reading the body, so it carries no registry
classification at all — it is the case where we know least, and merging them would hide that.

An empty reason is treated as a bug (`unspecified`) rather than silently meaning "no reason needed",
matching how `BlockReasonUnspecified` is used one level up.

## Why this is separate from #340

**It was found while testing that PR, but it does not depend on it.**

Across every test scenario the provider `block_reason` had **one** value in 68 observations, and
`Reported` was **true** in all 46 — both invariant. The cause is structural: §2 deleted
`too-many-dead-sessions` and `never-served-successfully`, which were the two reasons that made the
field discriminate, and both surviving production callers of `blockProvider` pass
`reportProvider=true`.

MAG-2599's own justification for recording a reason was:

> *"a provider blocked for `too-many-dead-sessions` is never reported, so the reconnect loop can
> never release it, while one blocked for `all-endpoints-disabled` is"*

§2 deleted the half of that sentence that made it a distinction. **The endpoint level is where the
remaining distinctions actually are.**

The change itself is independent: it touches the two `MarkUnhealthy` call sites that already exist on
`main`, and needs nothing from #340. **When #340 lands it adds a third call site** — a node error
inside an HTTP 200 — which should pass `EndpointDisableNodeError`. One line.

## Tests

| Test | Pins |
|---|---|
| `IsRecorded` | each reason reaches both the endpoint and the health snapshot |
| `EmptyWhileEnabled` | no reason while serving, and none below the threshold |
| `ClearedOnReEnable` | cleared with `DisabledAt` on a successful relay |
| `NotRewrittenWhileDisabled` | a later failure of another kind does not overwrite it |
| `ProbeReEnableClearsThenRecordsAfresh` | a trial re-enable clears it; the next episode records its own |
| `EmptyBecomesUnspecified` | a missing reason is visible, not absent |
| `ListCoversEveryDeclaredConstant` | a per-reason gauge cannot acquire a series that never returns to 0 |

## Verification

`go build`, `go vet`, `gofmt` clean. Full `go test ./...` green.

## Follow-up, not in this PR

A per-reason metric. The `AllEndpointDisableReasons()` list exists so the gauge can publish a zero
for unused reasons and stay self-correcting — mirroring `AllBlockReasons()` — but no gauge is wired
yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VnZf2owXiRWzPUXpnTNoX

