### PR TITLE
fix(metrics): make /readyz observed from boot and fast on health transitions

### DIFF
--- a/docs/LOCAL-COMPOSE.md
+++ b/docs/LOCAL-COMPOSE.md
@@ -145,9 +145,12 @@ the cache overlay (`docker/docker-compose.cache.yml`) so the preserved
 `cache-be:` has a sidecar to reach.
 
 Note: `/metrics/overall-health` (and the container health status) is
-fail-closed and reports 503 until the first relays health-check cycle —
-`--relays-health-interval` defaults to 5 minutes, so a freshly started stack
-is "unhealthy" while it warms up even though relays already serve.
+fail-closed: it reports 503 until at least one chain has verified a provider,
+which happens as endpoint setup completes — a freshly started stack turns 200
+as soon as its relays serve. A 503 that persists means no upstream answers the
+health probe; while unhealthy the router re-probes every
+`--relays-health-unhealthy-interval` (default 15s), so recovery shows within
+seconds of an upstream coming back.
 
 ## Example configs
 

--- a/docs/RESP-CACHE.md
+++ b/docs/RESP-CACHE.md
@@ -633,6 +633,8 @@ Router 2 stays up on `:3365`; `--stop` removes both.
 | Relays fail or the smoke check fails | Public endpoint rate limits. Set `ETH_RPC_URL_1/2` and `ETH_WS_URL_1/2` to your own endpoints. |
 
 Readiness timing note: `/metrics/overall-health` (and the container health that follows it)
-starts **fail-closed** and reports 503 until the first relays health-check cycle completes —
-`--relays-health-interval` defaults to 5 minutes. A freshly started stack showing 503 while
-serving relays is warming up, not broken; the lanes shorten the interval for this reason.
+starts **fail-closed** and turns 200 once at least one chain has verified a provider — at
+endpoint-setup completion on a healthy boot. A 503 that persists means no upstream answers the
+health probe; while unhealthy the router re-probes every `--relays-health-unhealthy-interval`
+(default 15s), so recovery shows within seconds. The lanes also shorten `--relays-health-interval`
+so the periodic backstop sweep runs often enough to watch.

--- a/protocol/common/cobra_common.go
+++ b/protocol/common/cobra_common.go
@@ -28,7 +28,11 @@ const (
 	CDNCacheDurationFlag    = "cdn-cache-duration"     // how long to cache the preflight response default 24 hours (in seconds) "86400"
 	RelaysHealthEnableFlag  = "relays-health-enable"   // enable relays health check, default true
 	RelayHealthIntervalFlag = "relays-health-interval" // interval between each relay health check, default 5m
-	SharedStateFlag         = "shared-state"
+	// interval between relay health checks while a chain is unhealthy, default 15s. Recovery of an
+	// unhealthy chain is only ever discovered by the health probe (a not-ready pod receives no real
+	// relays), so the probe tightens to this cadence until the chain is healthy again.
+	RelayHealthUnhealthyIntervalFlag = "relays-health-unhealthy-interval"
+	SharedStateFlag                  = "shared-state"
 	// SetRelayRetryLimitFlag controls the maximum number of retry attempts on relay errors
 	// (both node errors and protocol errors) for consumers and smart routers.
 	SetRelayRetryLimitFlag = "set-relay-retry-limit"
@@ -151,23 +155,24 @@ const (
 
 // helper struct to propagate flags deeper into the code in an organized manner
 type ConsumerCmdFlags struct {
-	HeadersFlag              string        // comma separated list of headers, or * for all, default simple cors specification headers
-	CredentialsFlag          string        // access-control-allow-credentials, defaults to "true"
-	OriginFlag               string        // comma separated list of origins, or * for all, default enabled completely
-	MethodsFlag              string        // whether to allow access control headers *, most proxies have their own access control so its not required
-	ExposeHeadersFlag        string        // Access-Control-Expose-Headers — response headers the browser is allowed to read (e.g. Lava-Provider-Address). Empty = none.
-	CDNCacheDuration         string        // how long to cache the preflight response defaults 24 hours (in seconds) "86400"
-	RelaysHealthEnableFlag   bool          // enables relay health check
-	RelaysHealthIntervalFlag time.Duration // interval for relay health check
-	DebugRelays              bool          // enables debug mode for relays
-	StaticSpecPaths          []string      // paths to spec sources (files, directories, or remote URLs). Later entries override earlier for same chain ID.
-	GitHubToken              string        // GitHub personal access token for accessing private repositories
-	GitLabToken              string        // GitLab personal access token for accessing private repositories
-	EpochDuration            time.Duration // duration of each epoch for time-based epoch system (standalone mode)
-	EnableSelectionStats     bool          // enables selection stats header for debugging provider selection
-	DebugAddress             string        // address for the debug HTTP server, e.g. ":9999". Empty = disabled.
-	ResponseCompression      string        // "gzip" (default), "brotli", or "off" — controls client-facing response compression
-	ShutdownGracePeriod      time.Duration // graceful shutdown deadline; passed to chain listeners and upstream cleanup
+	HeadersFlag                       string        // comma separated list of headers, or * for all, default simple cors specification headers
+	CredentialsFlag                   string        // access-control-allow-credentials, defaults to "true"
+	OriginFlag                        string        // comma separated list of origins, or * for all, default enabled completely
+	MethodsFlag                       string        // whether to allow access control headers *, most proxies have their own access control so its not required
+	ExposeHeadersFlag                 string        // Access-Control-Expose-Headers — response headers the browser is allowed to read (e.g. Lava-Provider-Address). Empty = none.
+	CDNCacheDuration                  string        // how long to cache the preflight response defaults 24 hours (in seconds) "86400"
+	RelaysHealthEnableFlag            bool          // enables relay health check
+	RelaysHealthIntervalFlag          time.Duration // interval for relay health check
+	RelaysHealthUnhealthyIntervalFlag time.Duration // probe interval while a chain is unhealthy (recovery detection latency)
+	DebugRelays                       bool          // enables debug mode for relays
+	StaticSpecPaths                   []string      // paths to spec sources (files, directories, or remote URLs). Later entries override earlier for same chain ID.
+	GitHubToken                       string        // GitHub personal access token for accessing private repositories
+	GitLabToken                       string        // GitLab personal access token for accessing private repositories
+	EpochDuration                     time.Duration // duration of each epoch for time-based epoch system (standalone mode)
+	EnableSelectionStats              bool          // enables selection stats header for debugging provider selection
+	DebugAddress                      string        // address for the debug HTTP server, e.g. ":9999". Empty = disabled.
+	ResponseCompression               string        // "gzip" (default), "brotli", or "off" — controls client-facing response compression
+	ShutdownGracePeriod               time.Duration // graceful shutdown deadline; passed to chain listeners and upstream cleanup
 }
 
 // default rolling logs behavior (if enabled) will store 3 files each 100MB for up to 1 day every time.

--- a/protocol/metrics/health_probes_test.go
+++ b/protocol/metrics/health_probes_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -78,4 +79,38 @@ func TestReadyz_AliasesHealthOverall(t *testing.T) {
 
 	m.UpdateHealthCheckStatus(false)
 	require.Equal(t, getStatus(t, srv.URL+"/metrics/health-overall"), getStatus(t, srv.URL+"/readyz"))
+}
+
+// The gauge and /readyz report the same state, so they must not disagree — and
+// they did, from birth: the constructor set the gauge to 1 while
+// endpointsHealthChecksOk started fail-closed at 0. A router that had verified
+// nothing reported healthy, and one that never became healthy went on doing so,
+// which is how a 503 on /readyz sat next to a gauge reading 1 on a live tenant.
+func TestOverallHealthGaugeAgreesWithReadyz(t *testing.T) {
+	m := NewSmartRouterMetricsManager(SmartRouterMetricsManagerOptions{})
+	require.NotNil(t, m)
+	srv := probeServer(m)
+	defer srv.Close()
+
+	// At construction nothing has checked a provider: both halves say unhealthy.
+	require.Equal(t, http.StatusServiceUnavailable, getStatus(t, srv.URL+"/readyz"),
+		"/readyz must be fail-closed before the first health check")
+	require.Equal(t, 0.0, gaugeValue(t, m.routerOverallHealth),
+		"the gauge must not claim healthy before anything has verified it")
+
+	// Both halves move together, in both directions.
+	m.UpdateHealthCheckStatus(true)
+	require.Equal(t, http.StatusOK, getStatus(t, srv.URL+"/readyz"))
+	require.Equal(t, 1.0, gaugeValue(t, m.routerOverallHealth))
+
+	m.UpdateHealthCheckStatus(false)
+	require.Equal(t, http.StatusServiceUnavailable, getStatus(t, srv.URL+"/readyz"))
+	require.Equal(t, 0.0, gaugeValue(t, m.routerOverallHealth))
+}
+
+func gaugeValue(t *testing.T, g prometheus.Gauge) float64 {
+	t.Helper()
+	var m dto.Metric
+	require.NoError(t, g.Write(&m))
+	return m.GetGauge().GetValue()
 }

--- a/protocol/metrics/health_probes_test.go
+++ b/protocol/metrics/health_probes_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -106,6 +107,40 @@ func TestOverallHealthGaugeAgreesWithReadyz(t *testing.T) {
 	m.UpdateHealthCheckStatus(false)
 	require.Equal(t, http.StatusServiceUnavailable, getStatus(t, srv.URL+"/readyz"))
 	require.Equal(t, 0.0, gaugeValue(t, m.routerOverallHealth))
+}
+
+// A health transition reaches /readyz the moment it happens, via the
+// per-monitor callback the aggregator installs at registration — not up to a
+// full aggregator interval later. Both tickers here are an hour, so every
+// /readyz change inside this test is transition-driven; a tick-driven
+// implementation would leave /readyz frozen for the whole test.
+func TestReadyz_FlipsOnTransitionWithoutWaitingForTicker(t *testing.T) {
+	m := NewSmartRouterMetricsManager(SmartRouterMetricsManagerOptions{})
+	require.NotNil(t, m)
+	srv := probeServer(m)
+	defer srv.Close()
+
+	rma := NewRelaysMonitorAggregator(time.Hour, m)
+	monitor := NewRelaysMonitor(time.Hour, time.Hour, "ETH1", "jsonrpc")
+	rma.RegisterRelaysMonitor("ETH1jsonrpc", monitor)
+
+	// Nothing has published yet — /readyz still serves its fail-closed initial
+	// value even though the monitor's own default is optimistic.
+	require.Equal(t, http.StatusServiceUnavailable, getStatus(t, srv.URL+"/readyz"))
+
+	// healthy → unhealthy transition (boot validation found nothing usable).
+	monitor.SeedInitialHealth(false)
+	require.Equal(t, http.StatusServiceUnavailable, getStatus(t, srv.URL+"/readyz"))
+
+	// unhealthy → healthy: a successful relay flips readiness immediately.
+	monitor.LogRelay()
+	require.Equal(t, http.StatusOK, getStatus(t, srv.URL+"/readyz"),
+		"a recovery transition must reach /readyz without waiting for the aggregator ticker")
+
+	// healthy → unhealthy: a failed probe pulls the pod immediately.
+	monitor.recordProbeResult(false)
+	require.Equal(t, http.StatusServiceUnavailable, getStatus(t, srv.URL+"/readyz"),
+		"a failure transition must reach /readyz without waiting for the aggregator ticker")
 }
 
 func gaugeValue(t *testing.T, g prometheus.Gauge) float64 {

--- a/protocol/metrics/relays_monitor.go
+++ b/protocol/metrics/relays_monitor.go
@@ -16,19 +16,47 @@ type RelaysMonitor struct {
 	relaySender func() (bool, error)
 	ticker      *time.Ticker
 	interval    time.Duration
-	lock        sync.RWMutex
+	// Probe cadence while the chain is unhealthy. Recovery discovery rides the
+	// probe: a pod whose /readyz is 503 is out of the Service, so no real relay
+	// will arrive to flip health via LogRelay — waiting a full healthy-cadence
+	// interval (5 minutes by default) to re-probe means up to that long of
+	// refusing traffic the chain could already serve. While healthy the probe
+	// stays lazy (and LogRelay defers it entirely under real traffic).
+	unhealthyInterval time.Duration
+	lock              sync.RWMutex
 
 	isHealthy uint32
+	// Fired on every healthy<->unhealthy transition (not on every store) with
+	// the new state. Stored atomically because storeHealthStatus runs on probe
+	// goroutines and the relay hot path (LogRelay) concurrently with
+	// registration. The aggregator installs it so transitions publish to
+	// /readyz immediately instead of waiting for the aggregator's ticker.
+	onStatusChange atomic.Pointer[func(healthy bool)]
 }
 
-func NewRelaysMonitor(interval time.Duration, chainID, apiInterface string) *RelaysMonitor {
-	return &RelaysMonitor{
-		chainID:      chainID,
-		apiInterface: apiInterface,
-		ticker:       time.NewTicker(interval),
-		interval:     interval,
-		isHealthy:    1, // setting process to healthy by default, after init relays we know if its truly healthy or not.
+func NewRelaysMonitor(interval, unhealthyInterval time.Duration, chainID, apiInterface string) *RelaysMonitor {
+	if unhealthyInterval <= 0 || unhealthyInterval > interval {
+		unhealthyInterval = interval
 	}
+	return &RelaysMonitor{
+		chainID:           chainID,
+		apiInterface:      apiInterface,
+		ticker:            time.NewTicker(interval),
+		interval:          interval,
+		unhealthyInterval: unhealthyInterval,
+		isHealthy:         1, // setting process to healthy by default, after init relays we know if its truly healthy or not.
+	}
+}
+
+// SetOnStatusChange installs the transition callback. The callback must not
+// call back into this RelaysMonitor's lock-taking methods (IsHealthy is fine —
+// it is a bare atomic read).
+func (sem *RelaysMonitor) SetOnStatusChange(callback func(healthy bool)) {
+	if sem == nil {
+		return
+	}
+
+	sem.onStatusChange.Store(&callback)
 }
 
 // SeedInitialHealth overrides the optimistic default before Start runs.
@@ -74,7 +102,7 @@ func (sem *RelaysMonitor) Start(ctx context.Context) {
 
 	go func() {
 		success, _ := sem.relaySender()
-		sem.storeHealthStatus(success)
+		sem.recordProbeResult(success)
 	}()
 	go sem.startInner(ctx)
 }
@@ -89,12 +117,30 @@ func (sem *RelaysMonitor) startInner(ctx context.Context) {
 				utils.LogAttr("apiInterface", sem.apiInterface),
 				utils.LogAttr("health result", success),
 			)
-			sem.storeHealthStatus(success)
+			sem.recordProbeResult(success)
 		case <-ctx.Done():
 			sem.ticker.Stop()
 			return
 		}
 	}
+}
+
+// recordProbeResult stores a probe verdict and sets the next probe's cadence
+// from it: lazy while healthy, unhealthyInterval while not — the probe is the
+// only recovery path for a pod that readiness has already pulled out of
+// rotation. LogRelay stays on the healthy cadence unconditionally, since a
+// successful real relay is itself proof of health.
+func (sem *RelaysMonitor) recordProbeResult(success bool) {
+	sem.storeHealthStatus(success)
+
+	interval := sem.interval
+	if !success {
+		interval = sem.unhealthyInterval
+	}
+
+	sem.lock.Lock()
+	defer sem.lock.Unlock()
+	sem.ticker.Reset(interval)
 }
 
 func (sem *RelaysMonitor) LogRelay() {
@@ -123,7 +169,15 @@ func (sem *RelaysMonitor) storeHealthStatus(healthy bool) {
 		value = 1
 	}
 
-	atomic.StoreUint32(&sem.isHealthy, value)
+	// Swap, not Store: the old value tells us whether this is a transition,
+	// and only transitions notify — LogRelay stores true on every successful
+	// relay, so notifying on every store would fire on the hot path.
+	old := atomic.SwapUint32(&sem.isHealthy, value)
+	if old != value {
+		if callback := sem.onStatusChange.Load(); callback != nil {
+			(*callback)(healthy)
+		}
+	}
 }
 
 func (sem *RelaysMonitor) loadHealthStatus() bool {

--- a/protocol/metrics/relays_monitor.go
+++ b/protocol/metrics/relays_monitor.go
@@ -129,10 +129,10 @@ func (sem *RelaysMonitor) startInner(ctx context.Context) {
 // from it: lazy while healthy, unhealthyInterval while not — the probe is the
 // only recovery path for a pod that readiness has already pulled out of
 // rotation. LogRelay stays on the healthy cadence unconditionally, since a
-// successful real relay is itself proof of health.
+// successful real relay is itself proof of health. Verdict and cadence are
+// written under one lock, as LogRelay does, so a relay landing between the two
+// cannot leave a healthy chain on the unhealthy cadence.
 func (sem *RelaysMonitor) recordProbeResult(success bool) {
-	sem.storeHealthStatus(success)
-
 	interval := sem.interval
 	if !success {
 		interval = sem.unhealthyInterval
@@ -140,6 +140,7 @@ func (sem *RelaysMonitor) recordProbeResult(success bool) {
 
 	sem.lock.Lock()
 	defer sem.lock.Unlock()
+	sem.storeHealthStatus(success)
 	sem.ticker.Reset(interval)
 }
 

--- a/protocol/metrics/relays_monitor_aggregator.go
+++ b/protocol/metrics/relays_monitor_aggregator.go
@@ -41,6 +41,17 @@ func (rma *RelaysMonitorAggregator) RegisterRelaysMonitor(rpcEndpointKey string,
 
 func (rma *RelaysMonitorAggregator) StartMonitoring(ctx context.Context) {
 	go func() {
+		// Evaluate once before waiting on the ticker. Without this the first
+		// health check is a whole interval away — 5 minutes by default — and
+		// for that entire window /readyz serves its fail-closed initial value
+		// rather than an observed one. A pod that is already relaying reads as
+		// not-ready, and a pod that can serve nothing reads the same way, so
+		// the two are indistinguishable exactly when it matters: at rollout.
+		//
+		// This does not shorten the window to the first HEALTHY result, which
+		// is still bounded by the ticker — it makes the state observed rather
+		// than assumed from t=0.
+		rma.runHealthCheck()
 		for {
 			select {
 			case <-rma.ticker.C:

--- a/protocol/metrics/relays_monitor_aggregator.go
+++ b/protocol/metrics/relays_monitor_aggregator.go
@@ -37,6 +37,15 @@ func (rma *RelaysMonitorAggregator) RegisterRelaysMonitor(rpcEndpointKey string,
 	rma.lock.Lock()
 	defer rma.lock.Unlock()
 	rma.relaysMonitors[rpcEndpointKey] = relaysMonitor
+	// Publish on every state transition, not just on ticks. The aggregate is a
+	// read of per-monitor atomics plus a few gauge writes, so re-evaluating on
+	// a flip is effectively free — and it is what lets /readyz change the
+	// moment a chain's health changes instead of up to a full ticker interval
+	// later. The callback fires only on transitions (see storeHealthStatus),
+	// so relay-hot-path LogRelay calls don't reach here in steady state.
+	relaysMonitor.SetOnStatusChange(func(bool) {
+		rma.runHealthCheck()
+	})
 }
 
 func (rma *RelaysMonitorAggregator) StartMonitoring(ctx context.Context) {
@@ -48,9 +57,9 @@ func (rma *RelaysMonitorAggregator) StartMonitoring(ctx context.Context) {
 		// not-ready, and a pod that can serve nothing reads the same way, so
 		// the two are indistinguishable exactly when it matters: at rollout.
 		//
-		// This does not shorten the window to the first HEALTHY result, which
-		// is still bounded by the ticker — it makes the state observed rather
-		// than assumed from t=0.
+		// After this, transitions publish immediately via the per-monitor
+		// callback wired in RegisterRelaysMonitor; the ticker below is the
+		// backstop that re-reads everything on a fixed cadence regardless.
 		rma.runHealthCheck()
 		for {
 			select {
@@ -65,8 +74,13 @@ func (rma *RelaysMonitorAggregator) StartMonitoring(ctx context.Context) {
 }
 
 func (rma *RelaysMonitorAggregator) runHealthCheck() {
-	rma.lock.RLock()
-	defer rma.lock.RUnlock()
+	// Full Lock, not RLock: this runs from the ticker AND from per-monitor
+	// transition callbacks, and two concurrent evaluations could interleave
+	// their UpdateHealthCheckStatus writes so the stale one lands last.
+	// Serializing the whole read-evaluate-publish keeps the published state the
+	// one computed from the most recent read.
+	rma.lock.Lock()
+	defer rma.lock.Unlock()
 
 	overallHealth := false
 

--- a/protocol/metrics/relays_monitor_test.go
+++ b/protocol/metrics/relays_monitor_test.go
@@ -2,23 +2,53 @@ package metrics
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
+// Recovery of an unhealthy chain is only ever discovered by the probe — a pod
+// that readiness pulled out of rotation receives no real relays to flip health
+// via LogRelay. So while unhealthy the probe must run on the tight cadence: with
+// the healthy cadence set to an hour here, observing the recovery at all within
+// this test proves the unhealthy cadence took over.
+func TestRelaysMonitor_ProbesFasterWhileUnhealthy(t *testing.T) {
+	var healthy atomic.Bool
+	relaySender := func() (bool, error) { return healthy.Load(), nil }
+
+	monitor := NewRelaysMonitor(time.Hour, 10*time.Millisecond, "test_chain", "rest")
+	monitor.SetRelaySender(relaySender)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	monitor.Start(ctx)
+
+	// The immediate probe fails: unhealthy, and the ticker tightens.
+	require.Eventually(t, func() bool { return !monitor.IsHealthy() }, time.Second, time.Millisecond,
+		"the immediate probe's failure must mark the monitor unhealthy")
+
+	// The upstream comes back. An hour-cadence ticker would never see this
+	// inside the test; the unhealthy cadence sees it within milliseconds.
+	healthy.Store(true)
+	require.Eventually(t, func() bool { return monitor.IsHealthy() }, time.Second, time.Millisecond,
+		"recovery must be observed on the unhealthy cadence, not the healthy one")
+}
+
 func TestHappyFlow(t *testing.T) {
-	isHealthy := true
+	// atomic: read by the monitor's probe goroutines while the test writes it.
+	var isHealthy atomic.Bool
+	isHealthy.Store(true)
 	relaySender := func() (bool, error) {
-		return isHealthy, nil
+		return isHealthy.Load(), nil
 	}
 
 	interval := time.Second * 3
 	extraTimeToWait := time.Second
 	timeToSleep := interval + extraTimeToWait
 
-	relaysMonitor := NewRelaysMonitor(interval, "test_chain", "rest")
+	relaysMonitor := NewRelaysMonitor(interval, interval, "test_chain", "rest")
 	relaysMonitor.SetRelaySender(relaySender)
 	relaysMonitor.Start(context.Background())
 
@@ -36,7 +66,7 @@ func TestHappyFlow(t *testing.T) {
 		require.True(t, relaysMonitor.IsHealthy())
 
 		// Set to false
-		isHealthy = false
+		isHealthy.Store(false)
 
 		// Sleep for the interval
 		time.Sleep(timeToSleep)

--- a/protocol/metrics/smartrouter_metrics_manager.go
+++ b/protocol/metrics/smartrouter_metrics_manager.go
@@ -347,7 +347,14 @@ func NewSmartRouterMetricsManager(options SmartRouterMetricsManagerOptions) *Sma
 		Help: "Overall health of the RPC smart router (1=healthy, 0=unhealthy).",
 	})
 	routerOverallHealth = registerOrReuse(routerOverallHealth)
-	routerOverallHealth.Set(1)
+	// 0, not 1. This gauge is the reporting half of the same state /readyz
+	// serves, and endpointsHealthChecksOk below starts fail-closed at 0 — so
+	// setting it to 1 here made the two disagree from birth. Nothing has
+	// verified a provider at construction time, and the first health check is a
+	// full RelaysMonitorAggregator interval away, so a 1 here is a claim the
+	// process cannot support: every router reported healthy for its first
+	// minutes, and a router that never became healthy went on reporting it.
+	routerOverallHealth.Set(0)
 
 	routerOverallHealthBreakdown := registerOrReuse(prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "smartrouter_overall_health_breakdown",

--- a/protocol/rpcsmartrouter/boot_resilience_test.go
+++ b/protocol/rpcsmartrouter/boot_resilience_test.go
@@ -178,7 +178,7 @@ func TestRetryIntervalFor(t *testing.T) {
 func TestSeedInitialHealth_DarkChainReportsUnhealthyImmediately(t *testing.T) {
 	// The monitor is optimistic by default, which would answer 200 on the health
 	// path for a chain that came up with nothing to serve from.
-	monitor := metrics.NewRelaysMonitor(time.Minute, "BSC", "jsonrpc")
+	monitor := metrics.NewRelaysMonitor(time.Minute, time.Minute, "BSC", "jsonrpc")
 	require.True(t, monitor.IsHealthy(), "default is optimistic")
 
 	monitor.SeedInitialHealth(false)

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -71,6 +71,12 @@ var (
 	Yaml_config_properties         = []string{"network-address", "chain-id", "api-interface"}
 	RelaysHealthEnableFlagDefault  = true
 	RelayHealthIntervalFlagDefault = 5 * time.Minute
+	// Probe cadence while a chain is unhealthy. A pod whose /readyz is 503 is out
+	// of the Service, so recovery is only ever discovered by the crafted-relay
+	// probe — at the healthy cadence that is up to 5 minutes of refusing traffic
+	// the chain can already serve. 15s bounds recovery detection tightly while
+	// costing probes only on chains that are actually down.
+	RelayHealthUnhealthyIntervalFlagDefault = 15 * time.Second
 
 	// StaticProviderDummyStake is used for stake-based provider selection weighting.
 	// For static providers that do NOT specify an explicit stake, we keep this at 0 so CalcWeightsByStake
@@ -2806,7 +2812,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 
 	var relaysMonitor *metrics.RelaysMonitor
 	if options.cmdFlags.RelaysHealthEnableFlag {
-		relaysMonitor = metrics.NewRelaysMonitor(options.cmdFlags.RelaysHealthIntervalFlag, rpcEndpoint.ChainID, rpcEndpoint.ApiInterface)
+		relaysMonitor = metrics.NewRelaysMonitor(options.cmdFlags.RelaysHealthIntervalFlag, options.cmdFlags.RelaysHealthUnhealthyIntervalFlag, rpcEndpoint.ChainID, rpcEndpoint.ApiInterface)
 		// Boot validation already knows whether anything can serve, so don't let the
 		// monitor's optimistic default claim health for a chain that came up dark.
 		relaysMonitor.SeedInitialHealth(chainServable)
@@ -3328,23 +3334,24 @@ rpcsmartrouter smartrouter_examples/smartrouter_eth.yml --cache-be "127.0.0.1:77
 			}
 
 			consumerPropagatedFlags := common.ConsumerCmdFlags{
-				HeadersFlag:              viper.GetString(common.CorsHeadersFlag),
-				CredentialsFlag:          viper.GetString(common.CorsCredentialsFlag),
-				OriginFlag:               viper.GetString(common.CorsOriginFlag),
-				MethodsFlag:              viper.GetString(common.CorsMethodsFlag),
-				ExposeHeadersFlag:        viper.GetString(common.CorsExposeHeadersFlag),
-				CDNCacheDuration:         viper.GetString(common.CDNCacheDurationFlag),
-				RelaysHealthEnableFlag:   viper.GetBool(common.RelaysHealthEnableFlag),
-				RelaysHealthIntervalFlag: viper.GetDuration(common.RelayHealthIntervalFlag),
-				DebugRelays:              viper.GetBool(DebugRelaysFlagName),
-				StaticSpecPaths:          viper.GetStringSlice(common.UseStaticSpecFlag),
-				GitHubToken:              viper.GetString(common.GitHubTokenFlag),
-				GitLabToken:              viper.GetString(common.GitLabTokenFlag),
-				EpochDuration:            epochDuration,
-				EnableSelectionStats:     viper.GetBool(common.EnableSelectionStatsHeaderFlag),
-				DebugAddress:             viper.GetString("debug-address"),
-				ResponseCompression:      viper.GetString(common.ResponseCompressionFlag),
-				ShutdownGracePeriod:      viper.GetDuration(common.ShutdownGracePeriodFlag),
+				HeadersFlag:                       viper.GetString(common.CorsHeadersFlag),
+				CredentialsFlag:                   viper.GetString(common.CorsCredentialsFlag),
+				OriginFlag:                        viper.GetString(common.CorsOriginFlag),
+				MethodsFlag:                       viper.GetString(common.CorsMethodsFlag),
+				ExposeHeadersFlag:                 viper.GetString(common.CorsExposeHeadersFlag),
+				CDNCacheDuration:                  viper.GetString(common.CDNCacheDurationFlag),
+				RelaysHealthEnableFlag:            viper.GetBool(common.RelaysHealthEnableFlag),
+				RelaysHealthIntervalFlag:          viper.GetDuration(common.RelayHealthIntervalFlag),
+				RelaysHealthUnhealthyIntervalFlag: viper.GetDuration(common.RelayHealthUnhealthyIntervalFlag),
+				DebugRelays:                       viper.GetBool(DebugRelaysFlagName),
+				StaticSpecPaths:                   viper.GetStringSlice(common.UseStaticSpecFlag),
+				GitHubToken:                       viper.GetString(common.GitHubTokenFlag),
+				GitLabToken:                       viper.GetString(common.GitLabTokenFlag),
+				EpochDuration:                     epochDuration,
+				EnableSelectionStats:              viper.GetBool(common.EnableSelectionStatsHeaderFlag),
+				DebugAddress:                      viper.GetString("debug-address"),
+				ResponseCompression:               viper.GetString(common.ResponseCompressionFlag),
+				ShutdownGracePeriod:               viper.GetDuration(common.ShutdownGracePeriodFlag),
 			}
 
 			rpcSmartRouterSharedState := viper.GetBool(common.SharedStateFlag)
@@ -3480,6 +3487,7 @@ rpcsmartrouter smartrouter_examples/smartrouter_eth.yml --cache-be "127.0.0.1:77
 	// relays health check related flags
 	cmdRPCSmartRouter.Flags().Bool(common.RelaysHealthEnableFlag, RelaysHealthEnableFlagDefault, "enables relays health check")
 	cmdRPCSmartRouter.Flags().Duration(common.RelayHealthIntervalFlag, RelayHealthIntervalFlagDefault, "interval between relay health checks")
+	cmdRPCSmartRouter.Flags().Duration(common.RelayHealthUnhealthyIntervalFlag, RelayHealthUnhealthyIntervalFlagDefault, "probe interval while a chain is unhealthy; bounds how fast /readyz recovers after upstreams come back (clamped to relays-health-interval)")
 	// Registered as a flagset-owned Bool (NOT BoolVar bound to the lavasession global): BoolVar writes
 	// the bound global at registration time, which raced probe goroutines reading it. Applied to the
 	// atomic global in RunE via lavasession.SetDebugProbes.

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -3485,7 +3485,7 @@ rpcsmartrouter smartrouter_examples/smartrouter_eth.yml --cache-be "127.0.0.1:77
 	cmdRPCSmartRouter.Flags().String(common.CDNCacheDurationFlag, "86400", "set up preflight options response cache duration, default 86400 (24h in seconds)")
 	cmdRPCSmartRouter.Flags().Bool(common.SharedStateFlag, false, "Share state across router replicas through the cache backend (cache-be or resp-cache): the consumer consistency seen-block travels through either. The per-endpoint chain-tracker poll observations (an upstream polled about once per interval fleet-wide instead of once per pod) additionally require --cache-be — the RESP backend does not carry them, so a RESP-backed router polls locally and logs a warning (docs/RESP-CACHE.md)")
 	// relays health check related flags
-	cmdRPCSmartRouter.Flags().Bool(common.RelaysHealthEnableFlag, RelaysHealthEnableFlagDefault, "enables relays health check")
+	cmdRPCSmartRouter.Flags().Bool(common.RelaysHealthEnableFlag, RelaysHealthEnableFlagDefault, "enables relays health check; when false, /readyz and /metrics/overall-health report 503 unconditionally, so keep it on under a readiness probe")
 	cmdRPCSmartRouter.Flags().Duration(common.RelayHealthIntervalFlag, RelayHealthIntervalFlagDefault, "interval between relay health checks")
 	cmdRPCSmartRouter.Flags().Duration(common.RelayHealthUnhealthyIntervalFlag, RelayHealthUnhealthyIntervalFlagDefault, "probe interval while a chain is unhealthy; bounds how fast /readyz recovers after upstreams come back (clamped to relays-health-interval)")
 	// Registered as a flagset-owned Bool (NOT BoolVar bound to the lavasession global): BoolVar writes

--- a/scripts/pre_setups/init_smartrouter_eth_redis_demo.sh
+++ b/scripts/pre_setups/init_smartrouter_eth_redis_demo.sh
@@ -573,10 +573,10 @@ fi
 } > "$CONFIG_FILE"
 
 # --- router ------------------------------------------------------------------
-# --relays-health-interval: /metrics/overall-health starts FAIL-CLOSED (503) and
-# only flips once the health aggregator's first TICK fires. At the 5m production
-# default a freshly booted demo shows 503 while happily serving relays, which
-# reads as "broken" to an audience. Shorten the cadence instead of waiting.
+# --relays-health-interval: cadence of the periodic health sweep. Readiness
+# itself is fail-closed only until endpoint setup verifies a provider, so a
+# freshly booted demo turns 200 as soon as it serves; the short cadence keeps
+# the periodic re-check visible in the logs during a demo.
 echo "[Setup] starting the smart router (:${ROUTER_PORT})"
 screen -d -m -S "$ROUTER_SCREEN" bash -c "cd $PROJECT_ROOT && source ~/.bashrc; smartrouter \
 $CONFIG_REL \

--- a/scripts/pre_setups/init_smartrouter_eth_resp_cache.sh
+++ b/scripts/pre_setups/init_smartrouter_eth_resp_cache.sh
@@ -176,12 +176,10 @@ echo "        --resp-cache-addresses 127.0.0.1:${VALKEY_PORT} (overrides the con
 # No --skip-websocket-verification: the example config supplies a WS leg per
 # provider and this lane must prove that.
 #
-# --relays-health-interval: /metrics/overall-health starts FAIL-CLOSED (503) and
-# only flips once RelaysMonitorAggregator runs its first sweep — and that
-# aggregator acts on the first TICK, never immediately. At the 5m production
-# default the endpoint is therefore legitimately 503 for five minutes after
-# boot, which no reasonable lane can wait out. We shorten the cadence for the
-# lane instead of sleeping blindly: readiness is then observed, not assumed.
+# --relays-health-interval: cadence of the periodic health sweep. Readiness is
+# fail-closed only until endpoint setup verifies a provider, so the lane's
+# router turns 200 as soon as it serves; a short cadence keeps the periodic
+# backstop sweep frequent enough to observe within the lane's budget.
 HEALTH_INTERVAL="${HEALTH_INTERVAL:-15s}"
 screen -d -m -S "$SCREEN_NAME" bash -c "cd $PROJECT_ROOT && source ~/.bashrc; smartrouter \
 $CONFIG_REL \
@@ -258,9 +256,8 @@ if [[ "$RUN_DEMO" == "1" ]]; then
     [[ "$LAVA_HEALTH" == "200" ]] && note "router /lava/health" "200" \
         || { note "router /lava/health" "$LAVA_HEALTH (expected 200)"; DEMO_FAIL=1; }
 
-    # 2. metrics health — overall-health is fail-closed until the aggregator's
-    #    first sweep (cadence set by --relays-health-interval above), so poll
-    #    rather than sampling once. The budget must exceed that interval.
+    # 2. metrics health — overall-health is fail-closed until endpoint setup
+    #    has verified a provider, so poll rather than sampling once.
     OVERALL=""
     for _ in $(seq 1 60); do
         OVERALL=$(curl -s -o /dev/null -w '%{http_code}' -m 10 "http://127.0.0.1:${METRICS_PORT}/metrics/overall-health")


### PR DESCRIPTION
`smartrouter_overall_health` is `Set(1)` at construction, while `endpointsHealthChecksOk` — the flag `/readyz` serves and the other half of the same write in `UpdateOverallHealthStatus` — starts fail-closed at `0`.

So from birth until the first health check the two disagree. The gauge reports healthy on a router that has verified no provider, and keeps reporting it on a router that never becomes healthy.

Observed on a live tenant: `/readyz` returning **503** beside `smartrouter_overall_health` reading **1**, sampled simultaneously, three times, on a router that was serving `eth_blockNumber` normally.

## Four changes

1. **The gauge starts at 0**, matching the flag. Nothing has checked a provider at construction time, so `1` was a claim the process could not support.
2. **The aggregator evaluates once before entering the ticker loop.** It waited a full interval — 5 minutes by default — so for that window `/readyz` served its *initial* value rather than an observed one. Since every monitor is seeded from boot validation (`SeedInitialHealth`), this first pass genuinely distinguishes a pod that verified a provider from one that came up dark — `/readyz` turns 200 the moment endpoint setup completes, not one interval later.
3. **Health transitions publish to `/readyz` immediately.** Each `RelaysMonitor` now fires a callback on every healthy↔unhealthy transition (and only on transitions — `LogRelay` on the relay hot path does not reach it in steady state), and the aggregator re-evaluates on that callback instead of waiting for its ticker. The aggregate is a read of per-monitor atomics plus a few gauge writes, so this is effectively free. The ticker stays as a fixed-cadence backstop.
4. **Unhealthy chains re-probe fast.** A pod whose `/readyz` is 503 is out of the Service, so no real relay will ever arrive to flip health via `LogRelay` — recovery is only ever discovered by the crafted-relay probe, which ran at the same lazy 5-minute cadence. The probe now tightens to `--relays-health-unhealthy-interval` (default **15s**, clamped to `relays-health-interval`) while a chain is unhealthy, and returns to the lazy cadence on the first healthy verdict. While healthy nothing changes: `LogRelay` keeps deferring the probe entirely under real traffic, so the extra probes cost anything only on chains that are actually down.

Net effect on `/readyz` latency:
- **Boot** (≥1 usable provider verified): 200 as soon as endpoint setup completes — was setup + one 5m interval.
- **All upstreams down → one recovers**: 200 within ~15s of the upstream serving again — was up to two 5m intervals (~10m).
- **All upstreams die**: 503 within one probe interval of the failure being observed, published immediately — the same two-interval lag existed in this direction too.

## Two things this changes that are worth knowing

- **A single failed probe now pulls a single-chain pod immediately.** Before, the aggregator's lag meant a transient probe failure was usually overwritten by `LogRelay` before it was ever published — an accidental debounce that only worked because the pod stayed in rotation. Now the 503 publishes at once. This is acceptable because the probe is a crafted relay with 6 retries (a failure means every provider failed it), and the chart's readiness probe needs 3 consecutive failures over 30 s while the 15 s re-probe restores a 200 in between. But it is a real change in sensitivity, not just latency.
- **The ~15 s recovery claim covers providers that are present but failing.** A chain with an empty pairing list blocks the probe in `waitForPairing`, so its recovery is driven by pairing filling in, not by the tighter ticker.

Also in this PR: `docs/LOCAL-COMPOSE.md`, `docs/RESP-CACHE.md` and two `pre_setups` lane comments described the old one-interval boot window and are rewritten for the current behaviour; the `--relays-health-enable` help now says that `false` pins `/readyz` at 503. The docs-site rows for the new flag and the `/livez` / `/readyz` endpoints are in [Magma-Devs/docs#41](https://github.com/Magma-Devs/docs/pull/41) (MAG-3436).

## Measured

On `lab` (DEV), router v1.4.0, before this change: `/readyz` was 503 from boot and turned 200 at pod age **5m40s** — one aggregator interval. `/livez` and `/metrics` were 200 throughout, and the gauge read 1 the whole time.

## Tests

- `TestOverallHealthGaugeAgreesWithReadyz` asserts the gauge and `/readyz` agree at construction and move together in both directions. **Verified it fails on the previous code** (`the gauge must not claim healthy before anything has verified it`) and passes with the fix.
- `TestReadyz_FlipsOnTransitionWithoutWaitingForTicker` runs both tickers at an hour so any `/readyz` change is transition-driven; it asserts a seed-unhealthy, a successful relay, and a failed probe each reach `/readyz` immediately. **Verified it fails with the callback wiring removed** (`a recovery transition must reach /readyz without waiting for the aggregator ticker`).
- `TestRelaysMonitor_ProbesFasterWhileUnhealthy` sets the healthy cadence to an hour and the unhealthy cadence to 10ms; observing the recovery at all inside the test proves the tight cadence took over.
- Full `protocol/metrics` green under `-race` (this surfaced a pre-existing data race in `TestHappyFlow`'s shared bool, fixed here with an atomic), full `protocol/rpcsmartrouter` green, `golangci-lint` 0 issues on the touched packages.

## Why it matters beyond the metric

smart-router-helm-chart#94 repoints the router's readiness probe from `/metrics` to `/readyz` — the fix for a readiness defect that has cost measured request loss on every rolling restart. That PR is currently held because `/readyz`'s boot behaviour was indistinguishable from it being broken. With this PR `/readyz` is observed from setup-complete onward and recovers within seconds, which is the behaviour a readiness probe needs.

#Closes MAG-3342

Jira ticket: MAG-3342

