### PR TITLE
feat(lavasession): let stateful relays broadcast to the backup tier (MAG-3338)

### DIFF
--- a/protocol/common/cobra_common.go
+++ b/protocol/common/cobra_common.go
@@ -36,6 +36,10 @@ const (
 	// SetRelayRetryLimitFlag controls the maximum number of retry attempts on relay errors
 	// (both node errors and protocol errors) for consumers and smart routers.
 	SetRelayRetryLimitFlag = "set-relay-retry-limit"
+	// StatefulToBackupFlag widens the stateful broadcast to the backup tier. Off by default:
+	// a stateful relay reaches every provider it selects, so turning this on sends every
+	// stateful request to the backup as well — including the ones the primaries serve fine.
+	StatefulToBackupFlag = "stateful-to-backup"
 	// BatchNodeErrorOnAny controls batch request error detection for JSON-RPC batch requests
 	BatchNodeErrorOnAnyFlag = "batch-node-error-on-any"
 

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -94,6 +94,15 @@ type ConsumerSessionManager struct {
 	// Production uses the process-wide holdoff.Shared; tests inject a clock-pinned one.
 	rateLimitHoldoff *holdoff.Registry
 
+	// statefulToBackup widens a stateful relay's broadcast to the backup tier
+	// (--stateful-to-backup). It lives here, rather than as a package variable, because one
+	// manager serves exactly one chain + api-interface: a customer who wants transaction
+	// broadcast mirrored to an expensive backup on one chain rarely wants it on all of them.
+	//
+	// The zero value is the safe one. Left unset, a stateful relay reaches primaries only,
+	// which is the behaviour of every release before this field existed.
+	statefulToBackup bool
+
 	// contains a sorted list of blocked addresses, sorted by their cu used this epoch for higher chance of response
 	currentlyBlockedProviderAddresses []string
 
@@ -1796,28 +1805,142 @@ func (csm *ConsumerSessionManager) GetSessions(ctx context.Context, wantedProvid
 	}
 }
 
-// csm must be rlocked here
-func (csm *ConsumerSessionManager) getTopTenProvidersForStatefulCalls(validAddresses []string, ignoredProvidersList map[string]struct{}) []string {
-	// sort by cu used, easiest to sort by that factor as it probably means highest QOS and easily read by atomic
-	customSort := func(i, j int) bool {
-		return csm.pairing[validAddresses[i]].atomicReadUsedComputeUnits() > csm.pairing[validAddresses[j]].atomicReadUsedComputeUnits()
+// statefulFanoutPerTier caps how many providers a stateful relay broadcasts to within one tier.
+// It bounds the fan-out, not the number of tiers: primaries and backups are capped separately, so
+// enabling the backup tier widens the broadcast instead of evicting primaries from it.
+const statefulFanoutPerTier = 10
+
+// getProvidersForStatefulCalls returns the providers a stateful relay broadcasts to.
+//
+// The primary tier is always included. The backup tier is appended only when this chain enables it
+// (--stateful-to-backup, off by default), and it is appended rather than merged: each tier is
+// ranked on its own and primaries come first. Ranking the two together would mean comparing compute
+// units served between a warm primary and a cold backup, a number that says nothing about either —
+// and since the cap is what decides who survives, a merged ranking would let a backup that has been
+// serving for a while start pushing primaries out of the broadcast.
+//
+// Order does not decide who is relayed to: every address returned here gets a session and its own
+// goroutine. It decides only who survives the cap.
+//
+// csm must be rlocked here.
+func (csm *ConsumerSessionManager) getProvidersForStatefulCalls(ctx context.Context, validAddresses []string, ignoredProvidersList map[string]struct{}, addon string, extensions []string) []string {
+	providers := csm.rankStatefulTier(validAddresses, ignoredProvidersList)
+	if !csm.statefulToBackup {
+		return providers
 	}
-	// Sort the slice using the custom sorting rule
-	sort.Slice(validAddresses, customSort)
-	addresses := []string{}
-	wantedLength := 10
-	for _, sortedAddress := range validAddresses {
-		// skip ignored providers
-		if _, foundInIgnoredProviderList := ignoredProvidersList[sortedAddress]; foundInIgnoredProviderList {
+
+	backups := csm.rankStatefulTier(csm.eligibleBackupsForStateful(ctx, ignoredProvidersList, addon, extensions), ignoredProvidersList)
+	if len(backups) == 0 {
+		return providers
+	}
+
+	// Only logged when the backup tier actually joins a broadcast, so a router with the flag off —
+	// or with no eligible backup — pays nothing and says nothing. When it does fire it is worth an
+	// INFO: a metered tier has just been engaged on a request the primaries may well serve.
+	utils.LavaFormatInfo("stateful relay broadcasting to the backup tier as well",
+		utils.LogAttr("primaries", providers),
+		utils.LogAttr("backups", backups),
+		utils.LogAttr("addon", addon),
+		utils.LogAttr("extensions", extensions),
+		utils.LogAttr("GUID", ctx),
+	)
+	return append(providers, backups...)
+}
+
+// rankStatefulTier orders one tier's addresses by compute units served, highest first, drops the
+// providers this request has already tried, and caps what is left at statefulFanoutPerTier.
+//
+// It never reorders its argument. validAddresses can be the cached addon-address slice shared with
+// every other reader of that router key, and sorting it in place — as this code used to — races
+// them under the read lock this runs beneath.
+//
+// Ties break on the address so the broadcast is reproducible. Compute units are equal for every
+// provider on a freshly started router, which makes the tie the common case rather than the corner
+// one.
+//
+// csm must be rlocked here.
+func (csm *ConsumerSessionManager) rankStatefulTier(addresses []string, ignoredProvidersList map[string]struct{}) []string {
+	ranked := make([]string, 0, len(addresses))
+	for _, address := range addresses {
+		if _, alreadyTried := ignoredProvidersList[address]; alreadyTried {
 			continue
 		}
-		// fill the slice until we have 10 providers who are not ignored
-		addresses = append(addresses, sortedAddress)
-		if len(addresses) >= wantedLength {
-			break
-		}
+		ranked = append(ranked, address)
 	}
-	return addresses
+
+	sort.Slice(ranked, func(i, j int) bool {
+		cuI, cuJ := csm.usedComputeUnits(ranked[i]), csm.usedComputeUnits(ranked[j])
+		if cuI != cuJ {
+			return cuI > cuJ
+		}
+		return ranked[i] < ranked[j]
+	})
+
+	if len(ranked) > statefulFanoutPerTier {
+		ranked = ranked[:statefulFanoutPerTier]
+	}
+	return ranked
+}
+
+// eligibleBackupsForStateful returns the backups a stateful broadcast may include: not already
+// tried by this request, not blocked, able to serve the addon and extensions asked for, and not
+// currently held off after a 429.
+//
+// The hold-off is a plain exclusion here, unlike filterRateLimitedProviders, which keeps the
+// soonest-to-expire candidate rather than leave a request with nowhere to go. That rescue cannot be
+// needed on this path: the backup tier is additive, and a stateful broadcast only gets here with at
+// least one primary already chosen.
+//
+// csm must be rlocked here.
+func (csm *ConsumerSessionManager) eligibleBackupsForStateful(ctx context.Context, ignoredProvidersList map[string]struct{}, addon string, extensions []string) []string {
+	eligible := make([]string, 0, len(csm.backupProviders))
+	for address, provider := range csm.backupProviders {
+		if provider == nil {
+			continue
+		}
+		if _, alreadyTried := ignoredProvidersList[address]; alreadyTried {
+			continue
+		}
+		if _, blocked := csm.blockedBackupProviders[address]; blocked {
+			continue
+		}
+		if !provider.IsSupportingAddon(addon) || !provider.IsSupportingExtensions(extensions, ctx) {
+			continue
+		}
+		if csm.rateLimitHoldoff != nil {
+			if _, heldOff := csm.rateLimitHoldoff.ProviderReadyAt(address); heldOff {
+				continue
+			}
+		}
+		eligible = append(eligible, address)
+	}
+	return eligible
+}
+
+// usedComputeUnits reads a provider's compute units served this epoch, whichever tier it belongs
+// to. Unknown addresses report 0 and therefore rank last, which is the right answer for the only
+// way one can occur: a provider dropped from the pairing between selection and this read.
+//
+// csm must be rlocked here.
+func (csm *ConsumerSessionManager) usedComputeUnits(address string) uint64 {
+	if provider := csm.providerByAddress(address); provider != nil {
+		return provider.atomicReadUsedComputeUnits()
+	}
+	return 0
+}
+
+// providerByAddress resolves an address to its session pool across both tiers.
+//
+// Everything that walks a selected-provider list has to go through this rather than reach into
+// csm.pairing directly, because a stateful broadcast can now carry backup addresses alongside
+// primary ones and csm.pairing does not hold backups.
+//
+// csm must be rlocked here.
+func (csm *ConsumerSessionManager) providerByAddress(address string) *ConsumerSessionsWithProvider {
+	if provider, ok := csm.pairing[address]; ok {
+		return provider
+	}
+	return csm.backupProviders[address]
 }
 
 // convertSelectionStatsToMetrics converts SelectionStats to metrics format with all provider scores
@@ -2047,7 +2170,7 @@ func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context
 
 	var providers []string
 	if stateful == common.CONSISTENCY_SELECT_ALL_PROVIDERS && csm.providerOptimizer.Strategy() != provideroptimizer.StrategyCost {
-		providers = csm.getTopTenProvidersForStatefulCalls(validAddresses, ignoredProvidersList)
+		providers = csm.getProvidersForStatefulCalls(ctx, validAddresses, ignoredProvidersList, addon, extensions)
 	} else if stickiness != "" {
 		var selectionStats *provideroptimizer.SelectionStats
 		providers, selectionStats = csm.providerOptimizer.ChooseUpstreamWithStats(ctx, validAddresses, ignoredProvidersList, cu, requestedBlock)
@@ -2389,12 +2512,16 @@ func (csm *ConsumerSessionManager) getValidConsumerSessionsWithProvider(ctx cont
 	for {
 		// Iterate over providers
 		for _, providerAddress := range providerAddresses {
-			consumerSessionsWithProvider := csm.pairing[providerAddress]
+			// Both tiers, because a stateful broadcast may include backups (--stateful-to-backup)
+			// and those live outside csm.pairing. An address in neither map is still a genuine
+			// invariant break in selection, and still fatal.
+			consumerSessionsWithProvider := csm.providerByAddress(providerAddress)
 			if consumerSessionsWithProvider == nil {
 				utils.LavaFormatFatal("invalid provider address returned from csm.getValidProviderAddresses", nil,
 					utils.Attribute{Key: "providerAddress", Value: providerAddress},
 					utils.Attribute{Key: "all_providerAddresses", Value: providerAddresses},
 					utils.Attribute{Key: "pairing", Value: csm.pairing},
+					utils.Attribute{Key: "backupProviders", Value: csm.backupProviders},
 					utils.Attribute{Key: "epochAtStart", Value: currentEpoch},
 					utils.Attribute{Key: "currentEpoch", Value: csm.atomicReadCurrentEpoch()},
 					utils.Attribute{Key: "validAddresses", Value: csm.getValidAddresses(addon, extensions, ctx)},
@@ -3498,6 +3625,16 @@ func NewConsumerSessionManager(
 // This must be called after creating the ConsumerSessionManager
 func (csm *ConsumerSessionManager) SetLavaBlockHeightCallback(getLavaBlockHeight func() int64) {
 	csm.getLavaBlockHeight = getLavaBlockHeight
+}
+
+// SetStatefulToBackup widens this chain's stateful broadcast to the backup tier
+// (--stateful-to-backup). Call it during setup, before the manager serves any relay; it is not
+// safe to flip under traffic and there is no reason to.
+//
+// Left unset the manager keeps stateful relays on the primary tier, which is what every release
+// before this flag did.
+func (csm *ConsumerSessionManager) SetStatefulToBackup(enabled bool) {
+	csm.statefulToBackup = enabled
 }
 
 // ResetTransientFailureState clears every cross-epoch failure-tracking store

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -1829,7 +1829,7 @@ func (csm *ConsumerSessionManager) getProvidersForStatefulCalls(ctx context.Cont
 		return providers
 	}
 
-	backups := csm.rankStatefulTier(csm.eligibleBackupsForStateful(ctx, ignoredProvidersList, addon, extensions), ignoredProvidersList)
+	backups := csm.rankStatefulTier(csm.eligibleBackupsForStateful(ctx, ignoredProvidersList, addon, extensions, providers), ignoredProvidersList)
 	if len(backups) == 0 {
 		return providers
 	}
@@ -1883,8 +1883,15 @@ func (csm *ConsumerSessionManager) rankStatefulTier(addresses []string, ignoredP
 }
 
 // eligibleBackupsForStateful returns the backups a stateful broadcast may include: not already
-// tried by this request, not blocked, able to serve the addon and extensions asked for, and not
-// currently held off after a 429.
+// chosen from the primary tier, not already tried by this request, not blocked, able to serve the
+// addon and extensions asked for, and not currently held off after a 429.
+//
+// alreadySelected is the primary tier's result. UpdateAllProviders builds the two pools from
+// separate inputs with no dedup, so one address can sit in both — and appending it twice would put
+// the caller's target above what its session map can hold, so the caller's "enough providers" check
+// would never fire and every stateful relay would pay a second, pointless selection pass. A linear
+// scan rather than a set: alreadySelected is capped at statefulFanoutPerTier, so building one costs
+// more than the comparisons it saves.
 //
 // The hold-off is a plain exclusion here, unlike filterRateLimitedProviders, which keeps the
 // soonest-to-expire candidate rather than leave a request with nowhere to go. That rescue cannot be
@@ -1892,10 +1899,13 @@ func (csm *ConsumerSessionManager) rankStatefulTier(addresses []string, ignoredP
 // least one primary already chosen.
 //
 // csm must be rlocked here.
-func (csm *ConsumerSessionManager) eligibleBackupsForStateful(ctx context.Context, ignoredProvidersList map[string]struct{}, addon string, extensions []string) []string {
+func (csm *ConsumerSessionManager) eligibleBackupsForStateful(ctx context.Context, ignoredProvidersList map[string]struct{}, addon string, extensions []string, alreadySelected []string) []string {
 	eligible := make([]string, 0, len(csm.backupProviders))
 	for address, provider := range csm.backupProviders {
 		if provider == nil {
+			continue
+		}
+		if slices.Contains(alreadySelected, address) {
 			continue
 		}
 		if _, alreadyTried := ignoredProvidersList[address]; alreadyTried {

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -1893,6 +1893,15 @@ func (csm *ConsumerSessionManager) rankStatefulTier(addresses []string, ignoredP
 // scan rather than a set: alreadySelected is capped at statefulFanoutPerTier, so building one costs
 // more than the comparisons it saves.
 //
+// currentlyBlockedProviderAddresses is deliberately NOT consulted, and the omission is a decision
+// rather than an oversight: a provider blocked out of the primary tier for repeated failures can
+// still be broadcast to as a backup. It only bites for an address configured in both pools — one
+// blocked as a primary is absent from validAddresses, so it is absent from alreadySelected and this
+// exclusion does not catch it — and ValidateUniqueProviderNames rejects that configuration at boot,
+// so nothing reaches it today. Whether a node the router has already judged bad should serve as the
+// backup it is paying for is a policy question, and changing it here would widen this change past
+// the broadcast. Revisit it with the tier consolidation, not in passing.
+//
 // The hold-off is a plain exclusion here, unlike filterRateLimitedProviders, which keeps the
 // soonest-to-expire candidate rather than leave a request with nowhere to go. That rescue cannot be
 // needed on this path: the backup tier is additive, and a stateful broadcast only gets here with at

--- a/protocol/lavasession/stateful_to_backup_test.go
+++ b/protocol/lavasession/stateful_to_backup_test.go
@@ -1,0 +1,274 @@
+package lavasession
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/holdoff"
+	"github.com/stretchr/testify/require"
+)
+
+// FAILOVER-TASKS section 4a: a stateful relay broadcasts to every provider it selects, and
+// --stateful-to-backup widens that broadcast to the backup tier.
+//
+// The flag is off by default, so the first thing every test here has to pin is that the default
+// behaviour is byte-identical to what shipped before the flag existed.
+
+func mkStatefulProvider(address string) *ConsumerSessionsWithProvider {
+	return &ConsumerSessionsWithProvider{
+		PublicLavaAddress: address,
+		Endpoints:         []*Endpoint{{NetworkAddress: grpcListener, Enabled: true, Connections: []*EndpointConnection{}}},
+		Sessions:          map[int64]*SingleConsumerSession{},
+		MaxComputeUnits:   200,
+		PairingEpoch:      firstEpochHeight,
+	}
+}
+
+// setupStatefulCSM returns a manager with the given primaries and backups, all healthy.
+func setupStatefulCSM(t *testing.T, primaries, backups []string) *ConsumerSessionManager {
+	t.Helper()
+	csm := CreateConsumerSessionManager()
+	primaryMap := map[uint64]*ConsumerSessionsWithProvider{}
+	for i, address := range primaries {
+		primaryMap[uint64(i)] = mkStatefulProvider(address)
+	}
+	var backupMap map[uint64]*ConsumerSessionsWithProvider
+	if len(backups) > 0 {
+		backupMap = map[uint64]*ConsumerSessionsWithProvider{}
+		for i, address := range backups {
+			backupMap[uint64(i)] = mkStatefulProvider(address)
+		}
+	}
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, primaryMap, backupMap))
+	return csm
+}
+
+// statefulSelection runs the stateful candidate selection the way getValidProviderAddresses does.
+func statefulSelection(csm *ConsumerSessionManager, ignored map[string]struct{}) []string {
+	csm.lock.RLock()
+	defer csm.lock.RUnlock()
+	if ignored == nil {
+		ignored = map[string]struct{}{}
+	}
+	return csm.getProvidersForStatefulCalls(context.Background(), csm.validAddresses, ignored, "", nil)
+}
+
+// The default. A backup tier exists and is healthy, and a stateful relay still does not touch it.
+func TestStatefulToBackup_OffByDefault(t *testing.T) {
+	csm := setupStatefulCSM(t, []string{"primary-a", "primary-b"}, []string{"backup-1"})
+
+	require.False(t, csm.statefulToBackup, "the flag must default to off")
+
+	selected := statefulSelection(csm, nil)
+	require.ElementsMatch(t, []string{"primary-a", "primary-b"}, selected,
+		"with the flag off a stateful relay must reach primaries only")
+}
+
+// With the flag on, the backup joins the same broadcast — it is not a fallback here.
+func TestStatefulToBackup_On_BroadcastsToBothTiers(t *testing.T) {
+	csm := setupStatefulCSM(t, []string{"primary-a", "primary-b"}, []string{"backup-1"})
+	csm.SetStatefulToBackup(true)
+
+	selected := statefulSelection(csm, nil)
+	require.ElementsMatch(t, []string{"primary-a", "primary-b", "backup-1"}, selected)
+	require.Equal(t, "backup-1", selected[len(selected)-1],
+		"backups are appended after the primary tier, never interleaved")
+}
+
+// Primaries come first even when a backup has served far more compute units. This is the whole
+// point of ranking the tiers separately: a warm backup must never displace a primary.
+func TestStatefulToBackup_PrimariesRankAheadOfAWarmerBackup(t *testing.T) {
+	csm := setupStatefulCSM(t, []string{"primary-a"}, []string{"backup-1"})
+	csm.SetStatefulToBackup(true)
+
+	// Give the backup a large CU total and leave the primary at zero — the reverse of the order
+	// we require, so a merged ranking would fail this test.
+	require.NoError(t, csm.backupProviders["backup-1"].addUsedComputeUnits(150, 0))
+
+	selected := statefulSelection(csm, nil)
+	require.Equal(t, []string{"primary-a", "backup-1"}, selected)
+}
+
+// The cap bounds each tier on its own, so turning the backup tier on widens the broadcast rather
+// than pushing primaries out of it.
+func TestStatefulToBackup_CapIsPerTier(t *testing.T) {
+	primaries := make([]string, 0, statefulFanoutPerTier+3)
+	for i := 0; i < statefulFanoutPerTier+3; i++ {
+		primaries = append(primaries, "primary-"+string(rune('a'+i)))
+	}
+	csm := setupStatefulCSM(t, primaries, []string{"backup-1", "backup-2"})
+	csm.SetStatefulToBackup(true)
+
+	selected := statefulSelection(csm, nil)
+	require.Len(t, selected, statefulFanoutPerTier+2,
+		"the primary tier is capped at %d and both backups are added on top", statefulFanoutPerTier)
+	require.Subset(t, selected, []string{"backup-1", "backup-2"},
+		"a full primary tier must not squeeze the backups out")
+}
+
+// A backup blocked this epoch is not a candidate, exactly as it is not one on the fallback path.
+func TestStatefulToBackup_SkipsBlockedBackup(t *testing.T) {
+	csm := setupStatefulCSM(t, []string{"primary-a"}, []string{"backup-1", "backup-2"})
+	csm.SetStatefulToBackup(true)
+
+	csm.lock.Lock()
+	csm.blockedBackupProviders["backup-1"] = struct{}{}
+	csm.lock.Unlock()
+
+	selected := statefulSelection(csm, nil)
+	require.ElementsMatch(t, []string{"primary-a", "backup-2"}, selected)
+}
+
+// Providers this request already tried are dropped from both tiers.
+func TestStatefulToBackup_SkipsAlreadyTried(t *testing.T) {
+	csm := setupStatefulCSM(t, []string{"primary-a", "primary-b"}, []string{"backup-1"})
+	csm.SetStatefulToBackup(true)
+
+	ignored := map[string]struct{}{"primary-a": {}, "backup-1": {}}
+	require.Equal(t, []string{"primary-b"}, statefulSelection(csm, ignored))
+}
+
+// A backup held off after a 429 is excluded outright. filterRateLimitedProviders keeps the
+// soonest-to-expire candidate when a request would otherwise have nowhere to go; that rescue is
+// meaningless here because the backup tier is additive and a primary has already been chosen.
+func TestStatefulToBackup_SkipsHeldOffBackup(t *testing.T) {
+	csm := setupStatefulCSM(t, []string{"primary-a"}, []string{"backup-1"})
+	csm.SetStatefulToBackup(true)
+
+	// A private registry, never holdoff.Shared: the shared one is process-wide, so recording a
+	// strike on it would hold "backup-1" off for every later test in this package.
+	csm.rateLimitHoldoff = holdoff.NewRegistry()
+	csm.rateLimitHoldoff.RecordRateLimit("backup-1", "http://backup-1/url", 0)
+
+	require.Equal(t, []string{"primary-a"}, statefulSelection(csm, nil),
+		"a rate-limited backup must not be pulled into a broadcast the primaries can serve")
+}
+
+// A backup that cannot serve the requested addon is not a candidate.
+func TestStatefulToBackup_SkipsBackupMissingAddon(t *testing.T) {
+	csm := setupStatefulCSM(t, []string{"primary-a"}, []string{"backup-1"})
+	csm.SetStatefulToBackup(true)
+
+	csm.lock.RLock()
+	selected := csm.getProvidersForStatefulCalls(context.Background(), csm.validAddresses, map[string]struct{}{}, "archive", nil)
+	csm.lock.RUnlock()
+
+	require.Equal(t, []string{"primary-a"}, selected,
+		"the backup declares no addons, so it cannot join an archive broadcast")
+}
+
+// The flag with no backups configured is a no-op rather than an error.
+func TestStatefulToBackup_OnWithNoBackupsConfigured(t *testing.T) {
+	csm := setupStatefulCSM(t, []string{"primary-a", "primary-b"}, nil)
+	csm.SetStatefulToBackup(true)
+
+	require.ElementsMatch(t, []string{"primary-a", "primary-b"}, statefulSelection(csm, nil))
+}
+
+// Two identical requests must select the same providers in the same order. Compute units are equal
+// across providers on a freshly started router, so the tie-break is the common case, not the corner
+// one, and an unstable sort would make the broadcast unreproducible.
+func TestStatefulToBackup_SelectionIsDeterministic(t *testing.T) {
+	csm := setupStatefulCSM(t, []string{"primary-a", "primary-b", "primary-c"}, []string{"backup-1", "backup-2"})
+	csm.SetStatefulToBackup(true)
+
+	first := statefulSelection(csm, nil)
+	for i := 0; i < 20; i++ {
+		require.Equal(t, first, statefulSelection(csm, nil), "selection must not vary between identical requests")
+	}
+}
+
+// providerByAddress is what stops a backup address reaching the session builder's LavaFormatFatal.
+func TestProviderByAddress_ResolvesBothTiers(t *testing.T) {
+	csm := setupStatefulCSM(t, []string{"primary-a"}, []string{"backup-1"})
+
+	csm.lock.RLock()
+	defer csm.lock.RUnlock()
+
+	require.NotNil(t, csm.providerByAddress("primary-a"))
+	require.NotNil(t, csm.providerByAddress("backup-1"), "a backup address must resolve, not return nil and crash the router")
+	require.Nil(t, csm.providerByAddress("nobody"))
+}
+
+// The selection used to sort its argument in place, and its argument is the addon-address slice
+// cached and shared with every other reader of that router key — under a READ lock. Concurrent
+// stateful relays therefore sorted and ranged the same backing array at once. Run with -race.
+func TestStatefulSelection_DoesNotMutateTheSharedAddressSlice(t *testing.T) {
+	csm := setupStatefulCSM(t, []string{"primary-a", "primary-b", "primary-c"}, []string{"backup-1"})
+	csm.SetStatefulToBackup(true)
+
+	ctx := context.Background()
+
+	// Warm the addon-address cache first. Until cacheAddonAddresses has run, getValidAddresses
+	// recomputes a fresh slice per call and there is nothing shared to race over — so without this
+	// the test passes even against the in-place sort it exists to catch.
+	csm.cacheAddonAddresses("", nil, ctx)
+
+	csm.lock.RLock()
+	before := append([]string(nil), csm.getValidAddresses("", nil, ctx)...)
+	csm.lock.RUnlock()
+
+	// Drive getValidProviderAddresses, because it is what hands the stateful selection the cached
+	// addon-address slice. Selecting from csm.validAddresses directly would touch a different
+	// backing array from the one the readers below range, and the race would go unseen.
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			csm.lock.RLock()
+			defer csm.lock.RUnlock()
+			_, _ = csm.getValidProviderAddresses(ctx, 1, map[string]struct{}{}, cuForFirstRequest, servicedBlockNumber, "", nil, common.CONSISTENCY_SELECT_ALL_PROVIDERS, "", "")
+		}()
+		go func() {
+			defer wg.Done()
+			csm.lock.RLock()
+			defer csm.lock.RUnlock()
+			for _, address := range csm.getValidAddresses("", nil, ctx) {
+				_ = address
+			}
+		}()
+	}
+	wg.Wait()
+
+	csm.lock.RLock()
+	after := append([]string(nil), csm.getValidAddresses("", nil, ctx)...)
+	csm.lock.RUnlock()
+
+	sort.Strings(before)
+	sortedAfter := append([]string(nil), after...)
+	sort.Strings(sortedAfter)
+	require.Equal(t, before, sortedAfter, "the shared slice must keep its membership")
+}
+
+// End to end through GetSessions: the flag decides whether the returned session map spans tiers.
+func TestStatefulToBackup_GetSessionsSpansTiers(t *testing.T) {
+	ctx := context.Background()
+
+	off := setupStatefulCSM(t, []string{"primary-a", "primary-b"}, []string{"backup-1"})
+	sessions, err := off.GetSessions(ctx, 1, cuForFirstRequest, NewUsedProviders(nil), servicedBlockNumber, "", nil, common.CONSISTENCY_SELECT_ALL_PROVIDERS, 0, "", "")
+	require.NoError(t, err)
+	require.NotContains(t, sessions, "backup-1", "flag off: the broadcast must stay on the primary tier")
+	require.Len(t, sessions, 2)
+
+	on := setupStatefulCSM(t, []string{"primary-a", "primary-b"}, []string{"backup-1"})
+	on.SetStatefulToBackup(true)
+	sessions, err = on.GetSessions(ctx, 1, cuForFirstRequest, NewUsedProviders(nil), servicedBlockNumber, "", nil, common.CONSISTENCY_SELECT_ALL_PROVIDERS, 0, "", "")
+	require.NoError(t, err)
+	require.Contains(t, sessions, "backup-1", "flag on: the backup joins the same broadcast")
+	require.Len(t, sessions, 3)
+}
+
+// A non-stateful relay is untouched by the flag: it still picks one provider, from the primary tier.
+func TestStatefulToBackup_DoesNotAffectStatelessRelays(t *testing.T) {
+	csm := setupStatefulCSM(t, []string{"primary-a", "primary-b"}, []string{"backup-1"})
+	csm.SetStatefulToBackup(true)
+
+	sessions, err := csm.GetSessions(context.Background(), 1, cuForFirstRequest, NewUsedProviders(nil), servicedBlockNumber, "", nil, common.NO_STATE, 0, "", "")
+	require.NoError(t, err)
+	require.Len(t, sessions, 1, "a stateless relay still goes to exactly one provider")
+	require.NotContains(t, sessions, "backup-1")
+}

--- a/protocol/lavasession/stateful_to_backup_test.go
+++ b/protocol/lavasession/stateful_to_backup_test.go
@@ -160,6 +160,29 @@ func TestStatefulToBackup_SkipsBackupMissingAddon(t *testing.T) {
 		"the backup declares no addons, so it cannot join an archive broadcast")
 }
 
+// A provider configured in both tiers must be broadcast to once. UpdateAllProviders does not dedup
+// the two pools, and a repeated address puts the caller's target above what its session map can
+// hold: the "enough providers" check then never fires and every stateful relay pays a second,
+// pointless selection pass.
+func TestStatefulToBackup_ProviderInBothTiersAppearsOnce(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+	dual := mkStatefulProvider("dual-provider")
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight,
+		map[uint64]*ConsumerSessionsWithProvider{0: dual, 1: mkStatefulProvider("primary-b")},
+		map[uint64]*ConsumerSessionsWithProvider{0: mkStatefulProvider("backup-1"), 1: dual}))
+	csm.SetStatefulToBackup(true)
+
+	selected := statefulSelection(csm, nil)
+	require.ElementsMatch(t, []string{"dual-provider", "primary-b", "backup-1"}, selected,
+		"the overlapping provider is broadcast to once, on its primary side")
+
+	sessions, err := csm.GetSessions(context.Background(), 1, cuForFirstRequest, NewUsedProviders(nil),
+		servicedBlockNumber, "", nil, common.CONSISTENCY_SELECT_ALL_PROVIDERS, 0, "", "")
+	require.NoError(t, err)
+	require.Len(t, sessions, len(selected),
+		"the selection count must be reachable by the session map, or the caller's target never fires")
+}
+
 // The flag with no backups configured is a no-op rather than an error.
 func TestStatefulToBackup_OnWithNoBackupsConfigured(t *testing.T) {
 	csm := setupStatefulCSM(t, []string{"primary-a", "primary-b"}, nil)

--- a/protocol/lavasession/stateful_to_backup_test.go
+++ b/protocol/lavasession/stateful_to_backup_test.go
@@ -2,7 +2,6 @@ package lavasession
 
 import (
 	"context"
-	"sort"
 	"sync"
 	"testing"
 
@@ -225,6 +224,13 @@ func TestStatefulSelection_DoesNotMutateTheSharedAddressSlice(t *testing.T) {
 
 	ctx := context.Background()
 
+	// Distinct compute units, or this test cannot fail. With every provider equal the descending
+	// comparator never returns true, sort.Slice performs no swaps, and the in-place mutation this
+	// test exists to catch produces neither a reordering nor a write for -race to flag.
+	require.NoError(t, csm.pairing["primary-a"].addUsedComputeUnits(10, 0))
+	require.NoError(t, csm.pairing["primary-b"].addUsedComputeUnits(20, 0))
+	require.NoError(t, csm.pairing["primary-c"].addUsedComputeUnits(30, 0))
+
 	// Warm the addon-address cache first. Until cacheAddonAddresses has run, getValidAddresses
 	// recomputes a fresh slice per call and there is nothing shared to race over — so without this
 	// the test passes even against the in-place sort it exists to catch.
@@ -261,10 +267,10 @@ func TestStatefulSelection_DoesNotMutateTheSharedAddressSlice(t *testing.T) {
 	after := append([]string(nil), csm.getValidAddresses("", nil, ctx)...)
 	csm.lock.RUnlock()
 
-	sort.Strings(before)
-	sortedAfter := append([]string(nil), after...)
-	sort.Strings(sortedAfter)
-	require.Equal(t, before, sortedAfter, "the shared slice must keep its membership")
+	// Order, not just membership: an in-place sort permutes the slice without changing what is in
+	// it, so a membership comparison passes against the very bug this guards. Asserting order is
+	// also what makes the guard reachable from `make test`, which runs no -race.
+	require.Equal(t, before, after, "the shared cached slice must not be reordered by selection")
 }
 
 // End to end through GetSessions: the flag decides whether the returned session map spans tiers.

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -2423,6 +2423,10 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	activeSubscriptionProvidersStorage := lavasession.NewActiveSubscriptionProvidersStorage()
 	sessionManager := lavasession.NewConsumerSessionManager(rpcEndpoint, optimizer, smartRouterMetricsManager, smartRouterIdentifier, activeSubscriptionProvidersStorage)
 
+	// Read per manager rather than once for the process: one manager serves one chain +
+	// api-interface, so the value is already scoped where a per-chain override would need it.
+	sessionManager.SetStatefulToBackup(viper.GetBool(common.StatefulToBackupFlag))
+
 	// Set callback to get Lava blockchain block height for RelaySession.Epoch
 	// Smart router doesn't connect to blockchain, so calculate approximate block height from epoch
 	// Epoch duration is 15 minutes (900 seconds), and Lava block time is ~15 seconds
@@ -3498,6 +3502,10 @@ rpcsmartrouter smartrouter_examples/smartrouter_eth.yml --cache-be "127.0.0.1:77
 	cmdRPCSmartRouter.Flags().Duration(common.EpochDurationFlag, 0, "duration of each epoch for time-based epoch system (e.g., 30m, 1h). If not set, epochs are disabled")
 	cmdRPCSmartRouter.Flags().Duration(common.ShutdownGracePeriodFlag, common.DefaultShutdownGracePeriod, "graceful shutdown deadline for in-flight requests and WebSocket clients")
 	cmdRPCSmartRouter.Flags().IntVar(&relaycore.RelayRetryLimit, common.SetRelayRetryLimitFlag, 2, "max total relay retry attempts across all error types (node and protocol errors combined; 0 disables retries)")
+	cmdRPCSmartRouter.Flags().Bool(common.StatefulToBackupFlag, false, "also broadcast stateful relays (transaction submission) to the backup tier. OFF by default: a stateful relay reaches every provider it selects, so this sends EVERY stateful request to the backup — including the ones the primaries serve fine — and a fast backup can win the race and cancel the primaries. Turn it on to maximise the chance a transaction lands, accepting the backup spend")
+	if err := viper.BindPFlag(common.StatefulToBackupFlag, cmdRPCSmartRouter.Flags().Lookup(common.StatefulToBackupFlag)); err != nil {
+		utils.LavaFormatFatal("failed to bind stateful-to-backup flag", err)
+	}
 	cmdRPCSmartRouter.Flags().BoolVar(&rpcInterfaceMessages.BatchNodeErrorOnAny, common.BatchNodeErrorOnAnyFlag, false, "if true, batch requests are treated as node errors if ANY sub-request fails; if false (default), only if ALL fail")
 	// optimizer qos sampling cadence — drives the in-memory /metrics
 	// selection-score cache and the OTel optimizer_qos emit.


### PR DESCRIPTION
#Closes MAG-3338

Jira ticket: MAG-3338

## Why

A stateful relay — transaction submission — does not pick one provider. It **broadcasts** to every provider it selects at once and takes the first success. That shape is why a configured backup tier was invisible to it, in two independent ways: selection read the primary pool only, and a stateful relay never retries, so the "primaries exhausted → backup" route that every read uses can never fire for it.

Measured on a live router before this change, two primaries failing and a healthy backup configured:

| | primary-a | primary-b | backup-1 | client got |
|---|---|---|---|---|
| stateful write | 3 | 3 | **0** | the node error |

## What

`--stateful-to-backup` widens the stateful broadcast to include the backup tier. **Default `false`** — nothing moves for an existing deployment. The value is stored per session manager, and one manager serves one chain + api-interface, so the scope a per-chain override would need already exists.

**Both tiers are broadcast to at once, not one after the other.** A stateful relay has no second attempt to fall back into, so a backup absent from the first broadcast is never reached. Sending the same signed transaction to more nodes is what transaction broadcast already does and the hash is identical, so this raises no double-execution question — allowing a stateful *retry* would have, which is why that alternative was rejected.

**Each tier is ranked and capped on its own, primaries first.** Ranking them together would compare a warm primary against a cold backup, and since the cap decides who survives, a backup that had been serving a while would start pushing primaries out of the broadcast. Order does not decide who is relayed to — every selected provider is — only who survives the cap.

A backup joins on the same terms as a primary: not blocked, serves the addon and extensions asked for, and **not held off after a 429**. That last check is new for the backup tier; the existing fallback path does not do it.

### What turning it on costs

None of this is obvious from the flag name, so it is stated here and in the flag help:

- the backup is engaged on **every** stateful relay, including the ones the primaries serve fine — a per-request cost on a metered tier, not a per-outage one;
- a fast backup can **win the race**; the winner cancels the rest, so the spend can buy an answer that was already arriving. Cancelled relays carry no QoS penalty (MAG-2648), so this distorts spend, not scoring;
- the backup vendor sees every transaction.

### Two pre-existing defects fixed on the way

Both are older than this feature and both sit in the code it touches:

- the session builder resolved addresses through `csm.pairing` alone, so the first backup address to reach it would have hit `LavaFormatFatal` — a crash, not a fallback;
- the stateful selection sorted the **shared** cached address slice **in place** under a read lock, so two concurrent stateful relays sorted and ranged the same array. It now sorts a copy, with an address tie-break so an all-equal compute-unit list (every provider on a fresh router) still selects reproducibly.

## Test plan

- [x] `make test` at this commit — 33 packages ok. See "Known gaps" for one flake.
- [x] `make lint` — clean
- [x] `go test -race` on the new selection — clean
- [x] The shared-slice guard was **verified against a faithful pre-fix reproduction** (in-place sort of the caller's slice, fresh return slice — what the original did): it now fails **3/3 without `-race`** and reports 3 data races with it, and passes both ways against the code as shipped. An earlier revision of this description claimed the guard was load-bearing when it was not — see Review round 1.
- [x] 13 new unit tests: flag off/on, tier ordering, per-tier cap, blocked backup, already-tried, held-off backup, missing addon, no backups configured, determinism, both-tier lookup, the race, `GetSessions` end to end, and reads unaffected
- [x] Live router, 7 scenarios, fake upstreams on fresh ports:

| Scenario | primaries | backups | result |
|---|---|---|---|
| stateful, flag **off** | 3+3 | **0** | node error — identical to baseline |
| stateless read, flag off | 3+3 | 3 | still reaches backup via the fallback path |
| stateful, flag **on**, primaries failing | 3+3 | **3** | backup serves, client gets a success |
| stateful, flag on, primaries **healthy** | 3+3 | **3** | backup engaged anyway; won 2 of 3 races |
| stateless read, flag on | 3 | **0** | reads untouched by the flag |
| 5 primaries + 2 backups, flag on | 15 | **6** | 7 sends per relay, nothing trimmed |
| backup returns 429, flag on | — | 1 then 0 | one strike, 35s hold-off, excluded from later broadcasts |

Zero panics and zero fatals across seven router starts — specifically no hit on the `LavaFormatFatal` above.

### To reproduce the live runs

Fake upstreams answer the router's housekeeping honestly and fail only the customer relay, so the endpoint stays healthy and only the behaviour under test fails. Two traps that produced wrong answers first, both now guarded: every upstream must be healthy **before** the router boots (otherwise providers fail startup verification and never enter the pairing), and the fake chain heads must agree (otherwise the consistency pre-filter skips a provider without consuming the error budget).

## Review round 1 (@avitenzer) — both findings confirmed by reproduction, both fixed

**A provider configured in both tiers was broadcast to twice** (`0cc56e3`). `UpdateAllProviders` builds the two pools from separate inputs with no dedup and the file documents an address in both as legitimate, so the backup tier could re-add a provider the primary tier had already chosen. The duplicate was not the damage: it put the caller's target above what a map keyed by address can hold, so the "enough providers" check never fired, control fell through to a second full selection pass under the read lock, and that pass logged `Pairing list empty` while the relay was being served by every provider it had selected — on every stateful relay in that configuration. Reproduced: `selected` had 4 entries, `sessions` had 3.

The exclusion went where the other four already are, in `eligibleBackupsForStateful` beside already-tried / blocked / wrong-addon / held-off, rather than into a new mechanism at the call site.

One correction in the PR's favour: this is **not reachable through the product's config**. `ValidateUniqueProviderNames` groups both lists by chain + api-interface + name at boot, so a shared name fails before a listener binds. It is fixed because the file's own contract permits the overlap and other code in it handles it deliberately.

**The shared-slice guard could not fail against its own bug** (`f3cdb3b`). `setupStatefulCSM` left every provider at zero compute units, so the descending comparator never returned true, `sort.Slice` performed no swaps, and there was no reordering and no write to detect. My original verification was invalid: the "pre-fix" code I measured against also aliased the *return* value, so the race it reported came from `append`, not from the sort. Fixed with distinct compute units and an **order-sensitive** assertion — a membership comparison passes against an in-place permutation, and asserting order is what makes the guard reachable from `make test`, which runs no `-race`. The production fix was never in doubt; the guard was.

Two items from that review were deliberately **not** changed:

- the wrong-tier compute-units lookup needs no fix — with the duplicate excluded, a dual-pool address never reaches the backup ranking, so there is nothing left to rank by the wrong pool's counter;
- `eligibleBackupsForStateful` still does not check `currentlyBlockedProviderAddresses`, so a provider blocked out of the primary tier could serve as a backup. It is absent from `validAddresses` and therefore from the new exclusion. That is a policy decision rather than a defect and wants its own change. My recommendation: skip it — a node the router already judged bad gives no real redundancy and you would be paying the backup vendor for it.

## Known gaps — please read before approving

- **The Helm chart cannot set this flag.** `charts/smart-router/templates/routers_deployment.yaml` uses a fixed, enumerated arg list with no `extraArgs` escape hatch, so merging this delivers a flag no Kubernetes deployment can turn on. **Post-merge work, owner @Tomelia1999:** a companion chart PR adding a values key — ideally per-router, like `providerOptimizerAvailabilityWeight` already is, to match the per-chain scoping here.
- **Cap rule deviates from the original proposal.** The plan said "10 primaries, then all eligible backups"; this implements **10 per tier**. An unbounded tier in a fan-out is a latent problem, and no real deployment has more than 10 backups, so it is behaviourally identical today.
- **`TestBlockReason_SurvivesTheEpochTransition` failed once** under `make test` on this branch and passed on rerun. Not classified: branch `make test` 1 fail / 1 pass, fork-point `make test` 0 fail / 1 pass, the package alone 5/5 on both sides. Arguing against it being this PR's: `block_reason_test.go` sorts first so it runs *before* any test added here, and this diff touches none of `blockProvider` / `UpdateAllProviders` / `blockedRecord` / `CreateConsumerSessionManager`. Flagged rather than dismissed.
- **All primaries blocked + flag on** falls to the existing single-backup fallback, not the widened broadcast — the empty-pool check precedes the stateful branch. Not a regression; the flag only widens while at least one primary is healthy.
- **Log volume:** one INFO line per stateful relay while the tier is engaged. On a high-transaction chain that is per-transaction output.
- **Pre-existing fragility in the selection loops, not touched here.** The "do I have enough providers?" check sets its target from a slice length and compares it to a map size, uses `==` rather than `>=`, and returns a short group silently — you can ask for seven providers, get three, and nothing logs it. The duplicate above is one way to trip the first of those; there are others. Worth its own ticket rather than mixing a refactor of shared selection code into this change.
- **Ticket obligations not independently verified.** I could not read MAG-3338 (no Jira access from this environment), so the diff has not been checked against what the ticket actually asks for. A reviewer who can open it should do that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S95m47jBa9iHmksf7f1t4m
