### PR TITLE
fix(rpcsmartrouter): relay subscription pushes named after their payload (MAG-3345)

### DIFF
--- a/protocol/chainlib/chainproxy/rpcclient/handler.go
+++ b/protocol/chainlib/chainproxy/rpcclient/handler.go
@@ -241,6 +241,11 @@ func (h *handler) handleImmediate(msg *JsonrpcMessage) bool {
 			h.handleSubscriptionResultEthereum(msg)
 			return true
 		} else if strings.HasSuffix(msg.Method, solanaNotificationMethodSuffix) {
+			// Unreachable: isEthereumNotification above already required the
+			// "_subscription" suffix, which no *Notification method has. Solana frames
+			// are served by the isSubscriptionNotification case below instead — left
+			// in place only so removing it is not confused with a behaviour change
+			// (MAG-3359).
 			h.handleSubscriptionResultSolana(msg)
 			return true
 		}
@@ -273,17 +278,16 @@ func (h *handler) handleImmediate(msg *JsonrpcMessage) bool {
 // fell through to handleCallMsg, which has no id and no matching method to serve, so the
 // router answered the node with an "invalid request" error for every push it received.
 func (h *handler) handleSubscriptionResultByParams(msg *JsonrpcMessage) {
-	var result ethereumSubscriptionResult
-	if err := json.Unmarshal(msg.Params, &result); err != nil {
+	id, ok := subscriptionIDFromParams(msg.Params)
+	if !ok {
 		utils.LavaFormatTrace("Dropping invalid subscription message",
-			utils.LogAttr("err", err),
 			utils.LogAttr("params", string(msg.Params)),
 		)
 		h.log.Debug("Dropping invalid subscription message")
 		return
 	}
-	if h.clientSubs[result.ID] != nil {
-		h.clientSubs[result.ID].deliver(msg)
+	if h.clientSubs[id] != nil {
+		h.clientSubs[id].deliver(msg)
 	}
 }
 

--- a/protocol/chainlib/chainproxy/rpcclient/handler.go
+++ b/protocol/chainlib/chainproxy/rpcclient/handler.go
@@ -17,6 +17,7 @@
 package rpcclient
 
 import (
+	"bytes"
 	"context"
 	"reflect"
 	"strconv"
@@ -299,7 +300,10 @@ func (h *handler) deliverSubscriptionPush(msg *JsonrpcMessage, subscriptionID st
 		sub.deliver(msg)
 		return true
 	}
-	if msg.hasValidID() {
+	// An explicit "id":null is not a request id — hasValidID only rejects objects and
+	// arrays, so `null` passes it. Letting that through to the call path answers the node
+	// with "invalid request" for a late push, which is the MAG-3345 symptom itself.
+	if msg.hasValidID() && !bytes.Equal(msg.ID, null) {
 		return false
 	}
 	// Late frames after an unsubscribe land here routinely, so this is a trace and not a

--- a/protocol/chainlib/chainproxy/rpcclient/handler.go
+++ b/protocol/chainlib/chainproxy/rpcclient/handler.go
@@ -255,8 +255,35 @@ func (h *handler) handleImmediate(msg *JsonrpcMessage) bool {
 		h.handleResponse(msg)
 		h.log.Trace("Handled RPC response", "reqid", idForLog{msg.ID}, "duration", time.Since(start))
 		return true
+	case msg.isSubscriptionNotification():
+		// Last, so the method-name cases above keep first claim on anything they
+		// already recognise. This one matches on the params envelope alone, which is
+		// how Substrate pushes arrive — see isSubscriptionNotification.
+		h.handleSubscriptionResultByParams(msg)
+		return true
 	default:
 		return false
+	}
+}
+
+// handleSubscriptionResultByParams delivers a subscription notification identified by its
+// params envelope rather than by its method name.
+//
+// Returning false for these from handleImmediate was worse than dropping them: the frame
+// fell through to handleCallMsg, which has no id and no matching method to serve, so the
+// router answered the node with an "invalid request" error for every push it received.
+func (h *handler) handleSubscriptionResultByParams(msg *JsonrpcMessage) {
+	var result ethereumSubscriptionResult
+	if err := json.Unmarshal(msg.Params, &result); err != nil {
+		utils.LavaFormatTrace("Dropping invalid subscription message",
+			utils.LogAttr("err", err),
+			utils.LogAttr("params", string(msg.Params)),
+		)
+		h.log.Debug("Dropping invalid subscription message")
+		return
+	}
+	if h.clientSubs[result.ID] != nil {
+		h.clientSubs[result.ID].deliver(msg)
 	}
 }
 

--- a/protocol/chainlib/chainproxy/rpcclient/handler.go
+++ b/protocol/chainlib/chainproxy/rpcclient/handler.go
@@ -243,13 +243,32 @@ func (h *handler) handleImmediate(msg *JsonrpcMessage) bool {
 		} else if strings.HasSuffix(msg.Method, solanaNotificationMethodSuffix) {
 			// Unreachable: isEthereumNotification above already required the
 			// "_subscription" suffix, which no *Notification method has. Solana frames
-			// are served by the isSubscriptionNotification case below instead — left
-			// in place only so removing it is not confused with a behaviour change
-			// (MAG-3359).
+			// are served by the shape-based case below instead — left in place only so
+			// removing it is not confused with a behaviour change (MAG-3359).
 			h.handleSubscriptionResultSolana(msg)
 			return true
 		}
 		return false
+	case msg.Method != "" && msg.Params != nil:
+		// Shape-based delivery: a method-bearing frame whose params name a subscription.
+		// The method-name cases above keep first claim on anything they already
+		// recognise; this catches the rest, which is how Substrate and Solana pushes
+		// arrive — see subscriptionIDFromParams.
+		//
+		// It sits BEFORE the StarkNet case deliberately. That predicate matches any
+		// id-less method-bearing frame carrying a result, so a push that also sets a
+		// top-level result would be swallowed there and answered with "invalid request"
+		// — the very MAG-3345 symptom this exists to remove. StarkNet's own frames put
+		// the id in result and carry no params, so they never enter this case.
+		//
+		// The id is parsed once and handed to the delivery path. The sibling handlers
+		// above re-parse inside the handler, which here would mean decoding the whole
+		// payload twice for every frame delivered.
+		id, named := subscriptionIDFromParams(msg.Params)
+		if !named {
+			return false
+		}
+		return h.deliverSubscriptionPush(msg, id)
 	case msg.isStarkNetPathfinderNotification():
 		if strings.HasSuffix(msg.Method, ethereumNotificationMethodSuffix) {
 			h.handleSubscriptionResultStarkNetPathfinder(msg)
@@ -260,35 +279,38 @@ func (h *handler) handleImmediate(msg *JsonrpcMessage) bool {
 		h.handleResponse(msg)
 		h.log.Trace("Handled RPC response", "reqid", idForLog{msg.ID}, "duration", time.Since(start))
 		return true
-	case msg.isSubscriptionNotification():
-		// Last, so the method-name cases above keep first claim on anything they
-		// already recognise. This one matches on the params envelope alone, which is
-		// how Substrate pushes arrive — see isSubscriptionNotification.
-		h.handleSubscriptionResultByParams(msg)
-		return true
 	default:
 		return false
 	}
 }
 
-// handleSubscriptionResultByParams delivers a subscription notification identified by its
-// params envelope rather than by its method name.
+// deliverSubscriptionPush hands a push frame to the subscription it names, reporting
+// whether this handler claimed the frame.
 //
-// Returning false for these from handleImmediate was worse than dropping them: the frame
-// fell through to handleCallMsg, which has no id and no matching method to serve, so the
-// router answered the node with an "invalid request" error for every push it received.
-func (h *handler) handleSubscriptionResultByParams(msg *JsonrpcMessage) {
-	id, ok := subscriptionIDFromParams(msg.Params)
-	if !ok {
-		utils.LavaFormatTrace("Dropping invalid subscription message",
-			utils.LogAttr("params", string(msg.Params)),
-		)
-		h.log.Debug("Dropping invalid subscription message")
-		return
+// Claiming matters as much as delivering. Before MAG-3345 an unrecognised push fell
+// through to handleCallMsg, which had no id and no matching method to serve, so the router
+// answered the node with an "invalid request" for every frame it received. But a frame that
+// carries a request id is a request the peer expects answered, and swallowing it silently
+// would leave the peer waiting on a reply that never comes — so an id-bearing frame that
+// matches no subscription is handed back to the call path, while an id-less one (a genuine
+// JSON-RPC notification, which nobody is waiting on) is claimed and dropped with a trace.
+func (h *handler) deliverSubscriptionPush(msg *JsonrpcMessage, subscriptionID string) bool {
+	if sub := h.clientSubs[subscriptionID]; sub != nil {
+		sub.deliver(msg)
+		return true
 	}
-	if h.clientSubs[id] != nil {
-		h.clientSubs[id].deliver(msg)
+	if msg.hasValidID() {
+		return false
 	}
+	// Late frames after an unsubscribe land here routinely, so this is a trace and not a
+	// warning — but it is logged, because a subscription registered under a key the push
+	// does not name is otherwise indistinguishable from a healthy idle one, which is
+	// exactly the failure mode MAG-3345 was.
+	utils.LavaFormatTrace("Dropping subscription push with no matching subscription",
+		utils.LogAttr("method", msg.Method),
+		utils.LogAttr("subscriptionID", subscriptionID),
+	)
+	return true
 }
 
 func (h *handler) handleSubscriptionResultStarkNetPathfinder(msg *JsonrpcMessage) {
@@ -382,11 +404,12 @@ func (h *handler) handleResponse(msg *JsonrpcMessage) {
 		go op.sub.run()
 		h.clientSubs[op.sub.subid] = op.sub
 	} else {
-		// This is because StarkNet Pathfinder is returning an integer instead of a string in the result
-		var integerSubId int
+		// This is because StarkNet Pathfinder is returning an integer instead of a string in the result.
+		// int64 rather than int so this key cannot drift from CanonicalSubscriptionID's on a 32-bit build.
+		var integerSubId int64
 		if json.Unmarshal(msg.Result, &integerSubId) == nil {
 			op.err = nil
-			op.sub.subid = strconv.Itoa(integerSubId)
+			op.sub.subid = strconv.FormatInt(integerSubId, 10)
 			go op.sub.run()
 			h.clientSubs[op.sub.subid] = op.sub
 		}

--- a/protocol/chainlib/chainproxy/rpcclient/json.go
+++ b/protocol/chainlib/chainproxy/rpcclient/json.go
@@ -97,6 +97,34 @@ func (msg *JsonrpcMessage) isEthereumNotification() bool {
 		strings.HasSuffix(msg.Method, ethereumNotificationMethodSuffix)
 }
 
+// isSubscriptionNotification recognises a server-to-client subscription push by its
+// shape rather than by its method name: a method-bearing message whose params name a
+// string subscription.
+//
+// Every predicate above keys off the method name, which only works for chains that
+// name the frame after the subscription mechanism (eth_subscription, *Notification).
+// Substrate names it after the payload — chain_newHead, state_storage,
+// author_extrinsicUpdate — while using the identical {subscription, result} params
+// envelope as Ethereum. No suffix rule can cover that, so nothing delivered those
+// frames and every Substrate subscription was silently dead (MAG-3345).
+//
+// The string check keeps this off Solana, whose ids are integers. Solana pushes are
+// unhandled today for a separate reason — handleImmediate's solana branch sits inside
+// the isEthereumNotification case, and that predicate itself requires the
+// "_subscription" suffix, which "accountNotification" does not have, so the branch is
+// unreachable. Delivering them needs an integer-id router mapping the id mapper cannot
+// express, which is its own change; MAG-3345 is the Substrate gap.
+func (msg *JsonrpcMessage) isSubscriptionNotification() bool {
+	if msg.Method == "" || msg.Params == nil {
+		return false
+	}
+	var result ethereumSubscriptionResult
+	if err := json.Unmarshal(msg.Params, &result); err != nil {
+		return false
+	}
+	return result.ID != ""
+}
+
 func (msg *JsonrpcMessage) isTendermintNotification() bool {
 	var result tendermintSubscribeReply
 	err := json.Unmarshal(msg.Result, &result)

--- a/protocol/chainlib/chainproxy/rpcclient/json.go
+++ b/protocol/chainlib/chainproxy/rpcclient/json.go
@@ -139,30 +139,6 @@ func subscriptionIDFromParams(params json.RawMessage) (string, bool) {
 	return CanonicalSubscriptionID(envelope.Subscription)
 }
 
-// isSubscriptionNotification recognises a server-to-client subscription push by its
-// shape rather than by its method name: a method-bearing message whose params name a
-// subscription.
-//
-// Every predicate above keys off the method name, which only works for chains that
-// name the frame after the subscription mechanism (eth_subscription, *Notification).
-// Substrate names it after the payload — chain_newHead, state_storage,
-// author_extrinsicUpdate — while using the identical {subscription, result} params
-// envelope as Ethereum. No suffix rule can cover that, so nothing delivered those
-// frames and every Substrate subscription was silently dead (MAG-3345).
-//
-// Solana frames (accountNotification and friends) reach this case too, and for the same
-// reason: the solana branch above is unreachable, because its enclosing
-// isEthereumNotification requires the "_subscription" suffix that accountNotification
-// does not have. They differ only in numbering the subscription rather than naming it,
-// which CanonicalSubscriptionID absorbs (MAG-3359).
-func (msg *JsonrpcMessage) isSubscriptionNotification() bool {
-	if msg.Method == "" || msg.Params == nil {
-		return false
-	}
-	_, ok := subscriptionIDFromParams(msg.Params)
-	return ok
-}
-
 func (msg *JsonrpcMessage) isTendermintNotification() bool {
 	var result tendermintSubscribeReply
 	err := json.Unmarshal(msg.Result, &result)

--- a/protocol/chainlib/chainproxy/rpcclient/json.go
+++ b/protocol/chainlib/chainproxy/rpcclient/json.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -97,9 +98,50 @@ func (msg *JsonrpcMessage) isEthereumNotification() bool {
 		strings.HasSuffix(msg.Method, ethereumNotificationMethodSuffix)
 }
 
+// CanonicalSubscriptionID renders a raw JSON subscription id in the decimal-string form
+// the client dispatcher keys subscriptions under, and reports whether raw named one at all.
+//
+// A string id is used verbatim. A numbered id is rendered with strconv, matching how
+// handleResponse registers one: a node that answers subscribe with a number lands in the
+// integer fallback there and is stored under strconv.Itoa of it. Keying both shapes the
+// same way is what lets one lookup serve every chain — and why this is exported: the
+// router canonicalises upstream ids with it too, and a divergence between the two would
+// silently drop every push.
+//
+// Solana is the only supported chain that numbers its subscriptions (MAG-3359).
+func CanonicalSubscriptionID(raw json.RawMessage) (string, bool) {
+	if len(raw) == 0 {
+		return "", false
+	}
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		return asString, asString != ""
+	}
+	var asNumber int64
+	if err := json.Unmarshal(raw, &asNumber); err == nil {
+		return strconv.FormatInt(asNumber, 10), true
+	}
+	return "", false
+}
+
+// subscriptionIDFromParams returns the subscription named by a push frame's params
+// envelope, canonicalised for the clientSubs lookup.
+func subscriptionIDFromParams(params json.RawMessage) (string, bool) {
+	if params == nil {
+		return "", false
+	}
+	var envelope struct {
+		Subscription json.RawMessage `json:"subscription"`
+	}
+	if err := json.Unmarshal(params, &envelope); err != nil {
+		return "", false
+	}
+	return CanonicalSubscriptionID(envelope.Subscription)
+}
+
 // isSubscriptionNotification recognises a server-to-client subscription push by its
 // shape rather than by its method name: a method-bearing message whose params name a
-// string subscription.
+// subscription.
 //
 // Every predicate above keys off the method name, which only works for chains that
 // name the frame after the subscription mechanism (eth_subscription, *Notification).
@@ -108,21 +150,17 @@ func (msg *JsonrpcMessage) isEthereumNotification() bool {
 // envelope as Ethereum. No suffix rule can cover that, so nothing delivered those
 // frames and every Substrate subscription was silently dead (MAG-3345).
 //
-// The string check keeps this off Solana, whose ids are integers. Solana pushes are
-// unhandled today for a separate reason — handleImmediate's solana branch sits inside
-// the isEthereumNotification case, and that predicate itself requires the
-// "_subscription" suffix, which "accountNotification" does not have, so the branch is
-// unreachable. Delivering them needs an integer-id router mapping the id mapper cannot
-// express, which is its own change; MAG-3345 is the Substrate gap.
+// Solana frames (accountNotification and friends) reach this case too, and for the same
+// reason: the solana branch above is unreachable, because its enclosing
+// isEthereumNotification requires the "_subscription" suffix that accountNotification
+// does not have. They differ only in numbering the subscription rather than naming it,
+// which CanonicalSubscriptionID absorbs (MAG-3359).
 func (msg *JsonrpcMessage) isSubscriptionNotification() bool {
 	if msg.Method == "" || msg.Params == nil {
 		return false
 	}
-	var result ethereumSubscriptionResult
-	if err := json.Unmarshal(msg.Params, &result); err != nil {
-		return false
-	}
-	return result.ID != ""
+	_, ok := subscriptionIDFromParams(msg.Params)
+	return ok
 }
 
 func (msg *JsonrpcMessage) isTendermintNotification() bool {

--- a/protocol/chainlib/chainproxy/rpcclient/subscription_notification_test.go
+++ b/protocol/chainlib/chainproxy/rpcclient/subscription_notification_test.go
@@ -1,0 +1,86 @@
+package rpcclient
+
+import (
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCanonicalSubscriptionID covers the identity every subscription lookup is keyed on.
+// Strings pass through; numbers become their decimal form, matching how handleResponse
+// registers a node that answers subscribe with a number (MAG-3359).
+func TestCanonicalSubscriptionID(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		raw   string
+		want  string
+		named bool
+	}{
+		{"ethereum hex", `"0x9ce59a13059e417087c02d3236a0b1cc"`, "0x9ce59a13059e417087c02d3236a0b1cc", true},
+		{"substrate opaque", `"Ck1rTHhOa1hxTGV3"`, "Ck1rTHhOa1hxTGV3", true},
+		{"solana number", `23784`, "23784", true},
+		{"large number stays exact", `9007199254740993`, "9007199254740993", true},
+		{"empty string names nothing", `""`, "", false},
+		{"null names nothing", `null`, "", false},
+		{"object names nothing", `{"query":"tm.event='NewBlock'"}`, "", false},
+		{"float is not a subscription id", `1.5`, "", false},
+		{"absent", ``, "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, named := CanonicalSubscriptionID(json.RawMessage(tc.raw))
+			assert.Equal(t, tc.named, named)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestIsSubscriptionNotification pins which frames the shape-based case claims. It runs last
+// in handleImmediate, so it only ever sees what the method-name cases above declined.
+func TestIsSubscriptionNotification(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		msg  *JsonrpcMessage
+		want bool
+	}{
+		{
+			"substrate push",
+			&JsonrpcMessage{Method: "chain_newHead", Params: json.RawMessage(`{"subscription":"Ck1rTHhOa1hxTGV3","result":{}}`)},
+			true,
+		},
+		{
+			"solana push",
+			&JsonrpcMessage{Method: "accountNotification", Params: json.RawMessage(`{"subscription":23784,"result":{}}`)},
+			true,
+		},
+		{
+			"ethereum push (already claimed above, but the shape still matches)",
+			&JsonrpcMessage{Method: "eth_subscription", Params: json.RawMessage(`{"subscription":"0xabc","result":{}}`)},
+			true,
+		},
+		{
+			"a call with positional params names no subscription",
+			&JsonrpcMessage{ID: json.RawMessage(`1`), Method: "eth_getBalance", Params: json.RawMessage(`["0xabc","latest"]`)},
+			false,
+		},
+		{
+			"params without a subscription field",
+			&JsonrpcMessage{Method: "someNotification", Params: json.RawMessage(`{"result":{}}`)},
+			false,
+		},
+		{
+			"a response carries no method",
+			&JsonrpcMessage{ID: json.RawMessage(`1`), Result: json.RawMessage(`"0xabc"`)},
+			false,
+		},
+		{
+			"tendermint puts its identity in result, not params",
+			&JsonrpcMessage{Method: "", Result: json.RawMessage(`{"query":"tm.event='NewBlock'"}`)},
+			false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.msg.isSubscriptionNotification())
+		})
+	}
+}

--- a/protocol/chainlib/chainproxy/rpcclient/subscription_notification_test.go
+++ b/protocol/chainlib/chainproxy/rpcclient/subscription_notification_test.go
@@ -35,9 +35,10 @@ func TestCanonicalSubscriptionID(t *testing.T) {
 	}
 }
 
-// TestIsSubscriptionNotification pins which frames the shape-based case claims. It runs last
-// in handleImmediate, so it only ever sees what the method-name cases above declined.
-func TestIsSubscriptionNotification(t *testing.T) {
+// TestSubscriptionIDFromParams pins which frames the shape-based dispatch case claims. The
+// case guards on method and params being present before calling this, so the cases below
+// cover what it decides once past that guard.
+func TestSubscriptionIDFromParams(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		msg  *JsonrpcMessage
@@ -80,7 +81,8 @@ func TestIsSubscriptionNotification(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, tc.msg.isSubscriptionNotification())
+			_, ok := subscriptionIDFromParams(tc.msg.Params)
+			assert.Equal(t, tc.want, ok && tc.msg.Method != "")
 		})
 	}
 }

--- a/protocol/chainlib/chainproxy/rpcclient/subscription_notification_test.go
+++ b/protocol/chainlib/chainproxy/rpcclient/subscription_notification_test.go
@@ -1,6 +1,7 @@
 package rpcclient
 
 import (
+	"context"
 	"testing"
 
 	"github.com/goccy/go-json"
@@ -83,6 +84,50 @@ func TestSubscriptionIDFromParams(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, ok := subscriptionIDFromParams(tc.msg.Params)
 			assert.Equal(t, tc.want, ok && tc.msg.Method != "")
+		})
+	}
+}
+
+// stubConn is the minimal jsonWriter newHandler needs.
+type stubConn struct{ closedCh chan interface{} }
+
+func (s *stubConn) writeJSON(context.Context, interface{}) error { return nil }
+func (s *stubConn) closed() <-chan interface{}                   { return s.closedCh }
+func (s *stubConn) remoteAddr() string                           { return "stub" }
+
+func newTestHandler() *handler {
+	return newHandler(context.Background(), &stubConn{closedCh: make(chan interface{})},
+		func() ID { return ID("1") }, &serviceRegistry{})
+}
+
+// TestDeliverSubscriptionPush_ClaimsUnmatchedNotifications covers which unmatched frames the
+// dispatcher keeps and which it hands back to the call path.
+//
+// Handing one back means the router answers the node with "invalid request" — the MAG-3345
+// symptom. That is right for a request the peer is waiting on, and wrong for a push. The
+// distinction is the request id, and `"id":null` is the trap: hasValidID only rejects objects
+// and arrays, so a literal null passes it while meaning the opposite.
+func TestDeliverSubscriptionPush_ClaimsUnmatchedNotifications(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		id        json.RawMessage
+		wantClaim bool
+	}{
+		{"no id — a notification, nobody is waiting", nil, true},
+		{`explicit "id":null is still a notification`, json.RawMessage(`null`), true},
+		{"numeric id — a request that needs an answer", json.RawMessage(`7`), false},
+		{"string id — a request that needs an answer", json.RawMessage(`"abc"`), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler()
+			msg := &JsonrpcMessage{
+				Version: Vsn,
+				ID:      tc.id,
+				Method:  "chain_newHead",
+				Params:  json.RawMessage(`{"subscription":"nobody-is-subscribed","result":{}}`),
+			}
+			assert.Equal(t, tc.wantClaim, h.deliverSubscriptionPush(msg, "nobody-is-subscribed"),
+				"claiming an unmatched frame suppresses the invalid-request reply to the node")
 		})
 	}
 }

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
@@ -1,6 +1,7 @@
 package rpcsmartrouter
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -43,10 +44,15 @@ type directActiveSubscription struct {
 	subscribeMethod    string // Method name (e.g., "eth_subscribe", "subscribe")
 
 	// numericIDs records that this chain numbers its subscriptions rather than naming
-	// them, read from the subscribe response the node actually sent. It is a property of
-	// the chain, so it survives a reconnect even though upstreamID does not. Only the two
-	// places that cannot read the shape off the message in front of them consult it: the
-	// id issued to a joining client, and the param sent upstream on unsubscribe.
+	// them, read once from the subscribe response the node actually sent. It is a property
+	// of the chain, so it survives a reconnect even though upstreamID does not.
+	//
+	// It is the ONLY source of this fact. Every site that renders an id for the wire — the
+	// subscribe reply, a joining client's reply, the per-frame rewrite, the param sent
+	// upstream on teardown — reads it rather than re-sniffing whatever JSON is nearest,
+	// because re-deriving invites the sites to disagree: an upstream that numbers the
+	// subscribe result but quotes the id in its pushes would otherwise hand the client a
+	// number at subscribe time and quoted ids in every frame after.
 	numericIDs bool
 
 	// Client tracking - multiple clients can share one upstream subscription
@@ -771,7 +777,7 @@ func (dwsm *DirectWSSubscriptionManager) StartSubscription(
 	// requestID is the client's original JSON-RPC id (extracted at the top of this function);
 	// passing it explicitly ensures the response echoes the caller's id verbatim, including
 	// non-numeric ids like string UUIDs (JSON-RPC 2.0 §4.2).
-	firstReplyData, err := createSubscriptionReply(routerID, requestID, firstMsg, dwsm.apiInterface)
+	firstReplyData, err := createSubscriptionReply(routerID, requestID, firstMsg, dwsm.apiInterface, numericIDs)
 	if err != nil {
 		upstreamSub.Unsubscribe()
 		dwsm.failPendingSubscription(hashedParams)
@@ -1137,7 +1143,6 @@ func (dwsm *DirectWSSubscriptionManager) UnsubscribeAll(
 	return nil
 }
 
-// getHashedParams extracts and hashes the subscription parameters from a protocol message
 // generateRouterID issues a router subscription id shaped like the ones this chain uses.
 //
 // Chains that number their subscriptions get a number, because the client hands the id
@@ -1152,6 +1157,7 @@ func (dwsm *DirectWSSubscriptionManager) generateRouterID(clientKey string, nume
 	return dwsm.idMapper.GenerateRouterID(clientKey)
 }
 
+// getHashedParams extracts and hashes the subscription parameters from a protocol message
 func (dwsm *DirectWSSubscriptionManager) getHashedParams(protocolMessage chainlib.ProtocolMessage) (hashedParams string, params []byte, err error) {
 	params, err = gojson.Marshal(protocolMessage.GetRPCMessage().GetParams())
 	if err != nil {
@@ -1231,7 +1237,7 @@ func (dwsm *DirectWSSubscriptionManager) checkForActiveSubscriptionAndConnect(
 	if existingRouterID, exists := activeSub.clientRouterIDs[clientKey]; exists {
 		// Create reply with client's existing router ID and their request ID
 		// For Tendermint: uses originalResult to preserve {"query":"..."} format
-		replyData, err := createSubscriptionReplyFromRouterID(existingRouterID, requestID, dwsm.apiInterface, activeSub.originalResult)
+		replyData, err := createSubscriptionReplyFromRouterID(existingRouterID, requestID, dwsm.apiInterface, activeSub.originalResult, activeSub.numericIDs)
 		if err != nil {
 			utils.LavaFormatWarning("DirectWS: failed to create reply for existing client", err)
 			return activeSub.firstReply, false
@@ -1265,7 +1271,7 @@ func (dwsm *DirectWSSubscriptionManager) checkForActiveSubscriptionAndConnect(
 
 	// Create first reply with this client's unique router ID and their request ID
 	// For Tendermint: uses originalResult to preserve {"query":"..."} format
-	replyData, err := createSubscriptionReplyFromRouterID(clientRouterID, requestID, dwsm.apiInterface, activeSub.originalResult)
+	replyData, err := createSubscriptionReplyFromRouterID(clientRouterID, requestID, dwsm.apiInterface, activeSub.originalResult, activeSub.numericIDs)
 	if err != nil {
 		utils.LavaFormatWarning("DirectWS: failed to create reply for joining client", err)
 		return activeSub.firstReply, true // Fallback to original reply
@@ -1463,7 +1469,7 @@ func (dwsm *DirectWSSubscriptionManager) routeMessageToClients(
 	// Rewrite subscription ID per-client and send
 	for clientKey, info := range clients {
 		// Rewrite the message with this client's unique router ID
-		rewrittenMsg, err := rewriteSubscriptionID(msg, info.routerID)
+		rewrittenMsg, err := rewriteSubscriptionID(msg, info.routerID, activeSub.numericIDs)
 		if err != nil {
 			utils.LavaFormatWarning("DirectWS: failed to rewrite subscription ID for client", err,
 				utils.LogAttr("clientKey", clientKey),
@@ -1752,14 +1758,28 @@ func extractSubscriptionID(msg *rpcclient.JsonrpcMessage) string {
 }
 
 // subscriptionIDsAreNumeric reports whether a node numbers its subscriptions rather than
-// naming them, read from the raw JSON the node sent rather than from the chain id. Solana
-// is the only supported chain that does.
+// naming them, read from the raw JSON the node sent rather than from the chain id.
+//
+// Solana is the case this was written for, but the test is on the shape and not the chain,
+// so any node answering subscribe with a number takes this path — the repo's own dispatcher
+// records a second such implementation in handleResponse ("StarkNet Pathfinder is returning
+// an integer instead of a string in the result"). Do not read the Solana references nearby
+// as an exhaustive list of who is affected.
+//
+// The leading-byte check is load-bearing, not defensive: json.Unmarshal decodes `null` into
+// an int64 as a no-op and returns a NIL error, so the decode alone reports null as a number.
+// A node answering subscribe with {"result":null} would otherwise flip a string-id chain
+// onto the numeric path and hand its clients an id type they have never seen.
 func subscriptionIDsAreNumeric(raw json.RawMessage) bool {
-	if len(raw) == 0 {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return false
+	}
+	if first := trimmed[0]; first != '-' && (first < '0' || first > '9') {
 		return false
 	}
 	var asNumber int64
-	return json.Unmarshal(raw, &asNumber) == nil
+	return json.Unmarshal(trimmed, &asNumber) == nil
 }
 
 // subscriptionIDValue renders a canonical (decimal-string) subscription id for the wire in
@@ -1770,10 +1790,10 @@ func subscriptionIDsAreNumeric(raw json.RawMessage) bool {
 // and hands that straight back to accountUnsubscribe, so a string there is an id it cannot
 // use.
 //
-// An id that does not parse falls back to the string form. That is unreachable rather than
-// handled: every id reaching here on a numeric chain came from GenerateNumericRouterID or
-// from a node response already canonicalised through CanonicalSubscriptionID. The fallback
-// exists so a future caller cannot turn a bad id into a different valid-looking one.
+// An id that does not parse falls back to the string form, which is the safe direction. A
+// router id on a numeric chain always comes from GenerateNumericRouterID and always parses,
+// so the fallback is there to stop a future caller turning a bad id into a different
+// valid-looking one, not because a current path reaches it.
 func subscriptionIDValue(id string, numeric bool) any {
 	if numeric {
 		if asNumber, err := strconv.ParseInt(id, 10, 64); err == nil {
@@ -1815,7 +1835,7 @@ func getSubscriptionID(apiInterface string, responseMsg *rpcclient.JsonrpcMessag
 // originalMsg.ID is the upstream rpcclient's internal counter, which the client never sent
 // and must not see (JSON-RPC 2.0 §4.2 requires the response id to match the request id
 // exactly, including type: string ids stay strings).
-func createSubscriptionReply(routerID string, requestID json.RawMessage, originalMsg *rpcclient.JsonrpcMessage, apiInterface string) ([]byte, error) {
+func createSubscriptionReply(routerID string, requestID json.RawMessage, originalMsg *rpcclient.JsonrpcMessage, apiInterface string, numericIDs bool) ([]byte, error) {
 	if originalMsg == nil {
 		return nil, fmt.Errorf("original message is nil")
 	}
@@ -1844,7 +1864,7 @@ func createSubscriptionReply(routerID string, requestID json.RawMessage, origina
 	response := map[string]interface{}{
 		"jsonrpc": "2.0",
 		"id":      requestID,
-		"result":  subscriptionIDValue(routerID, subscriptionIDsAreNumeric(originalMsg.Result)),
+		"result":  subscriptionIDValue(routerID, numericIDs),
 	}
 
 	return json.Marshal(response)
@@ -1854,7 +1874,7 @@ func createSubscriptionReply(routerID string, requestID json.RawMessage, origina
 // Used when a client joins an existing subscription and needs their unique router ID in the response.
 // The requestID must match the client's original eth_subscribe request per JSON-RPC 2.0 spec.
 // For Tendermint, originalResult contains the query object that must be preserved.
-func createSubscriptionReplyFromRouterID(routerID string, requestID json.RawMessage, apiInterface string, originalResult json.RawMessage) ([]byte, error) {
+func createSubscriptionReplyFromRouterID(routerID string, requestID json.RawMessage, apiInterface string, originalResult json.RawMessage, numericIDs bool) ([]byte, error) {
 	// For Tendermint: preserve the original result format {"query":"..."}
 	// Tendermint clients expect the query object back, not a router ID
 	if apiInterface == "tendermintrpc" && originalResult != nil {
@@ -1872,7 +1892,7 @@ func createSubscriptionReplyFromRouterID(routerID string, requestID json.RawMess
 	response := map[string]interface{}{
 		"jsonrpc": "2.0",
 		"id":      requestID,
-		"result":  subscriptionIDValue(routerID, subscriptionIDsAreNumeric(originalResult)),
+		"result":  subscriptionIDValue(routerID, numericIDs),
 	}
 
 	return json.Marshal(response)
@@ -1885,11 +1905,12 @@ func createSubscriptionReplyFromRouterID(routerID string, requestID json.RawMess
 // rather than from a fixed {subscription, result} pair, so anything a chain adds alongside
 // them survives the rewrite.
 //
-// The router id is written back in the shape the frame used: a number where the upstream
-// numbered its subscription, a string where it named one. Requiring a string here used to
-// exclude Solana entirely, which was correct while router ids were always strings and is
-// wrong now that they follow the chain (MAG-3359).
-func rewriteParamsSubscriptionID(params json.RawMessage, routerID string) json.RawMessage {
+// The router id is written back in the shape the CHAIN uses, per the subscription's
+// recorded numericIDs rather than the shape of the frame in hand — the two can disagree,
+// and the subscription is the one that decided what the client was given. Requiring a
+// string here used to exclude Solana entirely, which was correct while router ids were
+// always strings and is wrong now that they follow the chain (MAG-3359).
+func rewriteParamsSubscriptionID(params json.RawMessage, routerID string, numericIDs bool) json.RawMessage {
 	if params == nil {
 		return nil
 	}
@@ -1904,7 +1925,7 @@ func rewriteParamsSubscriptionID(params json.RawMessage, routerID string) json.R
 	if _, named := rpcclient.CanonicalSubscriptionID(raw); !named {
 		return nil
 	}
-	newID, err := json.Marshal(subscriptionIDValue(routerID, subscriptionIDsAreNumeric(raw)))
+	newID, err := json.Marshal(subscriptionIDValue(routerID, numericIDs))
 	if err != nil {
 		return nil
 	}
@@ -1919,7 +1940,7 @@ func rewriteParamsSubscriptionID(params json.RawMessage, routerID string) json.R
 // rewriteSubscriptionID rewrites the subscription ID in a notification message
 // For params-carried subscriptions (EVM, Substrate): rewrites params.subscription with router ID
 // For Tendermint: notifications contain query in result, passed through as-is
-func rewriteSubscriptionID(msg *rpcclient.JsonrpcMessage, routerID string) ([]byte, error) {
+func rewriteSubscriptionID(msg *rpcclient.JsonrpcMessage, routerID string, numericIDs bool) ([]byte, error) {
 	if msg == nil {
 		return nil, fmt.Errorf("message is nil")
 	}
@@ -1932,7 +1953,7 @@ func rewriteSubscriptionID(msg *rpcclient.JsonrpcMessage, routerID string) ([]by
 	// so an == "eth_subscription" test rewrote EVM and let Substrate through carrying the
 	// UPSTREAM id — an id the client was never given and cannot match to its subscription
 	// (MAG-3345). The method is echoed back rather than hard-coded for the same reason.
-	if rewritten := rewriteParamsSubscriptionID(msg.Params, routerID); rewritten != nil {
+	if rewritten := rewriteParamsSubscriptionID(msg.Params, routerID, numericIDs); rewritten != nil {
 		response := map[string]any{
 			"jsonrpc": "2.0",
 			"method":  msg.Method,

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
@@ -1952,7 +1952,7 @@ func rewriteParamsSubscriptionID(params json.RawMessage, routerID string, numeri
 		return nil, nil
 	}
 	if _, named := rpcclient.CanonicalSubscriptionID(raw); !named {
-		return nil, fmt.Errorf("subscription id is neither a string nor a number: %s", raw)
+		return nil, fmt.Errorf("subscription id names no subscription: %s", raw)
 	}
 	newID, err := json.Marshal(subscriptionIDValue(routerID, numericIDs))
 	if err != nil {

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
@@ -1195,8 +1195,16 @@ func (dwsm *DirectWSSubscriptionManager) extractSubscriptionIDFromUnsubscribe(pr
 	}
 
 	// Everything else: a JSON-RPC array whose first element names the subscription — a
-	// string on EVM and Substrate, a number on Solana. Decoding into json.RawMessage rather
-	// than `any` is what keeps a large numeric id exact; a float64 would not (MAG-3359).
+	// string on EVM and Substrate, a number on Solana. Decoding into json.RawMessage keeps
+	// both shapes in one branch and hands them to the same canonicaliser the dispatcher
+	// uses, rather than type-switching on `any` (MAG-3359).
+	//
+	// It does NOT rescue precision, despite the obvious temptation to claim so: the caller
+	// hands us params that GetRPCMessage already decoded into `any`, so a large integer was
+	// rounded to float64 before this function ran and paramsBytes above re-marshals the
+	// rounded value. Router ids stay well inside 2^53 (see numericRouterIDBase), so nothing
+	// is currently at risk — but the rounding happens upstream of here and a fix belongs
+	// there, not in this decode.
 	var paramsArray []json.RawMessage
 	if err := gojson.Unmarshal(paramsBytes, &paramsArray); err == nil && len(paramsArray) > 0 {
 		if id, ok := rpcclient.CanonicalSubscriptionID(paramsArray[0]); ok {
@@ -1779,7 +1787,11 @@ func subscriptionIDsAreNumeric(raw json.RawMessage) bool {
 		return false
 	}
 	var asNumber int64
-	return json.Unmarshal(trimmed, &asNumber) == nil
+	// gojson, not encoding/json: CanonicalSubscriptionID decodes with gojson, and these two
+	// have to agree on every input or the router issues an id in a shape whose upstream
+	// counterpart it cannot key on. Two implementations of one decision is what produced
+	// the null divergence above.
+	return gojson.Unmarshal(trimmed, &asNumber) == nil
 }
 
 // subscriptionIDValue renders a canonical (decimal-string) subscription id for the wire in
@@ -1899,7 +1911,14 @@ func createSubscriptionReplyFromRouterID(routerID string, requestID json.RawMess
 }
 
 // rewriteParamsSubscriptionID returns params with its "subscription" field replaced by
-// routerID, or nil when params is not a subscription envelope carrying a string id.
+// routerID.
+//
+// It returns (nil, nil) when params is not a subscription envelope at all, which is the
+// caller's signal to try the other shapes. It returns an error when params IS one but names
+// its subscription in a shape no router id can stand in for: passing that through would
+// hand every client the UPSTREAM id — the same id for all of them — quietly defeating the
+// per-client indirection that unsubscribe depends on. The pre-MAG-3345 code failed loudly
+// there and so does this.
 //
 // Sibling fields are preserved: the envelope is rebuilt from what upstream actually sent
 // rather than from a fixed {subscription, result} pair, so anything a chain adds alongside
@@ -1910,31 +1929,31 @@ func createSubscriptionReplyFromRouterID(routerID string, requestID json.RawMess
 // and the subscription is the one that decided what the client was given. Requiring a
 // string here used to exclude Solana entirely, which was correct while router ids were
 // always strings and is wrong now that they follow the chain (MAG-3359).
-func rewriteParamsSubscriptionID(params json.RawMessage, routerID string, numericIDs bool) json.RawMessage {
+func rewriteParamsSubscriptionID(params json.RawMessage, routerID string, numericIDs bool) (json.RawMessage, error) {
 	if params == nil {
-		return nil
+		return nil, nil
 	}
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(params, &fields); err != nil {
-		return nil
+		return nil, nil
 	}
 	raw, ok := fields["subscription"]
 	if !ok {
-		return nil
+		return nil, nil
 	}
 	if _, named := rpcclient.CanonicalSubscriptionID(raw); !named {
-		return nil
+		return nil, fmt.Errorf("subscription id is neither a string nor a number: %s", raw)
 	}
 	newID, err := json.Marshal(subscriptionIDValue(routerID, numericIDs))
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	fields["subscription"] = newID
 	rewritten, err := json.Marshal(fields)
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	return rewritten
+	return rewritten, nil
 }
 
 // rewriteSubscriptionID rewrites the subscription ID in a notification message
@@ -1953,7 +1972,11 @@ func rewriteSubscriptionID(msg *rpcclient.JsonrpcMessage, routerID string, numer
 	// so an == "eth_subscription" test rewrote EVM and let Substrate through carrying the
 	// UPSTREAM id — an id the client was never given and cannot match to its subscription
 	// (MAG-3345). The method is echoed back rather than hard-coded for the same reason.
-	if rewritten := rewriteParamsSubscriptionID(msg.Params, routerID, numericIDs); rewritten != nil {
+	rewritten, err := rewriteParamsSubscriptionID(msg.Params, routerID, numericIDs)
+	if err != nil {
+		return nil, err
+	}
+	if rewritten != nil {
 		response := map[string]any{
 			"jsonrpc": "2.0",
 			"method":  msg.Method,

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -40,6 +41,13 @@ type directActiveSubscription struct {
 	// Subscription params for restoration after reconnect
 	subscriptionParams []byte // Original subscription params (JSON)
 	subscribeMethod    string // Method name (e.g., "eth_subscribe", "subscribe")
+
+	// numericIDs records that this chain numbers its subscriptions rather than naming
+	// them, read from the subscribe response the node actually sent. It is a property of
+	// the chain, so it survives a reconnect even though upstreamID does not. Only the two
+	// places that cannot read the shape off the message in front of them consult it: the
+	// id issued to a joining client, and the param sent upstream on unsubscribe.
+	numericIDs bool
 
 	// Client tracking - multiple clients can share one upstream subscription
 	connectedClients map[string]*common.SafeChannelSender[*pairingtypes.RelayReply]
@@ -742,8 +750,10 @@ func (dwsm *DirectWSSubscriptionManager) StartSubscription(
 
 	// Generate router subscription ID (for EVM deduplication)
 	// For Tendermint, the query string is the identifier, but we still generate
-	// router IDs for internal tracking (not exposed to clients)
-	routerID := dwsm.idMapper.GenerateRouterID(clientKey)
+	// router IDs for internal tracking (not exposed to clients).
+	// The id must be shaped like the one this chain issues, which the node just told us.
+	numericIDs := firstMsg != nil && subscriptionIDsAreNumeric(firstMsg.Result)
+	routerID := dwsm.generateRouterID(clientKey, numericIDs)
 
 	// Extract upstream subscription ID based on API interface
 	// - EVM chains: subscription ID is in the response result (hex string)
@@ -789,6 +799,7 @@ func (dwsm *DirectWSSubscriptionManager) StartSubscription(
 		hashedParams:         hashedParams,
 		subscriptionParams:   subscriptionParams, // Store for restoration after reconnect
 		subscribeMethod:      subscribeMethod,    // Store for restoration (eth_subscribe, subscribe, etc.)
+		numericIDs:           numericIDs,         // Chain-level, so it outlives any one upstream id
 		connectedClients:     make(map[string]*common.SafeChannelSender[*pairingtypes.RelayReply]),
 		firstReply:           firstReply,
 		originalResult:       originalResult, // Store for Tendermint joining clients
@@ -909,6 +920,7 @@ func (dwsm *DirectWSSubscriptionManager) Unsubscribe(
 	// Get upstream connection and params before unlock for the CallContext
 	conn := activeSub.upstreamConnection
 	upstreamID := activeSub.upstreamID
+	numericIDs := activeSub.numericIDs
 	subscribeMethod := activeSub.subscribeMethod
 	// Only call upstream when we're the last client (single client on this subscription)
 	lastClient := len(activeSub.connectedClients) == 1
@@ -922,7 +934,9 @@ func (dwsm *DirectWSSubscriptionManager) Unsubscribe(
 	if dwsm.apiInterface == "tendermintrpc" {
 		unsubscribeParams = map[string]interface{}{"query": upstreamID}
 	} else {
-		unsubscribeParams = []interface{}{upstreamID}
+		// The node is told its own id, in its own shape: Solana rejects the decimal string
+		// the router canonicalises to internally.
+		unsubscribeParams = []interface{}{subscriptionIDValue(upstreamID, numericIDs)}
 	}
 
 	dwsm.lock.Unlock()
@@ -1124,6 +1138,20 @@ func (dwsm *DirectWSSubscriptionManager) UnsubscribeAll(
 }
 
 // getHashedParams extracts and hashes the subscription parameters from a protocol message
+// generateRouterID issues a router subscription id shaped like the ones this chain uses.
+//
+// Chains that number their subscriptions get a number, because the client hands the id
+// straight back on unsubscribe. The router still issues its OWN id rather than passing the
+// upstream one through: an upstream id does not survive a reconnect — handleUpstreamDisconnect
+// re-subscribes and the node answers with a different one — whereas a router id is stable for
+// the life of the client's subscription, which is the whole reason the indirection exists.
+func (dwsm *DirectWSSubscriptionManager) generateRouterID(clientKey string, numeric bool) string {
+	if numeric {
+		return dwsm.idMapper.GenerateNumericRouterID()
+	}
+	return dwsm.idMapper.GenerateRouterID(clientKey)
+}
+
 func (dwsm *DirectWSSubscriptionManager) getHashedParams(protocolMessage chainlib.ProtocolMessage) (hashedParams string, params []byte, err error) {
 	params, err = gojson.Marshal(protocolMessage.GetRPCMessage().GetParams())
 	if err != nil {
@@ -1160,10 +1188,12 @@ func (dwsm *DirectWSSubscriptionManager) extractSubscriptionIDFromUnsubscribe(pr
 		}
 	}
 
-	// For EVM: try to extract as array (JSON-RPC style: ["subscription_id"])
-	var paramsArray []any
+	// Everything else: a JSON-RPC array whose first element names the subscription — a
+	// string on EVM and Substrate, a number on Solana. Decoding into json.RawMessage rather
+	// than `any` is what keeps a large numeric id exact; a float64 would not (MAG-3359).
+	var paramsArray []json.RawMessage
 	if err := gojson.Unmarshal(paramsBytes, &paramsArray); err == nil && len(paramsArray) > 0 {
-		if id, ok := paramsArray[0].(string); ok {
+		if id, ok := rpcclient.CanonicalSubscriptionID(paramsArray[0]); ok {
 			return id, nil
 		}
 	}
@@ -1210,8 +1240,10 @@ func (dwsm *DirectWSSubscriptionManager) checkForActiveSubscriptionAndConnect(
 	}
 
 	// Generate a unique router ID for this joining client (for EVM deduplication)
-	// For Tendermint, we still generate IDs for internal tracking but don't expose them
-	clientRouterID := dwsm.idMapper.GenerateRouterID(clientKey)
+	// For Tendermint, we still generate IDs for internal tracking but don't expose them.
+	// The joining client must be issued an id of the same shape as the one the first
+	// client got, which only activeSub still knows.
+	clientRouterID := dwsm.generateRouterID(clientKey, activeSub.numericIDs)
 
 	// Register the mapping: this client's router ID -> shared upstream ID
 	dwsm.idMapper.RegisterMapping(clientRouterID, activeSub.upstreamID)
@@ -1705,15 +1737,48 @@ func extractRequestID(data []byte) json.RawMessage {
 	return req.ID
 }
 
-// extractSubscriptionID extracts the subscription ID from the first response (EVM style)
-// For EVM chains: the subscription ID is returned as a hex string in the result field
+// extractSubscriptionID extracts the subscription ID from the first response.
+//
+// EVM and Substrate name the subscription with a string; Solana numbers it. Both are
+// canonicalised to the decimal-string form the rpcclient dispatcher keys subscriptions
+// under, using that package's own helper so the two cannot drift apart — they are the
+// same identity, and a divergence would strand every push (MAG-3359).
 func extractSubscriptionID(msg *rpcclient.JsonrpcMessage) string {
 	if msg == nil || msg.Result == nil {
 		return ""
 	}
-	var id string
-	if err := json.Unmarshal(msg.Result, &id); err != nil {
-		return ""
+	id, _ := rpcclient.CanonicalSubscriptionID(msg.Result)
+	return id
+}
+
+// subscriptionIDsAreNumeric reports whether a node numbers its subscriptions rather than
+// naming them, read from the raw JSON the node sent rather than from the chain id. Solana
+// is the only supported chain that does.
+func subscriptionIDsAreNumeric(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var asNumber int64
+	return json.Unmarshal(raw, &asNumber) == nil
+}
+
+// subscriptionIDValue renders a canonical (decimal-string) subscription id for the wire in
+// the shape its chain uses: a JSON number where the node numbers its subscriptions, a
+// string everywhere else.
+//
+// The shape is not cosmetic. A Solana client stores whatever the subscribe response gave it
+// and hands that straight back to accountUnsubscribe, so a string there is an id it cannot
+// use.
+//
+// An id that does not parse falls back to the string form. That is unreachable rather than
+// handled: every id reaching here on a numeric chain came from GenerateNumericRouterID or
+// from a node response already canonicalised through CanonicalSubscriptionID. The fallback
+// exists so a future caller cannot turn a bad id into a different valid-looking one.
+func subscriptionIDValue(id string, numeric bool) any {
+	if numeric {
+		if asNumber, err := strconv.ParseInt(id, 10, 64); err == nil {
+			return asNumber
+		}
 	}
 	return id
 }
@@ -1773,11 +1838,13 @@ func createSubscriptionReply(routerID string, requestID json.RawMessage, origina
 		return json.Marshal(obj)
 	}
 
-	// For EVM: response carries the router ID (not the upstream hex) and the caller's id.
+	// Everything else: the response carries the router ID (not the upstream one) and the
+	// caller's id, rendered in the shape this chain names subscriptions with. Solana is
+	// jsonrpc, so it lands here rather than in the Tendermint branch above.
 	response := map[string]interface{}{
 		"jsonrpc": "2.0",
 		"id":      requestID,
-		"result":  routerID,
+		"result":  subscriptionIDValue(routerID, subscriptionIDsAreNumeric(originalMsg.Result)),
 	}
 
 	return json.Marshal(response)
@@ -1799,12 +1866,13 @@ func createSubscriptionReplyFromRouterID(routerID string, requestID json.RawMess
 		return json.Marshal(response)
 	}
 
-	// For EVM: create response with the client's unique router ID and their original request ID
-	// JSON-RPC 2.0 requires the response ID to match the request ID exactly
+	// Everything else: the client's unique router ID and their original request ID, in the
+	// shape this chain names subscriptions with. JSON-RPC 2.0 requires the response ID to
+	// match the request ID exactly.
 	response := map[string]interface{}{
 		"jsonrpc": "2.0",
 		"id":      requestID,
-		"result":  routerID,
+		"result":  subscriptionIDValue(routerID, subscriptionIDsAreNumeric(originalResult)),
 	}
 
 	return json.Marshal(response)
@@ -1817,9 +1885,10 @@ func createSubscriptionReplyFromRouterID(routerID string, requestID json.RawMess
 // rather than from a fixed {subscription, result} pair, so anything a chain adds alongside
 // them survives the rewrite.
 //
-// Returning nil for a non-string id keeps Solana out: its ids are integers, and a router id
-// is not one, so writing a string in would hand the client an id of a type its own
-// unsubscribe cannot use.
+// The router id is written back in the shape the frame used: a number where the upstream
+// numbered its subscription, a string where it named one. Requiring a string here used to
+// exclude Solana entirely, which was correct while router ids were always strings and is
+// wrong now that they follow the chain (MAG-3359).
 func rewriteParamsSubscriptionID(params json.RawMessage, routerID string) json.RawMessage {
 	if params == nil {
 		return nil
@@ -1832,11 +1901,10 @@ func rewriteParamsSubscriptionID(params json.RawMessage, routerID string) json.R
 	if !ok {
 		return nil
 	}
-	var upstreamID string
-	if err := json.Unmarshal(raw, &upstreamID); err != nil {
+	if _, named := rpcclient.CanonicalSubscriptionID(raw); !named {
 		return nil
 	}
-	newID, err := json.Marshal(routerID)
+	newID, err := json.Marshal(subscriptionIDValue(routerID, subscriptionIDsAreNumeric(raw)))
 	if err != nil {
 		return nil
 	}

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
@@ -1935,6 +1935,16 @@ func rewriteParamsSubscriptionID(params json.RawMessage, routerID string, numeri
 	}
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(params, &fields); err != nil {
+		// Not a JSON object, so not an envelope this can rewrite — a positional params
+		// array lands here, and passing it through is right. Traced rather than silent
+		// because the pre-MAG-3345 code returned an error for an eth_subscription frame
+		// whose params would not decode, and the caller skipped that client; anything
+		// reaching here now is forwarded carrying the UPSTREAM id instead. No delivered
+		// frame can reach it today (the dispatcher already decoded these params to find
+		// the subscription), so this is the trace that would show that changing.
+		utils.LavaFormatTrace("DirectWS: subscription params are not an object, forwarding unrewritten",
+			utils.LogAttr("err", err),
+		)
 		return nil, nil
 	}
 	raw, ok := fields["subscription"]

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
@@ -1810,39 +1810,65 @@ func createSubscriptionReplyFromRouterID(routerID string, requestID json.RawMess
 	return json.Marshal(response)
 }
 
+// rewriteParamsSubscriptionID returns params with its "subscription" field replaced by
+// routerID, or nil when params is not a subscription envelope carrying a string id.
+//
+// Sibling fields are preserved: the envelope is rebuilt from what upstream actually sent
+// rather than from a fixed {subscription, result} pair, so anything a chain adds alongside
+// them survives the rewrite.
+//
+// Returning nil for a non-string id keeps Solana out: its ids are integers, and a router id
+// is not one, so writing a string in would hand the client an id of a type its own
+// unsubscribe cannot use.
+func rewriteParamsSubscriptionID(params json.RawMessage, routerID string) json.RawMessage {
+	if params == nil {
+		return nil
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(params, &fields); err != nil {
+		return nil
+	}
+	raw, ok := fields["subscription"]
+	if !ok {
+		return nil
+	}
+	var upstreamID string
+	if err := json.Unmarshal(raw, &upstreamID); err != nil {
+		return nil
+	}
+	newID, err := json.Marshal(routerID)
+	if err != nil {
+		return nil
+	}
+	fields["subscription"] = newID
+	rewritten, err := json.Marshal(fields)
+	if err != nil {
+		return nil
+	}
+	return rewritten
+}
+
 // rewriteSubscriptionID rewrites the subscription ID in a notification message
-// For EVM (eth_subscription): rewrites params.subscription with router ID
+// For params-carried subscriptions (EVM, Substrate): rewrites params.subscription with router ID
 // For Tendermint: notifications contain query in result, passed through as-is
 func rewriteSubscriptionID(msg *rpcclient.JsonrpcMessage, routerID string) ([]byte, error) {
 	if msg == nil {
 		return nil, fmt.Errorf("message is nil")
 	}
 
-	// EVM subscription notifications format:
+	// Subscription notifications that carry the id in params:
 	// {"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0x...","result":{...}}}
-	if msg.Method == "eth_subscription" && msg.Params != nil {
-		var params struct {
-			Subscription string          `json:"subscription"`
-			Result       json.RawMessage `json:"result"`
-		}
-		if err := json.Unmarshal(msg.Params, &params); err != nil {
-			return nil, err
-		}
-
-		// Rewrite with router ID
-		newParams := map[string]any{
-			"subscription": routerID,
-			"result":       params.Result,
-		}
-		paramsBytes, err := json.Marshal(newParams)
-		if err != nil {
-			return nil, err
-		}
-
+	//
+	// Match the envelope, not the method name. Substrate uses this exact shape but names
+	// the frame after the payload (chain_newHead, state_storage, author_extrinsicUpdate),
+	// so an == "eth_subscription" test rewrote EVM and let Substrate through carrying the
+	// UPSTREAM id — an id the client was never given and cannot match to its subscription
+	// (MAG-3345). The method is echoed back rather than hard-coded for the same reason.
+	if rewritten := rewriteParamsSubscriptionID(msg.Params, routerID); rewritten != nil {
 		response := map[string]any{
 			"jsonrpc": "2.0",
-			"method":  "eth_subscription",
-			"params":  json.RawMessage(paramsBytes),
+			"method":  msg.Method,
+			"params":  json.RawMessage(rewritten),
 		}
 		return json.Marshal(response)
 	}

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
@@ -1550,18 +1550,35 @@ func TestRewriteSubscriptionID_SolanaNumeric(t *testing.T) {
 	assert.JSONEq(t, `{"context":{"slot":5208469}}`, string(parsed.Params.Result))
 }
 
-// TestRewriteSubscriptionID_NonScalarIDUntouched keeps the rewrite off anything that is not
-// a string or a number, rather than coercing it.
-func TestRewriteSubscriptionID_NonScalarIDUntouched(t *testing.T) {
+// TestRewriteSubscriptionID_UnusableIDIsAnError covers an envelope that names its
+// subscription in a shape no router id can stand in for.
+//
+// Passing it through would be worse than failing: every client sharing the subscription
+// would receive the same UPSTREAM id, silently defeating the per-client indirection that
+// unsubscribe depends on. routeMessageToClients logs the error and drops the frame for that
+// client, which is what the pre-MAG-3345 code did for a params blob it could not parse.
+func TestRewriteSubscriptionID_UnusableIDIsAnError(t *testing.T) {
 	msg := &rpcclient.JsonrpcMessage{
 		Method: "oddNotification",
 		Params: json.RawMessage(`{"subscription":{"nested":true},"result":{}}`),
 	}
 
+	_, err := rewriteSubscriptionID(msg, "1000001", false)
+	require.Error(t, err, "an object id must not be silently passed through")
+	assert.Contains(t, err.Error(), "neither a string nor a number")
+}
+
+// TestRewriteSubscriptionID_NonEnvelopePassesThrough keeps that error off frames that are
+// not subscription envelopes at all — those still fall through to the other shapes.
+func TestRewriteSubscriptionID_NonEnvelopePassesThrough(t *testing.T) {
+	msg := &rpcclient.JsonrpcMessage{
+		Method: "someNotification",
+		Params: json.RawMessage(`{"height":"12345"}`),
+	}
+
 	result, err := rewriteSubscriptionID(msg, "1000001", false)
-	require.NoError(t, err)
-	assert.Contains(t, string(result), `"nested":true`,
-		"an object id is not something a router id can stand in for; pass it through")
+	require.NoError(t, err, "params that name no subscription are not this function's business")
+	assert.Contains(t, string(result), `"height":"12345"`)
 }
 
 // TestExtractSubscriptionID_Numeric covers the upstream id arriving as a number. Returning

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
@@ -34,6 +34,14 @@ type mockSubscriptionServer struct {
 	lock            sync.RWMutex
 	writeMu         sync.Mutex // serializes conn.WriteMessage — gorilla requires a single concurrent writer
 	messageInterval time.Duration
+
+	// notificationMethod is the JSON-RPC method the push frames carry, and subscriptionID
+	// is the id handed back on subscribe. Both default to the EVM shape. Substrate names
+	// its frames after the payload and its ids are not hex, and a harness that can only
+	// speak EVM is exactly why MAG-3345 went unnoticed: every existing test here asserted
+	// against the one shape the router happened to handle.
+	notificationMethod string
+	subscriptionID     string
 }
 
 // safeWriteMessage serializes WS writes: handleWS (response) and the spawned sendSubscriptionMessages
@@ -47,9 +55,11 @@ func (ms *mockSubscriptionServer) safeWriteMessage(conn *websocket.Conn, message
 
 func newMockSubscriptionServer() *mockSubscriptionServer {
 	ms := &mockSubscriptionServer{
-		upgrader:        websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }},
-		subscriptions:   make(map[string]chan struct{}),
-		messageInterval: 100 * time.Millisecond,
+		upgrader:           websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }},
+		subscriptions:      make(map[string]chan struct{}),
+		messageInterval:    100 * time.Millisecond,
+		notificationMethod: "eth_subscription",
+		subscriptionID:     "0x" + strings.Repeat("f", 32),
 	}
 
 	ms.server = httptest.NewServer(http.HandlerFunc(ms.handleWS))
@@ -151,9 +161,8 @@ func (ms *mockSubscriptionServer) createSubscription() string {
 	ms.lock.Lock()
 	defer ms.lock.Unlock()
 
-	subID := "0x" + strings.Repeat("f", 32)[:32] // Simple subscription ID
-	ms.subscriptions[subID] = make(chan struct{})
-	return subID
+	ms.subscriptions[ms.subscriptionID] = make(chan struct{})
+	return ms.subscriptionID
 }
 
 func (ms *mockSubscriptionServer) closeSubscription(subID string) {
@@ -187,7 +196,7 @@ func (ms *mockSubscriptionServer) sendSubscriptionMessages(conn *websocket.Conn,
 			// Send subscription notification
 			notification := map[string]interface{}{
 				"jsonrpc": "2.0",
-				"method":  "eth_subscription",
+				"method":  ms.notificationMethod,
 				"params": map[string]interface{}{
 					"subscription": subID,
 					"result": map[string]interface{}{
@@ -1434,6 +1443,62 @@ func TestRewriteSubscriptionID_EVM(t *testing.T) {
 
 	assert.Equal(t, "eth_subscription", parsed.Method)
 	assert.Equal(t, "0xrouter123", parsed.Params.Subscription) // Should be rewritten
+}
+
+// TestRewriteSubscriptionID_Substrate is the unit half of MAG-3345. Substrate uses the
+// same params envelope as EVM but names the frame after the payload, so matching on
+// method == "eth_subscription" passed these through untouched — the client received the
+// upstream id instead of the router id it was issued at subscribe time.
+func TestRewriteSubscriptionID_Substrate(t *testing.T) {
+	substrateMsg := &rpcclient.JsonrpcMessage{
+		Method: "chain_newHead",
+		Params: json.RawMessage(`{"subscription":"Ck1rTHhOa1hxTGV3","result":{"number":"0x1234"}}`),
+	}
+
+	result, err := rewriteSubscriptionID(substrateMsg, "rs_router_1")
+	require.NoError(t, err)
+
+	var parsed struct {
+		Method string `json:"method"`
+		Params struct {
+			Subscription string          `json:"subscription"`
+			Result       json.RawMessage `json:"result"`
+		} `json:"params"`
+	}
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	assert.Equal(t, "chain_newHead", parsed.Method,
+		"the frame's own method must survive; the client dispatches on it")
+	assert.Equal(t, "rs_router_1", parsed.Params.Subscription,
+		"subscription must be the router id, not the upstream id")
+	assert.JSONEq(t, `{"number":"0x1234"}`, string(parsed.Params.Result),
+		"the payload must be relayed unchanged")
+}
+
+// TestRewriteSubscriptionID_SolanaUntouched pins the boundary of the MAG-3345 rewrite.
+// Solana's ids are integers, so a router id cannot stand in for one. Matching on the
+// params envelope brings those frames into range of the rewrite for the first time, and
+// they must keep falling through to pass-through rather than acquiring a string id.
+func TestRewriteSubscriptionID_SolanaUntouched(t *testing.T) {
+	solanaMsg := &rpcclient.JsonrpcMessage{
+		Method: "accountNotification",
+		Params: json.RawMessage(`{"subscription":23784,"result":{"context":{"slot":5208469}}}`),
+	}
+
+	result, err := rewriteSubscriptionID(solanaMsg, "rs_router_1")
+	require.NoError(t, err)
+
+	var parsed struct {
+		Method string `json:"method"`
+		Params struct {
+			Subscription json.RawMessage `json:"subscription"`
+		} `json:"params"`
+	}
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	assert.Equal(t, "accountNotification", parsed.Method)
+	assert.JSONEq(t, `23784`, string(parsed.Params.Subscription),
+		"an integer subscription id must not be replaced by a string router id")
 }
 
 // TestDirectWSSubscriptionManager_TendermintAPIInterface tests manager with Tendermint API interface
@@ -2706,4 +2771,90 @@ func TestEndToEnd_UnsubscribeSendsTheSpecMethodUpstream(t *testing.T) {
 		"the router must tear down with the spec's own unsubscribe method; observed=%v", observed)
 	require.NotContains(t, observed, "unsubscribe",
 		"the derivation fallback sent this literal method, which no Substrate node implements; observed=%v", observed)
+}
+
+// TestEndToEnd_SubstratePushFrameReachesClient is the regression for MAG-3345: no Substrate
+// subscription had ever relayed a push frame end-to-end. The subscribe call itself always
+// succeeded, which is what made the gap silent — nothing errored, frames simply never came.
+//
+// It runs against a real WebSocket, so the whole delivery path is live: the rpcclient
+// dispatcher that decides whether a frame is a subscription push at all, and the manager's
+// per-client id rewrite. Two independent defects sat on that path, and the assertions below
+// separate them:
+//
+//   - rpcclient's handleImmediate only recognised pushes whose method ended in
+//     "_subscription"/"Notification" (or carried a Tendermint query). chain_newHead matches
+//     none of those, so the frame was never delivered to the subscription — worse, it fell
+//     through to the call path and the router answered the node with "invalid request".
+//     Nothing arrives on repliesChan at all.
+//   - rewriteSubscriptionID keyed on method == "eth_subscription", so even once delivered,
+//     a Substrate frame reached the client carrying the UPSTREAM id rather than the router
+//     id the client was handed at subscribe time.
+//
+// Either bug alone leaves the subscription unusable, so both are asserted.
+func TestEndToEnd_SubstratePushFrameReachesClient(t *testing.T) {
+	mockSrv := newMockSubscriptionServer()
+	mockSrv.messageInterval = 20 * time.Millisecond
+	// A Substrate node names the frame after the payload, and its ids are opaque
+	// base58-ish strings — not hex, so nothing here can pass by matching an "0x" prefix.
+	mockSrv.notificationMethod = "chain_newHead"
+	mockSrv.subscriptionID = "Ck1rTHhOa1hxTGV3"
+	defer mockSrv.Close()
+
+	nodeUrl := &common.NodeUrl{Url: mockSrv.URL()}
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc", "AVN", "jsonrpc",
+		[]*common.NodeUrl{nodeUrl},
+		nil, nil, nil,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const dappID, ip, wsUID = "dapp-avn", "192.168.99.97", "ws-avn"
+	subscribeBody, err := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0", "method": "chain_subscribeNewHeads", "params": []interface{}{}, "id": 1,
+	})
+	require.NoError(t, err)
+	subscribeMsg := &mockWSProtocolMessageWithRawData{
+		mockWSProtocolMessage: mockWSProtocolMessage{method: "chain_subscribeNewHeads", params: []interface{}{}},
+		rawData:               subscribeBody,
+	}
+
+	reply, repliesChan, err := manager.StartSubscription(ctx, subscribeMsg, dappID, ip, wsUID, nil)
+	require.NoError(t, err, "the subscribe half always worked, including before the fix")
+	require.NotNil(t, reply)
+	require.NotNil(t, repliesChan)
+
+	var subResp map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(reply.Data, &subResp))
+	var routerSubID string
+	require.NoError(t, json.Unmarshal(subResp["result"], &routerSubID))
+	require.NotEmpty(t, routerSubID)
+	require.NotEqual(t, mockSrv.subscriptionID, routerSubID,
+		"the router must issue its own id, otherwise the rewrite assertion below proves nothing")
+
+	select {
+	case notif := <-repliesChan:
+		require.NotNil(t, notif, "a Substrate subscription must deliver push frames")
+
+		var frame struct {
+			Method string `json:"method"`
+			Params struct {
+				Subscription string          `json:"subscription"`
+				Result       json.RawMessage `json:"result"`
+			} `json:"params"`
+		}
+		require.NoError(t, json.Unmarshal(notif.Data, &frame))
+
+		assert.Equal(t, "chain_newHead", frame.Method,
+			"the frame must keep the method the node sent — a Substrate client dispatches on it")
+		assert.Equal(t, routerSubID, frame.Params.Subscription,
+			"the push must carry the router id issued at subscribe time, not the upstream id %q",
+			mockSrv.subscriptionID)
+		assert.NotEmpty(t, frame.Params.Result, "the payload must be relayed")
+	case <-time.After(5 * time.Second):
+		t.Fatal("no push frame reached the client within 5s — the subscription is dead end-to-end")
+	}
 }

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -42,6 +43,16 @@ type mockSubscriptionServer struct {
 	// against the one shape the router happened to handle.
 	notificationMethod string
 	subscriptionID     string
+
+	// numericIDs makes the server number its subscriptions instead of naming them, which
+	// is what Solana does and what no test here could express before MAG-3359.
+	// firstNumericID is the id the first such subscription gets.
+	numericIDs     bool
+	firstNumericID int
+
+	// subscriptionSeq makes successive ids distinct, so a test can tell a restored
+	// subscription from the one it replaced.
+	subscriptionSeq int
 }
 
 // safeWriteMessage serializes WS writes: handleWS (response) and the spawned sendSubscriptionMessages
@@ -60,6 +71,7 @@ func newMockSubscriptionServer() *mockSubscriptionServer {
 		messageInterval:    100 * time.Millisecond,
 		notificationMethod: "eth_subscription",
 		subscriptionID:     "0x" + strings.Repeat("f", 32),
+		firstNumericID:     23784,
 	}
 
 	ms.server = httptest.NewServer(http.HandlerFunc(ms.handleWS))
@@ -100,7 +112,7 @@ func (ms *mockSubscriptionServer) handleWS(w http.ResponseWriter, r *http.Reques
 		// Everything gets a reply. Dropping an unrecognised method would make a
 		// regression hang out the router's 10s CallContext timeout instead of
 		// failing fast.
-		if subID, ok := firstStringParam(req.Params); ok && ms.hasSubscription(subID) {
+		if subID, ok := ms.firstSubscriptionParam(req.Params); ok && ms.hasSubscription(subID) {
 			ms.closeSubscription(subID)
 			response := map[string]interface{}{
 				"jsonrpc": "2.0",
@@ -112,27 +124,43 @@ func (ms *mockSubscriptionServer) handleWS(w http.ResponseWriter, r *http.Reques
 			continue
 		}
 
-		subID := ms.createSubscription()
+		subID, wireID := ms.createSubscription()
 		response := map[string]interface{}{
 			"jsonrpc": "2.0",
 			"id":      req.ID,
-			"result":  subID,
+			"result":  wireID,
 		}
 		respBytes, _ := json.Marshal(response)
 		ms.safeWriteMessage(conn, websocket.TextMessage, respBytes)
-		go ms.sendSubscriptionMessages(conn, subID)
+		go ms.sendSubscriptionMessages(conn, subID, wireID)
 	}
 }
 
-// firstStringParam returns params[0] when it is a string, which is the shape every
-// unsubscribe in every spec uses to name the subscription being torn down.
-func firstStringParam(params interface{}) (string, bool) {
+// firstSubscriptionParam returns params[0] rendered the way createSubscription keys
+// subscriptions: a string verbatim, a number in decimal.
+//
+// Accepting the number matters. Solana numbers its subscriptions, so a string-only check
+// reads accountUnsubscribe(23784) as a fresh subscribe and answers with a new id instead of
+// tearing the old one down — which is the same "the harness can only speak EVM" blindness
+// that hid MAG-3345.
+func (ms *mockSubscriptionServer) firstSubscriptionParam(params interface{}) (string, bool) {
 	list, ok := params.([]interface{})
 	if !ok || len(list) == 0 {
 		return "", false
 	}
-	s, ok := list[0].(string)
-	return s, ok
+	switch v := list[0].(type) {
+	case string:
+		// A node that numbers its subscriptions does not answer to a quoted id. Being
+		// strict here is what makes the teardown param's shape observable: a lenient mock
+		// accepts the router's canonical decimal string and hides the bug.
+		if ms.numericIDs {
+			return "", false
+		}
+		return v, true
+	case float64:
+		return strconv.FormatInt(int64(v), 10), true
+	}
+	return "", false
 }
 
 func (ms *mockSubscriptionServer) recordMethod(method string) {
@@ -157,12 +185,27 @@ func (ms *mockSubscriptionServer) hasSubscription(subID string) bool {
 	return ok
 }
 
-func (ms *mockSubscriptionServer) createSubscription() string {
+// createSubscription mints the next subscription id: the key the server tracks it under,
+// and the JSON value it puts on the wire. The first non-numeric id is subscriptionID
+// unchanged, so tests written against the old fixed-id harness keep their expectations.
+func (ms *mockSubscriptionServer) createSubscription() (key string, wire any) {
 	ms.lock.Lock()
 	defer ms.lock.Unlock()
 
-	ms.subscriptions[ms.subscriptionID] = make(chan struct{})
-	return ms.subscriptionID
+	ms.subscriptionSeq++
+	if ms.numericIDs {
+		id := ms.firstNumericID + ms.subscriptionSeq - 1
+		key = strconv.Itoa(id)
+		ms.subscriptions[key] = make(chan struct{})
+		return key, id
+	}
+
+	key = ms.subscriptionID
+	if ms.subscriptionSeq > 1 {
+		key = fmt.Sprintf("%s-%d", ms.subscriptionID, ms.subscriptionSeq)
+	}
+	ms.subscriptions[key] = make(chan struct{})
+	return key, key
 }
 
 func (ms *mockSubscriptionServer) closeSubscription(subID string) {
@@ -175,7 +218,7 @@ func (ms *mockSubscriptionServer) closeSubscription(subID string) {
 	}
 }
 
-func (ms *mockSubscriptionServer) sendSubscriptionMessages(conn *websocket.Conn, subID string) {
+func (ms *mockSubscriptionServer) sendSubscriptionMessages(conn *websocket.Conn, subID string, wireID any) {
 	ms.lock.RLock()
 	closeCh, exists := ms.subscriptions[subID]
 	ms.lock.RUnlock()
@@ -198,7 +241,7 @@ func (ms *mockSubscriptionServer) sendSubscriptionMessages(conn *websocket.Conn,
 				"jsonrpc": "2.0",
 				"method":  ms.notificationMethod,
 				"params": map[string]interface{}{
-					"subscription": subID,
+					"subscription": wireID,
 					"result": map[string]interface{}{
 						"number": counter,
 					},
@@ -1475,30 +1518,76 @@ func TestRewriteSubscriptionID_Substrate(t *testing.T) {
 		"the payload must be relayed unchanged")
 }
 
-// TestRewriteSubscriptionID_SolanaUntouched pins the boundary of the MAG-3345 rewrite.
-// Solana's ids are integers, so a router id cannot stand in for one. Matching on the
-// params envelope brings those frames into range of the rewrite for the first time, and
-// they must keep falling through to pass-through rather than acquiring a string id.
-func TestRewriteSubscriptionID_SolanaUntouched(t *testing.T) {
+// TestRewriteSubscriptionID_SolanaNumeric supersedes MAG-3345's
+// TestRewriteSubscriptionID_SolanaUntouched, which asserted that a Solana frame passed
+// through carrying the upstream id. That was the correct boundary while router ids were
+// always strings — a string id is one a Solana client cannot hand back to
+// accountUnsubscribe. Now that router ids follow the chain's own shape, the frame must be
+// rewritten like any other, with the id staying a JSON number (MAG-3359).
+func TestRewriteSubscriptionID_SolanaNumeric(t *testing.T) {
 	solanaMsg := &rpcclient.JsonrpcMessage{
 		Method: "accountNotification",
 		Params: json.RawMessage(`{"subscription":23784,"result":{"context":{"slot":5208469}}}`),
 	}
 
-	result, err := rewriteSubscriptionID(solanaMsg, "rs_router_1")
+	result, err := rewriteSubscriptionID(solanaMsg, "1000001")
 	require.NoError(t, err)
 
 	var parsed struct {
 		Method string `json:"method"`
 		Params struct {
 			Subscription json.RawMessage `json:"subscription"`
+			Result       json.RawMessage `json:"result"`
 		} `json:"params"`
 	}
 	require.NoError(t, json.Unmarshal(result, &parsed))
 
 	assert.Equal(t, "accountNotification", parsed.Method)
-	assert.JSONEq(t, `23784`, string(parsed.Params.Subscription),
-		"an integer subscription id must not be replaced by a string router id")
+	assert.JSONEq(t, `1000001`, string(parsed.Params.Subscription),
+		"the router id must replace the upstream id")
+	assert.Equal(t, "1000001", string(parsed.Params.Subscription),
+		"and must stay a JSON number — a quoted id is one accountUnsubscribe cannot use")
+	assert.JSONEq(t, `{"context":{"slot":5208469}}`, string(parsed.Params.Result))
+}
+
+// TestRewriteSubscriptionID_NonScalarIDUntouched keeps the rewrite off anything that is not
+// a string or a number, rather than coercing it.
+func TestRewriteSubscriptionID_NonScalarIDUntouched(t *testing.T) {
+	msg := &rpcclient.JsonrpcMessage{
+		Method: "oddNotification",
+		Params: json.RawMessage(`{"subscription":{"nested":true},"result":{}}`),
+	}
+
+	result, err := rewriteSubscriptionID(msg, "1000001")
+	require.NoError(t, err)
+	assert.Contains(t, string(result), `"nested":true`,
+		"an object id is not something a router id can stand in for; pass it through")
+}
+
+// TestExtractSubscriptionID_Numeric covers the upstream id arriving as a number. Returning
+// "" here — which is what a string-only decode did — left the router with no mapping to
+// translate back to on unsubscribe.
+func TestExtractSubscriptionID_Numeric(t *testing.T) {
+	assert.Equal(t, "23784", extractSubscriptionID(&rpcclient.JsonrpcMessage{
+		Result: json.RawMessage(`23784`),
+	}), "a numbered subscription must canonicalise to its decimal string")
+
+	assert.Equal(t, "0xabc", extractSubscriptionID(&rpcclient.JsonrpcMessage{
+		Result: json.RawMessage(`"0xabc"`),
+	}), "a named subscription is unchanged")
+
+	assert.Equal(t, "", extractSubscriptionID(&rpcclient.JsonrpcMessage{
+		Result: json.RawMessage(`{"query":"tm.event='NewBlock'"}`),
+	}), "an object result names no subscription")
+}
+
+// TestSubscriptionIDValue_ShapesForTheWire pins the one place the string/number distinction
+// is allowed to exist: the wire. Everything inside the router is the decimal string.
+func TestSubscriptionIDValue_ShapesForTheWire(t *testing.T) {
+	assert.Equal(t, int64(1000001), subscriptionIDValue("1000001", true))
+	assert.Equal(t, "1000001", subscriptionIDValue("1000001", false))
+	assert.Equal(t, "rs_abc123_00001", subscriptionIDValue("rs_abc123_00001", true),
+		"an id that is not a number must not be mangled into one")
 }
 
 // TestDirectWSSubscriptionManager_TendermintAPIInterface tests manager with Tendermint API interface
@@ -2856,5 +2945,297 @@ func TestEndToEnd_SubstratePushFrameReachesClient(t *testing.T) {
 		assert.NotEmpty(t, frame.Params.Result, "the payload must be relayed")
 	case <-time.After(5 * time.Second):
 		t.Fatal("no push frame reached the client within 5s — the subscription is dead end-to-end")
+	}
+}
+
+// --- MAG-3359: chains that number their subscriptions -----------------------------------
+
+// TestUnsubscribeParamsExtraction_SolanaNumeric covers the client sending its id back as a
+// JSON number. A string-only type assertion rejected it outright, so the unsubscribe failed
+// before it ever reached the ownership check.
+func TestUnsubscribeParamsExtraction_SolanaNumeric(t *testing.T) {
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc", "SOLANA", "jsonrpc",
+		[]*common.NodeUrl{{Url: "ws://localhost:8900"}},
+		nil, nil, nil,
+	)
+
+	numeric := &mockWSProtocolMessage{
+		method: "accountUnsubscribe",
+		params: []interface{}{int64(1000001)},
+	}
+	id, err := manager.extractSubscriptionIDFromUnsubscribe(numeric)
+	require.NoError(t, err)
+	assert.Equal(t, "1000001", id, "a numbered id must canonicalise to its decimal string")
+
+	named := &mockWSProtocolMessage{
+		method: "eth_unsubscribe",
+		params: []interface{}{"0x1a2b3c4d"},
+	}
+	id, err = manager.extractSubscriptionIDFromUnsubscribe(named)
+	require.NoError(t, err)
+	assert.Equal(t, "0x1a2b3c4d", id, "a named id is unchanged")
+}
+
+// TestCreateSubscriptionReply_SolanaNumeric pins the reply shape. Solana's collection is
+// jsonrpc, so it lands in the same branch as EVM — the number/string decision has to come
+// from the node's own response, not from the api interface.
+func TestCreateSubscriptionReply_SolanaNumeric(t *testing.T) {
+	upstream := &rpcclient.JsonrpcMessage{
+		ID:     json.RawMessage(`7`),
+		Result: json.RawMessage(`23784`),
+	}
+
+	reply, err := createSubscriptionReply("1000001", json.RawMessage(`7`), upstream, "jsonrpc")
+	require.NoError(t, err)
+
+	var parsed struct {
+		ID     json.RawMessage `json:"id"`
+		Result json.RawMessage `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(reply, &parsed))
+	assert.JSONEq(t, `7`, string(parsed.ID))
+	assert.Equal(t, "1000001", string(parsed.Result),
+		"result must be the router id as a JSON number, not the upstream id and not a string")
+}
+
+// solanaSubscribeMessage builds the accountSubscribe the tests below drive the manager with.
+func solanaSubscribeMessage(t *testing.T, requestID int) *mockWSProtocolMessageWithRawData {
+	t.Helper()
+	const account = "Vote111111111111111111111111111111111111111"
+	body, err := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0", "method": "accountSubscribe",
+		"params": []interface{}{account}, "id": requestID,
+	})
+	require.NoError(t, err)
+	return &mockWSProtocolMessageWithRawData{
+		mockWSProtocolMessage: mockWSProtocolMessage{
+			method: "accountSubscribe",
+			params: []interface{}{account},
+		},
+		rawData: body,
+	}
+}
+
+// newSolanaMockServer returns a mock upstream that behaves like a Solana node: it numbers
+// its subscriptions and names its push frames after the payload.
+func newSolanaMockServer() *mockSubscriptionServer {
+	ms := newMockSubscriptionServer()
+	ms.messageInterval = 20 * time.Millisecond
+	ms.notificationMethod = "accountNotification"
+	ms.numericIDs = true
+	return ms
+}
+
+func newSolanaManager(nodeUrl *common.NodeUrl) *DirectWSSubscriptionManager {
+	return NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc", "SOLANA", "jsonrpc",
+		[]*common.NodeUrl{nodeUrl},
+		nil, nil, nil,
+	)
+}
+
+// numericSubscriptionID reads the id out of a subscribe reply, failing the test unless it is
+// an unquoted JSON number. The quoting is the whole point: a Solana client stores whatever
+// `result` gave it and hands that straight back to accountUnsubscribe.
+func numericSubscriptionID(t *testing.T, replyData []byte) int64 {
+	t.Helper()
+	var resp struct {
+		Result json.RawMessage `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(replyData, &resp))
+	var id int64
+	require.NoError(t, json.Unmarshal(resp.Result, &id),
+		"result must be a JSON number, got %s", resp.Result)
+	return id
+}
+
+// TestEndToEnd_SolanaNumericSubscriptionRoundTrip is the regression for MAG-3359. It runs
+// over a real WebSocket against a node that numbers its subscriptions, so every site the
+// ticket enumerated is live at once: the dispatcher that decides a frame is a push at all,
+// the upstream-id extraction, the reply shape, the per-frame rewrite, and both ends of
+// unsubscribe.
+//
+// Before the fix nothing arrived on repliesChan at all, exactly as for Substrate — the
+// dispatcher never recognised accountNotification, so the router answered the node with an
+// "invalid request" for every push instead of delivering it.
+func TestEndToEnd_SolanaNumericSubscriptionRoundTrip(t *testing.T) {
+	mockSrv := newSolanaMockServer()
+	defer mockSrv.Close()
+
+	manager := newSolanaManager(&common.NodeUrl{Url: mockSrv.URL()})
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const dappID, ip, wsUID = "dapp-sol", "192.168.99.96", "ws-sol"
+	reply, repliesChan, err := manager.StartSubscription(ctx, solanaSubscribeMessage(t, 1), dappID, ip, wsUID, nil)
+	require.NoError(t, err, "the subscribe half always worked")
+	require.NotNil(t, reply)
+	require.NotNil(t, repliesChan)
+
+	routerSubID := numericSubscriptionID(t, reply.Data)
+	require.NotEqual(t, int64(23784), routerSubID,
+		"the router must issue its own id; passing the upstream one through is what breaks on reconnect")
+
+	select {
+	case notif := <-repliesChan:
+		require.NotNil(t, notif, "a Solana subscription must deliver push frames")
+		var frame struct {
+			Method string `json:"method"`
+			Params struct {
+				Subscription json.RawMessage `json:"subscription"`
+				Result       json.RawMessage `json:"result"`
+			} `json:"params"`
+		}
+		require.NoError(t, json.Unmarshal(notif.Data, &frame))
+		assert.Equal(t, "accountNotification", frame.Method)
+		assert.Equal(t, strconv.FormatInt(routerSubID, 10), string(frame.Params.Subscription),
+			"the push must carry the router id, still unquoted")
+		assert.NotEmpty(t, frame.Params.Result, "the payload must be relayed")
+	case <-time.After(5 * time.Second):
+		t.Fatal("no push frame reached the client within 5s — the subscription is dead end-to-end")
+	}
+
+	unsubBody, err := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0", "method": "accountUnsubscribe",
+		"params": []interface{}{routerSubID}, "id": 2,
+	})
+	require.NoError(t, err)
+	unsubMsg := &mockWSProtocolMessageWithRawData{
+		mockWSProtocolMessage: mockWSProtocolMessage{
+			method: "accountUnsubscribe",
+			params: []interface{}{routerSubID},
+		},
+		rawData: unsubBody,
+	}
+
+	nodeResp, err := manager.Unsubscribe(ctx, unsubMsg, dappID, ip, wsUID, nil)
+	require.NoError(t, err, "unsubscribe with the issued numeric id must not be rejected")
+	require.NotNil(t, nodeResp)
+
+	observed := mockSrv.ObservedMethods()
+	require.Contains(t, observed, "accountSubscribe")
+	require.Contains(t, observed, "accountUnsubscribe")
+
+	mockSrv.lock.RLock()
+	leftover := len(mockSrv.subscriptions)
+	mockSrv.lock.RUnlock()
+	assert.Equal(t, 0, leftover,
+		"the node must have been sent its own integer id; the router id would have matched nothing there")
+}
+
+// TestEndToEnd_SolanaJoiningClientGetsItsOwnNumericID covers the dedup path. A second client
+// on the same params joins the one upstream subscription and is issued its own id — which
+// has to be a number too, since the id-shape decision lives on the subscription rather than
+// being re-derived from a node response the joining client never sees.
+func TestEndToEnd_SolanaJoiningClientGetsItsOwnNumericID(t *testing.T) {
+	mockSrv := newSolanaMockServer()
+	defer mockSrv.Close()
+
+	manager := newSolanaManager(&common.NodeUrl{Url: mockSrv.URL()})
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	firstReply, firstChan, err := manager.StartSubscription(ctx, solanaSubscribeMessage(t, 1), "dapp-a", "10.0.0.1", "ws-a", nil)
+	require.NoError(t, err)
+	require.NotNil(t, firstChan)
+	firstID := numericSubscriptionID(t, firstReply.Data)
+
+	secondReply, secondChan, err := manager.StartSubscription(ctx, solanaSubscribeMessage(t, 2), "dapp-b", "10.0.0.2", "ws-b", nil)
+	require.NoError(t, err)
+	require.NotNil(t, secondChan, "the second client must join, not be turned away")
+	secondID := numericSubscriptionID(t, secondReply.Data)
+
+	assert.NotEqual(t, firstID, secondID, "each client gets its own id")
+
+	require.Equal(t, 1, len(manager.activeSubscriptions),
+		"identical params must share one upstream subscription")
+
+	for name, ch := range map[string]<-chan *pairingtypes.RelayReply{"first": firstChan, "second": secondChan} {
+		select {
+		case notif := <-ch:
+			require.NotNil(t, notif)
+			assert.Contains(t, string(notif.Data), `"accountNotification"`,
+				"%s client should receive the push", name)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("%s client received no push frame within 5s", name)
+		}
+	}
+}
+
+// TestSolanaRouterIDSurvivesUpstreamReconnect is the assertion that encodes why the router
+// issues its own numeric id rather than relaying the node's.
+//
+// Passing the upstream id through would have been a far smaller change, and it is what the
+// ticket floated as the cheap option. This test is why it was rejected:
+// handleUpstreamDisconnect re-subscribes and the node answers with a DIFFERENT id, so a
+// client holding the upstream one would silently be left with an id that names nothing —
+// pushes tagged with an id it never saw, and an unsubscribe that cannot be matched.
+func TestSolanaRouterIDSurvivesUpstreamReconnect(t *testing.T) {
+	mockSrv := newSolanaMockServer()
+	defer mockSrv.Close()
+
+	manager := newSolanaManager(&common.NodeUrl{Url: mockSrv.URL()})
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	const dappID, ip, wsUID = "dapp-sol", "192.168.99.95", "ws-sol"
+	reply, repliesChan, err := manager.StartSubscription(ctx, solanaSubscribeMessage(t, 1), dappID, ip, wsUID, nil)
+	require.NoError(t, err)
+	routerSubID := numericSubscriptionID(t, reply.Data)
+
+	clientKey := manager.CreateWebSocketConnectionUniqueKey(dappID, ip, wsUID)
+
+	manager.lock.RLock()
+	require.Len(t, manager.activeSubscriptions, 1)
+	var hashedParams string
+	var activeSub *directActiveSubscription
+	for hp, sub := range manager.activeSubscriptions {
+		hashedParams, activeSub = hp, sub
+	}
+	upstreamBefore := activeSub.upstreamID
+	manager.lock.RUnlock()
+
+	require.Equal(t, "23784", upstreamBefore, "the first upstream subscription")
+
+	// Drain whatever the original subscription already delivered, so the frame asserted on
+	// below is unambiguously one the restored subscription produced.
+	drain := time.After(200 * time.Millisecond)
+drainLoop:
+	for {
+		select {
+		case <-repliesChan:
+		case <-drain:
+			break drainLoop
+		}
+	}
+
+	manager.handleUpstreamDisconnect(ctx, hashedParams, activeSub)
+
+	manager.lock.RLock()
+	upstreamAfter := activeSub.upstreamID
+	routerIDAfter := activeSub.clientRouterIDs[clientKey]
+	manager.lock.RUnlock()
+
+	require.NotEqual(t, upstreamBefore, upstreamAfter,
+		"the node must have issued a new id, or this test proves nothing")
+	assert.Equal(t, strconv.FormatInt(routerSubID, 10), routerIDAfter,
+		"the client's id must be unchanged across the reconnect — that is what the indirection buys")
+
+	select {
+	case notif := <-repliesChan:
+		require.NotNil(t, notif)
+		var frame struct {
+			Params struct {
+				Subscription json.RawMessage `json:"subscription"`
+			} `json:"params"`
+		}
+		require.NoError(t, json.Unmarshal(notif.Data, &frame))
+		assert.Equal(t, strconv.FormatInt(routerSubID, 10), string(frame.Params.Subscription),
+			"post-reconnect frames must still carry the id the client holds, not upstream %q", upstreamAfter)
+	case <-time.After(5 * time.Second):
+		t.Fatal("no push frame after the reconnect — the subscription was not restored")
 	}
 }

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
@@ -1495,7 +1495,7 @@ func TestRewriteSubscriptionID_EVM(t *testing.T) {
 func TestRewriteSubscriptionID_Substrate(t *testing.T) {
 	substrateMsg := &rpcclient.JsonrpcMessage{
 		Method: "chain_newHead",
-		Params: json.RawMessage(`{"subscription":"Ck1rTHhOa1hxTGV3","result":{"number":"0x1234"}}`),
+		Params: json.RawMessage(`{"subscription":"Ck1rTHhOa1hxTGV3","result":{"number":"0x1234"},"extra":"keepme"}`),
 	}
 
 	result, err := rewriteSubscriptionID(substrateMsg, "rs_router_1", false)
@@ -1506,6 +1506,7 @@ func TestRewriteSubscriptionID_Substrate(t *testing.T) {
 		Params struct {
 			Subscription string          `json:"subscription"`
 			Result       json.RawMessage `json:"result"`
+			Extra        json.RawMessage `json:"extra"`
 		} `json:"params"`
 	}
 	require.NoError(t, json.Unmarshal(result, &parsed))
@@ -1516,6 +1517,10 @@ func TestRewriteSubscriptionID_Substrate(t *testing.T) {
 		"subscription must be the router id, not the upstream id")
 	assert.JSONEq(t, `{"number":"0x1234"}`, string(parsed.Params.Result),
 		"the payload must be relayed unchanged")
+	assert.JSONEq(t, `"keepme"`, string(parsed.Params.Extra),
+		"a sibling field must survive: preserving them is the whole reason the rewrite "+
+			"rebuilds the envelope from a map instead of a fixed {subscription, result} "+
+			"struct, and without this assertion a revert to the struct passes every test")
 }
 
 // TestRewriteSubscriptionID_SolanaNumeric supersedes MAG-3345's

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
@@ -1447,7 +1447,7 @@ func TestRewriteSubscriptionID_Tendermint(t *testing.T) {
 	}
 
 	// Should pass through unchanged (Tendermint doesn't need ID rewriting)
-	result, err := rewriteSubscriptionID(tendermintMsg, "router-id-123")
+	result, err := rewriteSubscriptionID(tendermintMsg, "router-id-123", false)
 	require.NoError(t, err)
 
 	var parsed map[string]json.RawMessage
@@ -1471,7 +1471,7 @@ func TestRewriteSubscriptionID_EVM(t *testing.T) {
 		Params: json.RawMessage(`{"subscription":"0xoriginal","result":{"blockNumber":"0x1234"}}`),
 	}
 
-	result, err := rewriteSubscriptionID(evmMsg, "0xrouter123")
+	result, err := rewriteSubscriptionID(evmMsg, "0xrouter123", false)
 	require.NoError(t, err)
 
 	var parsed struct {
@@ -1498,7 +1498,7 @@ func TestRewriteSubscriptionID_Substrate(t *testing.T) {
 		Params: json.RawMessage(`{"subscription":"Ck1rTHhOa1hxTGV3","result":{"number":"0x1234"}}`),
 	}
 
-	result, err := rewriteSubscriptionID(substrateMsg, "rs_router_1")
+	result, err := rewriteSubscriptionID(substrateMsg, "rs_router_1", false)
 	require.NoError(t, err)
 
 	var parsed struct {
@@ -1530,7 +1530,7 @@ func TestRewriteSubscriptionID_SolanaNumeric(t *testing.T) {
 		Params: json.RawMessage(`{"subscription":23784,"result":{"context":{"slot":5208469}}}`),
 	}
 
-	result, err := rewriteSubscriptionID(solanaMsg, "1000001")
+	result, err := rewriteSubscriptionID(solanaMsg, "1000001", true)
 	require.NoError(t, err)
 
 	var parsed struct {
@@ -1558,7 +1558,7 @@ func TestRewriteSubscriptionID_NonScalarIDUntouched(t *testing.T) {
 		Params: json.RawMessage(`{"subscription":{"nested":true},"result":{}}`),
 	}
 
-	result, err := rewriteSubscriptionID(msg, "1000001")
+	result, err := rewriteSubscriptionID(msg, "1000001", false)
 	require.NoError(t, err)
 	assert.Contains(t, string(result), `"nested":true`,
 		"an object id is not something a router id can stand in for; pass it through")
@@ -1649,7 +1649,7 @@ func TestCreateSubscriptionReply_Tendermint(t *testing.T) {
 	}
 
 	// For Tendermint, should return original result format (not router ID)
-	replyData, err := createSubscriptionReply("router-id-ignored", json.RawMessage(`1`), originalMsg, "tendermintrpc")
+	replyData, err := createSubscriptionReply("router-id-ignored", json.RawMessage(`1`), originalMsg, "tendermintrpc", false)
 	require.NoError(t, err)
 
 	// Parse the response
@@ -1689,7 +1689,7 @@ func TestCreateSubscriptionReply_Tendermint_PreservesUpstreamFields(t *testing.T
 		},
 	}
 
-	replyData, err := createSubscriptionReply("ignored", json.RawMessage(`"abc"`), originalMsg, "tendermintrpc")
+	replyData, err := createSubscriptionReply("ignored", json.RawMessage(`"abc"`), originalMsg, "tendermintrpc", false)
 	require.NoError(t, err)
 
 	var resp map[string]json.RawMessage
@@ -1722,7 +1722,7 @@ func TestCreateSubscriptionReply_EVM(t *testing.T) {
 	routerID := "0xrouter456"
 
 	// For EVM, should replace upstream ID with router ID
-	replyData, err := createSubscriptionReply(routerID, json.RawMessage(`1`), originalMsg, "jsonrpc")
+	replyData, err := createSubscriptionReply(routerID, json.RawMessage(`1`), originalMsg, "jsonrpc", false)
 	require.NoError(t, err)
 
 	// Parse the response
@@ -1748,7 +1748,7 @@ func TestCreateSubscriptionReplyFromRouterID_Tendermint(t *testing.T) {
 	clientRequestID := json.RawMessage(`42`)
 
 	// For Tendermint, should return query format with client's request ID
-	replyData, err := createSubscriptionReplyFromRouterID("router-id-ignored", clientRequestID, "tendermintrpc", originalResult)
+	replyData, err := createSubscriptionReplyFromRouterID("router-id-ignored", clientRequestID, "tendermintrpc", originalResult, false)
 	require.NoError(t, err)
 
 	// Parse the response
@@ -1779,7 +1779,7 @@ func TestCreateSubscriptionReplyFromRouterID_EVM(t *testing.T) {
 	clientRouterID := "0xclient-router-id"
 
 	// For EVM, should return router ID (originalResult not used)
-	replyData, err := createSubscriptionReplyFromRouterID(clientRouterID, clientRequestID, "jsonrpc", nil)
+	replyData, err := createSubscriptionReplyFromRouterID(clientRouterID, clientRequestID, "jsonrpc", nil, false)
 	require.NoError(t, err)
 
 	// Parse the response
@@ -1808,7 +1808,7 @@ func TestTendermintSubscriptionEndToEnd(t *testing.T) {
 		}
 
 		// Create reply for Tendermint
-		reply, err := createSubscriptionReply("any-router-id", json.RawMessage(`1`), upstreamResponse, "tendermintrpc")
+		reply, err := createSubscriptionReply("any-router-id", json.RawMessage(`1`), upstreamResponse, "tendermintrpc", false)
 		require.NoError(t, err)
 
 		// Client should see the query format, not a router ID
@@ -1825,7 +1825,7 @@ func TestTendermintSubscriptionEndToEnd(t *testing.T) {
 		}
 
 		// Rewrite should pass through unchanged for Tendermint
-		rewritten, err := rewriteSubscriptionID(notification, "some-router-id")
+		rewritten, err := rewriteSubscriptionID(notification, "some-router-id", false)
 		require.NoError(t, err)
 
 		// Should still contain the query and data
@@ -2181,7 +2181,7 @@ func TestCreateSubscriptionReply_EchoesStringRequestID(t *testing.T) {
 		}
 
 		clientID := json.RawMessage(`"client-uuid-1"`)
-		replyData, err := createSubscriptionReply("rs_abc123_00001", clientID, upstream, "jsonrpc")
+		replyData, err := createSubscriptionReply("rs_abc123_00001", clientID, upstream, "jsonrpc", false)
 		require.NoError(t, err)
 
 		var resp map[string]json.RawMessage
@@ -2200,7 +2200,7 @@ func TestCreateSubscriptionReply_EchoesStringRequestID(t *testing.T) {
 			Result:  json.RawMessage(`"0xabc"`),
 		}
 
-		replyData, err := createSubscriptionReply("rs_xxx_00001", json.RawMessage(`42`), upstream, "jsonrpc")
+		replyData, err := createSubscriptionReply("rs_xxx_00001", json.RawMessage(`42`), upstream, "jsonrpc", false)
 		require.NoError(t, err)
 
 		var resp map[string]json.RawMessage
@@ -2216,7 +2216,7 @@ func TestCreateSubscriptionReply_EchoesStringRequestID(t *testing.T) {
 			Result:  json.RawMessage(`{"query":"tm.event='NewBlock'"}`),
 		}
 
-		replyData, err := createSubscriptionReply("ignored", json.RawMessage(`"abc"`), upstream, "tendermintrpc")
+		replyData, err := createSubscriptionReply("ignored", json.RawMessage(`"abc"`), upstream, "tendermintrpc", false)
 		require.NoError(t, err)
 
 		var resp map[string]json.RawMessage
@@ -2987,7 +2987,7 @@ func TestCreateSubscriptionReply_SolanaNumeric(t *testing.T) {
 		Result: json.RawMessage(`23784`),
 	}
 
-	reply, err := createSubscriptionReply("1000001", json.RawMessage(`7`), upstream, "jsonrpc")
+	reply, err := createSubscriptionReply("1000001", json.RawMessage(`7`), upstream, "jsonrpc", true)
 	require.NoError(t, err)
 
 	var parsed struct {
@@ -3150,7 +3150,10 @@ func TestEndToEnd_SolanaJoiningClientGetsItsOwnNumericID(t *testing.T) {
 
 	assert.NotEqual(t, firstID, secondID, "each client gets its own id")
 
-	require.Equal(t, 1, len(manager.activeSubscriptions),
+	manager.lock.RLock()
+	activeCount := len(manager.activeSubscriptions)
+	manager.lock.RUnlock()
+	require.Equal(t, 1, activeCount,
 		"identical params must share one upstream subscription")
 
 	for name, ch := range map[string]<-chan *pairingtypes.RelayReply{"first": firstChan, "second": secondChan} {
@@ -3173,6 +3176,12 @@ func TestEndToEnd_SolanaJoiningClientGetsItsOwnNumericID(t *testing.T) {
 // handleUpstreamDisconnect re-subscribes and the node answers with a DIFFERENT id, so a
 // client holding the upstream one would silently be left with an id that names nothing —
 // pushes tagged with an id it never saw, and an unsubscribe that cannot be matched.
+//
+// Scope: this calls handleUpstreamDisconnect directly rather than provoking a real upstream
+// error, so it exercises the restore path and NOT listenForUpstreamMessages' cleanup-ownership
+// handoff (which is covered by TestListenForUpstreamMessages_ReconnectSkipsCleanup). One
+// consequence is that the original listener goroutine is still selecting when the restored one
+// starts; both fan out to the same clients, so the assertions below are unaffected.
 func TestSolanaRouterIDSurvivesUpstreamReconnect(t *testing.T) {
 	mockSrv := newSolanaMockServer()
 	defer mockSrv.Close()
@@ -3237,5 +3246,71 @@ drainLoop:
 			"post-reconnect frames must still carry the id the client holds, not upstream %q", upstreamAfter)
 	case <-time.After(5 * time.Second):
 		t.Fatal("no push frame after the reconnect — the subscription was not restored")
+	}
+}
+
+// TestSubscriptionIDsAreNumeric is the guard on the one decision that picks a client's id
+// type. It is separated out because the shape decision and the id canonicalisation are two
+// different functions, and a case covered on only one of them is how `null` slipped through:
+// json.Unmarshal decodes null into an int64 with a NIL error, so a plain decode reports it as
+// a number while CanonicalSubscriptionID correctly reports it as naming nothing.
+func TestSubscriptionIDsAreNumeric(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"solana number", `23784`, true},
+		{"zero", `0`, true},
+		{"negative", `-5`, true},
+		{"leading whitespace", "  23784", true},
+		{"ethereum hex string", `"0x9ce59a13"`, false},
+		{"substrate opaque string", `"Ck1rTHhOa1hxTGV3"`, false},
+		{"null is not a number", `null`, false},
+		{"tendermint query object", `{"query":"tm.event='NewBlock'"}`, false},
+		{"array", `[1]`, false},
+		{"absent", ``, false},
+		{"true", `true`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, subscriptionIDsAreNumeric(json.RawMessage(tc.raw)),
+				"subscriptionIDsAreNumeric(%s)", tc.raw)
+		})
+	}
+}
+
+// TestSubscriptionIDsAreNumeric_AgreesWithCanonicalisation pins the two halves together. A
+// value this reports as numeric must be one CanonicalSubscriptionID also accepts, or the
+// router would issue an id in a shape whose upstream counterpart it cannot key on.
+func TestSubscriptionIDsAreNumeric_AgreesWithCanonicalisation(t *testing.T) {
+	for _, raw := range []string{`23784`, `0`, `null`, `""`, `"0xabc"`, `{}`, `[1]`, `1.5`} {
+		if subscriptionIDsAreNumeric(json.RawMessage(raw)) {
+			_, named := rpcclient.CanonicalSubscriptionID(json.RawMessage(raw))
+			assert.True(t, named,
+				"%s reads as numeric but names no subscription — the two halves disagree", raw)
+		}
+	}
+}
+
+// TestGenerateNumericRouterID covers the generator whose output the client is handed
+// verbatim: ids must be numbers, must be distinct, and must sit above the range a node
+// plausibly issues so they cannot be mistaken for an upstream id in the unsubscribe lookup.
+func TestGenerateNumericRouterID(t *testing.T) {
+	mapper := NewSubscriptionIDMapper()
+
+	seen := make(map[string]struct{}, 100)
+	for i := 0; i < 100; i++ {
+		id := mapper.GenerateNumericRouterID()
+
+		parsed, err := strconv.ParseInt(id, 10, 64)
+		require.NoError(t, err, "a numeric router id must parse as a number, got %q", id)
+		assert.GreaterOrEqual(t, parsed, int64(numericRouterIDBase),
+			"ids must sit above the base, or they can collide with a node's own ids")
+		assert.Less(t, parsed, int64(1)<<53,
+			"ids must stay below 2^53 or a JavaScript client cannot round-trip them")
+
+		_, dup := seen[id]
+		require.False(t, dup, "ids must be distinct, %q repeated at i #%d", id, i)
+		seen[id] = struct{}{}
 	}
 }

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
@@ -244,6 +244,10 @@ func (ms *mockSubscriptionServer) sendSubscriptionMessages(conn *websocket.Conn,
 					"subscription": wireID,
 					"result": map[string]interface{}{
 						"number": counter,
+						// Provenance: which upstream subscription produced this frame.
+						// Without it a post-reconnect assertion cannot tell a restored
+						// frame from one the previous subscription is still pushing.
+						"upstream": wireID,
 					},
 				},
 			}
@@ -1570,7 +1574,7 @@ func TestRewriteSubscriptionID_UnusableIDIsAnError(t *testing.T) {
 
 	_, err := rewriteSubscriptionID(msg, "1000001", false)
 	require.Error(t, err, "an object id must not be silently passed through")
-	assert.Contains(t, err.Error(), "neither a string nor a number")
+	assert.Contains(t, err.Error(), "names no subscription")
 }
 
 // TestRewriteSubscriptionID_NonEnvelopePassesThrough keeps that error off frames that are
@@ -2998,6 +3002,21 @@ func TestUnsubscribeParamsExtraction_SolanaNumeric(t *testing.T) {
 	id, err = manager.extractSubscriptionIDFromUnsubscribe(named)
 	require.NoError(t, err)
 	assert.Equal(t, "0x1a2b3c4d", id, "a named id is unchanged")
+
+	// The shape production actually delivers. GetRPCMessage decodes params into
+	// interface{}, so a client's numeric id arrives as a float64 and is re-marshalled from
+	// one — the int64 above never exercises that. This fails loudly if the id range is ever
+	// raised toward 2^53, where float64 stops being exact.
+	for _, id := range []float64{1 << 40, (1 << 40) + 1, (1 << 40) + 99999, (1 << 53) - 1} {
+		asFloat := &mockWSProtocolMessage{
+			method: "accountUnsubscribe",
+			params: []interface{}{id},
+		}
+		got, err := manager.extractSubscriptionIDFromUnsubscribe(asFloat)
+		require.NoError(t, err)
+		assert.Equal(t, strconv.FormatInt(int64(id), 10), got,
+			"a float64 id must round-trip exactly, id=%v", id)
+	}
 }
 
 // TestCreateSubscriptionReply_SolanaNumeric pins the reply shape. Solana's collection is
@@ -3255,19 +3274,40 @@ drainLoop:
 	assert.Equal(t, strconv.FormatInt(routerSubID, 10), routerIDAfter,
 		"the client's id must be unchanged across the reconnect — that is what the indirection buys")
 
-	select {
-	case notif := <-repliesChan:
+	// Read until a frame from the RESTORED subscription arrives. The previous upstream
+	// subscription is never torn down here — handleUpstreamDisconnect is called directly,
+	// so ReconnectWithBackoff finds the pool already healthy and returns without dropping
+	// the connection, and the mock keeps pushing on the old id. Without checking
+	// provenance this assertion could be satisfied by a pre-reconnect frame and would
+	// guard nothing.
+	deadline := time.After(5 * time.Second)
+	for {
+		var notif *pairingtypes.RelayReply
+		select {
+		case notif = <-repliesChan:
+		case <-deadline:
+			t.Fatal("no push frame from the restored subscription within 5s")
+		}
 		require.NotNil(t, notif)
+
 		var frame struct {
 			Params struct {
 				Subscription json.RawMessage `json:"subscription"`
+				Result       struct {
+					Upstream json.RawMessage `json:"upstream"`
+				} `json:"result"`
 			} `json:"params"`
 		}
 		require.NoError(t, json.Unmarshal(notif.Data, &frame))
+
 		assert.Equal(t, strconv.FormatInt(routerSubID, 10), string(frame.Params.Subscription),
-			"post-reconnect frames must still carry the id the client holds, not upstream %q", upstreamAfter)
-	case <-time.After(5 * time.Second):
-		t.Fatal("no push frame after the reconnect — the subscription was not restored")
+			"every frame must carry the id the client holds, not an upstream id")
+
+		if string(frame.Params.Result.Upstream) == upstreamAfter {
+			break // this one demonstrably came from the restored subscription
+		}
+		require.Equal(t, upstreamBefore, string(frame.Params.Result.Upstream),
+			"a frame came from neither the original nor the restored subscription")
 	}
 }
 

--- a/protocol/rpcsmartrouter/subscription_id_mapper.go
+++ b/protocol/rpcsmartrouter/subscription_id_mapper.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strconv"
 	"sync"
 	"sync/atomic"
 )
@@ -30,8 +31,25 @@ type SubscriptionIDMapper struct {
 	// clientCounters tracks per-client monotonic counters for ID generation
 	clientCounters map[string]*atomic.Uint64
 
+	// numericCounter backs GenerateNumericRouterID. It is process-wide rather than
+	// per-client because a numeric id is handed to the client verbatim and is compared
+	// against upstream ids during unsubscribe, so it has to be unique across all clients.
+	numericCounter atomic.Uint64
+
 	lock sync.RWMutex
 }
+
+// numericRouterIDBase offsets generated numeric ids clear of the range nodes use for their
+// own, so a router id can never collide with some other subscription's upstream id during
+// the unsubscribe lookup — without that lookup having to know which is which.
+//
+// The base is deliberately far above anything a node plausibly issues rather than merely
+// above what Solana is observed to issue today, so the guarantee does not rest on node
+// behaviour. The ceiling is the other side of it: ids are JSON numbers, and a JavaScript
+// client parses them as float64, so base plus counter has to stay under 2^53 to survive the
+// round trip. 2^40 leaves roughly four thousand times more headroom than any one process
+// will ever need.
+const numericRouterIDBase = 1 << 40
 
 // NewSubscriptionIDMapper creates a new subscription ID mapper
 func NewSubscriptionIDMapper() *SubscriptionIDMapper {
@@ -60,6 +78,17 @@ func (m *SubscriptionIDMapper) GenerateRouterID(clientKey string) string {
 	count := counter.Add(1)
 
 	return fmt.Sprintf("rs_%s_%05d", clientHash, count)
+}
+
+// GenerateNumericRouterID creates a router subscription ID for chains that number their
+// subscriptions rather than naming them (Solana). The id is returned in the same canonical
+// decimal-string form as every other id here — every map in this type stays string-keyed —
+// and is rendered as a JSON number only where it reaches the wire.
+//
+// Unlike GenerateRouterID the counter is not per-client: the value is visible to the client
+// and is matched against upstream ids on unsubscribe, so it must be globally unique.
+func (m *SubscriptionIDMapper) GenerateNumericRouterID() string {
+	return strconv.FormatUint(numericRouterIDBase+m.numericCounter.Add(1), 10)
 }
 
 // RegisterMapping creates the bidirectional mapping between router and upstream IDs.

--- a/protocol/rpcsmartrouter/subscription_id_mapper.go
+++ b/protocol/rpcsmartrouter/subscription_id_mapper.go
@@ -31,9 +31,12 @@ type SubscriptionIDMapper struct {
 	// clientCounters tracks per-client monotonic counters for ID generation
 	clientCounters map[string]*atomic.Uint64
 
-	// numericCounter backs GenerateNumericRouterID. It is process-wide rather than
-	// per-client because a numeric id is handed to the client verbatim and is compared
-	// against upstream ids during unsubscribe, so it has to be unique across all clients.
+	// numericCounter backs GenerateNumericRouterID. Unlike clientCounters it is not
+	// per-client: a numeric id is handed to the client verbatim and is compared against
+	// upstream ids during unsubscribe, so it has to be unique across every client this
+	// mapper serves. That is the scope the lookups actually need — each manager builds its
+	// own mapper, so two managers do issue the same numbers, and nothing may key across
+	// them on this value.
 	numericCounter atomic.Uint64
 
 	lock sync.RWMutex
@@ -86,7 +89,8 @@ func (m *SubscriptionIDMapper) GenerateRouterID(clientKey string) string {
 // and is rendered as a JSON number only where it reaches the wire.
 //
 // Unlike GenerateRouterID the counter is not per-client: the value is visible to the client
-// and is matched against upstream ids on unsubscribe, so it must be globally unique.
+// and is matched against upstream ids on unsubscribe, so it must be unique across every
+// client this mapper serves.
 func (m *SubscriptionIDMapper) GenerateNumericRouterID() string {
 	return strconv.FormatUint(numericRouterIDBase+m.numericCounter.Add(1), 10)
 }

--- a/protocol/rpcsmartrouter/subscription_id_mapper.go
+++ b/protocol/rpcsmartrouter/subscription_id_mapper.go
@@ -1,7 +1,9 @@
 package rpcsmartrouter
 
 import (
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"strconv"
@@ -92,7 +94,30 @@ func (m *SubscriptionIDMapper) GenerateRouterID(clientKey string) string {
 // and is matched against upstream ids on unsubscribe, so it must be unique across every
 // client this mapper serves.
 func (m *SubscriptionIDMapper) GenerateNumericRouterID() string {
-	return strconv.FormatUint(numericRouterIDBase+m.numericCounter.Add(1), 10)
+	return strconv.FormatUint(numericRouterIDBase+m.numericCounter.Add(randomIDStride()), 10)
+}
+
+// maxIDStride bounds how far one id advances the counter. The span between
+// numericRouterIDBase and the 2^53 ceiling leaves room for roughly 1.7e10 ids at the average
+// stride, which no process will approach.
+const maxIDStride = 1 << 20
+
+// randomIDStride returns how far the counter advances for the next numeric id.
+//
+// A fixed +1 would make these ids a public counter: any client can subscribe twice and read
+// off exactly how many subscriptions the manager issued to everyone else in between. The
+// string path avoids that by namespacing per client (rs_{clientHash}_{counter}); a bare
+// number cannot. Seeding the counter randomly at construction would hide the absolute total
+// but NOT that delta, so the stride itself is what has to vary.
+//
+// It stays monotonic, so uniqueness remains structural rather than probabilistic.
+func randomIDStride() uint64 {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// A predictable id beats failing to issue one; uniqueness is unaffected.
+		return 1
+	}
+	return 1 + uint64(binary.BigEndian.Uint32(b[:])%maxIDStride)
 }
 
 // RegisterMapping creates the bidirectional mapping between router and upstream IDs.


### PR DESCRIPTION
Closes [MAG-3345](https://magmadevs.atlassian.net/browse/MAG-3345)

Jira ticket: MAG-3345

## The bug

No Substrate subscription had ever delivered a push frame through the router. The subscribe call itself always succeeded, which is what made the gap silent: nothing errored at boot or at subscribe time, frames simply never arrived. The ticket's suggested control case — `eth_subscribe` works, Substrate does not — localised it the same way it did for MAG-3297.

**Two independent defects sat on the delivery path**, both of them the same assumption: that a push frame can be recognised by its method name.

**1. `rpcclient`: the frame was never delivered.** `handleImmediate` only claimed a frame whose method ended in `_subscription` or `Notification`, or that carried a Tendermint query. Substrate names the frame after the *payload* — `chain_newHead`, `state_storage`, `author_extrinsicUpdate` — while using Ethereum's exact `{subscription, result}` params envelope, so no suffix rule could match it.

The frame was not merely dropped. It fell through to `handleCallMsg`, which has no id and no matching method to serve, so **the router answered the node with an `invalid request` error for every push it received.**

**2. `rewriteSubscriptionID`: the id was wrong.** It keyed on `msg.Method == "eth_subscription"`, so even once delivered, a Substrate frame reached the client carrying the **upstream** id — one the client was never issued and cannot match to its subscription.

Either defect alone leaves the subscription unusable. Both now match the params envelope instead of the method name; the frame's own method is echoed back rather than hard-coded, and params are rebuilt from what upstream sent so sibling fields survive.

## Verification

Each defect was proved to fail independently by reverting the fixes against the new tests:

| state | result |
| --- | --- |
| both fixes reverted | 5s timeout — *"no push frame reached the client"* |
| only the dispatcher fixed | fails at 0.02s — the frame **arrives**, carrying the upstream id |
| both applied | pass |

`protocol/chainlib/...`, `protocol/rpcsmartrouter` and `protocol/lavasession` are green under `-race`. `go vet ./...` and `gofmt` clean.

**Boundary:** verified against a mock upstream over a real WebSocket, not a live Substrate node, and the Phase 8 sweep was not re-run. This removes the mechanism that made all 24 probes fail; it is not a claim that 24/24 now pass.

## Tests

The harness could only speak EVM, which is why nothing here caught this — every existing test asserted against the one shape the router happened to handle. The mock upstream's notification method and subscription id are now fields, so it can serve a Substrate node, and the Substrate test uses a non-hex id (`Ck1rTHhOa1hxTGV3`) so nothing can pass by matching an `0x` prefix.

- `TestEndToEnd_SubstratePushFrameReachesClient` — runs over a real WebSocket, so the whole path is live. Asserts both defects separately: the frame arrives, keeps its own method, and carries the router id.
- `TestRewriteSubscriptionID_Substrate` — the unit half.
- `TestRewriteSubscriptionID_SolanaUntouched` — pins the boundary below.

## Two adjacent findings, deliberately not fixed here

**Solana pushes are dropped today, and still are.** `handleImmediate`'s `solanaNotificationMethodSuffix` branch is unreachable: its enclosing `isEthereumNotification()` predicate itself requires the `_subscription` suffix, which `accountNotification` does not have. Confirmed empirically. Both new guards require the subscription id to be a JSON string, which deliberately keeps Solana's integer ids out — delivering them needs an integer-id router mapping the id mapper cannot express. Worth its own ticket.

**The last hop is not a verbatim relay.** `consumer_websocket_manager.go` runs each push through `outputFormatter`, which injects the *subscribe request's* id into every notification — JSON-RPC notifications should not carry one. Pre-existing, identical for EVM, and it touches neither the method nor `params.subscription`, so it does not affect this fix. Flagging rather than changing it, since it would move EVM behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHyKbFQzzmj9e1bE9yKRa


[MAG-3345]: https://magmadevs.atlassian.net/browse/MAG-3345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ