### PR TITLE
fix(security): redact node-url credentials before they leave the process

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -30,6 +30,13 @@ This document is an extension to [CONTRIBUTING](./CONTRIBUTING.md) and provides 
     * malleability
     * code must be always deterministic
 * Thread safety. If some functionality is not thread-safe, or uses something that is not thread-safe, then clearly indicate the risk on each level.
+* Upstream node-urls are credentials. Many carry the vendor api key in their path
+  or query, so a raw `NodeUrl.Url` must never reach a log, an error returned to a
+  client, a metric label or a span attribute. `utils.RedactURL` (and
+  `NodeUrl.UrlStr()`, which uses it) is the display form; `utils.RedactSecrets`
+  strips urls out of arbitrary text such as a `*url.Error` message. `LavaFormatLog`
+  applies it to every message and attribute, so ordinary logging is already safe —
+  what needs care is any path that formats a url without going through it.
 
 ### Documentation
 

--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -37,6 +37,12 @@ This document is an extension to [CONTRIBUTING](./CONTRIBUTING.md) and provides 
   strips urls out of arbitrary text such as a `*url.Error` message. `LavaFormatLog`
   applies it to every message and attribute, so ordinary logging is already safe —
   what needs care is any path that formats a url without going through it.
+* Request headers are credentials too — `auth-config.auth-headers` outbound, the
+  caller's own key inbound. Never log a header map directly; render it with
+  `utils.RedactHeaders` / `utils.RedactHeaderMap`, or `common.RedactMetadata` for
+  relay metadata. These fail closed: header names are always shown, values only
+  for a small allow-list of transport headers, because auth header names are
+  operator-configured and no deny-list can enumerate them.
 
 ### Documentation
 

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/grpcMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/grpcMessage.go
@@ -16,6 +16,7 @@ import (
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcclient"
 	dyncodec "github.com/magma-Devs/smart-router/protocol/chainlib/grpcproxy/dyncodec"
+	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/parser"
 	"github.com/magma-Devs/smart-router/utils"
 	"github.com/magma-Devs/smart-router/utils/sigs"
@@ -45,7 +46,7 @@ func (gm *GrpcMessage) GetRawRequestHash() ([]byte, error) {
 	headers := gm.GetHeaders()
 	headersByteArray, err := json.Marshal(headers)
 	if err != nil {
-		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headers", headers))
+		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headers", common.RedactMetadata(headers)))
 		return []byte{}, err
 	}
 	pathByteArray := []byte(gm.Path)

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/jsonRPCMessage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcclient"
+	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/parser"
 	"github.com/magma-Devs/smart-router/utils"
 	"github.com/magma-Devs/smart-router/utils/sigs"
@@ -40,7 +41,7 @@ func (jm *JsonrpcMessage) GetRawRequestHash() ([]byte, error) {
 	headers := jm.GetHeaders()
 	headersByteArray, err := json.Marshal(headers)
 	if err != nil {
-		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headers", headers))
+		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headers", common.RedactMetadata(headers)))
 		return []byte{}, err
 	}
 

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcclient"
+	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/parser"
 	"github.com/magma-Devs/smart-router/utils"
 	"github.com/magma-Devs/smart-router/utils/sigs"
@@ -42,7 +43,7 @@ func (rm *RestMessage) GetRawRequestHash() ([]byte, error) {
 	headers := rm.GetHeaders()
 	headersByteArray, err := json.Marshal(headers)
 	if err != nil {
-		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headers", headers))
+		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headers", common.RedactMetadata(headers)))
 		return []byte{}, err
 	}
 	pathByteArray := []byte(rm.Path)

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/tendermintRPCMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/tendermintRPCMessage.go
@@ -8,6 +8,7 @@ import (
 	"github.com/goccy/go-json"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcclient"
+	"github.com/magma-Devs/smart-router/protocol/common"
 	"github.com/magma-Devs/smart-router/protocol/parser"
 	"github.com/magma-Devs/smart-router/utils"
 
@@ -33,7 +34,7 @@ func (tm *TendermintrpcMessage) GetRawRequestHash() ([]byte, error) {
 	headers := tm.GetHeaders()
 	headersByteArray, err := json.Marshal(headers)
 	if err != nil {
-		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headers", headers))
+		utils.LavaFormatError("Failed marshalling headers on jsonRpc message", err, utils.LogAttr("headers", common.RedactMetadata(headers)))
 		return []byte{}, err
 	}
 	methodByteArray := []byte(tm.Method + tm.Path)

--- a/protocol/chainlib/grpc.go
+++ b/protocol/chainlib/grpc.go
@@ -419,7 +419,7 @@ func (apil *GrpcChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 		utils.LavaFormatDebug("in <<< GRPC Relay ",
 			utils.LogAttr("GUID", ctx),
 			utils.LogAttr("_method", method),
-			utils.LogAttr("headers", grpcHeaders),
+			utils.LogAttr("headers", common.RedactMetadata(grpcHeaders)),
 		)
 		metricsData := metrics.NewRelayAnalytics(dappID, apil.endpoint.ChainID, apiInterface)
 		metricsData.SetProcessingTimestampBeforeRelay(startTime)
@@ -854,7 +854,7 @@ func (cp *GrpcChainProxy) SendNodeMsg(ctx context.Context, chainMessage ChainMes
 
 	utils.LavaFormatTrace("provider sending node message",
 		utils.LogAttr("_method", nodeMessage.Path),
-		utils.LogAttr("headers", metadataMap),
+		utils.LogAttr("headers", utils.RedactHeaderMap(metadataMap)),
 		utils.LogAttr("apiInterface", "grpc"),
 	)
 

--- a/protocol/chainlib/grpcproxy/grpcproxy.go
+++ b/protocol/chainlib/grpcproxy/grpcproxy.go
@@ -177,7 +177,7 @@ func makeProxyFunc(callBack ProxyCallBack, streamCallBack StreamProxyCallBack) g
 		}
 
 		if err := stream.SetHeader(md); err != nil {
-			utils.LavaFormatError("Got error when setting header", err, utils.LogAttr("headers", md))
+			utils.LavaFormatError("Got error when setting header", err, utils.LogAttr("headers", utils.RedactHeaders(md)))
 		}
 		return stream.SendMsg(respBytes)
 	}
@@ -199,7 +199,7 @@ func serveServerStream(stream grpc.ServerStream, response *StreamResponse) error
 
 	if len(response.Metadata) > 0 {
 		if err := stream.SetHeader(lowercaseMetadata(response.Metadata)); err != nil {
-			utils.LavaFormatError("Got error when setting stream header", err, utils.LogAttr("headers", response.Metadata))
+			utils.LavaFormatError("Got error when setting stream header", err, utils.LogAttr("headers", utils.RedactHeaders(response.Metadata)))
 		}
 	}
 

--- a/protocol/chainlib/jsonRPC.go
+++ b/protocol/chainlib/jsonRPC.go
@@ -490,7 +490,7 @@ func (apil *JsonRPCChainListener) Serve(ctx context.Context, cmdFlags common.Con
 			utils.LogAttr("seed", msgSeed),
 			utils.LogAttr("body", logFormattedMsg),
 			utils.LogAttr("dappID", dappID),
-			utils.LogAttr("headers", headers),
+			utils.LogAttr("headers", common.RedactMetadata(headers)),
 		)
 
 		relayResult, err := apil.relaySender.SendRelay(ctx, path, msg, http.MethodPost, dappID, userIp, metricsData, headers)

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -303,7 +303,7 @@ func (apil *RestChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 			utils.LogAttr("dappID", dappID),
 			utils.LogAttr("msgSeed", msgSeed),
 			utils.LogAttr("body", requestBody),
-			utils.LogAttr("headers", restHeaders),
+			utils.LogAttr("headers", common.RedactMetadata(restHeaders)),
 		)
 		relayResult, err := apil.relaySender.SendRelay(ctx, path+query, requestBody, http.MethodPost, dappID, userIp, analytics, restHeaders)
 		reply := relayResult.GetReply()
@@ -372,7 +372,7 @@ func (apil *RestChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 			utils.LogAttr("path", path),
 			utils.LogAttr("seed", msgSeed),
 			utils.LogAttr("dappID", dappID),
-			utils.LogAttr("headers", restHeaders),
+			utils.LogAttr("headers", common.RedactMetadata(restHeaders)),
 		)
 
 		relayResult, err := apil.relaySender.SendRelay(ctx, path+query, "", fiberCtx.Method(), dappID, userIp, analytics, restHeaders)
@@ -508,7 +508,7 @@ func (rcp *RestChainProxy) SendNodeMsg(ctx context.Context, chainMessage ChainMe
 
 	utils.LavaFormatInfo("Sending request to node from provider",
 		utils.LogAttr("_method", nodeMessage.Path),
-		utils.LogAttr("headers", req.Header),
+		utils.LogAttr("headers", utils.RedactHeaders(req.Header)),
 		utils.LogAttr("apiInterface", "rest"),
 	)
 

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -491,7 +491,7 @@ func (apil *TendermintRpcChainListener) Serve(ctx context.Context, cmdFlags comm
 			utils.LogAttr("seed", msgSeed),
 			utils.LogAttr("_msg", logFormattedMsg),
 			utils.LogAttr("dappID", dappID),
-			utils.LogAttr("headers", headers),
+			utils.LogAttr("headers", common.RedactMetadata(headers)),
 		)
 		relayResult, err := apil.relaySender.SendRelay(ctx, "", msg, "", dappID, userIp, metricsData, headers)
 		reply := relayResult.GetReply()
@@ -562,7 +562,7 @@ func (apil *TendermintRpcChainListener) Serve(ctx context.Context, cmdFlags comm
 			utils.LogAttr("GUID", ctx),
 			utils.LogAttr("_msg", path),
 			utils.LogAttr("dappID", dappID),
-			utils.LogAttr("headers", headers),
+			utils.LogAttr("headers", common.RedactMetadata(headers)),
 		)
 		relayResult, err := apil.relaySender.SendRelay(ctx, path+query, "", "", dappID, userIp, metricsData, headers)
 		msgSeed := strconv.FormatUint(guid, 10)

--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/url"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -570,4 +571,27 @@ func GetIpFromGrpcContext(ctx context.Context) string {
 		}
 	}
 	return ""
+}
+
+// RedactMetadata renders relay metadata for logging with sensitive header values
+// withheld. Relay metadata carries the same credentials as an http.Header — the
+// caller's own api key inbound, the configured auth-headers outbound — so it gets
+// the same treatment; see utils.RedactHeaders.
+func RedactMetadata(md []pairingtypes.Metadata) string {
+	sorted := make([]pairingtypes.Metadata, len(md))
+	copy(sorted, md)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, entry := range sorted {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(entry.Name)
+		b.WriteByte(':')
+		b.WriteString(utils.RedactHeaderValue(entry.Name, entry.Value))
+	}
+	b.WriteByte('}')
+	return b.String()
 }

--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -157,13 +157,12 @@ func (nurl NodeUrl) String() string {
 	return urlStr
 }
 
+// UrlStr renders the node-url for display — logs, error text, the health
+// command. It keeps scheme://host[:port] and drops the rest, because vendors put
+// the api key in the userinfo, the path (".../v2/<key>") or the query. Never use
+// it to dial; NodeUrl.Url is the address.
 func (nurl *NodeUrl) UrlStr() string {
-	parsedURL, err := url.Parse(nurl.Url)
-	if err != nil {
-		return nurl.Url
-	}
-	parsedURL.User = nil
-	return parsedURL.String()
+	return utils.RedactURL(nurl.Url)
 }
 
 func (url *NodeUrl) GetAuthHeaders() map[string]string {

--- a/protocol/common/node_url_redaction_test.go
+++ b/protocol/common/node_url_redaction_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
 )
 
 // MAG-3330: UrlStr is the display form of a node-url — it feeds logs, error text
@@ -38,4 +40,36 @@ func TestNodeUrl_UrlStr_DoesNotMutateUrl(t *testing.T) {
 	nurl := NodeUrl{Url: raw}
 	_ = nurl.UrlStr()
 	assert.Equal(t, raw, nurl.Url)
+}
+
+// Relay metadata carries the same credentials as an http.Header — the caller's
+// own key inbound, the configured auth-headers outbound.
+func TestRedactMetadata(t *testing.T) {
+	md := []pairingtypes.Metadata{
+		{Name: "x-api-key", Value: "AbC123SecretKey"},
+		{Name: "content-type", Value: "application/json"},
+		{Name: "authorization", Value: "Bearer AbC123SecretKey"},
+	}
+
+	got := RedactMetadata(md)
+
+	assert.NotContains(t, got, "AbC123SecretKey")
+	assert.Contains(t, got, "content-type:application/json")
+	// Sorted, so the rendering is stable across runs.
+	assert.Equal(t, "{authorization:[redacted], content-type:application/json, x-api-key:[redacted]}", got)
+}
+
+// The input slice must not be reordered — it is live relay data, not a copy.
+func TestRedactMetadata_DoesNotMutateInput(t *testing.T) {
+	md := []pairingtypes.Metadata{
+		{Name: "zeta", Value: "1"},
+		{Name: "alpha", Value: "2"},
+	}
+	_ = RedactMetadata(md)
+	assert.Equal(t, "zeta", md[0].Name)
+	assert.Equal(t, "alpha", md[1].Name)
+}
+
+func TestRedactMetadata_Empty(t *testing.T) {
+	assert.Equal(t, "{}", RedactMetadata(nil))
 }

--- a/protocol/common/node_url_redaction_test.go
+++ b/protocol/common/node_url_redaction_test.go
@@ -1,0 +1,41 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// MAG-3330: UrlStr is the display form of a node-url — it feeds logs, error text
+// and the health command. Vendors put the api key in the path or the query, so
+// stripping the userinfo alone is not enough.
+func TestNodeUrl_UrlStr_DropsCredentials(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"key in path", "https://eth-mainnet.example.com/v2/AbC123SecretKey", "https://eth-mainnet.example.com/[redacted]"},
+		{"key in query", "https://node.example.com/rpc?apikey=AbC123SecretKey", "https://node.example.com/[redacted]"},
+		{"key in userinfo", "https://user:s3cr3t@node.example.com/rpc", "https://node.example.com/[redacted]"},
+		{"nothing to drop", "https://node.example.com", "https://node.example.com"},
+		{"host and port kept", "grpc://node.example.com:9090", "grpc://node.example.com:9090"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nurl := NodeUrl{Url: tt.url}
+			assert.Equal(t, tt.want, nurl.UrlStr())
+			// String() builds on UrlStr, so it must not reintroduce the credential.
+			assert.NotContains(t, nurl.String(), "AbC123SecretKey")
+			assert.NotContains(t, nurl.String(), "s3cr3t")
+		})
+	}
+}
+
+// The dialing address is untouched — only the display form is redacted.
+func TestNodeUrl_UrlStr_DoesNotMutateUrl(t *testing.T) {
+	raw := "https://eth-mainnet.example.com/v2/AbC123SecretKey"
+	nurl := NodeUrl{Url: raw}
+	_ = nurl.UrlStr()
+	assert.Equal(t, raw, nurl.Url)
+}

--- a/protocol/endpointstate/endpoint_poller.go
+++ b/protocol/endpointstate/endpoint_poller.go
@@ -385,7 +385,7 @@ func (ecf *EndpointPoller) ObserveLatestBlockPoll(block int64, transportLatency 
 // For JSON-RPC/POST requests, requestData is the JSON body.
 func (ecf *EndpointPoller) sendRawRequest(ctx context.Context, requestData []byte, connectionType string, apiName string, kind string) ([]byte, error) {
 	if ecf.directConnection == nil {
-		return nil, fmt.Errorf("no direct connection for endpoint %s", ecf.endpointURL)
+		return nil, fmt.Errorf("no direct connection for endpoint %s", utils.RedactURL(ecf.endpointURL))
 	}
 	// Counted once the request is about to go out, so the number matches what the upstream
 	// node was actually asked for. Deliberately AFTER the no-connection guard above (nothing
@@ -433,7 +433,7 @@ func (ecf *EndpointPoller) sendRawRequest(ctx context.Context, requestData []byt
 func (ecf *EndpointPoller) doRESTRequest(ctx context.Context, method, path string, body []byte) ([]byte, error) {
 	httpDoer, ok := ecf.directConnection.(lavasession.HTTPDirectRPCDoer)
 	if !ok {
-		return nil, fmt.Errorf("connection does not support HTTP requests for endpoint %s", ecf.endpointURL)
+		return nil, fmt.Errorf("connection does not support HTTP requests for endpoint %s", utils.RedactURL(ecf.endpointURL))
 	}
 
 	fullURL, err := common.JoinURLPath(ecf.directConnection.GetURL(), path)

--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -712,7 +712,7 @@ func (w *WebSocketDirectRPCConnection) SendRequest(
 ) (*DirectRPCResponse, error) {
 	client, err := w.ensureClient(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial WebSocket %s: %w", w.nodeUrl.Url, err)
+		return nil, fmt.Errorf("failed to dial WebSocket %s: %w", w.nodeUrl.UrlStr(), err)
 	}
 
 	// Decode the already-built request body to recover id/method/params for the
@@ -721,7 +721,7 @@ func (w *WebSocketDirectRPCConnection) SendRequest(
 	// CallContext accepts.
 	var reqMsg rpcInterfaceMessages.JsonrpcMessage
 	if err := json.Unmarshal(data, &reqMsg); err != nil {
-		return nil, fmt.Errorf("failed to parse JSON-RPC request for WebSocket %s: %w", w.nodeUrl.Url, err)
+		return nil, fmt.Errorf("failed to parse JSON-RPC request for WebSocket %s: %w", w.nodeUrl.UrlStr(), err)
 	}
 
 	// Send a connection-unique wire id so concurrent requests can't collide in
@@ -742,7 +742,7 @@ func (w *WebSocketDirectRPCConnection) SendRequest(
 
 	respBytes, err := json.Marshal(&out)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal WebSocket response for %s: %w", w.nodeUrl.Url, err)
+		return nil, fmt.Errorf("failed to marshal WebSocket response for %s: %w", w.nodeUrl.UrlStr(), err)
 	}
 	utils.LavaFormatTrace("WebSocket SendRequest succeeded",
 		utils.LogAttr("endpoint", w.nodeUrl.Url),
@@ -762,7 +762,7 @@ func (w *WebSocketDirectRPCConnection) ensureClient(ctx context.Context) (*rpccl
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.closed {
-		return nil, fmt.Errorf("WebSocket connection is closed for endpoint %s", w.nodeUrl.Url)
+		return nil, fmt.Errorf("WebSocket connection is closed for endpoint %s", w.nodeUrl.UrlStr())
 	}
 	if w.client != nil {
 		return w.client, nil

--- a/protocol/metrics/rpcconsumer_logs.go
+++ b/protocol/metrics/rpcconsumer_logs.go
@@ -176,7 +176,12 @@ func (rpccl *RPCConsumerLogs) GetUniqueGuidResponseForError(responseError error,
 		Error_GUID: msgSeed,
 	}
 	if ReturnMaskedErrors == "false" {
-		data.Error = responseError.Error()
+		// Every client-facing error envelope — jsonrpc, tendermint, rest, grpc and
+		// ws — is built here, so this is the one place that has to strip upstream
+		// credentials. net/http's *url.Error embeds the full request url and Go
+		// masks only the userinfo password, so a transport failure would otherwise
+		// hand the caller the node-url's api key.
+		data.Error = utils.RedactSecrets(responseError.Error())
 	}
 
 	utils.LavaFormatError("UniqueGuidResponseForError", responseError, utils.Attribute{Key: "msgSeed", Value: msgSeed})

--- a/protocol/metrics/rpcconsumer_logs_test.go
+++ b/protocol/metrics/rpcconsumer_logs_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -292,4 +294,37 @@ func TestLavaFormat_GUIDAttachedToNormalLogPaths(t *testing.T) {
 	// normal-path key is the literal "GUID".
 	_, hasErrorGUID := parsed["Error_GUID"]
 	assert.False(t, hasErrorGUID, "normal-path log must not carry Error_GUID field")
+}
+
+// MAG-3330: every client-facing error envelope is built here, so an upstream
+// node-url's api key must not survive into it. The router runs with
+// ReturnMaskedErrors="false" (no -ldflags sets it), which is the branch that
+// copies the error text into the response, so that is the branch under test.
+func TestGetUniqueGuidResponseForError_RedactsUpstreamURL(t *testing.T) {
+	require.Equal(t, "false", ReturnMaskedErrors, "the unmasked branch is the shipped default")
+
+	plog, err := NewRPCConsumerLogs(nil, nil, nil)
+	require.Nil(t, err)
+	utils.SetGlobalLoggingLevel("fatal") // this path logs the error too; keep the output quiet
+
+	const secret = "AbC123SecretKey"
+	// The exact shape net/http produces: Go masks only the userinfo password, so
+	// a key in the path reaches us intact.
+	transportErr := fmt.Errorf("http request failed: %w", &url.Error{
+		Op:  "Post",
+		URL: "https://eth-mainnet.example.com/v2/" + secret,
+		Err: errors.New("connection reset by peer"),
+	})
+	require.Contains(t, transportErr.Error(), secret, "precondition: the raw error carries the key")
+
+	envelope := plog.GetUniqueGuidResponseForError(transportErr, "msgSeed")
+
+	assert.NotContains(t, envelope, secret)
+
+	errObject := &ErrorData{}
+	require.Nil(t, json.Unmarshal([]byte(envelope), errObject))
+	assert.Equal(t, "msgSeed", errObject.GUID)
+	// Still actionable: the host and the cause survive, only the credential goes.
+	assert.Contains(t, errObject.Error1, "eth-mainnet.example.com")
+	assert.Contains(t, errObject.Error1, "connection reset by peer")
 }

--- a/protocol/metrics/smartrouter_metrics_manager.go
+++ b/protocol/metrics/smartrouter_metrics_manager.go
@@ -1050,7 +1050,11 @@ func (m *SmartRouterMetricsManager) resolveProviderNames(urlOrName string) []str
 		copy(out, names)
 		return out
 	}
-	return []string{urlOrName}
+	// Unregistered input is either a provider name (passed straight through by
+	// callers that already resolved it) or a url that never reached
+	// RegisterEndpoint. RedactIfURL leaves the name alone — a lava address is not
+	// a url — and keeps a node-url's api key out of a scraped, retained label.
+	return []string{utils.RedactIfURL(urlOrName)}
 }
 
 // resolveProviderName returns the first provider name configured for a given endpoint URL,

--- a/protocol/relaycore/results_manager.go
+++ b/protocol/relaycore/results_manager.go
@@ -154,7 +154,7 @@ func (rp *ResultsManagerInst) setValidResponse(response *RelayResponse, protocol
 		var reqHeaders interface{}
 		if response.RelayResult.Request != nil && response.RelayResult.Request.RelayData != nil {
 			reqPayload = string(response.RelayResult.Request.RelayData.Data)
-			reqHeaders = response.RelayResult.Request.RelayData.Metadata
+			reqHeaders = common.RedactMetadata(response.RelayResult.Request.RelayData.Metadata)
 		}
 		// Get request URL safely
 		requestUrl := ""
@@ -186,7 +186,7 @@ func (rp *ResultsManagerInst) setValidResponse(response *RelayResponse, protocol
 			utils.LogAttr("api", protocolMessage.GetApi().Name),
 			utils.LogAttr("requestUrl", requestUrl),
 			utils.LogAttr("payload", parser.CapStringLen(string(response.RelayResult.Reply.Data))),
-			utils.LogAttr("headers", response.RelayResult.Reply.Metadata),
+			utils.LogAttr("headers", common.RedactMetadata(response.RelayResult.Reply.Metadata)),
 			utils.LogAttr("requestPayload", parser.CapStringLen(reqPayload)),
 			utils.LogAttr("requestHeaders", reqHeaders),
 		)

--- a/protocol/rpcsmartrouter/direct_grpc_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_grpc_subscription_manager.go
@@ -1268,7 +1268,7 @@ func (dgm *DirectGRPCSubscriptionManager) selectFromTier(ctx context.Context, ti
 	if endpoint, exists := byURL[selectedURL]; exists {
 		return endpoint, nil
 	}
-	return nil, fmt.Errorf("optimizer selected unknown endpoint: %s", selectedURL)
+	return nil, fmt.Errorf("optimizer selected unknown endpoint: %s", utils.RedactURL(selectedURL))
 }
 
 func (dgm *DirectGRPCSubscriptionManager) checkClientSubscriptionLimit(clientKey string) error {

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
@@ -524,7 +524,7 @@ func (dwsm *DirectWSSubscriptionManager) selectFromTier(ctx context.Context, tie
 	selectedURL := selectedURLs[0]
 	selectedEndpoint, exists := byURL[selectedURL]
 	if !exists {
-		return nil, fmt.Errorf("optimizer selected unknown endpoint: %s", selectedURL)
+		return nil, fmt.Errorf("optimizer selected unknown endpoint: %s", utils.RedactURL(selectedURL))
 	}
 
 	utils.LavaFormatDebug("DirectWS: selected endpoint via optimizer",

--- a/protocol/tracing/span_helpers.go
+++ b/protocol/tracing/span_helpers.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/utils"
 )
 
 // SmartRouterTracerName is the OTel instrumentation scope name used for all
@@ -84,6 +85,9 @@ func RelaySpanFromContext(ctx context.Context) trace.Span {
 
 // RecordError records the error on the span and sets its status to Error.
 func RecordError(span trace.Span, err error) {
+	// Redacted before export: a transport failure's *url.Error carries the full
+	// upstream url, whose path and query hold the vendor api key.
+	err = utils.RedactSecretsErr(err)
 	span.RecordError(err)
 	span.SetStatus(otelcodes.Error, err.Error())
 }
@@ -213,7 +217,9 @@ func RecordHTTPRequest(span trace.Span, method, urlStr string) {
 	}
 	attrs := []attribute.KeyValue{
 		semconv.HTTPMethod(method),
-		semconv.HTTPURL(urlStr),
+		// scheme://host only — the path and query carry the vendor api key, and
+		// spans leave the process for a collector.
+		semconv.HTTPURL(utils.RedactURL(urlStr)),
 	}
 	attrs = appendNetPeer(attrs, urlStr)
 	span.SetAttributes(attrs...)

--- a/protocol/tracing/span_helpers_test.go
+++ b/protocol/tracing/span_helpers_test.go
@@ -373,10 +373,15 @@ const (
 )
 
 func TestRecordHTTPRequest(t *testing.T) {
+	// http.url is redacted to scheme://host before export (MAG-3330): spans leave
+	// the process for a collector, and upstream node-urls carry the vendor api key
+	// in their path or query. net.peer.* is derived from the raw url and is
+	// unaffected — a hostname and port are not credentials.
 	tests := []struct {
 		name        string
 		method      string
 		url         string
+		expectURL   string
 		expectHost  string
 		expectPort  int64
 		expectNoNet bool
@@ -385,6 +390,7 @@ func TestRecordHTTPRequest(t *testing.T) {
 			name:       "URL with explicit port",
 			method:     "POST",
 			url:        "https://provider.example.com:8443/jsonrpc",
+			expectURL:  "https://provider.example.com:8443/[redacted]",
 			expectHost: "provider.example.com",
 			expectPort: 8443,
 		},
@@ -392,12 +398,28 @@ func TestRecordHTTPRequest(t *testing.T) {
 			name:       "URL without port",
 			method:     "GET",
 			url:        "https://provider.example.com/jsonrpc",
+			expectURL:  "https://provider.example.com/[redacted]",
+			expectHost: "provider.example.com",
+		},
+		{
+			name:       "api key in path never reaches the span",
+			method:     "POST",
+			url:        "https://provider.example.com/v2/AbC123SecretKey",
+			expectURL:  "https://provider.example.com/[redacted]",
+			expectHost: "provider.example.com",
+		},
+		{
+			name:       "api key in query never reaches the span",
+			method:     "POST",
+			url:        "https://provider.example.com/rpc?apikey=AbC123SecretKey",
+			expectURL:  "https://provider.example.com/[redacted]",
 			expectHost: "provider.example.com",
 		},
 		{
 			name:        "malformed URL is best-effort skipped",
 			method:      "POST",
 			url:         "not-a-url",
+			expectURL:   "not-a-url",
 			expectNoNet: true,
 		},
 	}
@@ -409,7 +431,8 @@ func TestRecordHTTPRequest(t *testing.T) {
 			})
 
 			require.Equal(t, tc.method, attrs[keyHTTPMethod].AsString())
-			require.Equal(t, tc.url, attrs[keyHTTPURL].AsString())
+			require.Equal(t, tc.expectURL, attrs[keyHTTPURL].AsString())
+			require.NotContains(t, attrs[keyHTTPURL].AsString(), "AbC123SecretKey")
 
 			if tc.expectNoNet {
 				require.NotContains(t, attrs, keyNetPeerName)

--- a/utils/lavalog.go
+++ b/utils/lavalog.go
@@ -562,23 +562,30 @@ func LavaFormatLog(description string, err error, attributes []Attribute, severi
 			debugBufferEvent = dbgLogger.Trace()
 		}
 	}
+	// Everything below is written to a log sink or embedded in the returned
+	// error's message, and upstream node-urls carry api keys in their path and
+	// query. Redact once here rather than at every call site.
+	description = RedactSecrets(description)
 	output := description
 	attrStrings := []string{}
 	if err != nil {
-		logEvent = logEvent.Err(err)
+		// The log sinks get the redacted message; the returned error keeps err
+		// itself as its cause, so errors.Is/As are unaffected.
+		logErr := RedactSecretsErr(err)
+		logEvent = logEvent.Err(logErr)
 		if rollingLoggerEvent != nil {
-			rollingLoggerEvent = rollingLoggerEvent.Err(err)
+			rollingLoggerEvent = rollingLoggerEvent.Err(logErr)
 		}
 		if debugBufferEvent != nil {
-			debugBufferEvent = debugBufferEvent.Err(err)
+			debugBufferEvent = debugBufferEvent.Err(logErr)
 		}
-		output = fmt.Sprintf("%s ErrMsg: %s", output, err.Error())
+		output = fmt.Sprintf("%s ErrMsg: %s", output, logErr.Error())
 	}
 	if len(attributes) > 0 {
 		for idx, attr := range attributes {
 			key := attr.Key
 			val := attr.Value
-			st_val := StrValueForLog(val, key, idx, attributes)
+			st_val := RedactSecrets(StrValueForLog(val, key, idx, attributes))
 			logEvent = logEvent.Str(key, st_val)
 			if rollingLoggerEvent != nil {
 				rollingLoggerEvent = rollingLoggerEvent.Str(key, st_val)

--- a/utils/lavalog_redaction_test.go
+++ b/utils/lavalog_redaction_test.go
@@ -1,0 +1,107 @@
+package utils
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
+	zerolog "github.com/rs/zerolog"
+	zerologlog "github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureLog swaps the global zerolog sink for a buffer, runs fn, and returns
+// everything written. lavalog writes through a package-level singleton, so the
+// previous logger and level are restored before returning.
+func captureLog(t *testing.T, level zerolog.Level, fn func()) string {
+	t.Helper()
+	prevLogger := zerologlog.Logger
+	prevLevel := defaultGlobalLogLevel
+	t.Cleanup(func() {
+		zerologlog.Logger = prevLogger
+		defaultGlobalLogLevel = prevLevel
+	})
+
+	var buf bytes.Buffer
+	defaultGlobalLogLevel = level
+	zerologlog.Logger = zerolog.New(&buf).Level(level)
+	fn()
+	return buf.String()
+}
+
+const (
+	testSecretKey = "AbC123SecretKey"
+	testSecretURL = "https://eth-mainnet.example.com/v2/" + testSecretKey
+)
+
+// MAG-3330: ~87 call sites log a raw node-url. Redacting inside LavaFormatLog is
+// what covers all of them at once, so the wiring — not just RedactSecrets — is
+// what this asserts.
+func TestLavaFormatLog_RedactsURLInAttribute(t *testing.T) {
+	out := captureLog(t, zerolog.TraceLevel, func() {
+		LavaFormatInfo("created direct RPC connection", LogAttr("url", testSecretURL))
+	})
+
+	assert.NotContains(t, out, testSecretKey)
+	assert.Contains(t, out, "eth-mainnet.example.com", "the host stays, so the line is still actionable")
+	assert.Contains(t, out, "created direct RPC connection")
+}
+
+func TestLavaFormatLog_RedactsURLInWrappedError(t *testing.T) {
+	transportErr := fmt.Errorf("http request failed: %w", &url.Error{
+		Op:  "Post",
+		URL: testSecretURL,
+		Err: errors.New("connection reset by peer"),
+	})
+	require.Contains(t, transportErr.Error(), testSecretKey, "precondition")
+
+	var returned error
+	out := captureLog(t, zerolog.TraceLevel, func() {
+		returned = LavaFormatError("relay failed", transportErr)
+	})
+
+	assert.NotContains(t, out, testSecretKey, "log sink")
+	// The returned error is what propagates toward the client envelope.
+	assert.NotContains(t, returned.Error(), testSecretKey, "returned error message")
+	assert.Contains(t, returned.Error(), "connection reset by peer")
+	// The cause is untouched, so errors.Is/As still work through the wrap.
+	var urlErr *url.Error
+	assert.True(t, errors.As(returned, &urlErr))
+}
+
+func TestLavaFormatLog_RedactsURLAcrossEveryLevel(t *testing.T) {
+	levels := map[string]func(){
+		"info":    func() { LavaFormatInfo("m", LogAttr("url", testSecretURL)) },
+		"debug":   func() { LavaFormatDebug("m", LogAttr("url", testSecretURL)) },
+		"trace":   func() { LavaFormatTrace("m", LogAttr("url", testSecretURL)) },
+		"warning": func() { LavaFormatWarning("m", nil, LogAttr("url", testSecretURL)) },
+		"error":   func() { LavaFormatError("m", nil, LogAttr("url", testSecretURL)) },
+	}
+	for name, emit := range levels {
+		t.Run(name, func(t *testing.T) {
+			out := captureLog(t, zerolog.TraceLevel, emit)
+			require.NotEmpty(t, strings.TrimSpace(out), "the level must actually emit")
+			assert.NotContains(t, out, testSecretKey)
+		})
+	}
+}
+
+// Redaction must not cost the rest of the line: an attribute that follows a url
+// in the same call has to survive intact.
+func TestLavaFormatLog_KeepsAttributesAfterAURL(t *testing.T) {
+	out := captureLog(t, zerolog.TraceLevel, func() {
+		LavaFormatInfo("relay",
+			LogAttr("url", testSecretURL),
+			LogAttr("method", "eth_call"),
+			LogAttr("chainId", "ETH1"),
+		)
+	})
+
+	assert.NotContains(t, out, testSecretKey)
+	assert.Contains(t, out, "eth_call")
+	assert.Contains(t, out, "ETH1")
+}

--- a/utils/lavalog_redaction_test.go
+++ b/utils/lavalog_redaction_test.go
@@ -34,8 +34,9 @@ func captureLog(t *testing.T, level zerolog.Level, fn func()) string {
 }
 
 const (
-	testSecretKey = "AbC123SecretKey"
-	testSecretURL = "https://eth-mainnet.example.com/v2/" + testSecretKey
+	testSecretKey           = "AbC123SecretKey"
+	testSecretURL           = "https://eth-mainnet.example.com/v2/" + testSecretKey
+	testSchemeLessSecretURL = "eth-mainnet.example.com/v2/" + testSecretKey
 )
 
 // MAG-3330: ~87 call sites log a raw node-url. Redacting inside LavaFormatLog is
@@ -49,6 +50,15 @@ func TestLavaFormatLog_RedactsURLInAttribute(t *testing.T) {
 	assert.NotContains(t, out, testSecretKey)
 	assert.Contains(t, out, "eth-mainnet.example.com", "the host stays, so the line is still actionable")
 	assert.Contains(t, out, "created direct RPC connection")
+}
+
+func TestLavaFormatLog_RedactsSchemeLessURLInAttribute(t *testing.T) {
+	out := captureLog(t, zerolog.TraceLevel, func() {
+		LavaFormatInfo("created direct RPC connection", LogAttr("url", testSchemeLessSecretURL))
+	})
+
+	assert.NotContains(t, out, testSecretKey)
+	assert.Contains(t, out, "eth-mainnet.example.com")
 }
 
 func TestLavaFormatLog_RedactsURLInWrappedError(t *testing.T) {

--- a/utils/redact.go
+++ b/utils/redact.go
@@ -23,6 +23,11 @@ const RedactedURLMark = "/" + RedactedMark
 // needs to identify — always precedes them.
 var urlInText = regexp.MustCompile(`[a-zA-Z][a-zA-Z0-9+.\-]*://[^\s"'` + "`" + `<>\\^{}|\[\],;)]+`)
 
+// schemeLessURLInText matches a credential-bearing scheme-less node url while
+// requiring a recognizable host. That keeps ordinary prose, provider names,
+// lava addresses and bare host:port values untouched.
+var schemeLessURLInText = regexp.MustCompile(`\b(?:(?:localhost|(?:[a-zA-Z0-9-]+\.)+[a-zA-Z0-9-]+)(?::[0-9]+)?|[a-zA-Z0-9-]+:[0-9]+)[/?#][^\s"'` + "`" + `<>\\^{}|\[\],;)]+`)
+
 // RedactURL reduces one url to scheme://host[:port]. Upstream vendors carry the
 // api key in the userinfo, the path (".../v2/<key>") or the query
 // ("?apikey=<key>"), so everything past the host is dropped wholesale — a
@@ -78,13 +83,14 @@ func RedactIfURL(s string) string {
 // message embeds the full request url (Go masks only the userinfo password), or
 // a message that interpolated a node-url.
 //
-// The Contains check keeps this near-free for the log lines that hold no url,
+// The delimiter check keeps this near-free for the log lines that hold no url,
 // which is nearly all of them.
 func RedactSecrets(s string) string {
-	if !strings.Contains(s, "://") {
+	if !strings.Contains(s, "://") && !strings.ContainsAny(s, "/?#") {
 		return s
 	}
-	return urlInText.ReplaceAllStringFunc(s, RedactURL)
+	redacted := urlInText.ReplaceAllStringFunc(s, RedactURL)
+	return schemeLessURLInText.ReplaceAllStringFunc(redacted, RedactURL)
 }
 
 // RedactSecretsErr returns err with its message redacted, preserving the cause

--- a/utils/redact.go
+++ b/utils/redact.go
@@ -2,12 +2,16 @@ package utils
 
 import (
 	"regexp"
+	"sort"
 	"strings"
 )
 
+// RedactedMark stands in for any withheld value.
+const RedactedMark = "[redacted]"
+
 // RedactedURLMark replaces the credential-bearing tail of a url. It is a path
 // segment so a redacted url still reads as a url in logs and error text.
-const RedactedURLMark = "/[redacted]"
+const RedactedURLMark = "/" + RedactedMark
 
 // urlInText matches a scheme-qualified url inside arbitrary text. Anchoring on
 // "://" keeps prose and scheme-less identifiers — a host:port listen address, a
@@ -95,4 +99,85 @@ func RedactSecretsErr(err error) error {
 		return err
 	}
 	return &wrappedLavaError{msg: redacted, cause: err}
+}
+
+// safeHeaderValues names the headers whose values may be logged. Everything else
+// is withheld, because auth header names are operator-configured per node-url
+// (auth-config.auth-headers) and inbound requests carry the caller's own
+// credentials — no deny-list can enumerate either. Header NAMES are always
+// logged, so a redacted line still shows what was sent.
+var safeHeaderValues = map[string]struct{}{
+	"accept": {}, "accept-encoding": {}, "accept-language": {}, "allow": {},
+	"cache-control": {}, "connection": {}, "content-encoding": {},
+	"content-language": {}, "content-length": {}, "content-type": {},
+	"date": {}, "expect": {}, "host": {}, "keep-alive": {}, "server": {},
+	"te": {}, "trailer": {}, "transfer-encoding": {}, "upgrade": {},
+	"user-agent": {}, "vary": {}, "via": {},
+}
+
+// IsSensitiveHeader reports whether a header's value must be withheld from logs.
+// Fails closed: anything not explicitly known-safe is sensitive.
+func IsSensitiveHeader(name string) bool {
+	_, safe := safeHeaderValues[strings.ToLower(strings.TrimSpace(name))]
+	return !safe
+}
+
+// RedactHeaderValue returns value when the header is known-safe to log, and the
+// redaction mark otherwise.
+func RedactHeaderValue(name, value string) string {
+	if IsSensitiveHeader(name) {
+		return RedactedMark
+	}
+	return value
+}
+
+// RedactHeaders renders a header map for logging with sensitive values withheld.
+// Takes the unnamed map type so http.Header and grpc metadata.MD both assign to
+// it. Output is sorted by name — map iteration order would otherwise make log
+// lines differ run to run.
+func RedactHeaders(h map[string][]string) string {
+	names := make([]string, 0, len(h))
+	for name := range h {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, name := range names {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(name)
+		b.WriteByte(':')
+		if IsSensitiveHeader(name) {
+			b.WriteString(RedactedMark)
+			continue
+		}
+		b.WriteString(strings.Join(h[name], ","))
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+// RedactHeaderMap is RedactHeaders for a single-valued header map.
+func RedactHeaderMap(h map[string]string) string {
+	names := make([]string, 0, len(h))
+	for name := range h {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, name := range names {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(name)
+		b.WriteByte(':')
+		b.WriteString(RedactHeaderValue(name, h[name]))
+	}
+	b.WriteByte('}')
+	return b.String()
 }

--- a/utils/redact.go
+++ b/utils/redact.go
@@ -1,0 +1,98 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+// RedactedURLMark replaces the credential-bearing tail of a url. It is a path
+// segment so a redacted url still reads as a url in logs and error text.
+const RedactedURLMark = "/[redacted]"
+
+// urlInText matches a scheme-qualified url inside arbitrary text. Anchoring on
+// "://" keeps prose and scheme-less identifiers — a host:port listen address, a
+// provider name, a "dial tcp 10.0.0.1:443" — untouched.
+//
+// The match stops at ",;)" as well as at quotes and brackets so a url embedded in
+// a log attribute list ("{url:https://host/p,method:eth_call}") does not swallow
+// what follows it. No credential charset uses those, and the host — all this
+// needs to identify — always precedes them.
+var urlInText = regexp.MustCompile(`[a-zA-Z][a-zA-Z0-9+.\-]*://[^\s"'` + "`" + `<>\\^{}|\[\],;)]+`)
+
+// RedactURL reduces one url to scheme://host[:port]. Upstream vendors carry the
+// api key in the userinfo, the path (".../v2/<key>") or the query
+// ("?apikey=<key>"), so everything past the host is dropped wholesale — a
+// heuristic that kept "harmless-looking" segments would eventually keep a key.
+//
+// Scheme-less urls ("host/v2/<key>") are handled too: the config accepts them
+// and the direct-connection layer resolves the scheme from the api-interface.
+func RedactURL(raw string) string {
+	if raw == "" {
+		return raw
+	}
+
+	scheme, rest := "", raw
+	if i := strings.Index(raw, "://"); i >= 0 {
+		scheme, rest = raw[:i+3], raw[i+3:]
+	}
+
+	authority := rest
+	rest = ""
+	if i := strings.IndexAny(authority, "/?#"); i >= 0 {
+		authority, rest = authority[:i], authority[i:]
+	}
+
+	// "user:pass@host" keeps only "host".
+	if i := strings.LastIndex(authority, "@"); i >= 0 {
+		authority = authority[i+1:]
+	}
+
+	if authority == "" {
+		return scheme
+	}
+	// A bare "/" carries nothing, so it survives rather than becoming a mark.
+	if rest == "" || rest == "/" {
+		return scheme + authority + rest
+	}
+	return scheme + authority + RedactedURLMark
+}
+
+// RedactIfURL redacts s only when it looks like a url — it carries a "://"
+// scheme, or a path/query/fragment delimiter. Anything else comes back
+// untouched, which matters where the input is a url OR an identifier: a lava
+// provider address ("lava@provider") is not a url, and RedactURL would read its
+// "@" as userinfo and drop the prefix.
+func RedactIfURL(s string) string {
+	if strings.Contains(s, "://") || strings.ContainsAny(s, "/?#") {
+		return RedactURL(s)
+	}
+	return s
+}
+
+// RedactSecrets rewrites every url in s with RedactURL. Use it on any text that
+// may have picked up a url indirectly — an error from net/http, whose *url.Error
+// message embeds the full request url (Go masks only the userinfo password), or
+// a message that interpolated a node-url.
+//
+// The Contains check keeps this near-free for the log lines that hold no url,
+// which is nearly all of them.
+func RedactSecrets(s string) string {
+	if !strings.Contains(s, "://") {
+		return s
+	}
+	return urlInText.ReplaceAllStringFunc(s, RedactURL)
+}
+
+// RedactSecretsErr returns err with its message redacted, preserving the cause
+// so errors.Is/As still traverse it. Returns err unchanged when it holds no url.
+func RedactSecretsErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	redacted := RedactSecrets(msg)
+	if redacted == msg {
+		return err
+	}
+	return &wrappedLavaError{msg: redacted, cause: err}
+}

--- a/utils/redact_headers_test.go
+++ b/utils/redact_headers_test.go
@@ -1,0 +1,87 @@
+package utils
+
+import (
+	"net/http"
+	"testing"
+
+	"google.golang.org/grpc/metadata"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSensitiveHeader_FailsClosed(t *testing.T) {
+	// Known-safe transport headers keep their values.
+	for _, name := range []string{"Content-Type", "content-type", "  Accept  ", "User-Agent", "Host"} {
+		assert.False(t, IsSensitiveHeader(name), "%q should be loggable", name)
+	}
+
+	// Credential-bearing names, and — the point of failing closed — the
+	// operator-configured ones no deny-list could enumerate.
+	for _, name := range []string{
+		"Authorization", "authorization", "X-Api-Key", "x-lava-key", "Cookie",
+		"Proxy-Authorization", "X-Auth-Token",
+		"X-Vendor-Specific-Secret", "Some-Custom-Thing",
+	} {
+		assert.True(t, IsSensitiveHeader(name), "%q must be withheld", name)
+	}
+}
+
+func TestRedactHeaders_HTTPHeader(t *testing.T) {
+	// The shape of the leak: SetAuthHeaders puts the upstream credential on the
+	// request, and the next log line printed the whole header set.
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	h.Set("X-Api-Key", "AbC123SecretKey")
+	h.Set("Authorization", "Bearer AbC123SecretKey")
+
+	got := RedactHeaders(h)
+
+	assert.NotContains(t, got, "AbC123SecretKey")
+	// Names survive, so the line still says what was sent.
+	assert.Contains(t, got, "X-Api-Key")
+	assert.Contains(t, got, "Authorization")
+	assert.Contains(t, got, "Content-Type:application/json")
+}
+
+func TestRedactHeaders_GRPCMetadata(t *testing.T) {
+	// metadata.MD assigns to map[string][]string, so one helper covers it.
+	md := metadata.New(map[string]string{
+		"content-type": "application/grpc",
+		"x-api-key":    "AbC123SecretKey",
+	})
+
+	got := RedactHeaders(md)
+
+	assert.NotContains(t, got, "AbC123SecretKey")
+	assert.Contains(t, got, "content-type:application/grpc")
+	assert.Contains(t, got, "x-api-key:"+RedactedMark)
+}
+
+func TestRedactHeaderMap(t *testing.T) {
+	got := RedactHeaderMap(map[string]string{
+		"content-type":  "application/json",
+		"authorization": "Bearer AbC123SecretKey",
+	})
+
+	assert.NotContains(t, got, "AbC123SecretKey")
+	assert.Contains(t, got, "content-type:application/json")
+	assert.Contains(t, got, "authorization:"+RedactedMark)
+}
+
+// Map iteration order is random; unsorted output would make log lines differ
+// run to run and this test flake.
+func TestRedactHeaders_DeterministicOrder(t *testing.T) {
+	h := map[string][]string{
+		"zeta": {"1"}, "alpha": {"2"}, "mu": {"3"}, "beta": {"4"}, "omega": {"5"},
+	}
+	first := RedactHeaders(h)
+	for i := 0; i < 50; i++ {
+		assert.Equal(t, first, RedactHeaders(h))
+	}
+	assert.Equal(t, "{alpha:[redacted], beta:[redacted], mu:[redacted], omega:[redacted], zeta:[redacted]}", first)
+}
+
+func TestRedactHeaders_Empty(t *testing.T) {
+	assert.Equal(t, "{}", RedactHeaders(nil))
+	assert.Equal(t, "{}", RedactHeaderMap(nil))
+}

--- a/utils/redact_test.go
+++ b/utils/redact_test.go
@@ -1,0 +1,159 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// The shapes upstream vendors actually use for api keys.
+		{"key in path", "https://eth-mainnet.example.com/v2/AbC123SecretKey", "https://eth-mainnet.example.com/[redacted]"},
+		{"key as whole path", "https://node.example.com/AbC123SecretKey", "https://node.example.com/[redacted]"},
+		{"key in query", "https://node.example.com/rpc?apikey=AbC123SecretKey", "https://node.example.com/[redacted]"},
+		{"key in userinfo", "https://user:s3cr3t@node.example.com/rpc", "https://node.example.com/[redacted]"},
+		{"userinfo only", "https://user:s3cr3t@node.example.com", "https://node.example.com"},
+		{"key in fragment", "https://node.example.com#AbC123SecretKey", "https://node.example.com/[redacted]"},
+		{"scheme-less with key", "node.example.com/v2/AbC123SecretKey", "node.example.com/[redacted]"},
+
+		// Nothing secret to remove — these must survive intact so logs stay useful.
+		{"host only", "https://node.example.com", "https://node.example.com"},
+		{"host and port", "grpc://node.example.com:9090", "grpc://node.example.com:9090"},
+		{"trailing slash", "https://node.example.com/", "https://node.example.com/"},
+		{"ws host and port", "wss://node.example.com:443", "wss://node.example.com:443"},
+		{"scheme-less host and port", "node.example.com:9090", "node.example.com:9090"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, RedactURL(tt.in))
+		})
+	}
+}
+
+func TestRedactSecrets_LeavesNonURLTextAlone(t *testing.T) {
+	// Anchoring on "://" is what keeps prose, listen addresses and dial errors
+	// readable. A regression here makes every log line worse.
+	for _, s := range []string{
+		"failed relay, insufficient results",
+		"dial tcp 10.0.0.7:443: connect: connection refused",
+		"prometheus endpoint listening 0.0.0.0:7779",
+		"provider eth-primary-1 blocked",
+		"",
+	} {
+		assert.Equal(t, s, RedactSecrets(s))
+	}
+}
+
+func TestRedactSecrets_RedactsEmbeddedURLs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			// The exact shape net/http produces, quotes included.
+			name: "url.Error message",
+			in:   `Post "https://eth-mainnet.example.com/v2/SecretKey123": read tcp 10.0.0.1:53422->1.2.3.4:443: connection reset by peer`,
+			want: `Post "https://eth-mainnet.example.com/[redacted]": read tcp 10.0.0.1:53422->1.2.3.4:443: connection reset by peer`,
+		},
+		{
+			name: "two urls in one message",
+			in:   "failed https://a.example.com/v2/KEY1 then https://b.example.com/v3/KEY2",
+			want: "failed https://a.example.com/[redacted] then https://b.example.com/[redacted]",
+		},
+		{
+			name: "url in attribute-style text",
+			in:   "{url:https://node.example.com/v2/SecretKey123,method:eth_call}",
+			want: "{url:https://node.example.com/[redacted],method:eth_call}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, RedactSecrets(tt.in))
+		})
+	}
+}
+
+// The leak this fix exists for: Go masks only the userinfo password, so the key
+// in the path survives into the error message.
+func TestRedactSecrets_RealURLError(t *testing.T) {
+	const secret = "AbC123SecretKey"
+	raw := &url.Error{
+		Op:  "Post",
+		URL: "https://eth-mainnet.example.com/v2/" + secret,
+		Err: errors.New("connection reset by peer"),
+	}
+	wrapped := fmt.Errorf("http request failed: %w", raw)
+
+	require.Contains(t, wrapped.Error(), secret, "precondition: the raw error carries the key")
+	assert.NotContains(t, RedactSecrets(wrapped.Error()), secret)
+	assert.Contains(t, RedactSecrets(wrapped.Error()), "eth-mainnet.example.com")
+}
+
+func TestRedactSecretsErr_PreservesCause(t *testing.T) {
+	sentinel := errors.New("sentinel")
+	err := fmt.Errorf(`Post "https://node.example.com/v2/SecretKey123": %w`, sentinel)
+
+	redacted := RedactSecretsErr(err)
+	assert.NotContains(t, redacted.Error(), "SecretKey123")
+	assert.True(t, errors.Is(redacted, sentinel), "errors.Is must still reach the cause")
+
+	// No url means no allocation and no rewrap — the original error comes back.
+	plain := errors.New("no url here")
+	assert.Same(t, plain, RedactSecretsErr(plain))
+	assert.Nil(t, RedactSecretsErr(nil))
+}
+
+// Redaction runs at both the log layer and the client-error boundary, so an
+// already-redacted string passes through it a second time. It must be stable.
+func TestRedactSecrets_Idempotent(t *testing.T) {
+	for _, in := range []string{
+		"https://node.example.com/v2/AbC123SecretKey",
+		"https://node.example.com:9090/rpc?apikey=AbC123SecretKey",
+		`Post "https://node.example.com/v2/AbC123SecretKey": connection reset`,
+	} {
+		once := RedactSecrets(in)
+		assert.Equal(t, once, RedactSecrets(once), "second pass changed %q", once)
+		assert.NotContains(t, RedactSecrets(once), "AbC123SecretKey")
+	}
+}
+
+// The metrics fallback is fed either a node-url or an already-resolved provider
+// identifier. Mangling the latter silently renames a Prometheus series, so the
+// identifier cases matter as much as the url ones.
+func TestRedactIfURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Not urls — must survive byte-for-byte. A lava address carries an "@",
+		// which RedactURL would otherwise read as userinfo and strip.
+		{"lava provider address", "lava@harvestGenProvider", "lava@harvestGenProvider"},
+		{"lava bech32 address", "lava@1abcdefghijklmnop", "lava@1abcdefghijklmnop"},
+		{"provider name", "eth-primary-1", "eth-primary-1"},
+		{"host and port", "ep:8545", "ep:8545"},
+		{"empty", "", ""},
+
+		// Urls — redacted as usual.
+		{"url with scheme", "http://ep:8545", "http://ep:8545"},
+		{"url with key in path", "https://node.example.com/v2/AbC123SecretKey", "https://node.example.com/[redacted]"},
+		{"scheme-less url with key", "node.example.com/v2/AbC123SecretKey", "node.example.com/[redacted]"},
+		{"url with key in query", "https://node.example.com?apikey=AbC123SecretKey", "https://node.example.com/[redacted]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, RedactIfURL(tt.in))
+		})
+	}
+}

--- a/utils/redact_test.go
+++ b/utils/redact_test.go
@@ -48,6 +48,10 @@ func TestRedactSecrets_LeavesNonURLTextAlone(t *testing.T) {
 		"dial tcp 10.0.0.7:443: connect: connection refused",
 		"prometheus endpoint listening 0.0.0.0:7779",
 		"provider eth-primary-1 blocked",
+		"eth-primary-1",
+		"lava@harvestGenProvider",
+		"lava@1abcdefghijklmnop",
+		"ep:8545",
 		"",
 	} {
 		assert.Equal(t, s, RedactSecrets(s))
@@ -75,6 +79,16 @@ func TestRedactSecrets_RedactsEmbeddedURLs(t *testing.T) {
 			name: "url in attribute-style text",
 			in:   "{url:https://node.example.com/v2/SecretKey123,method:eth_call}",
 			want: "{url:https://node.example.com/[redacted],method:eth_call}",
+		},
+		{
+			name: "scheme-less url with key in path",
+			in:   "failed node.example.com/v2/SecretKey123",
+			want: "failed node.example.com/[redacted]",
+		},
+		{
+			name: "scheme-less url with key in query",
+			in:   `Post "node.example.com/rpc?apikey=SecretKey123": connection refused`,
+			want: `Post "node.example.com/[redacted]": connection refused`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Two credential channels are closed here: upstream node-urls (which carry the vendor api key in their path or query) and request headers (`auth-config.auth-headers` outbound, the caller's own key inbound). Neither belongs in a log sink, an error returned to a client, a metric label or a span attribute. Details in MAG-3330.

## 1. Node-url redaction

Redaction happens at two chokepoints rather than at every call site:

- **`LavaFormatLog`** redacts the description, the error and every attribute — all logging at once. The returned error keeps the original as its `cause`, so `errors.Is`/`As` are unaffected.
- **`GetUniqueGuidResponseForError`** builds every client-facing error envelope (jsonrpc, tendermint, rest, grpc, ws), so redacting there does not depend on log level.

Targeted fixes alongside them:

| Site | Before | After |
| --- | --- | --- |
| `NodeUrl.UrlStr` | stripped userinfo only | `scheme://host[:port]`, rest dropped |
| `tracing.RecordHTTPRequest` / `RecordError` | raw url in `http.url` and the error status | redacted before export |
| `resolveProviderNames` fallback | returned its input | fails closed via `RedactIfURL` |
| 6 `fmt.Errorf` sites | interpolated the url | redacted / `UrlStr()` |

`auth-config.auth-query` — a third credential form, appended as `?<secret>` by `AddAuthPath` — is covered by construction, since the whole query string is dropped.

## 2. Header redaction

Url redaction does not reach a header value, so headers get their own helpers: `utils.RedactHeaders` / `RedactHeaderMap` (`http.Header` and grpc `metadata.MD` both assign to the map type) and `common.RedactMetadata` for relay metadata. Applied at every header-logging site — the rest/jsonrpc/tendermint/grpc listeners and proxies, the grpc proxy's response metadata, the node-error troubleshooting log in `results_manager`, and the marshalling-failure logs in `rpcInterfaceMessages`.

**These fail closed.** Auth header names are operator-configured per node-url and inbound requests carry arbitrary caller credentials, so no deny-list can enumerate either. Values render only for a small allow-list of transport headers (`content-type`, `accept`, `user-agent`, …); everything else is withheld. Header **names** are always shown, so a redacted line still tells you what was sent:

```
{Content-Type:application/json, X-Vendor-Key:[redacted]}
```

Output is sorted, because map iteration order would otherwise make log lines differ run to run.

## Design notes

**Url redaction is host-only**, deliberately not a "keep the harmless segments" heuristic — that matches the existing `sanitizeEndpointURL` already used by `upstream_ws_pool.go` and `upstream_grpc_pool.go`. The host is what makes a log line actionable; anything past it is where credentials live. Call sites that need the request path already log it as its own attribute (e.g. `internalPath`).

**`ReturnMaskedErrors` is intentionally not flipped.** Setting it to `true` would elide the error text entirely and replace it with `"Internal server error"`, costing every customer their debuggability. Redacting instead keeps the host and the cause — `Post "https://<host>/[redacted]": connection reset by peer` — while dropping the credential.

**`RedactIfURL`** guards the one call site whose input may be a url *or* an identifier: a lava provider address carries an `@` that url parsing would otherwise read as userinfo, silently renaming a Prometheus series. Regression-tested.

## Not in scope

`/debug/endpoint-state` still reports `NetworkAddress` verbatim. It is gated behind `--debug-address` (off by default, and unset in every deployed config), and `/debug/poll-now` takes that same address back as **input** — redacting the output would break the MAG-2202 integration harness contract. Worth a follow-up that keys the harness off a stable id instead.

Two `LogAttr("headers", …)` calls in `rpcInterfaceMessages` actually pass `jm.Params` / `tm.Params` — a pre-existing mislabel, not a credential channel. Left alone.

## Test plan

- `go build ./...`, `go vet ./...` — clean
- `go test ./...` — full suite green
- `golangci-lint run ./utils/... ./protocol/...` — 0 issues
- New: `utils/redact_test.go` and `utils/redact_headers_test.go` (helper contracts, including non-url identifiers, idempotency, fail-closed header names, deterministic ordering), `utils/lavalog_redaction_test.go` (asserts the **wiring**, at every log level, and that a following attribute survives), `protocol/common/node_url_redaction_test.go` (`UrlStr` + `RedactMetadata`, including non-mutation of live relay data), and a regression test on the client-error envelope in `protocol/metrics/rpcconsumer_logs_test.go`
- Updated `protocol/tracing/span_helpers_test.go`, which asserted the previous verbatim behaviour, and added key-in-path / key-in-query cases
- Verified out-of-band against a **real** `http.Client` transport error (not a synthesized one) driven at a listener that resets the connection, and against a real `SetAuthHeaders` call on a real `http.Request` — in both cases the credential appeared in the pre-fix rendering and not in the post-fix one, while host, port and cause survived

## Operational follow-up

Credentials already written to a log sink should be treated as exposed and rotated.

Jira ticket: MAG-3330

Closes MAG-3330