### PR TITLE
feat(observability): report the pairing inventory and why the pool is empty (MAG-3331)

### DIFF
--- a/protocol/chainlib/chain_fetcher_addon_probe_test.go
+++ b/protocol/chainlib/chain_fetcher_addon_probe_test.go
@@ -95,7 +95,7 @@ func TestFetchLatestBlockNumKeepsBaseCollectionSemantics(t *testing.T) {
 
 	block, err := fetcher.FetchLatestBlockNum(context.Background())
 	require.Error(t, err)
-	require.Equal(t, int64(spectypes.NOT_APPLICABLE), block)
+	require.Equal(t, spectypes.NOT_APPLICABLE, block)
 }
 
 // acalaVerifications is the set GetVerifications returns for a node declaring

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -65,6 +65,19 @@ type ConsumerSessionManager struct {
 	pairingAddresses       map[uint64]string
 	pairingAddressesLength uint64
 
+	// pairingGeneration increments on every UpdateAllProviders. It is the key the pool-empty
+	// report throttles on: an empty pool is a property of the pairing, not of the request that
+	// tripped over it, so it is worth one WARN per pairing rather than one per relay.
+	pairingGeneration uint64
+
+	// poolEmptyReportMu guards the two fields below. A dedicated mutex rather than csm.lock: this
+	// is taken on the failing-relay path, and that path must not contend the manager's central
+	// lock just to decide whether a line has already been printed.
+	poolEmptyReportMu     sync.Mutex
+	poolEmptyReportedGen  uint64
+	poolEmptyReportedWhy  string
+	poolEmptyReportedEver bool
+
 	// lastPairingUpdate is when UpdateAllProviders last rebuilt the pairing. It is reported on the
 	// pool-empty line, where it separates a pool that was never populated (the provider failed its
 	// startup verification and was never added) from one that has drained since the last epoch —
@@ -626,6 +639,7 @@ func (csm *ConsumerSessionManager) UpdateAllProviders(epoch uint64, pairingList 
 	csm.stickySessions.DeleteOldSessions(previousEpoch)
 
 	csm.lastPairingUpdate = time.Now()
+	csm.pairingGeneration++
 
 	// The pairing inventory is the answer to "why was the primary not even a candidate?". A pool
 	// that never contained a provider and one that dropped it look identical from the selection
@@ -1093,20 +1107,62 @@ type poolInventory struct {
 	blockedCount      int
 	backupPoolSize    int
 	lastPairingUpdate time.Time
+
+	// capable counts pairing members that could serve THIS request — they pass the same
+	// addon/extension predicates the selectable set is built from — and capableBlocked how many of
+	// those are currently blocked.
+	//
+	// These exist because validCount cannot answer the question. validCount is the DEFAULT
+	// collection's size, while the emptiness that brings us here is addon-scoped, so comparing them
+	// is apples to oranges: a pairing of five with one archive provider that is blocked and four
+	// that never served archive has validCount=4 and reports "the addon filtered everything out",
+	// when the truth is that the single archive-capable provider is blocked. Scoping the counts to
+	// the request is what makes the reason survive contact with an addon.
+	capable        int
+	capableBlocked int
+
+	// generation is the pairing generation this snapshot was taken at, carried here rather than
+	// read separately so the throttle key and the counts it guards describe the same instant.
+	generation uint64
 }
 
-// snapshotPoolInventory reads the pool state for the diagnostic lines. Callers MUST NOT hold
-// csm.lock — this takes the read lock itself.
-func (csm *ConsumerSessionManager) snapshotPoolInventory() poolInventory {
+// snapshotPoolInventory reads the pool state for the diagnostic lines, scoped to the request that
+// found the pool empty. Callers MUST NOT hold csm.lock — this takes the read lock itself, and takes
+// it once so every field describes the same instant.
+func (csm *ConsumerSessionManager) snapshotPoolInventory(addon string, extensions []string, ctx context.Context) poolInventory {
 	csm.lock.RLock()
 	defer csm.lock.RUnlock()
-	return poolInventory{
+
+	blocked := make(map[string]struct{}, len(csm.currentlyBlockedProviderAddresses))
+	for _, address := range csm.currentlyBlockedProviderAddresses {
+		blocked[address] = struct{}{}
+	}
+
+	inventory := poolInventory{
 		pairingSize:       len(csm.pairingAddresses),
 		validCount:        len(csm.validAddresses),
 		blockedCount:      len(csm.currentlyBlockedProviderAddresses),
 		backupPoolSize:    len(csm.backupProviders),
 		lastPairingUpdate: csm.lastPairingUpdate,
+		generation:        csm.pairingGeneration,
 	}
+
+	// Same predicates CalculateAddonValidAddresses filters on, so "capable" means exactly "would
+	// have been selectable had it not been blocked".
+	for _, address := range csm.pairingAddresses {
+		provider, ok := csm.pairing[address]
+		if !ok || provider == nil {
+			continue
+		}
+		if !provider.IsSupportingAddon(addon) || !provider.IsSupportingExtensions(extensions, ctx) {
+			continue
+		}
+		inventory.capable++
+		if _, isBlocked := blocked[address]; isBlocked {
+			inventory.capableBlocked++
+		}
+	}
+	return inventory
 }
 
 // reason names WHY the selectable pool is empty, in the same kebab-case vocabulary as
@@ -1115,42 +1171,81 @@ func (csm *ConsumerSessionManager) snapshotPoolInventory() poolInventory {
 //
 //	pairing-empty        nothing was ever registered for this chain — the provider failed startup
 //	                     verification, or the epoch rebuilt with an empty list. Not a routing problem.
-//	addon-filtered       members survived into validAddresses, but none serves this addon/extension.
-//	no-usable-endpoints  members survived into validAddresses and the request asks for the default
-//	                     collection, which nothing filters except a provider having no usable
-//	                     endpoint. Registration succeeded, the endpoints behind it did not.
-//	all-blocked          every registered member is blocked. A routing problem, and the block
-//	                     reasons (MAG-2599) say which.
+//	addon-filtered       members are registered, and not one of them serves this addon/extension.
+//	                     A spec or config problem; no amount of routing recovers it.
+//	no-usable-endpoints  the request asks for the default collection, which every provider serves by
+//	                     definition, yet nothing is capable — the only predicate left is having at
+//	                     least one endpoint, so these providers registered with none.
+//	all-blocked          every member that COULD serve this request is blocked. A routing problem,
+//	                     and the block reasons (MAG-2599) say which.
 //
-// validCount is what separates the filtered causes from the blocked ones, and it is why the order
-// below is not negotiable. A member that is still in validAddresses was NOT taken out by blocking,
-// so if nothing is selectable the filter is what removed it. Testing blockedCount first — as this
-// did before — reported all-blocked for a pairing of five with one blocked member and four that
-// simply do not serve the requested addon, which is the mislabel this whole line exists to prevent.
+// Every branch keys on capable/capableBlocked, which are scoped to this request. Keying on
+// validCount instead — as this did before — compares the default collection's size against an
+// addon-scoped emptiness, and the two mislabels that produces are exact mirror images: testing
+// blockedCount first called a filtered pool "all-blocked", and testing validCount first called a
+// blocked pool "addon-filtered". Neither is fixed by reordering; both are fixed by counting the
+// providers that could actually have served.
 func (inv poolInventory) reason(addon string, extensions []string) string {
 	switch {
 	case inv.pairingSize == 0:
 		return "pairing-empty"
-	case inv.validCount > 0 && (addon != "" || len(extensions) > 0):
+	case inv.capable == 0 && (addon != "" || len(extensions) > 0):
 		return "addon-filtered"
-	case inv.validCount > 0:
+	case inv.capable == 0:
 		return "no-usable-endpoints"
-	case inv.blockedCount >= inv.pairingSize:
+	case inv.capableBlocked >= inv.capable:
 		return "all-blocked"
 	default:
-		// Members are registered, not all of them are blocked, and none reached validAddresses.
-		// Not a shape we model — name it rather than borrow one of the above.
+		// Providers that can serve this request exist and are not all blocked, yet nothing was
+		// selectable. Not a shape we model — name it rather than borrow one of the above.
 		return "unspecified"
 	}
 }
 
 // logPoolEmpty reports that nothing is selectable, and why. It is the one place the pool-empty
-// vocabulary is rendered, so the two call sites in releaseBlockedProvidersIfPoolEmpty — the guard's
-// empty-pairing return and the release itself — cannot drift into describing the same state
-// differently. Callers MUST NOT hold csm.lock: the inventory is snapshotted separately.
+// vocabulary is rendered, so the call sites in releaseBlockedProvidersIfPoolEmpty cannot drift into
+// describing the same state differently.
+//
+// The first report for a given pairing generation and reason goes to WARN; every repeat until one
+// of those changes goes to DEBUG. An empty pool is a property of the pairing, and the pairing does
+// not change between relays — a chain whose providers all failed startup verification stays empty
+// indefinitely, and this runs on every relay (more than once per relay, per GetSessions' retry
+// cascade). Reporting it per-relay at WARN would turn a permanent state into a sustained alert
+// stream, which is the log-flood this whole change set exists to reduce, only at a level alerts
+// fire on. Throttling on the generation means a genuinely new outage still warns immediately.
+//
+// Callers MUST NOT hold csm.lock: the inventory is snapshotted separately, and this takes
+// poolEmptyReportMu.
 func (csm *ConsumerSessionManager) logPoolEmpty(ctx context.Context, inventory poolInventory, addon string, extensions []string) {
-	utils.LavaFormatWarning("provider pool empty", nil,
-		utils.LogAttr("reason", inventory.reason(addon, extensions)),
+	why := inventory.reason(addon, extensions)
+
+	csm.poolEmptyReportMu.Lock()
+	generation := inventory.generation
+	firstForThisPairing := !csm.poolEmptyReportedEver ||
+		csm.poolEmptyReportedGen != generation ||
+		csm.poolEmptyReportedWhy != why
+	if firstForThisPairing {
+		csm.poolEmptyReportedEver = true
+		csm.poolEmptyReportedGen = generation
+		csm.poolEmptyReportedWhy = why
+	}
+	csm.poolEmptyReportMu.Unlock()
+
+	report := utils.LavaFormatDebug
+	if firstForThisPairing {
+		// LavaFormatWarning takes an error argument the debug form does not, so the two cannot share
+		// a function value the way the level-conditional sites elsewhere do.
+		report = func(description string, attributes ...utils.Attribute) error {
+			return utils.LavaFormatWarning(description, nil, attributes...)
+		}
+	}
+
+	report("provider pool empty",
+		utils.LogAttr("reason", why),
+		utils.LogAttr("repeat", !firstForThisPairing),
+		utils.LogAttr("pairing_generation", generation),
+		utils.LogAttr("capable", inventory.capable),
+		utils.LogAttr("capable_blocked", inventory.capableBlocked),
 		utils.LogAttr("spec", csm.rpcEndpoint.Key()),
 		utils.LogAttr("pairing_size", inventory.pairingSize),
 		utils.LogAttr("valid", inventory.validCount),
@@ -1234,15 +1329,22 @@ func (csm *ConsumerSessionManager) atomicReadNumberOfResets() (resets uint64) {
 // it is the frame that holds the pool inventory and the request GUID, so it can name the actual
 // cause and attribute it to a chain and a relay. Logging here as well only reproduced the same
 // event three more times, once at ERROR.
-func (csm *ConsumerSessionManager) resetValidAddresses(addon string, extensions []string) uint64 {
+// resetValidAddresses releases the blocked list and refills validAddresses from the pairing.
+//
+// didReset reports whether this call actually did that. The re-verify below can find the pool
+// already refilled — an epoch tick landing while we waited for the write lock — in which case this
+// is a no-op, and a caller that assumed otherwise would credit that epoch's recovery to a reset
+// that never ran. Returning the fact is what lets the caller describe what it actually did.
+func (csm *ConsumerSessionManager) resetValidAddresses(addon string, extensions []string) (numberOfResets uint64, didReset bool) {
 	csm.lock.Lock() // lock write
 	defer csm.lock.Unlock()
 	if len(csm.getValidAddresses(addon, extensions, context.Background())) == 0 { // re verify it didn't change while waiting for lock.
 		csm.setValidAddressesToDefaultValue(addon, extensions, context.Background(), ReleasePoolEmpty)
 		csm.numberOfResets += 1
+		didReset = true
 	}
 	// if len(csm.validAddresses) != 0 meaning we had a reset (or an epoch change), so we need to return the numberOfResets which is currently in csm
-	return csm.numberOfResets
+	return csm.numberOfResets, didReset
 }
 
 func (csm *ConsumerSessionManager) cacheAddonAddresses(addon string, extensions []string, ctx context.Context) []string {
@@ -1332,15 +1434,21 @@ func (csm *ConsumerSessionManager) releaseBlockedProvidersIfPoolEmpty(ctx contex
 	// the release for an empty pairing too — its loop over pairingAddresses never executes, so it
 	// returns false — and that return is the one shape this whole line exists to report. Taking the
 	// snapshot after the guard put the diagnosis on the far side of the branch that swallows it.
-	inventory := csm.snapshotPoolInventory()
+	inventory := csm.snapshotPoolInventory(addon, extensionNames, ctx)
 
 	if !csm.releaseCouldServeThisRequest(tempIgnoredProviders.providers, addon, extensionNames, ctx) {
 		// A declined release is usually ordinary retry exhaustion: this request has already tried
-		// every provider, releasing rescues nothing, and that stays at DEBUG. An empty pairing
-		// reaches the same return for the opposite reason — there was never a provider to try, so
-		// "every provider has already been tried" is not merely unhelpful, it is false. Nothing
-		// downstream can correct it either, because resetValidAddresses is never reached.
-		if inventory.pairingSize == 0 {
+		// every provider, releasing rescues nothing, and that stays at DEBUG.
+		//
+		// It is not always that, and the discriminator is whether this request tried anything — NOT
+		// whether the pairing is empty. releaseCouldServeThisRequest returns false for every
+		// structural emptiness too: an empty pairing, a pairing where nothing serves the requested
+		// addon, and a pairing whose members registered with no endpoints (IsSupportingExtensions
+		// is false for a zero-endpoint provider, so it fails the capability test even for the
+		// default collection). In all three nothing was tried, and "every provider has already been
+		// tried" is not merely unhelpful, it is false — the request tried nothing. Keying on
+		// pairingSize rescued only the first of the three and left the other two on the false line.
+		if len(tempIgnoredProviders.providers) == 0 {
 			csm.logPoolEmpty(ctx, inventory, addon, extensionNames)
 			return nil, false
 		}
@@ -1351,32 +1459,49 @@ func (csm *ConsumerSessionManager) releaseBlockedProvidersIfPoolEmpty(ctx contex
 
 	csm.logPoolEmpty(ctx, inventory, addon, extensionNames)
 
-	csm.resetValidAddresses(addon, extensionNames)
+	_, didReset := csm.resetValidAddresses(addon, extensionNames)
 
 	// The reset refills validAddresses straight from the pairing, so it can only restore what the
 	// pairing holds. With an empty pairing it is a no-op — and the line that used to report this
 	// said "RESET COMPLETED" at INFO either way, which reads as recovery precisely when none
 	// happened. Report the two outcomes as the different events they are.
 	restored := len(csm.cacheAddonAddresses(addon, extensionNames, ctx))
-	if restored == 0 {
-		// Re-snapshot. The reset cleared the blocked list and refilled validAddresses, so the
-		// pre-reset reason no longer describes the state we are in — reusing it would report
-		// all-blocked for a pool whose blocked list was just released and which still came up
-		// empty, naming the one cause the reset has already ruled out.
-		afterReset := csm.snapshotPoolInventory()
-		utils.LavaFormatWarning("pool reset recovered no providers", nil,
-			utils.LogAttr("reason", afterReset.reason(addon, extensionNames)),
+	switch {
+	case !didReset:
+		// The re-verify inside resetValidAddresses found the pool already refilled, so this call
+		// released nothing. Whatever repopulated it — an epoch tick that landed while we waited for
+		// the write lock — is not ours to claim, and "pool reset restored providers" would credit
+		// this request with a recovery it did not perform.
+		utils.LavaFormatDebug("pool refilled before the reset ran, nothing released",
+			utils.LogAttr("selectable", restored),
 			utils.LogAttr("spec", csm.rpcEndpoint.Key()),
-			utils.LogAttr("pairing_size", afterReset.pairingSize),
-			utils.LogAttr("released_from_blocked", inventory.blockedCount),
 			utils.LogAttr("addon", addon),
 			utils.LogAttr("extensions", extensionNames),
 			utils.LogAttr("GUID", ctx),
 		)
-	} else {
+	case restored == 0:
+		// Re-snapshot. The reset cleared the blocked list and refilled validAddresses, so the
+		// pre-reset reason no longer describes the state we are in — reusing it would report
+		// all-blocked for a pool whose blocked list was just released and which still came up
+		// empty, naming the one cause the reset has already ruled out.
+		afterReset := csm.snapshotPoolInventory(addon, extensionNames, ctx)
+		utils.LavaFormatWarning("pool reset recovered no providers", nil,
+			utils.LogAttr("reason", afterReset.reason(addon, extensionNames)),
+			utils.LogAttr("spec", csm.rpcEndpoint.Key()),
+			utils.LogAttr("pairing_size", afterReset.pairingSize),
+			// Named for its provenance: this count comes from the pre-reset snapshot, while the
+			// reason and size beside it come from the post-reset one. Two snapshots on one line is
+			// unavoidable here — the whole point is to contrast before with after — but a reader
+			// must not take them for one instant.
+			utils.LogAttr("blocked_before_reset", inventory.blockedCount),
+			utils.LogAttr("addon", addon),
+			utils.LogAttr("extensions", extensionNames),
+			utils.LogAttr("GUID", ctx),
+		)
+	default:
 		utils.LavaFormatInfo("pool reset restored providers",
 			utils.LogAttr("restored", restored),
-			utils.LogAttr("released_from_blocked", inventory.blockedCount),
+			utils.LogAttr("blocked_before_reset", inventory.blockedCount),
 			utils.LogAttr("spec", csm.rpcEndpoint.Key()),
 			utils.LogAttr("addon", addon),
 			utils.LogAttr("extensions", extensionNames),

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -1281,8 +1281,8 @@ func diffAddressSets(previous, current []string) (added, removed, carriedOver []
 	for _, address := range current {
 		currentSet[address] = struct{}{}
 	}
-	// Non-nil empties: a nil slice renders as "" in the log, which reads as a missing field rather
-	// than as "nothing changed".
+	// Non-nil empties. The log renders nil and empty identically (both ""), so this is for the
+	// callers: a returned slice is always safe to range over and append to.
 	added, removed, carriedOver = []string{}, []string{}, []string{}
 	for _, address := range current {
 		if _, existed := previousSet[address]; existed {
@@ -1316,25 +1316,17 @@ func (csm *ConsumerSessionManager) atomicReadNumberOfResets() (resets uint64) {
 	return atomic.LoadUint64(&csm.numberOfResets)
 }
 
-// reset the valid addresses list and increase numberOfResets
-//
-// The outcome is deliberately NOT logged here. It used to be, in three lines, and the last of them
-// blamed an expired or unpurchased subscription for an empty pool. The smart router has neither: it
-// has no subscription and no on-chain pairing, its provider set comes from the endpoint config and
-// from the epoch refresh that rebuilds it, and consumerPublicAddress is a locally generated
-// smart-router-<rand> identifier rather than an account. That line sent every reader of a real
-// customer capture to look at billing, and it fired roughly twice a second while doing it.
-//
-// The single caller reports the outcome instead — see releaseBlockedProvidersIfPoolEmpty — because
-// it is the frame that holds the pool inventory and the request GUID, so it can name the actual
-// cause and attribute it to a chain and a relay. Logging here as well only reproduced the same
-// event three more times, once at ERROR.
-// resetValidAddresses releases the blocked list and refills validAddresses from the pairing.
+// resetValidAddresses releases the blocked list, refills validAddresses from the pairing, and
+// increments numberOfResets.
 //
 // didReset reports whether this call actually did that. The re-verify below can find the pool
 // already refilled — an epoch tick landing while we waited for the write lock — in which case this
 // is a no-op, and a caller that assumed otherwise would credit that epoch's recovery to a reset
 // that never ran. Returning the fact is what lets the caller describe what it actually did.
+//
+// The outcome is reported by the single caller, releaseBlockedProvidersIfPoolEmpty, not here: that
+// frame holds the pool inventory and the request GUID, so it can name the cause and attribute it to
+// a chain and a relay.
 func (csm *ConsumerSessionManager) resetValidAddresses(addon string, extensions []string) (numberOfResets uint64, didReset bool) {
 	csm.lock.Lock() // lock write
 	defer csm.lock.Unlock()

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -593,6 +593,14 @@ func (csm *ConsumerSessionManager) UpdateAllProviders(epoch uint64, pairingList 
 	csm.providerOptimizer.UpdateWeights(weights, epoch)
 	go csm.consumerMetricsManager.ResetBlockedProvidersMetrics(csm.rpcEndpoint.ChainID, csm.rpcEndpoint.ApiInterface, providerAddressToEndpoint)
 
+	// Membership of the outgoing backup pool, captured before the map is replaced, for the same
+	// reason the pairing membership is: since MAG-2525 a chain can serve on backups alone, so a
+	// backup silently leaving the pool is the same invisible failure with the same blast radius.
+	previousBackupAddresses := make([]string, 0, len(csm.backupProviders))
+	for address := range csm.backupProviders {
+		previousBackupAddresses = append(previousBackupAddresses, address)
+	}
+
 	// Store backup providers separately from main pairing list for emergency fallback scenarios
 	csm.backupProviders = make(map[string]*ConsumerSessionsWithProvider, len(backupProviderList))
 	for _, provider := range backupProviderList {
@@ -621,15 +629,24 @@ func (csm *ConsumerSessionManager) UpdateAllProviders(epoch uint64, pairingList 
 
 	// The pairing inventory is the answer to "why was the primary not even a candidate?". A pool
 	// that never contained a provider and one that dropped it look identical from the selection
-	// path — every line there can only report what IS in the pool, never what left it. This runs
-	// once per epoch, not per relay, so INFO costs nothing and gives the log a periodic record of
-	// pool composition to correlate against.
+	// path — every line there can only report what IS in the pool, never what left it.
+	//
+	// Emitted on every provider-set push, not strictly once per epoch: readmitRecoveredProviders
+	// pushes a rebuilt set from its retry backoff timer too, which is a feature — a provider coming
+	// back shows up as `added` the moment it is readmitted. Either way it is nowhere near the relay
+	// path, so INFO costs nothing per request.
 	currentPairingAddresses := make([]string, 0, len(csm.pairing))
 	for address := range csm.pairing {
 		currentPairingAddresses = append(currentPairingAddresses, address)
 	}
 	sort.Strings(currentPairingAddresses)
+	currentBackupAddresses := make([]string, 0, len(csm.backupProviders))
+	for address := range csm.backupProviders {
+		currentBackupAddresses = append(currentBackupAddresses, address)
+	}
+	sort.Strings(currentBackupAddresses)
 	added, removed, carriedOver := diffAddressSets(previousPairingAddresses, currentPairingAddresses)
+	backupAdded, backupRemoved, _ := diffAddressSets(previousBackupAddresses, currentBackupAddresses)
 	utils.LavaFormatInfo("pairing updated",
 		utils.LogAttr("epoch", epoch),
 		utils.LogAttr("spec", csm.rpcEndpoint.Key()),
@@ -638,7 +655,10 @@ func (csm *ConsumerSessionManager) UpdateAllProviders(epoch uint64, pairingList 
 		utils.LogAttr("added", added),
 		utils.LogAttr("removed", removed),
 		utils.LogAttr("carried_over", carriedOver),
-		utils.LogAttr("backup_pool_size", len(csm.backupProviders)),
+		utils.LogAttr("backup_pool_size", len(currentBackupAddresses)),
+		utils.LogAttr("backup_providers", currentBackupAddresses),
+		utils.LogAttr("backup_added", backupAdded),
+		utils.LogAttr("backup_removed", backupRemoved),
 	)
 
 	// Close old connections OUTSIDE the lock to prevent blocking other operations
@@ -1063,28 +1083,84 @@ func (csm *ConsumerSessionManager) setValidAddressesToDefaultValue(addon string,
 	}
 }
 
-// poolEmptyReason names WHY the selectable pool is empty, in the same kebab-case vocabulary as
+// poolInventory is a snapshot of the state that explains an empty selectable pool, taken once
+// under a single RLock so every line reporting it agrees. Reading the fields one at a time across
+// separate locks would let a concurrent UpdateAllProviders land between them, and the resulting
+// line would describe a state that never existed.
+type poolInventory struct {
+	pairingSize       int
+	validCount        int
+	blockedCount      int
+	backupPoolSize    int
+	lastPairingUpdate time.Time
+}
+
+// snapshotPoolInventory reads the pool state for the diagnostic lines. Callers MUST NOT hold
+// csm.lock — this takes the read lock itself.
+func (csm *ConsumerSessionManager) snapshotPoolInventory() poolInventory {
+	csm.lock.RLock()
+	defer csm.lock.RUnlock()
+	return poolInventory{
+		pairingSize:       len(csm.pairingAddresses),
+		validCount:        len(csm.validAddresses),
+		blockedCount:      len(csm.currentlyBlockedProviderAddresses),
+		backupPoolSize:    len(csm.backupProviders),
+		lastPairingUpdate: csm.lastPairingUpdate,
+	}
+}
+
+// reason names WHY the selectable pool is empty, in the same kebab-case vocabulary as
 // BlockReason and EndpointDisableReason. The distinction is the whole point of the line: the causes
 // below are investigated in different places, and the empty pool they produce looks identical.
 //
-//	pairing-empty   nothing was ever registered for this chain — the provider failed startup
-//	                verification, or the epoch rebuilt with an empty list. Not a routing problem.
-//	all-blocked     the pairing has members and every one of them is blocked. A routing problem,
-//	                and the block reasons (MAG-2599) say which.
-//	addon-filtered  the pairing has usable members, but none serves this addon/extension.
-func poolEmptyReason(pairingSize, blockedCount int, addon string, extensions []string) string {
+//	pairing-empty        nothing was ever registered for this chain — the provider failed startup
+//	                     verification, or the epoch rebuilt with an empty list. Not a routing problem.
+//	addon-filtered       members survived into validAddresses, but none serves this addon/extension.
+//	no-usable-endpoints  members survived into validAddresses and the request asks for the default
+//	                     collection, which nothing filters except a provider having no usable
+//	                     endpoint. Registration succeeded, the endpoints behind it did not.
+//	all-blocked          every registered member is blocked. A routing problem, and the block
+//	                     reasons (MAG-2599) say which.
+//
+// validCount is what separates the filtered causes from the blocked ones, and it is why the order
+// below is not negotiable. A member that is still in validAddresses was NOT taken out by blocking,
+// so if nothing is selectable the filter is what removed it. Testing blockedCount first — as this
+// did before — reported all-blocked for a pairing of five with one blocked member and four that
+// simply do not serve the requested addon, which is the mislabel this whole line exists to prevent.
+func (inv poolInventory) reason(addon string, extensions []string) string {
 	switch {
-	case pairingSize == 0:
+	case inv.pairingSize == 0:
 		return "pairing-empty"
-	case blockedCount > 0:
-		return "all-blocked"
-	case addon != "" || len(extensions) > 0:
+	case inv.validCount > 0 && (addon != "" || len(extensions) > 0):
 		return "addon-filtered"
+	case inv.validCount > 0:
+		return "no-usable-endpoints"
+	case inv.blockedCount >= inv.pairingSize:
+		return "all-blocked"
 	default:
-		// The pairing holds unblocked providers that serve the default collection, yet nothing is
-		// selectable. Not a known shape — name it rather than mislabel it as one of the above.
+		// Members are registered, not all of them are blocked, and none reached validAddresses.
+		// Not a shape we model — name it rather than borrow one of the above.
 		return "unspecified"
 	}
+}
+
+// logPoolEmpty reports that nothing is selectable, and why. It is the one place the pool-empty
+// vocabulary is rendered, so the two call sites in releaseBlockedProvidersIfPoolEmpty — the guard's
+// empty-pairing return and the release itself — cannot drift into describing the same state
+// differently. Callers MUST NOT hold csm.lock: the inventory is snapshotted separately.
+func (csm *ConsumerSessionManager) logPoolEmpty(ctx context.Context, inventory poolInventory, addon string, extensions []string) {
+	utils.LavaFormatWarning("provider pool empty", nil,
+		utils.LogAttr("reason", inventory.reason(addon, extensions)),
+		utils.LogAttr("spec", csm.rpcEndpoint.Key()),
+		utils.LogAttr("pairing_size", inventory.pairingSize),
+		utils.LogAttr("valid", inventory.validCount),
+		utils.LogAttr("blocked", inventory.blockedCount),
+		utils.LogAttr("backup_pool", inventory.backupPoolSize),
+		utils.LogAttr("last_pairing_update", formatPairingUpdateTime(inventory.lastPairingUpdate)),
+		utils.LogAttr("addon", addon),
+		utils.LogAttr("extensions", extensions),
+		utils.LogAttr("GUID", ctx),
+	)
 }
 
 // formatPairingUpdateTime renders the last pairing rebuild for the log. The zero value means
@@ -1146,20 +1222,23 @@ func (csm *ConsumerSessionManager) atomicReadNumberOfResets() (resets uint64) {
 }
 
 // reset the valid addresses list and increase numberOfResets
+//
+// The outcome is deliberately NOT logged here. It used to be, in three lines, and the last of them
+// blamed an expired or unpurchased subscription for an empty pool. The smart router has neither: it
+// has no subscription and no on-chain pairing, its provider set comes from the endpoint config and
+// from the epoch refresh that rebuilds it, and consumerPublicAddress is a locally generated
+// smart-router-<rand> identifier rather than an account. That line sent every reader of a real
+// customer capture to look at billing, and it fired roughly twice a second while doing it.
+//
+// The single caller reports the outcome instead — see releaseBlockedProvidersIfPoolEmpty — because
+// it is the frame that holds the pool inventory and the request GUID, so it can name the actual
+// cause and attribute it to a chain and a relay. Logging here as well only reproduced the same
+// event three more times, once at ERROR.
 func (csm *ConsumerSessionManager) resetValidAddresses(addon string, extensions []string) uint64 {
 	csm.lock.Lock() // lock write
 	defer csm.lock.Unlock()
 	if len(csm.getValidAddresses(addon, extensions, context.Background())) == 0 { // re verify it didn't change while waiting for lock.
 		csm.setValidAddressesToDefaultValue(addon, extensions, context.Background(), ReleasePoolEmpty)
-		// only if length is larger than 0 after reset we actually reset. otherwise we don't have any providers for addon or extension
-		if len(csm.getValidAddresses(addon, extensions, context.Background())) != 0 {
-			utils.LavaFormatWarning("Provider pairing list is empty, resetting state.", nil, utils.Attribute{Key: "addon", Value: addon}, utils.Attribute{Key: "extensions", Value: extensions})
-		} else {
-			utils.LavaFormatWarning("No providers for asked addon or extension, list is empty after trying to reset", nil, utils.Attribute{Key: "addon", Value: addon}, utils.Attribute{Key: "extensions", Value: extensions})
-			if addon == "" && len(extensions) == 0 {
-				utils.LavaFormatError("User subscription might have expired or not purchased properly, pairing list is empty after reset.", nil, utils.LogAttr("consumer_address", csm.consumerPublicAddress))
-			}
-		}
 		csm.numberOfResets += 1
 	}
 	// if len(csm.validAddresses) != 0 meaning we had a reset (or an epoch change), so we need to return the numberOfResets which is currently in csm
@@ -1249,38 +1328,28 @@ func (csm *ConsumerSessionManager) releaseBlockedProvidersIfPoolEmpty(ctx contex
 		return nil, false
 	}
 
+	// Inventory of the pool, taken BEFORE the guard below rather than after it. The guard declines
+	// the release for an empty pairing too — its loop over pairingAddresses never executes, so it
+	// returns false — and that return is the one shape this whole line exists to report. Taking the
+	// snapshot after the guard put the diagnosis on the far side of the branch that swallows it.
+	inventory := csm.snapshotPoolInventory()
+
 	if !csm.releaseCouldServeThisRequest(tempIgnoredProviders.providers, addon, extensionNames, ctx) {
+		// A declined release is usually ordinary retry exhaustion: this request has already tried
+		// every provider, releasing rescues nothing, and that stays at DEBUG. An empty pairing
+		// reaches the same return for the opposite reason — there was never a provider to try, so
+		// "every provider has already been tried" is not merely unhelpful, it is false. Nothing
+		// downstream can correct it either, because resetValidAddresses is never reached.
+		if inventory.pairingSize == 0 {
+			csm.logPoolEmpty(ctx, inventory, addon, extensionNames)
+			return nil, false
+		}
 		utils.LavaFormatDebug("every provider has already been tried by this request, leaving the blocked list standing",
 			utils.LogAttr("addon", addon), utils.LogAttr("extensions", extensionNames), utils.LogAttr("GUID", ctx))
 		return nil, false
 	}
 
-	// Inventory of the pool, taken before the reset. "No valid providers" on its own cannot separate
-	// a pairing that never contained a primary from one whose every member is blocked, and the two
-	// lead to opposite investigations: the first is registration/verification (the provider never
-	// joined), the second is routing (it joined and was taken out). Read under RLock — every field
-	// below is written under csm.lock elsewhere, and this function runs unlocked because
-	// resetValidAddresses takes the write lock itself.
-	csm.lock.RLock()
-	pairingSize := len(csm.pairingAddresses)
-	validCount := len(csm.validAddresses)
-	blockedCount := len(csm.currentlyBlockedProviderAddresses)
-	backupPoolSize := len(csm.backupProviders)
-	lastPairingUpdate := csm.lastPairingUpdate
-	csm.lock.RUnlock()
-
-	utils.LavaFormatWarning("provider pool empty", nil,
-		utils.LogAttr("reason", poolEmptyReason(pairingSize, blockedCount, addon, extensionNames)),
-		utils.LogAttr("spec", csm.rpcEndpoint.Key()),
-		utils.LogAttr("pairing_size", pairingSize),
-		utils.LogAttr("valid", validCount),
-		utils.LogAttr("blocked", blockedCount),
-		utils.LogAttr("backup_pool", backupPoolSize),
-		utils.LogAttr("last_pairing_update", formatPairingUpdateTime(lastPairingUpdate)),
-		utils.LogAttr("addon", addon),
-		utils.LogAttr("extensions", extensionNames),
-		utils.LogAttr("GUID", ctx),
-	)
+	csm.logPoolEmpty(ctx, inventory, addon, extensionNames)
 
 	csm.resetValidAddresses(addon, extensionNames)
 
@@ -1290,9 +1359,16 @@ func (csm *ConsumerSessionManager) releaseBlockedProvidersIfPoolEmpty(ctx contex
 	// happened. Report the two outcomes as the different events they are.
 	restored := len(csm.cacheAddonAddresses(addon, extensionNames, ctx))
 	if restored == 0 {
+		// Re-snapshot. The reset cleared the blocked list and refilled validAddresses, so the
+		// pre-reset reason no longer describes the state we are in — reusing it would report
+		// all-blocked for a pool whose blocked list was just released and which still came up
+		// empty, naming the one cause the reset has already ruled out.
+		afterReset := csm.snapshotPoolInventory()
 		utils.LavaFormatWarning("pool reset recovered no providers", nil,
-			utils.LogAttr("reason", poolEmptyReason(pairingSize, blockedCount, addon, extensionNames)),
-			utils.LogAttr("pairing_size", pairingSize),
+			utils.LogAttr("reason", afterReset.reason(addon, extensionNames)),
+			utils.LogAttr("spec", csm.rpcEndpoint.Key()),
+			utils.LogAttr("pairing_size", afterReset.pairingSize),
+			utils.LogAttr("released_from_blocked", inventory.blockedCount),
 			utils.LogAttr("addon", addon),
 			utils.LogAttr("extensions", extensionNames),
 			utils.LogAttr("GUID", ctx),
@@ -1300,7 +1376,8 @@ func (csm *ConsumerSessionManager) releaseBlockedProvidersIfPoolEmpty(ctx contex
 	} else {
 		utils.LavaFormatInfo("pool reset restored providers",
 			utils.LogAttr("restored", restored),
-			utils.LogAttr("released_from_blocked", blockedCount),
+			utils.LogAttr("released_from_blocked", inventory.blockedCount),
+			utils.LogAttr("spec", csm.rpcEndpoint.Key()),
 			utils.LogAttr("addon", addon),
 			utils.LogAttr("extensions", extensionNames),
 			utils.LogAttr("GUID", ctx),

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -65,6 +65,12 @@ type ConsumerSessionManager struct {
 	pairingAddresses       map[uint64]string
 	pairingAddressesLength uint64
 
+	// lastPairingUpdate is when UpdateAllProviders last rebuilt the pairing. It is reported on the
+	// pool-empty line, where it separates a pool that was never populated (the provider failed its
+	// startup verification and was never added) from one that has drained since the last epoch —
+	// two causes that look identical once the pool is empty.
+	lastPairingUpdate time.Time
+
 	// contains all provider addresses that are currently valid
 	validAddresses []string
 	// provider addresses that were given a second chance instead of reporting them immediately
@@ -534,6 +540,13 @@ func (csm *ConsumerSessionManager) UpdateAllProviders(epoch uint64, pairingList 
 	// Save reference to old pairingPurge BEFORE updating, so we can close connections outside the lock
 	oldPairingPurge := csm.pairingPurge
 	csm.pairingPurge = csm.pairing
+	// Membership of the outgoing pairing, captured before the map is replaced, so the line at the
+	// end of this function can report what actually changed rather than only the new size. A
+	// provider silently dropping out between epochs is the failure this makes visible.
+	previousPairingAddresses := make([]string, 0, len(csm.pairing))
+	for address := range csm.pairing {
+		previousPairingAddresses = append(previousPairingAddresses, address)
+	}
 	csm.pairing = make(map[string]*ConsumerSessionsWithProvider, pairingListLength)
 	for idx, provider := range pairingList {
 		csm.pairingAddresses[idx] = provider.PublicLavaAddress
@@ -604,7 +617,29 @@ func (csm *ConsumerSessionManager) UpdateAllProviders(epoch uint64, pairingList 
 	// Clean up expired sticky sessions
 	csm.stickySessions.DeleteOldSessions(previousEpoch)
 
-	utils.LavaFormatDebug("updated providers", utils.Attribute{Key: "epoch", Value: epoch}, utils.Attribute{Key: "spec", Value: csm.rpcEndpoint.Key()})
+	csm.lastPairingUpdate = time.Now()
+
+	// The pairing inventory is the answer to "why was the primary not even a candidate?". A pool
+	// that never contained a provider and one that dropped it look identical from the selection
+	// path — every line there can only report what IS in the pool, never what left it. This runs
+	// once per epoch, not per relay, so INFO costs nothing and gives the log a periodic record of
+	// pool composition to correlate against.
+	currentPairingAddresses := make([]string, 0, len(csm.pairing))
+	for address := range csm.pairing {
+		currentPairingAddresses = append(currentPairingAddresses, address)
+	}
+	sort.Strings(currentPairingAddresses)
+	added, removed, carriedOver := diffAddressSets(previousPairingAddresses, currentPairingAddresses)
+	utils.LavaFormatInfo("pairing updated",
+		utils.LogAttr("epoch", epoch),
+		utils.LogAttr("spec", csm.rpcEndpoint.Key()),
+		utils.LogAttr("size", len(currentPairingAddresses)),
+		utils.LogAttr("providers", currentPairingAddresses),
+		utils.LogAttr("added", added),
+		utils.LogAttr("removed", removed),
+		utils.LogAttr("carried_over", carriedOver),
+		utils.LogAttr("backup_pool_size", len(csm.backupProviders)),
+	)
 
 	// Close old connections OUTSIDE the lock to prevent blocking other operations
 	// This is safe because after an entire epoch, it's impossible to have sessions connected to the old purged list
@@ -1028,6 +1063,74 @@ func (csm *ConsumerSessionManager) setValidAddressesToDefaultValue(addon string,
 	}
 }
 
+// poolEmptyReason names WHY the selectable pool is empty, in the same kebab-case vocabulary as
+// BlockReason and EndpointDisableReason. The distinction is the whole point of the line: the causes
+// below are investigated in different places, and the empty pool they produce looks identical.
+//
+//	pairing-empty   nothing was ever registered for this chain — the provider failed startup
+//	                verification, or the epoch rebuilt with an empty list. Not a routing problem.
+//	all-blocked     the pairing has members and every one of them is blocked. A routing problem,
+//	                and the block reasons (MAG-2599) say which.
+//	addon-filtered  the pairing has usable members, but none serves this addon/extension.
+func poolEmptyReason(pairingSize, blockedCount int, addon string, extensions []string) string {
+	switch {
+	case pairingSize == 0:
+		return "pairing-empty"
+	case blockedCount > 0:
+		return "all-blocked"
+	case addon != "" || len(extensions) > 0:
+		return "addon-filtered"
+	default:
+		// The pairing holds unblocked providers that serve the default collection, yet nothing is
+		// selectable. Not a known shape — name it rather than mislabel it as one of the above.
+		return "unspecified"
+	}
+}
+
+// formatPairingUpdateTime renders the last pairing rebuild for the log. The zero value means
+// UpdateAllProviders has not run yet, which is a genuinely different state from "rebuilt long ago"
+// and must not render as a zero timestamp that reads like 1 January year 1.
+func formatPairingUpdateTime(at time.Time) string {
+	if at.IsZero() {
+		return "never"
+	}
+	return at.UTC().Format(time.RFC3339)
+}
+
+// diffAddressSets reports how membership changed between two provider-address sets. Every result
+// is sorted so the log line is stable across epochs — the inputs come from Go map iteration, whose
+// order is deliberately randomised, and an unsorted line would read as churn on every epoch even
+// when nothing moved.
+func diffAddressSets(previous, current []string) (added, removed, carriedOver []string) {
+	previousSet := make(map[string]struct{}, len(previous))
+	for _, address := range previous {
+		previousSet[address] = struct{}{}
+	}
+	currentSet := make(map[string]struct{}, len(current))
+	for _, address := range current {
+		currentSet[address] = struct{}{}
+	}
+	// Non-nil empties: a nil slice renders as "" in the log, which reads as a missing field rather
+	// than as "nothing changed".
+	added, removed, carriedOver = []string{}, []string{}, []string{}
+	for _, address := range current {
+		if _, existed := previousSet[address]; existed {
+			carriedOver = append(carriedOver, address)
+		} else {
+			added = append(added, address)
+		}
+	}
+	for _, address := range previous {
+		if _, kept := currentSet[address]; !kept {
+			removed = append(removed, address)
+		}
+	}
+	sort.Strings(added)
+	sort.Strings(removed)
+	sort.Strings(carriedOver)
+	return added, removed, carriedOver
+}
+
 // reads cs.currentEpoch atomically
 func (csm *ConsumerSessionManager) atomicWriteCurrentEpoch(epoch uint64) {
 	atomic.StoreUint64(&csm.currentEpoch, epoch)
@@ -1152,9 +1255,57 @@ func (csm *ConsumerSessionManager) releaseBlockedProvidersIfPoolEmpty(ctx contex
 		return nil, false
 	}
 
-	utils.LavaFormatWarning("NO VALID PROVIDERS - TRIGGERING RESET", nil, utils.LogAttr("addon", addon), utils.LogAttr("extensions", extensionNames), utils.LogAttr("GUID", ctx))
+	// Inventory of the pool, taken before the reset. "No valid providers" on its own cannot separate
+	// a pairing that never contained a primary from one whose every member is blocked, and the two
+	// lead to opposite investigations: the first is registration/verification (the provider never
+	// joined), the second is routing (it joined and was taken out). Read under RLock — every field
+	// below is written under csm.lock elsewhere, and this function runs unlocked because
+	// resetValidAddresses takes the write lock itself.
+	csm.lock.RLock()
+	pairingSize := len(csm.pairingAddresses)
+	validCount := len(csm.validAddresses)
+	blockedCount := len(csm.currentlyBlockedProviderAddresses)
+	backupPoolSize := len(csm.backupProviders)
+	lastPairingUpdate := csm.lastPairingUpdate
+	csm.lock.RUnlock()
+
+	utils.LavaFormatWarning("provider pool empty", nil,
+		utils.LogAttr("reason", poolEmptyReason(pairingSize, blockedCount, addon, extensionNames)),
+		utils.LogAttr("spec", csm.rpcEndpoint.Key()),
+		utils.LogAttr("pairing_size", pairingSize),
+		utils.LogAttr("valid", validCount),
+		utils.LogAttr("blocked", blockedCount),
+		utils.LogAttr("backup_pool", backupPoolSize),
+		utils.LogAttr("last_pairing_update", formatPairingUpdateTime(lastPairingUpdate)),
+		utils.LogAttr("addon", addon),
+		utils.LogAttr("extensions", extensionNames),
+		utils.LogAttr("GUID", ctx),
+	)
+
 	csm.resetValidAddresses(addon, extensionNames)
-	utils.LavaFormatInfo("RESET COMPLETED", utils.LogAttr("addon", addon), utils.LogAttr("extensions", extensionNames), utils.LogAttr("newValidAddressesCount", len(csm.cacheAddonAddresses(addon, extensionNames, ctx))), utils.LogAttr("GUID", ctx))
+
+	// The reset refills validAddresses straight from the pairing, so it can only restore what the
+	// pairing holds. With an empty pairing it is a no-op — and the line that used to report this
+	// said "RESET COMPLETED" at INFO either way, which reads as recovery precisely when none
+	// happened. Report the two outcomes as the different events they are.
+	restored := len(csm.cacheAddonAddresses(addon, extensionNames, ctx))
+	if restored == 0 {
+		utils.LavaFormatWarning("pool reset recovered no providers", nil,
+			utils.LogAttr("reason", poolEmptyReason(pairingSize, blockedCount, addon, extensionNames)),
+			utils.LogAttr("pairing_size", pairingSize),
+			utils.LogAttr("addon", addon),
+			utils.LogAttr("extensions", extensionNames),
+			utils.LogAttr("GUID", ctx),
+		)
+	} else {
+		utils.LavaFormatInfo("pool reset restored providers",
+			utils.LogAttr("restored", restored),
+			utils.LogAttr("released_from_blocked", blockedCount),
+			utils.LogAttr("addon", addon),
+			utils.LogAttr("extensions", extensionNames),
+			utils.LogAttr("GUID", ctx),
+		)
+	}
 
 	sessionWithProviderMap, err := csm.getValidConsumerSessionsWithProvider(ctx, wantedProviderNumber, tempIgnoredProviders, cuNeededForSession, requestedBlock, addon, extensionNames, stateful, virtualEpoch, stickiness, selectedProvider, minGroups, perGroupTarget)
 	if err != nil {

--- a/protocol/lavasession/pool_inventory_test.go
+++ b/protocol/lavasession/pool_inventory_test.go
@@ -1,0 +1,115 @@
+package lavasession
+
+import (
+	"testing"
+	"time"
+)
+
+// The pool-empty reason exists to separate causes that are investigated in different places. A test
+// per branch, because collapsing any two of them back together is exactly the regression that makes
+// the line worthless again.
+func TestPoolEmptyReason_NamesTheCauseNotTheSymptom(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		pairingSize int
+		blocked     int
+		addon       string
+		extensions  []string
+		want        string
+	}{
+		{
+			// The zxb5l case: nothing was ever registered. Not a routing problem, and the block
+			// reasons have nothing to say about it — there is no provider to have blocked.
+			name: "nothing registered", pairingSize: 0, blocked: 0, want: "pairing-empty",
+		},
+		{
+			// pairing-empty wins even when a stale blocked count is present: with no pairing there is
+			// nothing for the reset to restore, which is the actionable fact.
+			name:        "nothing registered outranks a stale blocked count",
+			pairingSize: 0, blocked: 3, want: "pairing-empty",
+		},
+		{
+			name:        "pairing present and every member blocked",
+			pairingSize: 2, blocked: 2, want: "all-blocked",
+		},
+		{
+			name:        "addon filtered out the whole pairing",
+			pairingSize: 3, blocked: 0, addon: "debug", want: "addon-filtered",
+		},
+		{
+			name:        "extension filtered out the whole pairing",
+			pairingSize: 3, blocked: 0, extensions: []string{"archive"}, want: "addon-filtered",
+		},
+		{
+			// Unblocked providers serving the default collection, yet nothing selectable. Not a shape
+			// we model — it must not borrow one of the names above.
+			name:        "unmodelled shape is named, not mislabelled",
+			pairingSize: 3, blocked: 0, want: "unspecified",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := poolEmptyReason(tt.pairingSize, tt.blocked, tt.addon, tt.extensions); got != tt.want {
+				t.Fatalf("poolEmptyReason(%d, %d, %q, %v) = %q, want %q",
+					tt.pairingSize, tt.blocked, tt.addon, tt.extensions, got, tt.want)
+			}
+		})
+	}
+}
+
+// The whole value of the pairing line is `removed` — a provider silently dropping out between
+// epochs is the failure it exists to catch.
+func TestDiffAddressSets_ReportsWhatChanged(t *testing.T) {
+	added, removed, carried := diffAddressSets(
+		[]string{"tatum", "lava", "blockdaemon"},
+		[]string{"lava", "blockdaemon", "chainstack"},
+	)
+	assertAddresses(t, "added", added, []string{"chainstack"})
+	assertAddresses(t, "removed", removed, []string{"tatum"})
+	assertAddresses(t, "carried_over", carried, []string{"blockdaemon", "lava"})
+}
+
+// Inputs come from Go map iteration, which is deliberately randomised. Unsorted output would read as
+// churn on every epoch even when membership never moved.
+func TestDiffAddressSets_OutputIsSortedRegardlessOfInputOrder(t *testing.T) {
+	first, _, firstCarried := diffAddressSets([]string{"b", "a"}, []string{"a", "b", "z", "c"})
+	second, _, secondCarried := diffAddressSets([]string{"a", "b"}, []string{"c", "z", "b", "a"})
+	assertAddresses(t, "added (first order)", first, []string{"c", "z"})
+	assertAddresses(t, "added (second order)", second, []string{"c", "z"})
+	assertAddresses(t, "carried (first order)", firstCarried, []string{"a", "b"})
+	assertAddresses(t, "carried (second order)", secondCarried, []string{"a", "b"})
+}
+
+// A nil slice renders as "" in the log line, which reads as a missing field rather than as
+// "nothing changed" — the two must not look alike on the one line that reports pool churn.
+func TestDiffAddressSets_UnchangedMembershipRendersEmptyNotNil(t *testing.T) {
+	added, removed, carried := diffAddressSets([]string{"lava"}, []string{"lava"})
+	if added == nil || removed == nil {
+		t.Fatalf("added/removed must be non-nil when nothing changed, got added=%#v removed=%#v", added, removed)
+	}
+	assertAddresses(t, "added", added, []string{})
+	assertAddresses(t, "removed", removed, []string{})
+	assertAddresses(t, "carried_over", carried, []string{"lava"})
+}
+
+// "Never updated" and "updated at the zero time" are different states; only one of them is real.
+func TestFormatPairingUpdateTime_ZeroMeansNever(t *testing.T) {
+	if got := formatPairingUpdateTime(time.Time{}); got != "never" {
+		t.Fatalf("zero time rendered %q, want \"never\"", got)
+	}
+	at := time.Date(2026, 8, 27, 19, 58, 2, 0, time.UTC)
+	if got := formatPairingUpdateTime(at); got != "2026-08-27T19:58:02Z" {
+		t.Fatalf("rendered %q, want RFC3339 in UTC", got)
+	}
+}
+
+func assertAddresses(t *testing.T, field string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s = %v, want %v", field, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%s = %v, want %v", field, got, want)
+		}
+	}
+}

--- a/protocol/lavasession/pool_inventory_test.go
+++ b/protocol/lavasession/pool_inventory_test.go
@@ -1,8 +1,14 @@
 package lavasession
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 	"time"
+
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/magma-Devs/smart-router/utils"
+	"github.com/stretchr/testify/require"
 )
 
 // The pool-empty reason exists to separate causes that are investigated in different places. A test
@@ -12,6 +18,7 @@ func TestPoolEmptyReason_NamesTheCauseNotTheSymptom(t *testing.T) {
 	for _, tt := range []struct {
 		name        string
 		pairingSize int
+		validCount  int
 		blocked     int
 		addon       string
 		extensions  []string
@@ -20,39 +27,145 @@ func TestPoolEmptyReason_NamesTheCauseNotTheSymptom(t *testing.T) {
 		{
 			// The zxb5l case: nothing was ever registered. Not a routing problem, and the block
 			// reasons have nothing to say about it — there is no provider to have blocked.
-			name: "nothing registered", pairingSize: 0, blocked: 0, want: "pairing-empty",
+			name: "nothing registered", pairingSize: 0, validCount: 0, blocked: 0, want: "pairing-empty",
 		},
 		{
 			// pairing-empty wins even when a stale blocked count is present: with no pairing there is
 			// nothing for the reset to restore, which is the actionable fact.
 			name:        "nothing registered outranks a stale blocked count",
-			pairingSize: 0, blocked: 3, want: "pairing-empty",
+			pairingSize: 0, validCount: 0, blocked: 3, want: "pairing-empty",
 		},
 		{
 			name:        "pairing present and every member blocked",
-			pairingSize: 2, blocked: 2, want: "all-blocked",
+			pairingSize: 2, validCount: 0, blocked: 2, want: "all-blocked",
+		},
+		{
+			// The regression this ordering exists to prevent. Four of the five members are unblocked
+			// and simply do not serve the addon; testing blockedCount first called that all-blocked,
+			// which sends the reader to the block reasons for four providers that were never blocked.
+			name:        "one blocked member does not make a filtered pool all-blocked",
+			pairingSize: 5, validCount: 4, blocked: 1, addon: "archive", want: "addon-filtered",
 		},
 		{
 			name:        "addon filtered out the whole pairing",
-			pairingSize: 3, blocked: 0, addon: "debug", want: "addon-filtered",
+			pairingSize: 3, validCount: 3, blocked: 0, addon: "debug", want: "addon-filtered",
 		},
 		{
 			name:        "extension filtered out the whole pairing",
-			pairingSize: 3, blocked: 0, extensions: []string{"archive"}, want: "addon-filtered",
+			pairingSize: 3, validCount: 3, blocked: 0, extensions: []string{"archive"}, want: "addon-filtered",
 		},
 		{
-			// Unblocked providers serving the default collection, yet nothing selectable. Not a shape
-			// we model — it must not borrow one of the names above.
+			// Members survived into validAddresses and the request wants the default collection,
+			// which nothing filters except a provider having no usable endpoint. Registration
+			// succeeded; the endpoints behind it did not.
+			name:        "registered members with no usable endpoint",
+			pairingSize: 3, validCount: 3, blocked: 0, want: "no-usable-endpoints",
+		},
+		{
+			// Members registered, not all blocked, and none reached validAddresses. Not a shape we
+			// model — it must not borrow one of the names above.
 			name:        "unmodelled shape is named, not mislabelled",
-			pairingSize: 3, blocked: 0, want: "unspecified",
+			pairingSize: 5, validCount: 0, blocked: 1, want: "unspecified",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := poolEmptyReason(tt.pairingSize, tt.blocked, tt.addon, tt.extensions); got != tt.want {
-				t.Fatalf("poolEmptyReason(%d, %d, %q, %v) = %q, want %q",
-					tt.pairingSize, tt.blocked, tt.addon, tt.extensions, got, tt.want)
+			inv := poolInventory{pairingSize: tt.pairingSize, validCount: tt.validCount, blockedCount: tt.blocked}
+			if got := inv.reason(tt.addon, tt.extensions); got != tt.want {
+				t.Fatalf("poolInventory{pairing:%d valid:%d blocked:%d}.reason(%q, %v) = %q, want %q",
+					tt.pairingSize, tt.validCount, tt.blocked, tt.addon, tt.extensions, got, tt.want)
 			}
 		})
+	}
+}
+
+// The reason must be read off the REAL manager state, not only off hand-fed integers — a snapshot
+// that reads the wrong field would pass every table case above and still mislabel production.
+func TestSnapshotPoolInventory_ReadsTheRealState(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
+
+	full := csm.snapshotPoolInventory()
+	require.Equal(t, numberOfProviders, full.pairingSize)
+	require.Equal(t, numberOfProviders, full.validCount)
+	require.Zero(t, full.blockedCount)
+	require.False(t, full.lastPairingUpdate.IsZero(), "UpdateAllProviders must stamp the pairing time")
+
+	// Block every member: the pool is empty for a routing reason, and the reset can undo it.
+	for _, address := range append([]string{}, csm.validAddresses...) {
+		require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonTooManyDeadSessions, false, csm.atomicReadCurrentEpoch(), 0, 0, false, nil))
+	}
+	blocked := csm.snapshotPoolInventory()
+	require.Equal(t, "all-blocked", blocked.reason("", nil))
+
+	// An empty pairing is the other cause entirely, and the reset cannot undo it.
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight+1, nil, nil))
+	require.Equal(t, "pairing-empty", csm.snapshotPoolInventory().reason("", nil))
+}
+
+// An empty pairing is declined by releaseCouldServeThisRequest — its loop over pairingAddresses
+// never executes — so the diagnosis has to be emitted on the guard's side of that branch. Logging
+// it after the guard put the one line that explains this state behind the return that swallows it.
+func TestReleaseBlockedProvidersIfPoolEmpty_ReportsAnEmptyPairing(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, nil, nil))
+
+	require.False(t,
+		csm.releaseCouldServeThisRequest(map[string]struct{}{}, "", nil, context.Background()),
+		"an empty pairing must decline the release — this is the branch the report has to survive")
+
+	records := captureLogs(t, func() {
+		sessions, ok := csm.releaseBlockedProvidersIfPoolEmpty(context.Background(), 1,
+			&ignoredProviders{providers: map[string]struct{}{}}, 10, spectypes.NOT_APPLICABLE,
+			"", nil, 0, 0, "", "", 0, 0)
+		require.Nil(t, sessions)
+		require.False(t, ok, "nothing can be released from an empty pairing")
+	})
+
+	line := findLogRecord(records, "provider pool empty")
+	require.NotNil(t, line, "an empty pairing must report why the pool is empty, not fall silent")
+	require.Equal(t, "pairing-empty", line["reason"],
+		"the empty pairing must be named as such, never as retry exhaustion")
+
+	require.Nil(t, findLogRecord(records, "every provider has already been tried by this request, leaving the blocked list standing"),
+		"no provider was tried, because there are none — that line would be false here")
+}
+
+// A pool emptied by blocking is the opposite case: the release CAN rescue it, and the reset that
+// follows must be reported as the recovery it is.
+func TestReleaseBlockedProvidersIfPoolEmpty_ReportsARecoveredPool(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
+	for _, address := range append([]string{}, csm.validAddresses...) {
+		require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonTooManyDeadSessions, false, csm.atomicReadCurrentEpoch(), 0, 0, false, nil))
+	}
+
+	records := captureLogs(t, func() {
+		csm.releaseBlockedProvidersIfPoolEmpty(context.Background(), 1,
+			&ignoredProviders{providers: map[string]struct{}{}}, 10, spectypes.NOT_APPLICABLE,
+			"", nil, 0, 0, "", "", 0, 0)
+	})
+
+	empty := findLogRecord(records, "provider pool empty")
+	require.NotNil(t, empty)
+	require.Equal(t, "all-blocked", empty["reason"], "blocking is a routing cause, not a registration one")
+
+	require.NotNil(t, findLogRecord(records, "pool reset restored providers"),
+		"releasing the blocked list restores the pairing, and that is a recovery")
+	require.Nil(t, findLogRecord(records, "pool reset recovered no providers"))
+}
+
+// The line that blamed an expired subscription is gone. The smart router has no subscription and no
+// on-chain pairing, so no empty pool can ever be caused by one — and the line sent every reader of a
+// real customer capture to look at billing.
+func TestResetValidAddresses_DoesNotBlameASubscription(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, nil, nil))
+
+	records := captureLogs(t, func() { csm.resetValidAddresses("", nil) })
+
+	for _, record := range records {
+		require.NotContains(t, record["message"], "subscription",
+			"an empty pool must never be reported as a subscription problem")
 	}
 }
 
@@ -112,4 +225,35 @@ func assertAddresses(t *testing.T, field string, got, want []string) {
 			t.Fatalf("%s = %v, want %v", field, got, want)
 		}
 	}
+}
+
+// captureLogs records everything logged during fn as parsed JSON. It drives the real sink rather
+// than a stub, so a test asserting on a log line fails when the line stops being emitted — which is
+// the only failure mode that matters for a change whose entire product is log output.
+func captureLogs(t *testing.T, fn func()) []map[string]any {
+	t.Helper()
+	utils.EnableDebugLogBuffer(1000)
+	utils.ClearDebugLogBuffer()
+
+	fn()
+
+	raw := utils.ReadDebugLogBuffer("", time.Time{}, time.Time{}, 1000)
+	records := make([]map[string]any, 0, len(raw))
+	for _, line := range raw {
+		record := map[string]any{}
+		if err := json.Unmarshal(line, &record); err != nil {
+			continue // a record that is not JSON cannot be the structured line under test
+		}
+		records = append(records, record)
+	}
+	return records
+}
+
+func findLogRecord(records []map[string]any, message string) map[string]any {
+	for _, record := range records {
+		if record["message"] == message {
+			return record
+		}
+	}
+	return nil
 }

--- a/protocol/lavasession/pool_inventory_test.go
+++ b/protocol/lavasession/pool_inventory_test.go
@@ -16,63 +16,73 @@ import (
 // the line worthless again.
 func TestPoolEmptyReason_NamesTheCauseNotTheSymptom(t *testing.T) {
 	for _, tt := range []struct {
-		name        string
-		pairingSize int
-		validCount  int
-		blocked     int
-		addon       string
-		extensions  []string
-		want        string
+		name           string
+		pairingSize    int
+		capable        int
+		capableBlocked int
+		addon          string
+		extensions     []string
+		want           string
 	}{
 		{
 			// The zxb5l case: nothing was ever registered. Not a routing problem, and the block
 			// reasons have nothing to say about it — there is no provider to have blocked.
-			name: "nothing registered", pairingSize: 0, validCount: 0, blocked: 0, want: "pairing-empty",
+			name: "nothing registered", pairingSize: 0, want: "pairing-empty",
 		},
 		{
 			// pairing-empty wins even when a stale blocked count is present: with no pairing there is
 			// nothing for the reset to restore, which is the actionable fact.
 			name:        "nothing registered outranks a stale blocked count",
-			pairingSize: 0, validCount: 0, blocked: 3, want: "pairing-empty",
+			pairingSize: 0, capable: 0, capableBlocked: 3, want: "pairing-empty",
 		},
 		{
-			name:        "pairing present and every member blocked",
-			pairingSize: 2, validCount: 0, blocked: 2, want: "all-blocked",
+			name:        "pairing present and every member that could serve is blocked",
+			pairingSize: 2, capable: 2, capableBlocked: 2, want: "all-blocked",
 		},
 		{
-			// The regression this ordering exists to prevent. Four of the five members are unblocked
-			// and simply do not serve the addon; testing blockedCount first called that all-blocked,
-			// which sends the reader to the block reasons for four providers that were never blocked.
-			name:        "one blocked member does not make a filtered pool all-blocked",
-			pairingSize: 5, validCount: 4, blocked: 1, addon: "archive", want: "addon-filtered",
+			// The mislabel this line exists to prevent, in its first form: four of five members are
+			// unblocked and simply do not serve the addon. Keying on blockedCount called that
+			// all-blocked, sending the reader to block reasons for providers never blocked. Only one
+			// member is addon-capable and it is blocked, so the honest answer is all-blocked — for
+			// the ONE provider that matters, not the four that were never candidates.
+			name:        "one capable member, and it is blocked",
+			pairingSize: 5, capable: 1, capableBlocked: 1, addon: "archive", want: "all-blocked",
 		},
 		{
-			name:        "addon filtered out the whole pairing",
-			pairingSize: 3, validCount: 3, blocked: 0, addon: "debug", want: "addon-filtered",
+			// The same mislabel in its mirror form. Keying on validCount called this addon-filtered
+			// because four unrelated members were still valid, when the truth is that the two
+			// providers that serve the addon are both blocked.
+			name:        "capable members all blocked while unrelated members stay valid",
+			pairingSize: 6, capable: 2, capableBlocked: 2, extensions: []string{"archive"}, want: "all-blocked",
 		},
 		{
-			name:        "extension filtered out the whole pairing",
-			pairingSize: 3, validCount: 3, blocked: 0, extensions: []string{"archive"}, want: "addon-filtered",
+			// Genuinely filtered: not one member serves the addon. A spec or config problem, and no
+			// amount of routing recovers it.
+			name:        "no member serves the addon at all",
+			pairingSize: 3, capable: 0, addon: "debug", want: "addon-filtered",
 		},
 		{
-			// Members survived into validAddresses and the request wants the default collection,
-			// which nothing filters except a provider having no usable endpoint. Registration
-			// succeeded; the endpoints behind it did not.
-			name:        "registered members with no usable endpoint",
-			pairingSize: 3, validCount: 3, blocked: 0, want: "no-usable-endpoints",
+			name:        "no member serves the extension at all",
+			pairingSize: 3, capable: 0, extensions: []string{"archive"}, want: "addon-filtered",
 		},
 		{
-			// Members registered, not all blocked, and none reached validAddresses. Not a shape we
-			// model — it must not borrow one of the names above.
+			// The default collection is served by every provider by definition, so the only predicate
+			// left is having at least one endpoint. Nothing capable means they registered with none.
+			name:        "registered members with no endpoints at all",
+			pairingSize: 3, capable: 0, want: "no-usable-endpoints",
+		},
+		{
+			// Capable members exist and are not all blocked, yet nothing was selectable. Not a shape
+			// we model — it must not borrow one of the names above.
 			name:        "unmodelled shape is named, not mislabelled",
-			pairingSize: 5, validCount: 0, blocked: 1, want: "unspecified",
+			pairingSize: 5, capable: 3, capableBlocked: 1, want: "unspecified",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			inv := poolInventory{pairingSize: tt.pairingSize, validCount: tt.validCount, blockedCount: tt.blocked}
+			inv := poolInventory{pairingSize: tt.pairingSize, capable: tt.capable, capableBlocked: tt.capableBlocked}
 			if got := inv.reason(tt.addon, tt.extensions); got != tt.want {
-				t.Fatalf("poolInventory{pairing:%d valid:%d blocked:%d}.reason(%q, %v) = %q, want %q",
-					tt.pairingSize, tt.validCount, tt.blocked, tt.addon, tt.extensions, got, tt.want)
+				t.Fatalf("poolInventory{pairing:%d capable:%d capableBlocked:%d}.reason(%q, %v) = %q, want %q",
+					tt.pairingSize, tt.capable, tt.capableBlocked, tt.addon, tt.extensions, got, tt.want)
 			}
 		})
 	}
@@ -84,7 +94,7 @@ func TestSnapshotPoolInventory_ReadsTheRealState(t *testing.T) {
 	csm := CreateConsumerSessionManager()
 	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
 
-	full := csm.snapshotPoolInventory()
+	full := csm.snapshotPoolInventory("", nil, context.Background())
 	require.Equal(t, numberOfProviders, full.pairingSize)
 	require.Equal(t, numberOfProviders, full.validCount)
 	require.Zero(t, full.blockedCount)
@@ -94,12 +104,12 @@ func TestSnapshotPoolInventory_ReadsTheRealState(t *testing.T) {
 	for _, address := range append([]string{}, csm.validAddresses...) {
 		require.NoError(t, csm.blockProvider(context.Background(), address, BlockReasonTooManyDeadSessions, false, csm.atomicReadCurrentEpoch(), 0, 0, false, nil))
 	}
-	blocked := csm.snapshotPoolInventory()
+	blocked := csm.snapshotPoolInventory("", nil, context.Background())
 	require.Equal(t, "all-blocked", blocked.reason("", nil))
 
 	// An empty pairing is the other cause entirely, and the reset cannot undo it.
 	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight+1, nil, nil))
-	require.Equal(t, "pairing-empty", csm.snapshotPoolInventory().reason("", nil))
+	require.Equal(t, "pairing-empty", csm.snapshotPoolInventory("", nil, context.Background()).reason("", nil))
 }
 
 // An empty pairing is declined by releaseCouldServeThisRequest — its loop over pairingAddresses
@@ -159,12 +169,21 @@ func TestReleaseBlockedProvidersIfPoolEmpty_ReportsARecoveredPool(t *testing.T) 
 // real customer capture to look at billing.
 func TestResetValidAddresses_DoesNotBlameASubscription(t *testing.T) {
 	csm := CreateConsumerSessionManager()
-	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, nil, nil))
 
-	records := captureLogs(t, func() { csm.resetValidAddresses("", nil) })
+	// UpdateAllProviders is inside the capture on purpose. Resetting an empty pairing logs nothing
+	// at all now, so capturing only that leaves records empty and the assertion below iterates zero
+	// times — green whether or not the sink works, and green whether or not the line came back.
+	// Including the pairing update guarantees at least one record, which makes NotEmpty a real
+	// check that the sink is capturing and the loop a real check of what it captured.
+	records := captureLogs(t, func() {
+		require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, nil, nil))
+		csm.resetValidAddresses("", nil)
+	})
 
+	require.NotEmpty(t, records,
+		"the sink captured nothing — the assertion below would pass vacuously")
 	for _, record := range records {
-		require.NotContains(t, record["message"], "subscription",
+		require.NotContains(t, logMessage(record), "subscription",
 			"an empty pool must never be reported as a subscription problem")
 	}
 }
@@ -230,14 +249,33 @@ func assertAddresses(t *testing.T, field string, got, want []string) {
 // captureLogs records everything logged during fn as parsed JSON. It drives the real sink rather
 // than a stub, so a test asserting on a log line fails when the line stops being emitted — which is
 // the only failure mode that matters for a change whose entire product is log output.
+// debugRingCapacity is deliberately far above what these tests emit. The ring evicts oldest-first,
+// and the record every assertion here looks for — "provider pool empty" — is the FIRST one emitted
+// on the path. Size it to the run and any added logging silently evicts the line under test, turning
+// these into red tests that claim a log line was never emitted when it was emitted and dropped.
+const debugRingCapacity = 100000
+
+// logMessage reads a record's message without assuming it has one. A record reaching the shared ring
+// without a "message" key — a line sent via .Send() rather than .Msg() — would otherwise fail
+// require.NotContains on a nil argument, with an error about builtin len() that points nowhere near
+// the actual subject.
+func logMessage(record map[string]any) string {
+	message, _ := record["message"].(string)
+	return message
+}
+
 func captureLogs(t *testing.T, fn func()) []map[string]any {
 	t.Helper()
-	utils.EnableDebugLogBuffer(1000)
+	// EnableDebugLogBuffer swaps a process-global sink. Without the cleanup every later test in this
+	// binary keeps paying the copy-and-append on every log call, and the sink's documented
+	// "disabled by default" contract stays broken for the rest of the run.
+	utils.EnableDebugLogBuffer(debugRingCapacity)
+	t.Cleanup(utils.DisableDebugLogBuffer)
 	utils.ClearDebugLogBuffer()
 
 	fn()
 
-	raw := utils.ReadDebugLogBuffer("", time.Time{}, time.Time{}, 1000)
+	raw := utils.ReadDebugLogBuffer("", time.Time{}, time.Time{}, debugRingCapacity)
 	records := make([]map[string]any, 0, len(raw))
 	for _, line := range raw {
 		record := map[string]any{}
@@ -256,4 +294,65 @@ func findLogRecord(records []map[string]any, message string) map[string]any {
 		}
 	}
 	return nil
+}
+
+// The guard declines the release for every structural emptiness, not only an empty pairing: a
+// pairing where nothing serves the requested addon reaches the same return. Keying the diagnosis on
+// pairingSize rescued only the empty-pairing case and left this one reporting "every provider has
+// already been tried" — for a request that tried nothing at all.
+func TestReleaseBlockedProvidersIfPoolEmpty_ReportsAnAddonNothingServes(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
+
+	records := captureLogs(t, func() {
+		_, ok := csm.releaseBlockedProvidersIfPoolEmpty(context.Background(), 1,
+			&ignoredProviders{providers: map[string]struct{}{}}, 10, spectypes.NOT_APPLICABLE,
+			"nonexistent-addon", nil, 0, 0, "", "", 0, 0)
+		require.False(t, ok, "no provider serves this addon, so nothing can be released")
+	})
+
+	line := findLogRecord(records, "provider pool empty")
+	require.NotNil(t, line, "a pairing that cannot serve the addon must say so, not fall silent")
+	require.Equal(t, "addon-filtered", line["reason"],
+		"no member serves this addon — that is a config problem, not retry exhaustion")
+
+	require.Nil(t, findLogRecord(records, "every provider has already been tried by this request, leaving the blocked list standing"),
+		"nothing was tried: the ignored set was empty on entry")
+}
+
+// An empty pool is a property of the pairing, and the pairing does not change between relays. A
+// chain whose providers all failed startup verification stays empty indefinitely, and this path runs
+// on every relay — reporting it per-relay at WARN turns a permanent state into a sustained alert
+// stream, which is the log flood this work exists to reduce.
+func TestReleaseBlockedProvidersIfPoolEmpty_WarnsOncePerPairing(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, nil, nil))
+
+	callOnce := func() map[string]any {
+		var line map[string]any
+		records := captureLogs(t, func() {
+			csm.releaseBlockedProvidersIfPoolEmpty(context.Background(), 1,
+				&ignoredProviders{providers: map[string]struct{}{}}, 10, spectypes.NOT_APPLICABLE,
+				"", nil, 0, 0, "", "", 0, 0)
+		})
+		line = findLogRecord(records, "provider pool empty")
+		require.NotNil(t, line, "the state must still be reported on every pass, at some level")
+		return line
+	}
+
+	first := callOnce()
+	require.Equal(t, "warn", first["level"], "the first report for a pairing is the alertable one")
+	require.Equal(t, "false", first["repeat"])
+
+	second := callOnce()
+	require.Equal(t, "debug", second["level"],
+		"a repeat for the same pairing must not warn again — the state has not changed")
+	require.Equal(t, "true", second["repeat"])
+
+	// A genuinely new pairing is a new outage, and must warn immediately rather than inherit the
+	// throttle from the pairing that preceded it.
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight+1, nil, nil))
+	afterRebuild := callOnce()
+	require.Equal(t, "warn", afterRebuild["level"],
+		"a rebuilt pairing that is still empty is a fresh event, not a repeat")
 }

--- a/protocol/lavasession/pool_inventory_test.go
+++ b/protocol/lavasession/pool_inventory_test.go
@@ -211,8 +211,9 @@ func TestDiffAddressSets_OutputIsSortedRegardlessOfInputOrder(t *testing.T) {
 	assertAddresses(t, "carried (second order)", secondCarried, []string{"a", "b"})
 }
 
-// A nil slice renders as "" in the log line, which reads as a missing field rather than as
-// "nothing changed" — the two must not look alike on the one line that reports pool churn.
+// Unchanged membership returns empty slices rather than nil. The log cannot tell the two apart —
+// both render as "" — so this is a contract for the callers: a result is always safe to range over
+// and append to without a nil check.
 func TestDiffAddressSets_UnchangedMembershipRendersEmptyNotNil(t *testing.T) {
 	added, removed, carried := diffAddressSets([]string{"lava"}, []string{"lava"})
 	if added == nil || removed == nil {
@@ -355,4 +356,67 @@ func TestReleaseBlockedProvidersIfPoolEmpty_WarnsOncePerPairing(t *testing.T) {
 	afterRebuild := callOnce()
 	require.Equal(t, "warn", afterRebuild["level"],
 		"a rebuilt pairing that is still empty is a fresh event, not a repeat")
+}
+
+// The pairing inventory is the answer to "why was the primary not even a candidate?", and `removed`
+// is the field that carries it: a provider that silently leaves the pool between epochs is invisible
+// from the selection path, where every line reports what IS in the pool and none reports what left.
+//
+// This drives UpdateAllProviders through the real log sink rather than testing diffAddressSets in
+// isolation, for the same reason the pool-empty tests do: a helper test cannot tell you whether the
+// line is ever reached, and the line is the entire product of the change.
+func TestUpdateAllProviders_ReportsPairingMembershipAndChurn(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+
+	firstPush := captureLogs(t, func() {
+		require.NoError(t, csm.UpdateAllProviders(firstEpochHeight,
+			createNamedPairingList("gamma", "alpha", "beta"), nil))
+	})
+
+	line := findLogRecord(firstPush, "pairing updated")
+	require.NotNil(t, line, "every provider-set push must report the resulting membership")
+	require.Equal(t, "3", line["size"])
+	require.Equal(t, "alpha,beta,gamma", line["providers"],
+		"membership is sorted: the source is Go map iteration, and an unsorted line reads as churn")
+	require.Equal(t, "alpha,beta,gamma", line["added"], "the first push adds everything")
+	require.Equal(t, "", line["removed"])
+
+	// The push that matters. A provider dropping out between epochs is the failure this line exists
+	// to make visible, and `removed` is the only place it appears.
+	secondPush := captureLogs(t, func() {
+		require.NoError(t, csm.UpdateAllProviders(firstEpochHeight+1,
+			createNamedPairingList("alpha", "beta"), nil))
+	})
+
+	line = findLogRecord(secondPush, "pairing updated")
+	require.NotNil(t, line)
+	require.Equal(t, "gamma", line["removed"],
+		"a provider that left the pairing must be named — nothing else in the router reports it")
+	require.Equal(t, "alpha,beta", line["carried_over"])
+	require.Equal(t, "", line["added"])
+	require.Equal(t, "2", line["size"])
+}
+
+// The backup tier gets the same treatment for the same reason: since MAG-2525 a chain can serve on
+// backups alone, so a backup leaving the pool is the same invisible failure with the same blast
+// radius. Reported on its own fields so a backup change is not mistaken for a primary one.
+func TestUpdateAllProviders_ReportsBackupPoolChurnSeparately(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight,
+		createNamedPairingList("alpha"), createNamedPairingList("backup-one", "backup-two")))
+
+	records := captureLogs(t, func() {
+		require.NoError(t, csm.UpdateAllProviders(firstEpochHeight+1,
+			createNamedPairingList("alpha"), createNamedPairingList("backup-one")))
+	})
+
+	line := findLogRecord(records, "pairing updated")
+	require.NotNil(t, line)
+	require.Equal(t, "backup-two", line["backup_removed"],
+		"a backup leaving the pool is reported, and on the backup fields")
+	require.Equal(t, "1", line["backup_pool_size"])
+	require.Equal(t, "backup-one", line["backup_providers"])
+	// The primary tier did not move, and must not be reported as though it had.
+	require.Equal(t, "", line["removed"])
+	require.Equal(t, "alpha", line["carried_over"])
 }

--- a/utils/lavalog.go
+++ b/utils/lavalog.go
@@ -144,6 +144,19 @@ func EnableDebugLogBuffer(maxLines int) {
 	debugBufferLogger.Store(&logger)
 }
 
+// DisableDebugLogBuffer turns the ring-buffer sink back off and drops the ring.
+// EnableDebugLogBuffer swaps a process-global sink, so a test that enables it must
+// restore this state — otherwise every later log call in the binary keeps paying the
+// copy-and-append, and the sink's "disabled by default" contract is broken for
+// anything that inspects it afterwards.
+func DisableDebugLogBuffer() {
+	disabled := zerolog.New(io.Discard).Level(zerolog.Disabled)
+	debugBufferLogger.Store(&disabled)
+	debugRingMu.Lock()
+	debugRing = nil
+	debugRingMu.Unlock()
+}
+
 // ClearDebugLogBuffer drops every record currently in the ring. No-op when the
 // buffer was never enabled.
 func ClearDebugLogBuffer() {


### PR DESCRIPTION
#Closes MAG-3331
#Closes MAG-3391
Jira ticket: MAG-3331

## The problem

Two captures from the same customer, days apart, produced the same symptom — the primary never
served, a backup did — from **two different causes**, and production logs could not tell them
apart.

The second one (`polygon-mainnet-router-…zxb5l…20_25_13`, in
`agent_docs/bug-reports/gk8-investigations/`) logged this and nothing else:

```
INF 🔎 CALCULATING VALID ADDRESSES  totalValidAddresses=0  currentlyBlockedCount=0
WRN NO VALID PROVIDERS - TRIGGERING RESET
INF RESET COMPLETED                 newValidAddressesCount=0
INF [BackupProviders] Static providers exhausted  ignored_providers=map[]  backup_pool_size=2
```

`newValidAddressesCount=0` is the whole answer, and nothing says so. For a request with no addon,
`setValidAddressesToDefaultValue` refills `validAddresses` **straight from `csm.pairingAddresses`**:

```go
csm.validAddresses = make([]string, len(csm.pairingAddresses))
```

So the count after a reset *is* the pairing size. The primary was not blocked
(`currentlyBlockedCount=0`), not filtered (`addon=""`), not dropped mid-request
(`ignored_providers=map[]`) — **it had never been registered**. That is upstream of routing
entirely, and no line in the selection path can say it, because every line there reports what *is*
in the pool and none reports what left it.

## What this adds

### 1. Pairing inventory — once per provider-set push

`UpdateAllProviders` logged `epoch` and `spec`, at DEBUG. It now reports membership and churn, for
both tiers:

```
INF pairing updated  epoch=20  size=2  spec=POLYGONjsonrpc
    providers=[blockdaemon, lava]
    added=[]  removed=[tatum]  carried_over=[blockdaemon, lava]
    backup_pool_size=2  backup_providers=[lava, tatum]
    backup_added=[]  backup_removed=[]
```

**`removed` is the field that matters** — it is the only place a provider silently leaving the pool
between epochs becomes visible. The backup tier gets the same treatment: since MAG-2525 a chain can
serve on backups alone, so a backup dropping out is the same invisible failure with the same blast
radius.

Not strictly once per epoch — `readmitRecoveredProviders` pushes a rebuilt set from its retry
backoff timer too, which is a feature: a recovered provider shows up as `added` the moment it is
readmitted. Either way it is nowhere near the relay path.

### 2. Pool inventory — when selection finds nothing

`NO VALID PROVIDERS — TRIGGERING RESET` named the symptom and no cause:

```
WRN provider pool empty  reason=pairing-empty  spec=POLYGONjsonrpc
    pairing_size=0  valid=0  blocked=0  backup_pool=2
    last_pairing_update=2026-08-27T19:58:02Z
```

`reason` is a closed set, in the same kebab-case vocabulary as `BlockReason` (#336) and
`EndpointDisableReason` (#349):

| reason | means | where to look |
|---|---|---|
| `pairing-empty` | nothing was ever registered | verification / registration — **not routing** |
| `addon-filtered` | members reached `validAddresses`, none serves this addon/extension | spec / config |
| `no-usable-endpoints` | members reached `validAddresses`, and nothing filters the default collection except a provider having no usable endpoint | registration succeeded, the endpoints behind it did not |
| `all-blocked` | every registered member is blocked | routing; the block reasons say which |
| `unspecified` | an unmodelled shape — named, not mislabelled | — |

The order is load-bearing. `validCount` is what separates a filtered pool from a blocked one: a
member still in `validAddresses` was not taken out by blocking, so if nothing is selectable the
filter is what removed it. Testing `blockedCount` first reported `all-blocked` for a pairing of five
with **one** blocked member and four that simply do not serve the requested addon — the exact
mislabel this line exists to prevent.

**This line is emitted on both sides of the `releaseCouldServeThisRequest` guard, and that placement
is the point.** The guard declines the release for an empty pairing too — its loop over
`pairingAddresses` never executes, so it returns `false` — which means a report taken *after* the
guard can never print `reason=pairing-empty`. What prints instead is the guard's own DEBUG, `every
provider has already been tried by this request`, and for an empty pairing that is not merely
unhelpful: no provider was tried, because there are none.

`last_pairing_update` separates a pool that was **never populated** from one that has **drained
since the last epoch**. `"never"` when `UpdateAllProviders` has not yet run, which is a genuinely
different state from a zero timestamp.

### 3. `RESET COMPLETED` no longer claims success when it recovered nothing

It logged at INFO either way. With an empty pairing the reset is a no-op, and "completed" reads as
recovery precisely when none happened. Now two distinct outcomes:

```
INF pool reset restored providers      restored=2  released_from_blocked=2
WRN pool reset recovered no providers  reason=no-usable-endpoints  pairing_size=3  released_from_blocked=2
```

The failure branch re-snapshots rather than reusing the pre-reset counts: the reset has just
released the blocked list, so reporting `all-blocked` there would name the one cause it had already
ruled out.

### 4. The subscription line is deleted

`resetValidAddresses` logged three lines on an empty pool, the last of them:

```
ERR User subscription might have expired or not purchased properly, pairing list is empty after reset.
```

The smart router has no subscription and no on-chain pairing. Its provider set comes from the
endpoint config and the epoch refresh that rebuilds it, and `consumerPublicAddress` is a locally
generated `smart-router-<rand>` identifier, not an account. In the capture that started this it
fired **1,747 times in 24 minutes** — about twice a second — and it is the only ERROR of the group,
so it is what alerts fire on and what Grafana surfaces. Leaving it in place beside a correct WARN
would only have made the correct line the quieter one.

All three go. The single caller reports the outcome instead, because it is the frame that holds the
pool inventory and the request GUID, so it can name the cause and attribute it to a chain and a
relay.

> Anything keyed on the old string `User subscription might have expired` stops matching.
> `provider pool empty` is the stable string to alert on now.

## How to verify

Temporarily add `utils.SetGlobalLoggingLevel("info")` to the `TestMain` in
`consumer_session_manager_test.go`, then:

```bash
go test ./protocol/lavasession/ -run 'TestAllPrimariesBlocked_NoBackupReleasesTheBlockAsBefore' -count=1 -v
```

Actual output on this branch, `TestAllPrimariesBlocked_NoBackupReleasesTheBlockAsBefore`:

```
INF pairing updated added=lava@primary0,lava@primary1 backup_added= backup_pool_size=0
    backup_providers= backup_removed= carried_over= epoch=20
    providers=lava@primary0,lava@primary1 removed= size=2 spec=stubstub
WRN provider pool empty GUID= addon= backup_pool=0 blocked=2 extensions=
    last_pairing_update=2026-08-31T11:46:58Z pairing_size=2 reason=all-blocked spec=stubstub valid=0
INF pool reset restored providers GUID= addon= extensions= released_from_blocked=2 restored=2 spec=stubstub
```

```bash
go vet ./...              # clean at 49b164a
go test ./... -count=1    # 33 ok, 1 pre-existing flake — see below
```

> **`protocol/lavasession` has a pre-existing flaky test**, unrelated to this PR:
> `TestBlockRecord_CarriedRecordTakesTheScopeItIsReBlockedIn` (`block_reason_test.go:757`) fails
> intermittently with `expected: "moves-pools", actual: ""`. Reproduced **at the merge base
> `2b252df`** — 2 failures in 6 runs of `-run 'TestBlockReason|TestBlockRecord'` on code that
> predates this branch entirely — so it is not introduced here. It passes in isolation and fails
> under the full package, which is why CI is green. Worth its own ticket; it makes every full-suite
> claim in this repo probabilistic.

## Tests

`protocol/lavasession/pool_inventory_test.go`.

The reason table has one case per branch — collapsing any two of them back together is the
regression that makes the line worthless — including the partial-block case
(`pairing_size=5, valid=4, blocked=1, addon=archive`) that made the `all-blocked` mislabel possible.

Three of the tests drive the **real path through the real log sink**
(`utils.EnableDebugLogBuffer`), not the helpers in isolation, because the entire product of this
change is log output and a helper test cannot tell you whether the line is ever reached:

- `TestReleaseBlockedProvidersIfPoolEmpty_ReportsAnEmptyPairing` — asserts the empty pairing is
  named, and that the false "every provider has already been tried" line is **not** emitted.
  Fails on the parent commit with *"must report why the pool is empty, not fall silent"*.
- `TestReleaseBlockedProvidersIfPoolEmpty_ReportsARecoveredPool` — the opposite case: a pool
  emptied by blocking reports `all-blocked` and then reports the reset as a recovery.
- `TestResetValidAddresses_DoesNotBlameASubscription` — no line logged by the reset may mention a
  subscription.

Plus, on the pure helpers:

- `diffAddressSets` output is sorted regardless of input order — the inputs come from Go map
  iteration, and unsorted output would read as churn on every epoch even when nothing moved
- unchanged membership renders `[]`, not nil — a nil slice logs as `""`, which reads as a missing
  field rather than "nothing changed"
- the zero time renders `"never"`, not a year-1 timestamp

## Also folded in: the standing lint error (MAG-3391)

`protocol/chainlib/chain_fetcher_addon_probe_test.go:98` converted a value that already had the
target type — `int64(spectypes.NOT_APPLICABLE)`, where `NOT_APPLICABLE` is declared `int64 = -1`.
It sat on `main`, so every branch inherited it and every lint job log carried a red
`##[error] … unnecessary conversion (unconvert)`.

The `lint` check reported **pass** throughout, because the step is `continue-on-error`. That is the
part worth removing: the check that would tell a contributor their branch introduced a lint problem
is green regardless, and the log that would tell them instead already had a permanent error in it
for theirs to hide behind. With this and #365, the lint log is clean — verified empty on this
branch's run, not merely "pass".

Unrelated to the observability work, folded here to save a separate PR.

## Scope and follow-ups

Deliberately **not** in this PR:

- **`skip_reason`** — the per-request counterpart, for a provider that was chosen and then dropped
  during session acquisition (`!connected`, path-mismatch, addon-unsupported, CU-exhausted). That is
  the *other* capture's cause, and it wants `Endpoint.DisableReason()` from **#349**, so it should
  land after that merges.
- **The third declined-release shape.** `releaseCouldServeThisRequest` also returns false when the
  pairing has members but none of them supports the requested addon or extension — reported here as
  ordinary retry exhaustion. Distinguishing it needs the guard to return a reason rather than a
  bool, which is a wider change than this one.
- **A metric.** "Pool empty, with a reason" is a level, not an event, so it wants a gauge alongside
  the blocked-provider gauges #332 already publishes from `publishStateSizes`.
- ~~Deleting the remaining per-request narration in `rpcsmartrouter_server.go`~~ — done in #362,
  which demoted `🎬 STARTING TASK CHANNEL LOOP`, `📨 RECEIVED TASK FROM CHANNEL`, `UPDATING BATCH`
  and `LOOPING BACK TO RECEIVE NEXT TASK` to DEBUG. `GOROUTINES LAUNCHED` is still at INFO.

Both of the first two are written up in
`agent_docs/bug-reports/gk8-investigations/misleading-or-missing-logs/README.md`.

## Reviewer notes

- **golangci-lint** was not runnable on the author's machine (local binary v1.64.8 built with
  go1.24 vs the repo's Go 1.26.6). Since run in review on `protocol/lavasession/...` and `utils/...`:
  **0 issues**.
- **`🔎 CALCULATING VALID ADDRESSES` is deliberately left at INFO.** An earlier review of mine
  listed it for demotion as narration. That was wrong: it carries `totalValidAddresses` and
  `currentlyBlockedCount`, which are the two numbers that made this diagnosis possible. It does fire
  ~3× per request on the cache-miss path, which is worth fixing separately — as deduplication, not
  demotion.
- **`provider pool empty` is on the per-request path**, unlike the pairing inventory. It replaces
  `NO VALID PROVIDERS - TRIGGERING RESET` one-for-one at the same site, so volume is unchanged
  there — and net volume drops, because the three lines inside `resetValidAddresses` are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AT3qP8Dq5MtriUcYjMffMe


