### PR TITLE
feat(chainlib): admit a provider per collection at boot and per epoch (MAG-3326)

### DIFF
--- a/protocol/chainlib/chain_fetcher.go
+++ b/protocol/chainlib/chain_fetcher.go
@@ -166,13 +166,123 @@ func stopValidateRetries(err error) bool {
 	return err == nil || errors.Is(err, common.StatusCodeError429)
 }
 
+// admissionKey identifies one refused service on one node url. A comparable
+// struct rather than a joined string: the join needed a NUL sentinel, which is
+// an invariant every reader has to re-verify.
+type admissionKey struct {
+	url          string
+	internalPath string
+	service      string
+}
+
+// ProviderAdmission records the services a provider's node urls failed to answer
+// for, so a failure attributable to ONE service costs that service rather than
+// the whole provider (MAG-3326).
+//
+// "Service" is a name as it appears in NodeUrl.Addons, which mixes add-on and
+// extension names — the router's own config makes no distinction, and neither
+// does Endpoint.Addons/.Extensions, both of which are built from that one list.
+//
+// Empty means everything a url declared was admitted.
+type ProviderAdmission struct {
+	refused map[admissionKey]struct{}
+}
+
+// refusedServiceFor returns the service a failed verification should be charged
+// to, or "" when the failure belongs to no single service and is therefore fatal.
+//
+// EXTENSION FIRST, and this is the whole correctness of the feature. A
+// VerificationContainer carries both an Addon and an Extension, and the narrower
+// one is what was actually probed:
+//
+//   - {Addon:"", Extension:"archive"} — every EVM and cosmos spec keys the archive
+//     check this way, on the BASE collection. Charging it to Addon would find ""
+//     and take the fatal path, which is the motivating case of this whole ticket:
+//     "attach an archive url to a healthy provider, fail the archive check, lose
+//     the provider". Charging it to "archive" refuses archive and keeps the rest.
+//   - {Addon:"trace", Extension:"archive"} — ethereum's trace collection carries an
+//     archive-scoped pruning value. What failed is the node's archive-ness, not its
+//     trace support, so refusing "trace" would drop working traffic and leave the
+//     failing archive extension advertised.
+//   - {Addon:"debug", Extension:""} — an add-on with no extension scope; charge the
+//     add-on.
+//   - {Addon:"", Extension:""} — the base collection's own. Nothing narrower to
+//     fall back to, so it stays fatal.
+func refusedServiceFor(verification VerificationContainer) string {
+	if verification.Extension != "" {
+		return verification.Extension
+	}
+	return verification.Addon
+}
+
+func (a *ProviderAdmission) fail(url common.NodeUrl, service string) {
+	if a.refused == nil {
+		a.refused = map[admissionKey]struct{}{}
+	}
+	a.refused[admissionKey{url: url.Url, internalPath: url.InternalPath, service: service}] = struct{}{}
+}
+
+// Any reports whether any service was refused.
+func (a ProviderAdmission) Any() bool { return len(a.refused) > 0 }
+
+// AdmittedServices returns the services this url may still claim, and whether the
+// url is worth building an endpoint for at all.
+//
+// keep is false when a url that serves ONLY its add-ons (standalone-addons) has
+// had every one refused. Such a url has nothing left: emptying its service list
+// would flip ServesBaseCollection() to true and hand a node its operator declared
+// cannot answer the base collection straight back to base traffic — the MAG-3296
+// failure, re-entered from the other side.
+func (a ProviderAdmission) AdmittedServices(url common.NodeUrl) (services []string, keep bool) {
+	// The common case by far — every healthy provider, on every session rebuild
+	// (boot, each failed-provider retry, each epoch tick). Returning the input
+	// avoids an allocation per url per rebuild; the test pins slice identity
+	// rather than equality, since a deep compare would not notice its loss.
+	if !a.Any() || len(url.Addons) == 0 {
+		return url.Addons, true
+	}
+	services = make([]string, 0, len(url.Addons))
+	for _, service := range url.Addons {
+		if _, bad := a.refused[admissionKey{url: url.Url, internalPath: url.InternalPath, service: service}]; bad {
+			continue
+		}
+		services = append(services, service)
+	}
+	if len(services) == 0 && !url.ServesBaseCollection() {
+		return nil, false
+	}
+	return services, true
+}
+
 func (cf *ChainFetcher) Validate(ctx context.Context) error {
+	_, err := cf.validate(ctx, false)
+	return err
+}
+
+// ValidateCollections runs the same verifications Validate does, but a
+// Fail-severity failure that belongs to ONE service refuses that service instead
+// of the provider (MAG-3326). See refusedServiceFor for what "belongs to" means.
+//
+// A failure with no service to attribute it to stays fatal: the base collection's
+// own verifications, a head probe that never answered, GetVerifications itself. A
+// node that cannot serve the spec's primary surface has nothing narrower to fall
+// back to.
+//
+// Deliberately NOT derived: a base-collection failure does not turn a url into a
+// standalone-addons one. Only an operator can tell "serves only EVM by design"
+// from "its Substrate side is down right now".
+func (cf *ChainFetcher) ValidateCollections(ctx context.Context) (ProviderAdmission, error) {
+	return cf.validate(ctx, true)
+}
+
+func (cf *ChainFetcher) validate(ctx context.Context, perCollection bool) (ProviderAdmission, error) {
+	admission := ProviderAdmission{}
 	for _, url := range cf.endpoint.NodeUrls {
 		utils.LavaFormatInfo("starting validation for url", utils.LogAttr("url", url.String()))
 		addons := url.Addons
 		verifications, err := cf.chainParser.GetVerifications(addons, url.InternalPath, cf.endpoint.ApiInterface)
 		if err != nil {
-			return err
+			return admission, err
 		}
 		verifications = verificationsForNodeUrl(url, verifications)
 		if len(verifications) == 0 {
@@ -191,8 +301,11 @@ func (cf *ChainFetcher) Validate(ctx context.Context) error {
 				}
 			}
 			if err != nil {
+				// Not attributable to one service: the head probe is resolved from
+				// the url's collections as a whole, so a failure here says the node
+				// cannot answer any of them.
 				utils.LavaFormatError("failed to fetch latest block number", err)
-				return err
+				return admission, err
 			}
 		}
 		// invalidating cache as value might change
@@ -214,14 +327,25 @@ func (cf *ChainFetcher) Validate(ctx context.Context) error {
 				cf.verificationsStatus.Store(cf.getVerificationsKey(verification, cf.endpoint.ApiInterface, cf.endpoint.ChainID), false)
 				utils.LavaFormatWarning("failed verification on provider startup", err, utils.LogAttr("verification", verification.Name))
 				if verification.Severity == spectypes.ParseValue_Fail {
-					return utils.LavaFormatError("invalid Verification on provider startup", err, utils.Attribute{Key: "Addons", Value: addons}, utils.Attribute{Key: "verification", Value: verification.Name})
+					if service := refusedServiceFor(verification); perCollection && service != "" {
+						admission.fail(url, service)
+						utils.LavaFormatWarning("refusing one service for this url, keeping the provider", err,
+							utils.LogAttr("url", url.String()),
+							utils.LogAttr("service", service),
+							utils.LogAttr("addon", verification.Addon),
+							utils.LogAttr("extension", verification.Extension),
+							utils.LogAttr("verification", verification.Name),
+						)
+						continue
+					}
+					return admission, utils.LavaFormatError("invalid Verification on provider startup", err, utils.Attribute{Key: "Addons", Value: addons}, utils.Attribute{Key: "verification", Value: verification.Name})
 				}
 			} else {
 				cf.verificationsStatus.Store(cf.getVerificationsKey(verification, cf.endpoint.ApiInterface, cf.endpoint.ChainID), true)
 			}
 		}
 	}
-	return nil
+	return admission, nil
 }
 
 // VerificationResult is the outcome of running a single spec verification against one node URL.

--- a/protocol/chainlib/per_collection_admission_test.go
+++ b/protocol/chainlib/per_collection_admission_test.go
@@ -1,0 +1,236 @@
+package chainlib
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"unsafe"
+
+	"github.com/golang/mock/gomock"
+	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// MAG-3326. Admission used to be all-or-nothing: Validate returned on the first
+// Fail-severity verification, so a provider serving the base collection perfectly
+// and failing ONE service's verification was excluded from everything.
+//
+// The container shapes below are the ones specs/ actually produce. An earlier
+// draft of this feature keyed everything on Addon and its tests manufactured
+// {Addon:"archive"} — a container no spec ever builds — so the suite was green
+// while the motivating case was unfixed.
+
+// archiveOnBaseCollection is how every EVM and cosmos spec keys the archive check:
+// on the BASE collection (add_on ""), scoped by extension, severity omitted (Fail).
+// Verified against specs/ethereum.json.
+func archiveOnBaseCollection() VerificationContainer {
+	return VerificationContainer{
+		Name:            "pruning",
+		Value:           "0x0",
+		Severity:        spectypes.ParseValue_Fail,
+		VerificationKey: VerificationKey{Addon: "", Extension: "archive"},
+		ParseDirective:  spectypes.ParseDirective{FunctionTag: spectypes.FUNCTION_TAG_VERIFICATION, ApiName: "pruning"},
+	}
+}
+
+// archiveScopedOnTraceCollection is ethereum's trace collection carrying an
+// archive-scoped pruning value: {Addon:"trace", Extension:"archive"}.
+func archiveScopedOnTraceCollection() VerificationContainer {
+	v := archiveOnBaseCollection()
+	v.VerificationKey = VerificationKey{Addon: "trace", Extension: "archive"}
+	return v
+}
+
+func addonScoped(name, addon string) VerificationContainer {
+	v := archiveOnBaseCollection()
+	v.Name = name
+	v.VerificationKey = VerificationKey{Addon: addon}
+	return v
+}
+
+func baseCollectionOnly(name string) VerificationContainer {
+	v := archiveOnBaseCollection()
+	v.Name = name
+	v.VerificationKey = VerificationKey{}
+	return v
+}
+
+func TestRefusedServiceFor(t *testing.T) {
+	// Extension first: it is the narrower thing, and it is what was probed.
+	require.Equal(t, "archive", refusedServiceFor(archiveOnBaseCollection()),
+		"the motivating case — charging this to Addon finds \"\" and goes fatal")
+	require.Equal(t, "archive", refusedServiceFor(archiveScopedOnTraceCollection()),
+		"the node's archive-ness failed, not its trace support")
+	require.Equal(t, "debug", refusedServiceFor(addonScoped("enabled", "debug")))
+	require.Equal(t, "", refusedServiceFor(baseCollectionOnly("chain-id")),
+		"nothing narrower to fall back to — stays fatal")
+}
+
+func TestAdmittedServices(t *testing.T) {
+	t.Run("refuses only the named service", func(t *testing.T) {
+		url := common.NodeUrl{Url: "https://a", Addons: []string{"archive", "debug"}}
+		var admission ProviderAdmission
+		admission.fail(url, "archive")
+
+		services, keep := admission.AdmittedServices(url)
+		require.True(t, keep)
+		require.Equal(t, []string{"debug"}, services)
+		require.Equal(t, []string{"archive", "debug"}, url.Addons, "the config is never mutated")
+	})
+
+	t.Run("keyed by url and internal path", func(t *testing.T) {
+		root := common.NodeUrl{Url: "https://a", Addons: []string{"archive"}}
+		v2 := common.NodeUrl{Url: "https://a", InternalPath: "/v2", Addons: []string{"archive"}}
+		var admission ProviderAdmission
+		admission.fail(v2, "archive")
+
+		services, _ := admission.AdmittedServices(root)
+		require.Equal(t, []string{"archive"}, services, "the root path keeps it")
+		services, _ = admission.AdmittedServices(v2)
+		require.Empty(t, services)
+	})
+
+	// The regression an earlier draft shipped: emptying a standalone url's service
+	// list flips ServesBaseCollection() to true, handing a node its operator said
+	// cannot answer the base collection straight back to base traffic.
+	t.Run("a standalone url that kept nothing is dropped", func(t *testing.T) {
+		url := common.NodeUrl{Url: "https://evm", Addons: []string{"evm"}, StandaloneAddons: true}
+		require.False(t, url.ServesBaseCollection())
+
+		var admission ProviderAdmission
+		admission.fail(url, "evm")
+		services, keep := admission.AdmittedServices(url)
+		require.False(t, keep, "nothing left to serve — must not become a base-collection endpoint")
+		require.Empty(t, services)
+	})
+
+	t.Run("an ordinary url that kept nothing is still served", func(t *testing.T) {
+		url := common.NodeUrl{Url: "https://a", Addons: []string{"archive"}}
+		var admission ProviderAdmission
+		admission.fail(url, "archive")
+		services, keep := admission.AdmittedServices(url)
+		require.True(t, keep, "it still serves the base collection")
+		require.Empty(t, services)
+	})
+
+	t.Run("nothing refused returns the input without copying", func(t *testing.T) {
+		url := common.NodeUrl{Url: "https://a", Addons: []string{"archive"}}
+		var admission ProviderAdmission
+		services, keep := admission.AdmittedServices(url)
+		require.True(t, keep)
+		// Identity, not deep equality: require.Equal compares contents and would
+		// pass even if this allocated a fresh slice on every session rebuild.
+		require.True(t, unsafe.SliceData(services) == unsafe.SliceData(url.Addons))
+	})
+}
+
+func newValidationFetcher(t *testing.T, url common.NodeUrl, verifications []VerificationContainer, verifyErr error) *ChainFetcher {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	parser := NewMockChainParser(ctrl)
+	parser.EXPECT().GetVerifications(gomock.Any(), gomock.Any(), gomock.Any()).Return(verifications, nil).AnyTimes()
+	router := NewMockChainRouter(ctrl)
+	if verifyErr != nil {
+		// Verify returns at CraftChainMessage, so SendNodeMsg is never reached on
+		// the failure path — no expectation for it, or ctrl.Finish would not notice.
+		parser.EXPECT().CraftMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, verifyErr).AnyTimes()
+	} else {
+		parser.EXPECT().CraftMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, errors.New("unused")).AnyTimes()
+	}
+
+	return &ChainFetcher{
+		endpoint: &lavasession.RPCProviderEndpoint{
+			ChainID: "ETH1", ApiInterface: spectypes.APIInterfaceJsonRPC,
+			NodeUrls: []common.NodeUrl{url},
+		},
+		chainParser: parser,
+		chainRouter: router,
+	}
+}
+
+// TestValidateCollections_ArchiveUrlKeepsTheProvider is the ticket's motivating
+// case, in the shape specs/ethereum.json produces: "attach an archive url to an
+// otherwise healthy provider, have it fail the archive check, lose the provider".
+func TestValidateCollections_ArchiveUrlKeepsTheProvider(t *testing.T) {
+	url := common.NodeUrl{Url: "https://a", Addons: []string{"archive"}}
+	verifications := []VerificationContainer{archiveOnBaseCollection()}
+
+	t.Run("per-collection refuses only archive", func(t *testing.T) {
+		fetcher := newValidationFetcher(t, url, verifications, errors.New("not an archive node"))
+		admission, err := fetcher.ValidateCollections(context.Background())
+		require.NoError(t, err, "the provider survives a failure that belongs to one service")
+		require.True(t, admission.Any())
+
+		services, keep := admission.AdmittedServices(url)
+		require.True(t, keep)
+		require.Empty(t, services, "archive is refused; the base collection is untouched")
+	})
+
+	t.Run("the all-or-nothing path is unchanged", func(t *testing.T) {
+		fetcher := newValidationFetcher(t, url, verifications, errors.New("not an archive node"))
+		require.Error(t, fetcher.Validate(context.Background()))
+	})
+}
+
+// TestValidateCollections_ExtensionScopedFailureSparesTheAddon: what failed is the
+// node's archive-ness, so refusing "trace" would drop working traffic and leave the
+// failing extension advertised.
+func TestValidateCollections_ExtensionScopedFailureSparesTheAddon(t *testing.T) {
+	url := common.NodeUrl{Url: "https://a", Addons: []string{"trace", "archive"}, StandaloneAddons: true}
+	fetcher := newValidationFetcher(t, url, []VerificationContainer{archiveScopedOnTraceCollection()}, errors.New("not an archive node"))
+
+	admission, err := fetcher.ValidateCollections(context.Background())
+	require.NoError(t, err)
+	services, keep := admission.AdmittedServices(url)
+	require.True(t, keep)
+	require.Equal(t, []string{"trace"}, services, "trace works and is kept; archive failed and is refused")
+}
+
+// TestValidateCollections_BaseFailureIsStillFatal: a failure with no service to
+// attribute it to excludes the provider, and does NOT quietly turn the url into a
+// standalone-addons one.
+func TestValidateCollections_BaseFailureIsStillFatal(t *testing.T) {
+	url := common.NodeUrl{Url: "https://a", Addons: []string{"archive"}}
+	fetcher := newValidationFetcher(t, url,
+		[]VerificationContainer{baseCollectionOnly("chain-id"), archiveOnBaseCollection()}, errors.New("down"))
+
+	_, err := fetcher.ValidateCollections(context.Background())
+	require.Error(t, err, "a node that cannot serve the base collection has nothing narrower to fall back to")
+}
+
+func TestValidateCollections_SkippedVerificationsRefuseNothing(t *testing.T) {
+	url := common.NodeUrl{Url: "https://a", Addons: []string{"archive"}}
+	url.SkipVerifications = []string{common.SkipVerificationsWildcard}
+
+	fetcher := newValidationFetcher(t, url, []VerificationContainer{archiveOnBaseCollection()}, errors.New("down"))
+	admission, err := fetcher.ValidateCollections(context.Background())
+	require.NoError(t, err)
+	require.False(t, admission.Any(), "a verification that never ran cannot refuse anything")
+}
+
+// TestValidateCollections_HealthyProviderRefusesNothing covers the path every
+// healthy provider takes at boot, which no earlier test exercised — every fixture
+// failed, so a build where admission.fail were unreachable would have passed.
+func TestValidateCollections_HealthyProviderRefusesNothing(t *testing.T) {
+	url := common.NodeUrl{Url: "https://a", Addons: []string{"archive"}}
+	// A verification with neither a value nor a latest distance is inactive, so
+	// Verify returns nil without a relay — a genuine pass, not a skip.
+	inactive := archiveOnBaseCollection()
+	inactive.Value = ""
+	inactive.LatestDistance = 0
+
+	fetcher := newValidationFetcher(t, url, []VerificationContainer{inactive}, nil)
+	admission, err := fetcher.ValidateCollections(context.Background())
+	require.NoError(t, err)
+	require.False(t, admission.Any())
+
+	services, keep := admission.AdmittedServices(url)
+	require.True(t, keep)
+	require.Equal(t, []string{"archive"}, services)
+}

--- a/protocol/lavasession/standalone_addons_routing_test.go
+++ b/protocol/lavasession/standalone_addons_routing_test.go
@@ -82,6 +82,18 @@ func TestIsSupportingAddon_StandaloneAddons(t *testing.T) {
 	})
 }
 
+// extensionOnlyEndpoint is the production shape: Addons and Extensions are both
+// built from the same raw url.Addons list, so an extension name lands in both.
+func extensionOnlyEndpoint() *Endpoint {
+	return &Endpoint{
+		NetworkAddress:   "https://archive.example.com",
+		Enabled:          true,
+		Addons:           map[string]struct{}{"archive": {}},
+		Extensions:       map[string]struct{}{"archive": {}},
+		StandaloneAddons: true,
+	}
+}
+
 // TestStandaloneAddonsOnAnExtensionOnlyUrlServesNothing pins WHY the boot path
 // downgrades standalone-addons on a url that names no add-on collection.
 //
@@ -93,13 +105,7 @@ func TestIsSupportingAddon_StandaloneAddons(t *testing.T) {
 // passes — there are no verifications to fail — so a config typo yields a
 // silently dead endpoint. rpcsmartrouter.go downgrades the flag and warns.
 func TestStandaloneAddonsOnAnExtensionOnlyUrlServesNothing(t *testing.T) {
-	extensionOnly := &Endpoint{
-		NetworkAddress:   "https://archive.example.com",
-		Enabled:          true,
-		Addons:           map[string]struct{}{"archive": {}},
-		Extensions:       map[string]struct{}{"archive": {}},
-		StandaloneAddons: true,
-	}
+	extensionOnly := extensionOnlyEndpoint()
 
 	require.False(t, extensionOnly.CheckSupportForServices("", []string{"archive"}),
 		"archive traffic carries addon \"\", so the opt-out refuses it")
@@ -109,7 +115,9 @@ func TestStandaloneAddonsOnAnExtensionOnlyUrlServesNothing(t *testing.T) {
 	// Which is why the flag is downgraded before the endpoint is built. Same
 	// endpoint without it serves both, which is the behaviour an operator who
 	// wrote `addons: [archive]` expects.
-	downgraded := *extensionOnly
+	// Built fresh rather than copied: Endpoint carries a sync.RWMutex, and go vet
+	// rejects copying it.
+	downgraded := extensionOnlyEndpoint()
 	downgraded.StandaloneAddons = false
 	require.True(t, downgraded.CheckSupportForServices("", []string{"archive"}))
 	require.True(t, downgraded.CheckSupportForServices("", nil))

--- a/protocol/rpcsmartrouter/boot_resilience_test.go
+++ b/protocol/rpcsmartrouter/boot_resilience_test.go
@@ -63,7 +63,7 @@ func TestValidateProviderTier_PartitionsAndPreservesConfiguredOrder(t *testing.T
 
 	failedSet, failedOrdered := validateProviderTier(
 		context.Background(), providers, bootTestEndpoint(), nil, reverifyTierStatic,
-		failThese("p6", "p1", "p3"))
+		failThese("p6", "p1", "p3"), nil)
 
 	require.Len(t, failedSet, 3)
 	names := make([]string, 0, len(failedOrdered))
@@ -86,7 +86,7 @@ func TestValidateProviderTier_EmptyTierIsNotAnError(t *testing.T) {
 		func(context.Context, *lavasession.RPCStaticProviderEndpoint) error {
 			t.Fatal("validate must not be called for an empty tier")
 			return nil
-		})
+		}, nil)
 
 	require.Empty(t, failedSet)
 	require.Empty(t, failedOrdered)
@@ -99,7 +99,7 @@ func TestValidateProviderTier_AllProvidersFailingIsReportedNotFatal(t *testing.T
 
 	failedSet, failedOrdered := validateProviderTier(
 		context.Background(), providers, bootTestEndpoint(), nil, reverifyTierStatic,
-		failThese("dead1", "dead2", "dead3"))
+		failThese("dead1", "dead2", "dead3"), nil)
 
 	require.Len(t, failedSet, 3, "every provider failed")
 	require.Len(t, failedOrdered, 3, "and every one is queued for retry rather than aborting boot")
@@ -128,7 +128,7 @@ func TestValidateProviderTier_RunsConcurrently(t *testing.T) {
 				<-release
 				atomic.AddInt64(&inFlight, -1)
 				return nil
-			})
+			}, nil)
 	}()
 
 	require.Eventually(t, func() bool { return atomic.LoadInt64(&inFlight) > 1 }, 5*time.Second, 5*time.Millisecond,

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -2415,6 +2415,27 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	rpsr.sessionManagers[sessionManagerKey] = sessionManager
 	rpsr.mu.Unlock()
 
+	// Per-collection admission (MAG-3326). Refreshed by PHASE 1 below AND by every
+	// epoch re-validation, so a service refused once does not stay refused for the
+	// process lifetime — the endpoint builder runs on the retry and promote paths
+	// too, and a boot-time blip would otherwise outlive its cause until restart.
+	//
+	// Guarded because those paths do not all hold the router lock.
+	var admissionMu sync.RWMutex
+	admissionsByProvider := map[*lavasession.RPCStaticProviderEndpoint]chainlib.ProviderAdmission{}
+	admissionFor := func(provider *lavasession.RPCStaticProviderEndpoint) chainlib.ProviderAdmission {
+		admissionMu.RLock()
+		defer admissionMu.RUnlock()
+		return admissionsByProvider[provider]
+	}
+	recordAdmission := func(provider *lavasession.RPCStaticProviderEndpoint, admission chainlib.ProviderAdmission) {
+		admissionMu.Lock()
+		defer admissionMu.Unlock()
+		// Assigned unconditionally, including an empty admission: that is how a
+		// service that has recovered gets un-refused.
+		admissionsByProvider[provider] = admission
+	}
+
 	// Helper function to convert provider endpoints to sessions
 	convertProvidersToSessions := func(providerList []*lavasession.RPCStaticProviderEndpoint) map[uint64]*lavasession.ConsumerSessionsWithProvider {
 		sessions := make(map[uint64]*lavasession.ConsumerSessionsWithProvider)
@@ -2428,9 +2449,29 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 			}
 
 			endpoints := []*lavasession.Endpoint{}
+			// expandInternalPaths gets the RAW urls. Its subscription probe resolves a
+			// collection from the url's declared add-ons to decide ws-vs-http, and its
+			// doc requires the list it produces to mirror the chain router's, which is
+			// built from the untouched config — so narrowing the input here would move
+			// endpoints in or out per internal path as a side effect of admission
+			// (MAG-3326 review). The admission is applied to each endpoint below instead.
+			admission := admissionFor(provider)
 			for _, url := range expandInternalPaths(provider.NodeUrls, chainParser.GetAllInternalPaths(), subscriptionCollectionProbe(chainParser)) {
+				admittedServices, keep := admission.AdmittedServices(url)
+				if !keep {
+					// A url that serves only its add-ons and kept none has nothing left.
+					// Building it anyway would empty its service list, flip
+					// ServesBaseCollection() to true, and hand a node its operator
+					// declared cannot answer the base collection back to base traffic.
+					utils.LavaFormatWarning("dropping node url: every add-on it declared was refused", nil,
+						utils.LogAttr("url", url.Url),
+						utils.LogAttr("addons", url.Addons),
+						utils.LogAttr("provider", provider.Name),
+					)
+					continue
+				}
 				extensions := map[string]struct{}{}
-				for _, extension := range url.Addons {
+				for _, extension := range admittedServices {
 					extensions[extension] = struct{}{}
 				}
 
@@ -2446,7 +2487,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 				// traffic — a config typo with no diagnostic.
 				standaloneAddons := url.StandaloneAddons
 				if standaloneAddons {
-					declaredAddons, _, sepErr := chainParser.SeparateAddonsExtensions(ctx, url.Addons)
+					declaredAddons, _, sepErr := chainParser.SeparateAddonsExtensions(ctx, admittedServices)
 					if sepErr != nil || len(declaredAddons) == 0 {
 						utils.LavaFormatWarning("ignoring standalone-addons: url declares no add-on collection", sepErr,
 							utils.LogAttr("url", url.Url),
@@ -2586,9 +2627,9 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	// relaysMonitor seeding below), so it is pulled from rotation rather than
 	// silently accepting traffic it cannot serve.
 	failedStaticSet, failedStaticEndpoints := validateProviderTier(
-		ctx, relevantStaticProviderList, rpcEndpoint, chainParser, reverifyTierStatic, nil)
+		ctx, relevantStaticProviderList, rpcEndpoint, chainParser, reverifyTierStatic, nil, recordAdmission)
 	failedBackupSet, failedBackupEndpoints := validateProviderTier(
-		ctx, relevantBackupProviderList, rpcEndpoint, chainParser, reverifyTierBackup, nil)
+		ctx, relevantBackupProviderList, rpcEndpoint, chainParser, reverifyTierBackup, nil, recordAdmission)
 
 	healthyStaticCount := len(relevantStaticProviderList) - len(failedStaticSet)
 	healthyBackupCount := len(relevantBackupProviderList) - len(failedBackupSet)
@@ -2635,6 +2676,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 		chainParser:                chainParser,
 		rpcEndpoint:                rpcEndpoint,
 		convertProvidersToSessions: convertProvidersToSessions,
+		recordAdmission:            recordAdmission,
 		configuredStatic:           relevantStaticProviderList,
 		configuredBackup:           relevantBackupProviderList,
 	}

--- a/protocol/rpcsmartrouter/spec_reverifier.go
+++ b/protocol/rpcsmartrouter/spec_reverifier.go
@@ -77,6 +77,10 @@ type chainReverifyInputs struct {
 	// to validateProvider (real network probe). Tests inject a fake to exercise
 	// updateEpoch's orchestration without standing up upstreams.
 	validateFn func(context.Context, *lavasession.RPCStaticProviderEndpoint) error
+	// recordAdmission publishes a freshly computed per-collection admission so the
+	// endpoint builder stops using the boot-time one. Nil in tests that do not
+	// build endpoints.
+	recordAdmission func(*lavasession.RPCStaticProviderEndpoint, chainlib.ProviderAdmission)
 	// demoteFailStreak counts CONSECUTIVE failed re-verify cycles per active provider, keyed
 	// "<tier>|<name>" so a name configured in both tiers cannot share a counter. It is the only
 	// state that survives between epoch ticks, and it exists so a transient outage overlapping
@@ -197,7 +201,24 @@ func applyReverification(
 	probe := inputs.validateFn
 	if probe == nil {
 		probe = func(c context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
-			return validateProvider(c, p, inputs.chainParser, SpecReVerifyAttemptTimeout)
+			// Per-collection here too (MAG-3326). With the all-or-nothing Validate
+			// this path re-probed the UNSTRIPPED config every tick, failed on the
+			// same refused service, and demoted the whole provider once
+			// demoteFailStreak reached reverifyDemoteThreshold — undoing the boot
+			// admission about two ticks after boot, into a worse state than before.
+			//
+			// Recording the fresh admission on every tick is also what keeps a
+			// refusal from outliving the failure that caused it: a service that
+			// recovers is re-admitted at the next tick instead of staying refused
+			// until the process restarts.
+			admission, err := validateProviderCollections(c, p, inputs.chainParser, SpecReVerifyAttemptTimeout)
+			if err != nil {
+				return err
+			}
+			if inputs.recordAdmission != nil {
+				inputs.recordAdmission(p, admission)
+			}
+			return nil
 		}
 	}
 	if inputs.rateLimitHoldoff == nil {
@@ -439,14 +460,25 @@ func validateProviderTier(
 	chainParser chainlib.ChainParser,
 	tier reverifyTier,
 	validate func(context.Context, *lavasession.RPCStaticProviderEndpoint) error,
+	recordAdmission func(*lavasession.RPCStaticProviderEndpoint, chainlib.ProviderAdmission),
 ) (map[*lavasession.RPCStaticProviderEndpoint]struct{}, []*lavasession.RPCStaticProviderEndpoint) {
 	failedSet := make(map[*lavasession.RPCStaticProviderEndpoint]struct{})
 	if len(providers) == 0 {
 		return failedSet, nil
 	}
 	if validate == nil {
+		// Per-collection at boot, recording what each provider was admitted for.
+		// Returning nil for a service-attributable failure is the point: the
+		// provider stays, minus that service (MAG-3326).
 		validate = func(c context.Context, p *lavasession.RPCStaticProviderEndpoint) error {
-			return validateProvider(c, p, chainParser, BootValidateTimeout)
+			admission, err := validateProviderCollections(c, p, chainParser, BootValidateTimeout)
+			if err != nil {
+				return err
+			}
+			if recordAdmission != nil {
+				recordAdmission(p, admission)
+			}
+			return nil
 		}
 	}
 
@@ -538,6 +570,33 @@ func validateProvider(
 	chainParser chainlib.ChainParser,
 	timeout time.Duration,
 ) error {
+	_, err := validateProviderImpl(ctx, provider, chainParser, timeout, false)
+	return err
+}
+
+// validateProviderCollections is validateProvider with per-collection admission
+// (MAG-3326): a service whose verification fails is refused on its own and the
+// provider survives with the rest.
+func validateProviderCollections(
+	ctx context.Context,
+	provider *lavasession.RPCStaticProviderEndpoint,
+	chainParser chainlib.ChainParser,
+	timeout time.Duration,
+) (chainlib.ProviderAdmission, error) {
+	return validateProviderImpl(ctx, provider, chainParser, timeout, true)
+}
+
+// validateProviderImpl is the one body both share. The boot probe and the epoch
+// probe must behave identically apart from their attribution mode, and this area
+// has already paid for a hand-kept copy once — keeping them one function means a
+// change to the temporary router's lifetime cannot land in only one of them.
+func validateProviderImpl(
+	ctx context.Context,
+	provider *lavasession.RPCStaticProviderEndpoint,
+	chainParser chainlib.ChainParser,
+	timeout time.Duration,
+	perCollection bool,
+) (chainlib.ProviderAdmission, error) {
 	routerEndpoint, fetcherEndpoint := verificationEndpoints(provider)
 
 	attemptCtx, attemptCancel := context.WithTimeout(ctx, timeout)
@@ -554,7 +613,7 @@ func validateProvider(
 	parallelConnections := uint(lavasession.DefaultMaximumStreamsOverASingleConnection)
 	verificationRouter, err := chainlib.GetChainRouter(attemptCtx, parallelConnections, routerEndpoint, validationParser)
 	if err != nil {
-		return err
+		return chainlib.ProviderAdmission{}, err
 	}
 
 	verificationFetcher := chainlib.NewChainFetcher(attemptCtx, &chainlib.ChainFetcherOptions{
@@ -564,5 +623,8 @@ func validateProvider(
 		Cache:       nil,
 	})
 
-	return verificationFetcher.Validate(attemptCtx)
+	if perCollection {
+		return verificationFetcher.ValidateCollections(attemptCtx)
+	}
+	return chainlib.ProviderAdmission{}, verificationFetcher.Validate(attemptCtx)
 }


### PR DESCRIPTION
# Description

Reworks [#358](https://github.com/Magma-Devs/smart-router/pull/358) (MAG-3326) after review found the original commit did not deliver the ticket. Off `main` directly. **#358 should be closed in favour of this.**

The review is on #358; this is what it produced. Three correctness problems, all with tests built on the container shapes `specs/` actually produces — the previous suite could not catch any of them because its fixtures manufactured a shape no spec builds.

## 1. The motivating case was not fixed

The ticket exists to stop *"attach an archive url to an otherwise healthy provider, have it fail the archive check, lose the provider."* It still lost the provider.

Attribution charged a failure to `verification.Addon` alone. But a `VerificationContainer` carries **both** an `Addon` and an `Extension`, and every EVM and cosmos spec keys the archive check as an **extension on the base collection**. From `specs/ethereum.json`:

```
collection add_on='' | verification=pruning | extension='archive' | severity=None
```

so `Addon == ""` and the fatal path fired. `refusedServiceFor` now charges the **extension first**, falling back to the add-on. That is also the right answer for ethereum's `{Addon:"trace", Extension:"archive"}`: what failed is the node's archive-ness, so refusing `trace` would drop working traffic *and* leave the failing extension advertised.

## 2. The epoch path undid the boot rescue

For the case that did work, it survived about two ticks. `applyReverification` re-probed the **unstripped** config with the all-or-nothing `Validate` on every tick, failed on the same refused service, and demoted the whole provider once `demoteFailStreak` reached `reverifyDemoteThreshold` — into a worse state than before the change, with no path back (promotion needs a clean all-or-nothing pass, and it is not in `failedStaticProviders` for the retry loop). It probes per-collection now.

## 3. A standalone-addons url that kept nothing flipped to serving base

Emptying `Addons` makes `ServesBaseCollection()` return true, so a node whose operator declared it cannot answer the base surface was handed base traffic — the MAG-3296 failure re-entered from the other side. `AdmittedServices` reports `keep=false` for such a url and the boot path drops it with a warning.

## Also addressed from the review

- **Admissions were frozen at boot.** The endpoint builder is also the retry and promote path, so a transient blip refused a service until process restart — the permanence the copy semantics were chosen to avoid, relocated into the map. They are recorded under a lock by boot **and** by every epoch re-validation, so a recovered service is re-admitted at the next tick.
- **`expandInternalPaths` was fed stripped urls.** Its subscription probe resolves a collection from the declared add-ons to decide ws-vs-http, and its doc requires its output to mirror the chain router's, which is built from the untouched config. The admission is applied per-endpoint instead, so both see the same raw urls.
- **`validateProvider` and the per-collection variant share one body** rather than being a hand-kept copy that must not drift.
- **The composite key is a comparable struct**, not a NUL-joined string.
- **`AdmittedServices` returns the input slice when nothing was refused** — the common case on every rebuild. The test asserts slice *identity*, since a deep compare would not notice the allocation coming back.
- **A passing verification is covered** — the path every healthy provider takes at boot, which nothing exercised before. Every previous fixture failed, so a build where the refusal branch was unreachable would have passed.

Also fixes a `go vet` failure (`copies lock value`) in a test added on #345.

## Most critical to review

- `chain_fetcher.go` — `refusedServiceFor` (extension-first is the whole correctness of the feature) and `AdmittedServices` (the `keep=false` case).
- `spec_reverifier.go` — the epoch probe and the shared `validateProviderImpl`.
- `rpcsmartrouter.go` — the guarded admission store and where it is refreshed.

## Not covered

Not exercised against a live upstream: the discriminating case needs a node that passes the base collection and fails one service, which none of the Acala or Shiden endpoints does. The unit tests drive both entry points through the same verification set instead — `ValidateCollections` returns no error where `Validate` on identical input returns one, so the two paths cannot silently converge.

`go build ./...`, `go vet ./protocol/...` and the full `./protocol/...` suite are green.

## Jira ticket

Jira ticket: MAG-3326

---

## Author Checklist

I have...

* [x] read the [contribution guide](https://github.com/magma-Devs/smart-router/blob/main/CONTRIBUTING.md)
* [x] included the correct type prefix in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change — n/a; `validateProviderTier` is package-private and `Validate` keeps its signature and semantics
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests
* [x] updated the relevant documentation or specification, including comments for documenting Go code
* [ ] confirmed all CI checks have passed — pending first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHyKbFQzzmj9e1bE9yKRa
