### PR TITLE
feat(observability): say who served the relay and why it stopped (MAG-3331)

### DIFF
--- a/protocol/relaycore/interfaces.go
+++ b/protocol/relaycore/interfaces.go
@@ -49,6 +49,11 @@ type RelayStateSendInstructions struct {
 	Done           bool
 	RelayState     *RelayState
 	NumOfProviders int
+	// StopReason is why the state machine stopped, carried on the Done instruction so the
+	// request's final log line can say it. The policy already computes this for every stop
+	// ("Stateful", "MaxRetriesReached", …) and it was previously visible only at DEBUG, which
+	// left "why was there no second attempt?" unanswerable in production.
+	StopReason string
 }
 
 func (rssi *RelayStateSendInstructions) IsDone() bool {

--- a/protocol/relaycore/interfaces.go
+++ b/protocol/relaycore/interfaces.go
@@ -49,10 +49,9 @@ type RelayStateSendInstructions struct {
 	Done           bool
 	RelayState     *RelayState
 	NumOfProviders int
-	// StopReason is why the state machine stopped, carried on the Done instruction so the
-	// request's final log line can say it. The policy already computes this for every stop
-	// ("Stateful", "MaxRetriesReached", …) and it was previously visible only at DEBUG, which
-	// left "why was there no second attempt?" unanswerable in production.
+	// StopReason is why the state machine stopped ("Stateful", "MaxRetriesReached", …), carried
+	// on the Done instruction so the request's final log line can say why there was no further
+	// attempt. Empty on a non-Done instruction.
 	StopReason string
 }
 

--- a/protocol/relaycore/relay_processor.go
+++ b/protocol/relaycore/relay_processor.go
@@ -56,8 +56,8 @@ type RelayProcessor struct {
 	crossValidationFailFastReason string
 
 	// stopReason is why the state machine stopped this request ("Stateful", "MaxRetriesReached",
-	// "ProcessingTimeout", "Success", …). Carried here so the request's final log line can say why
-	// there was no further attempt — previously only visible at DEBUG on policy.Decide.
+	// "ProcessingTimeout", "Success", …), so the request's final log line can say why there was
+	// no further attempt. Guarded by rp.lock.
 	stopReason string
 }
 
@@ -301,8 +301,7 @@ func (rp *RelayProcessor) GetCrossValidationRelayDeadline() time.Time {
 }
 
 // SetStopReason records why the state machine stopped this request. Set once, on the Done
-// instruction, so the request's final line can report it — the same carrier idea as the
-// cross-validation fail-fast reason below.
+// instruction — the same carrier idea as the cross-validation fail-fast reason below.
 func (rp *RelayProcessor) SetStopReason(reason string) {
 	rp.lock.Lock()
 	defer rp.lock.Unlock()

--- a/protocol/relaycore/relay_processor.go
+++ b/protocol/relaycore/relay_processor.go
@@ -54,6 +54,11 @@ type RelayProcessor struct {
 	// lava-cross-validation-failure-reason header from it — the error returns are left byte-for-byte
 	// unchanged so the state machine's PairingListEmptyError stop logic is unaffected. Guarded by rp.lock.
 	crossValidationFailFastReason string
+
+	// stopReason is why the state machine stopped this request ("Stateful", "MaxRetriesReached",
+	// "ProcessingTimeout", "Success", …). Carried here so the request's final log line can say why
+	// there was no further attempt — previously only visible at DEBUG on policy.Decide.
+	stopReason string
 }
 
 // quorumStat is the per-hash agreement tally for cross-validation: how many providers returned this exact
@@ -293,6 +298,22 @@ func (rp *RelayProcessor) GetCrossValidationRelayDeadline() time.Time {
 	rp.lock.RLock()
 	defer rp.lock.RUnlock()
 	return rp.crossValidationRelayDeadline
+}
+
+// SetStopReason records why the state machine stopped this request. Set once, on the Done
+// instruction, so the request's final line can report it — the same carrier idea as the
+// cross-validation fail-fast reason below.
+func (rp *RelayProcessor) SetStopReason(reason string) {
+	rp.lock.Lock()
+	defer rp.lock.Unlock()
+	rp.stopReason = reason
+}
+
+// GetStopReason returns why the request stopped, or "" if the state machine never said.
+func (rp *RelayProcessor) GetStopReason() string {
+	rp.lock.RLock()
+	defer rp.lock.RUnlock()
+	return rp.stopReason
 }
 
 // SetCrossValidationFailFastReason records why a cross-validation request was aborted before any relay

--- a/protocol/relaycore/stop_reason_test.go
+++ b/protocol/relaycore/stop_reason_test.go
@@ -1,0 +1,35 @@
+package relaycore
+
+import "testing"
+
+// The stop reason travels state machine → Done instruction → processor → the request's final log
+// line. Each hop is trivial; the value is that the chain exists at all, because without it "why was
+// there no second attempt?" is answerable only at DEBUG.
+func TestRelayProcessor_StopReasonRoundTrips(t *testing.T) {
+	rp := &RelayProcessor{}
+
+	if got := rp.GetStopReason(); got != "" {
+		t.Fatalf("a processor that was never told should report %q, got %q", "", got)
+	}
+
+	rp.SetStopReason("Stateful")
+	if got := rp.GetStopReason(); got != "Stateful" {
+		t.Fatalf("GetStopReason() = %q, want %q", got, "Stateful")
+	}
+
+	// Last writer wins: a request that exhausts retries and then hits the processing timeout
+	// stopped for the timeout, and that is what the final line should say.
+	rp.SetStopReason("ProcessingTimeout")
+	if got := rp.GetStopReason(); got != "ProcessingTimeout" {
+		t.Fatalf("GetStopReason() = %q, want the most recent reason", got)
+	}
+}
+
+// Every terminating path names a reason. A Done instruction with an empty StopReason produces a
+// final line that silently omits the field, which is the state this change exists to remove.
+func TestRelayStateSendInstructions_CarriesTheStopReason(t *testing.T) {
+	instruction := RelayStateSendInstructions{Done: true, StopReason: "MaxRetriesReached"}
+	if instruction.StopReason == "" {
+		t.Fatal("the Done instruction must be able to carry a reason")
+	}
+}

--- a/protocol/relaycore/stop_reason_test.go
+++ b/protocol/relaycore/stop_reason_test.go
@@ -2,9 +2,9 @@ package relaycore
 
 import "testing"
 
-// The stop reason travels state machine → Done instruction → processor → the request's final log
-// line. Each hop is trivial; the value is that the chain exists at all, because without it "why was
-// there no second attempt?" is answerable only at DEBUG.
+// SendParsedRelay reads the reason off the processor for the final line and prints whatever it
+// finds, so the empty default is part of the contract: a request the state machine never named
+// must render a blank field, not a stale one.
 func TestRelayProcessor_StopReasonRoundTrips(t *testing.T) {
 	rp := &RelayProcessor{}
 
@@ -25,11 +25,18 @@ func TestRelayProcessor_StopReasonRoundTrips(t *testing.T) {
 	}
 }
 
-// Every terminating path names a reason. A Done instruction with an empty StopReason produces a
-// final line that silently omits the field, which is the state this change exists to remove.
-func TestRelayStateSendInstructions_CarriesTheStopReason(t *testing.T) {
-	instruction := RelayStateSendInstructions{Done: true, StopReason: "MaxRetriesReached"}
-	if instruction.StopReason == "" {
-		t.Fatal("the Done instruction must be able to carry a reason")
+// The deadline paths call stopReasonOr: the timeout ends the wait, but if the policy had already
+// decided to stop, THAT is why there was no further attempt and it is the more useful answer.
+// Reporting "ProcessingTimeout" over a recorded "Stateful" loses the fact the field exists for.
+func TestStateMachine_StopReasonOrPrefersTheRecordedReason(t *testing.T) {
+	sm := &UnifiedRelayStateMachine{}
+
+	if got := sm.stopReasonOr("ProcessingTimeout"); got != "ProcessingTimeout" {
+		t.Fatalf("with nothing recorded the fallback stands: got %q", got)
+	}
+
+	sm.setStopReason("Stateful")
+	if got := sm.stopReasonOr("ProcessingTimeout"); got != "Stateful" {
+		t.Fatalf("a recorded policy reason outranks the deadline fallback: got %q", got)
 	}
 }

--- a/protocol/relaycore/unified_relay_state_machine.go
+++ b/protocol/relaycore/unified_relay_state_machine.go
@@ -34,6 +34,27 @@ type UnifiedRelayStateMachine struct {
 	relayStateLock        sync.RWMutex
 	config                StateMachineConfig
 	policy                RelayPolicyInf
+
+	// stopReason is the policy's reason for the most recent decision to stop. It rides out on the
+	// Done instruction so the request's final line can report it. Guarded by relayStateLock: the
+	// decision is taken on the state machine's goroutine and read when Done is sent, which
+	// validateReturnCondition dispatches from another.
+	stopReason string
+}
+
+// setStopReason records why the state machine is stopping. Last writer wins, which is what the
+// final line wants — a request that exhausts retries and then hits the processing timeout stopped
+// for the timeout.
+func (sm *UnifiedRelayStateMachine) setStopReason(reason string) {
+	sm.relayStateLock.Lock()
+	defer sm.relayStateLock.Unlock()
+	sm.stopReason = reason
+}
+
+func (sm *UnifiedRelayStateMachine) getStopReason() string {
+	sm.relayStateLock.RLock()
+	defer sm.relayStateLock.RUnlock()
+	return sm.stopReason
 }
 
 func NewUnifiedRelayStateMachine(
@@ -269,7 +290,7 @@ func (sm *UnifiedRelayStateMachine) checkAndHandleTimeout(
 		utils.LogAttr("consecutiveBatchErrors", sm.policy.GetConsecutiveBatchErrors()),
 	)
 
-	relayTaskChannel <- RelayStateSendInstructions{Err: processingCtx.Err(), Done: true}
+	relayTaskChannel <- RelayStateSendInstructions{Err: processingCtx.Err(), Done: true, StopReason: "ProcessingTimeout"}
 	return true
 }
 
@@ -348,14 +369,22 @@ func (sm *UnifiedRelayStateMachine) GetRelayTaskChannel() (chan RelayStateSendIn
 				case SendSuccess:
 					// continue to select loop
 				case SendStop:
+					// This arm stops the request WITHOUT consulting the policy, so it has to name
+					// its own reason — the policy's Decide is never reached here and the field
+					// would otherwise be blank on exactly the exhaustion cases an operator is
+					// reading the line to understand.
 					if isPairingListEmpty && sm.config.EnableCircuitBreaker {
-						utils.LavaFormatWarning("Circuit breaker triggered: All providers exhausted, stopping retries",
+						sm.setStopReason("AllProvidersExhausted")
+						utils.LavaFormatWarning("Circuit breaker: all providers exhausted, stopping new attempts — relays already in flight may still answer",
 							nil,
 							utils.LogAttr("GUID", sm.ctx),
 							utils.LogAttr("batchNumber", sm.usedProviders.BatchNumber()),
 						)
 					} else if sm.usedProviders.BatchNumber() == 0 && sm.policy.GetConsecutiveBatchErrors() == sm.config.SendRelayAttempts+1 {
+						sm.setStopReason("FirstMessageFailed")
 						utils.LavaFormatWarning("Failed Sending First Message", err, utils.LogAttr("consecutive errors", sm.policy.GetConsecutiveBatchErrors()), utils.LogAttr("GUID", sm.ctx))
+					} else {
+						sm.setStopReason("SendStop")
 					}
 					go validateReturnCondition(err)
 				case SendRetry:
@@ -372,7 +401,7 @@ func (sm *UnifiedRelayStateMachine) GetRelayTaskChannel() (chan RelayStateSendIn
 				utils.LavaFormatTrace("[StateMachine] success := <-gotResults", utils.LogAttr("batch", sm.usedProviders.BatchNumber()), utils.LogAttr("GUID", sm.ctx))
 				if success {
 					utils.LavaFormatTrace("[StateMachine] successfully sent message", utils.LogAttr("GUID", sm.ctx))
-					relayTaskChannel <- RelayStateSendInstructions{Done: true}
+					relayTaskChannel <- RelayStateSendInstructions{Done: true, StopReason: "Success"}
 					return
 				}
 
@@ -403,6 +432,7 @@ func (sm *UnifiedRelayStateMachine) GetRelayTaskChannel() (chan RelayStateSendIn
 					sm.stateTransition(sm.getLatestState(), nodeErrors, &output.Mutation)
 					relayTaskChannel <- RelayStateSendInstructions{RelayState: sm.getLatestState(), NumOfProviders: 1}
 				} else {
+					sm.setStopReason(output.Reason)
 					// Don't return immediately — in-flight relays from earlier batches
 					// may still succeed. validateReturnCondition waits 15ms and checks
 					// whether any relays are still CurrentlyUsed before concluding.
@@ -430,7 +460,7 @@ func (sm *UnifiedRelayStateMachine) GetRelayTaskChannel() (chan RelayStateSendIn
 
 			case returnErr := <-returnCondition:
 				utils.LavaFormatTrace("[StateMachine] returnErr := <-returnCondition", utils.LogAttr("batch", sm.usedProviders.BatchNumber()), utils.LogAttr("GUID", sm.ctx))
-				relayTaskChannel <- RelayStateSendInstructions{Err: returnErr, Done: true}
+				relayTaskChannel <- RelayStateSendInstructions{Err: returnErr, Done: true, StopReason: sm.getStopReason()}
 				return
 
 			case <-processingCtx.Done():
@@ -447,7 +477,7 @@ func (sm *UnifiedRelayStateMachine) GetRelayTaskChannel() (chan RelayStateSendIn
 						utils.LogAttr("batchNumber", sm.usedProviders.BatchNumber()),
 						utils.LogAttr("consecutiveBatchErrors", sm.policy.GetConsecutiveBatchErrors()),
 					)
-					relayTaskChannel <- RelayStateSendInstructions{Err: processingCtx.Err(), Done: true}
+					relayTaskChannel <- RelayStateSendInstructions{Err: processingCtx.Err(), Done: true, StopReason: "ProcessingTimeout"}
 				}
 				return
 			}

--- a/protocol/relaycore/unified_relay_state_machine.go
+++ b/protocol/relaycore/unified_relay_state_machine.go
@@ -35,26 +35,35 @@ type UnifiedRelayStateMachine struct {
 	config                StateMachineConfig
 	policy                RelayPolicyInf
 
-	// stopReason is the policy's reason for the most recent decision to stop. It rides out on the
-	// Done instruction so the request's final line can report it. Guarded by relayStateLock: the
-	// decision is taken on the state machine's goroutine and read when Done is sent, which
-	// validateReturnCondition dispatches from another.
-	stopReason string
+	// stopReason is why the state machine stopped, carried out on the Done instruction so the
+	// request's final line can report it. Written and read only on the state machine's own
+	// goroutine; stopReasonLock guards it against a future caller off that goroutine.
+	stopReason     string
+	stopReasonLock sync.RWMutex
 }
 
-// setStopReason records why the state machine is stopping. Last writer wins, which is what the
-// final line wants — a request that exhausts retries and then hits the processing timeout stopped
-// for the timeout.
+// setStopReason records why the state machine is stopping. Last writer wins: a request that
+// exhausts retries and then hits the processing timeout stopped for the timeout.
 func (sm *UnifiedRelayStateMachine) setStopReason(reason string) {
-	sm.relayStateLock.Lock()
-	defer sm.relayStateLock.Unlock()
+	sm.stopReasonLock.Lock()
+	defer sm.stopReasonLock.Unlock()
 	sm.stopReason = reason
 }
 
 func (sm *UnifiedRelayStateMachine) getStopReason() string {
-	sm.relayStateLock.RLock()
-	defer sm.relayStateLock.RUnlock()
+	sm.stopReasonLock.RLock()
+	defer sm.stopReasonLock.RUnlock()
 	return sm.stopReason
+}
+
+// stopReasonOr returns the recorded reason, falling back to a caller-supplied one. The deadline
+// paths use it so a policy decision that already stopped the request — "Stateful", which is why
+// there was no retry — survives the timeout that ends the wait.
+func (sm *UnifiedRelayStateMachine) stopReasonOr(fallback string) string {
+	if reason := sm.getStopReason(); reason != "" {
+		return reason
+	}
+	return fallback
 }
 
 func NewUnifiedRelayStateMachine(
@@ -290,7 +299,7 @@ func (sm *UnifiedRelayStateMachine) checkAndHandleTimeout(
 		utils.LogAttr("consecutiveBatchErrors", sm.policy.GetConsecutiveBatchErrors()),
 	)
 
-	relayTaskChannel <- RelayStateSendInstructions{Err: processingCtx.Err(), Done: true, StopReason: "ProcessingTimeout"}
+	relayTaskChannel <- RelayStateSendInstructions{Err: processingCtx.Err(), Done: true, StopReason: sm.stopReasonOr("ProcessingTimeout")}
 	return true
 }
 
@@ -369,10 +378,9 @@ func (sm *UnifiedRelayStateMachine) GetRelayTaskChannel() (chan RelayStateSendIn
 				case SendSuccess:
 					// continue to select loop
 				case SendStop:
-					// This arm stops the request WITHOUT consulting the policy, so it has to name
-					// its own reason — the policy's Decide is never reached here and the field
-					// would otherwise be blank on exactly the exhaustion cases an operator is
-					// reading the line to understand.
+					// This arm stops without consulting the policy, so it names its own reason:
+					// Decide never runs here, and the field would otherwise be blank on exactly
+					// the exhaustion cases an operator reads the line to understand.
 					if isPairingListEmpty && sm.config.EnableCircuitBreaker {
 						sm.setStopReason("AllProvidersExhausted")
 						utils.LavaFormatWarning("Circuit breaker: all providers exhausted, stopping new attempts — relays already in flight may still answer",
@@ -384,7 +392,7 @@ func (sm *UnifiedRelayStateMachine) GetRelayTaskChannel() (chan RelayStateSendIn
 						sm.setStopReason("FirstMessageFailed")
 						utils.LavaFormatWarning("Failed Sending First Message", err, utils.LogAttr("consecutive errors", sm.policy.GetConsecutiveBatchErrors()), utils.LogAttr("GUID", sm.ctx))
 					} else {
-						sm.setStopReason("SendStop")
+						sm.setStopReason("BatchSendFailed")
 					}
 					go validateReturnCondition(err)
 				case SendRetry:
@@ -477,7 +485,7 @@ func (sm *UnifiedRelayStateMachine) GetRelayTaskChannel() (chan RelayStateSendIn
 						utils.LogAttr("batchNumber", sm.usedProviders.BatchNumber()),
 						utils.LogAttr("consecutiveBatchErrors", sm.policy.GetConsecutiveBatchErrors()),
 					)
-					relayTaskChannel <- RelayStateSendInstructions{Err: processingCtx.Err(), Done: true, StopReason: "ProcessingTimeout"}
+					relayTaskChannel <- RelayStateSendInstructions{Err: processingCtx.Err(), Done: true, StopReason: sm.stopReasonOr("ProcessingTimeout")}
 				}
 				return
 			}

--- a/protocol/rpcsmartrouter/relay_stop_reason_test.go
+++ b/protocol/rpcsmartrouter/relay_stop_reason_test.go
@@ -1,0 +1,127 @@
+package rpcsmartrouter
+
+import (
+	context "context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/chainlib"
+	"github.com/magma-Devs/smart-router/protocol/chainlib/extensionslib"
+	common "github.com/magma-Devs/smart-router/protocol/common"
+	lavasession "github.com/magma-Devs/smart-router/protocol/lavasession"
+	"github.com/magma-Devs/smart-router/protocol/relaycore"
+	"github.com/magma-Devs/smart-router/protocol/relaycoretest"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// newStopReasonHarness builds a state machine + processor over the REST mock chain, the same shape
+// the other state-machine tests use. tickerValue is long so hedge retries do not interleave.
+func newStopReasonHarness(t *testing.T) (*relaycore.RelayProcessor, *lavasession.UsedProviders) {
+	t.Helper()
+	ctx := context.Background()
+	serverHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	chainParser, _, _, closeServer, _, err := chainlib.CreateChainLibMocks(ctx, "LAVA", spectypes.APIInterfaceRest, serverHandler, nil, "../../", nil)
+	if closeServer != nil {
+		t.Cleanup(closeServer)
+	}
+	require.NoError(t, err)
+	chainMsg, err := chainParser.ParseMsg("/cosmos/base/tendermint/v1beta1/blocks/17", nil, http.MethodGet, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+	require.NoError(t, err)
+	protocolMessage := chainlib.NewProtocolMessage(chainMsg, nil, nil, "dapp", "123.11")
+	usedProviders := lavasession.NewUsedProviders(nil)
+	stateMachine, err := NewSmartRouterRelayStateMachine(ctx, usedProviders, &SmartRouterRelaySenderMock{retValue: nil, tickerValue: 10 * time.Second}, protocolMessage, nil, false)
+	require.NoError(t, err)
+	return relaycore.NewRelayProcessor(ctx, &common.DefaultCrossValidationParams, relaycoretest.RelayProcessorMetrics, relaycoretest.RelayProcessorMetrics, relaycoretest.RelayRetriesManagerInstance, stateMachine), usedProviders
+}
+
+// Every terminating path names a reason on the Done instruction, and ProcessRelaySend copies that
+// onto the processor for the request's final "relay finished" line. A blank reason there is the
+// state this exists to remove: it makes "why was there no second attempt?" unanswerable at INFO.
+//
+// These drive the real state machine, so dropping any of the reasons at their source — the
+// SendStop arm, the policy's stop branch, the success send, the deadline paths — fails here.
+func TestStopReason_EveryTerminalPathNamesOne(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		relayProcessor, usedProviders := newStopReasonHarness(t)
+		consumerSessionsMap := lavasession.ConsumerSessionsMap{"lava@test": &lavasession.SessionInfo{}}
+
+		relayTaskChannel, err := relayProcessor.GetRelayTaskChannel()
+		require.NoError(t, err)
+		for task := range relayTaskChannel {
+			if task.IsDone() {
+				require.Equal(t, "Success", task.StopReason,
+					"a relay that returned an answer stopped because it succeeded")
+				return
+			}
+			usedProviders.AddUsed(consumerSessionsMap, nil)
+			relayProcessor.UpdateBatch(nil)
+			relaycoretest.SendSuccessResp(relayProcessor, "lava@test", time.Millisecond*1)
+		}
+		t.Fatal("channel closed without a Done instruction")
+	})
+
+	// The first batch never leaves the router: UpdateBatch reports a send failure every attempt,
+	// so the SendStop arm — not the policy — is what ends the request.
+	t.Run("first message failed", func(t *testing.T) {
+		relayProcessor, _ := newStopReasonHarness(t)
+
+		relayTaskChannel, err := relayProcessor.GetRelayTaskChannel()
+		require.NoError(t, err)
+		for task := range relayTaskChannel {
+			if task.IsDone() {
+				require.Equal(t, "FirstMessageFailed", task.StopReason)
+				return
+			}
+			relayProcessor.UpdateBatch(fmt.Errorf("failed sending message"))
+		}
+		t.Fatal("channel closed without a Done instruction")
+	})
+
+	// The circuit breaker stops NEW attempts on an empty pairing list. It reaches Done without
+	// consulting the policy, which is why that arm has to name its own reason.
+	t.Run("all providers exhausted", func(t *testing.T) {
+		relayProcessor, _ := newStopReasonHarness(t)
+
+		relayTaskChannel, err := relayProcessor.GetRelayTaskChannel()
+		require.NoError(t, err)
+		for task := range relayTaskChannel {
+			if task.IsDone() {
+				require.Equal(t, "AllProvidersExhausted", task.StopReason)
+				return
+			}
+			relayProcessor.UpdateBatch(lavasession.PairingListEmptyError)
+		}
+		t.Fatal("channel closed without a Done instruction")
+	})
+
+	// A node error with the retry budget at zero is the policy's own stop. Its reason has to
+	// survive the hop out to the Done instruction rather than being replaced by a generic one —
+	// "ErrorToleranceExceeded" is what distinguishes it from the router simply giving up.
+	t.Run("policy stop carries the policy reason", func(t *testing.T) {
+		originalValue := relaycore.RelayRetryLimit
+		relaycore.RelayRetryLimit = 0
+		defer func() { relaycore.RelayRetryLimit = originalValue }()
+
+		relayProcessor, usedProviders := newStopReasonHarness(t)
+		consumerSessionsMap := lavasession.ConsumerSessionsMap{"lava@test": &lavasession.SessionInfo{}}
+
+		relayTaskChannel, err := relayProcessor.GetRelayTaskChannel()
+		require.NoError(t, err)
+		for task := range relayTaskChannel {
+			if task.IsDone() {
+				require.Equal(t, "ErrorToleranceExceeded", task.StopReason,
+					"the policy's reason, not a generic stop, is what explains the missing retry")
+				return
+			}
+			usedProviders.AddUsed(consumerSessionsMap, nil)
+			relayProcessor.UpdateBatch(nil)
+			relaycoretest.SendNodeError(relayProcessor, "lava@test", time.Millisecond*1)
+		}
+		t.Fatal("channel closed without a Done instruction")
+	})
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -1075,22 +1075,15 @@ func (rpcss *RPCSmartRouterServer) SendParsedRelay(
 		preferStructuralFailureReason(returnedResult, relayProcessor.GetCrossValidationFailFastReason())
 	}
 
-	// The one line that describes what the caller actually got. It fires once per request on the
-	// return path, and everything it reports is already in hand here — which is why the two
-	// questions it answers went unanswerable for so long over a line that was one field short.
+	// The one line describing what the caller got. It fires once per request that produced any
+	// result, and is the only place at INFO that names the provider behind a failed-over response.
 	//
-	// served_by names the provider whose bytes were returned. On a request that failed over, that
-	// is the ONLY place the winner appears at INFO: the per-endpoint success line is DEBUG, and
-	// promoting that instead would add a line to every successful relay to say what this one
-	// already knows.
+	// served_by is filled only when bytes were served. GetProvider() also returns a provider on a
+	// failed result, and reporting that would make the field lie on exactly the requests an
+	// operator reads most carefully; the per-endpoint line and `error` attribute those.
 	//
-	// stop_reason says why there was no further attempt. A stateful relay is not retried after a
-	// timeout — a possibly-executed write must not run twice — which is correct, and was invisible,
-	// so a write that died at the deadline looked identical to one the router simply gave up on.
-	// served_by is only filled when something was actually served. On a failed relay
-	// GetProvider() still returns the provider that produced the failure, and reporting that as
-	// "served_by" would have the field lie on exactly the requests an operator reads most
-	// carefully — the failure is already attributed by the per-endpoint line and by `error`.
+	// stop_reason says why there was no further attempt — a stateful relay is not retried after a
+	// timeout, since a possibly-executed write must not run twice.
 	servedBy := ""
 	statusCode := 0
 	if returnedResult != nil {
@@ -1248,12 +1241,14 @@ func (rpcss *RPCSmartRouterServer) ProcessRelaySend(ctx context.Context, protoco
 		return relayProcessor, err
 	}
 
-	utils.LavaFormatInfo("🎬 STARTING TASK CHANNEL LOOP",
+	// The loop's per-task scaffolding is DEBUG: it fires once per batch and reports nothing the
+	// terminal "relay finished" line does not already carry once per request.
+	utils.LavaFormatDebug("[RPCSmartRouterServer] task channel loop started",
 		utils.LogAttr("GUID", ctx),
 	)
 
 	for task := range relayTaskChannel {
-		utils.LavaFormatInfo("📨 RECEIVED TASK FROM CHANNEL",
+		utils.LavaFormatDebug("[RPCSmartRouterServer] task received",
 			utils.LogAttr("is_done", task.IsDone()),
 			utils.LogAttr("has_error", task.Err != nil),
 			utils.LogAttr("num_providers", task.NumOfProviders),
@@ -1261,9 +1256,7 @@ func (rpcss *RPCSmartRouterServer) ProcessRelaySend(ctx context.Context, protoco
 		)
 
 		if task.IsDone() {
-			// Hand the state machine's reason to the processor so the request's final line can
-			// report why there was no further attempt. Without it a stateful relay that times out
-			// simply stops, and the log gives a reader nothing to distinguish that from a bug.
+			// Hand the state machine's reason to the processor for the request's final line.
 			relayProcessor.SetStopReason(task.StopReason)
 			if task.Err != nil {
 				tracing.RecordError(span, task.Err)
@@ -1281,16 +1274,12 @@ func (rpcss *RPCSmartRouterServer) ProcessRelaySend(ctx context.Context, protoco
 			},
 		)
 
-		utils.LavaFormatInfo("UPDATING BATCH",
+		utils.LavaFormatDebug("[RPCSmartRouterServer] updating batch",
 			utils.LogAttr("error", err),
 			utils.LogAttr("GUID", ctx),
 		)
 
 		relayProcessor.UpdateBatch(err)
-
-		utils.LavaFormatInfo("LOOPING BACK TO RECEIVE NEXT TASK",
-			utils.LogAttr("GUID", ctx),
-		)
 	}
 
 	// shouldn't happen.

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -1075,8 +1075,34 @@ func (rpcss *RPCSmartRouterServer) SendParsedRelay(
 		preferStructuralFailureReason(returnedResult, relayProcessor.GetCrossValidationFailFastReason())
 	}
 
-	utils.LavaFormatInfo("ProcessingResult RETURNED",
-		utils.LogAttr("has_result", returnedResult != nil),
+	// The one line that describes what the caller actually got. It fires once per request on the
+	// return path, and everything it reports is already in hand here — which is why the two
+	// questions it answers went unanswerable for so long over a line that was one field short.
+	//
+	// served_by names the provider whose bytes were returned. On a request that failed over, that
+	// is the ONLY place the winner appears at INFO: the per-endpoint success line is DEBUG, and
+	// promoting that instead would add a line to every successful relay to say what this one
+	// already knows.
+	//
+	// stop_reason says why there was no further attempt. A stateful relay is not retried after a
+	// timeout — a possibly-executed write must not run twice — which is correct, and was invisible,
+	// so a write that died at the deadline looked identical to one the router simply gave up on.
+	// served_by is only filled when something was actually served. On a failed relay
+	// GetProvider() still returns the provider that produced the failure, and reporting that as
+	// "served_by" would have the field lie on exactly the requests an operator reads most
+	// carefully — the failure is already attributed by the per-endpoint line and by `error`.
+	servedBy := ""
+	statusCode := 0
+	if returnedResult != nil {
+		statusCode = returnedResult.StatusCode
+		if returnedResult.Reply != nil {
+			servedBy = returnedResult.GetProvider()
+		}
+	}
+	utils.LavaFormatInfo("relay finished",
+		utils.LogAttr("served_by", servedBy),
+		utils.LogAttr("stop_reason", relayProcessor.GetStopReason()),
+		utils.LogAttr("status", statusCode),
 		utils.LogAttr("has_reply", returnedResult != nil && returnedResult.Reply != nil),
 		utils.LogAttr("reply_size", func() int {
 			if returnedResult != nil && returnedResult.Reply != nil {
@@ -1235,10 +1261,10 @@ func (rpcss *RPCSmartRouterServer) ProcessRelaySend(ctx context.Context, protoco
 		)
 
 		if task.IsDone() {
-			utils.LavaFormatInfo("🏁 TASK IS DONE - RETURNING FROM ProcessRelaySend",
-				utils.LogAttr("error", task.Err),
-				utils.LogAttr("GUID", ctx),
-			)
+			// Hand the state machine's reason to the processor so the request's final line can
+			// report why there was no further attempt. Without it a stateful relay that times out
+			// simply stops, and the log gives a reader nothing to distinguish that from a bug.
+			relayProcessor.SetStopReason(task.StopReason)
 			if task.Err != nil {
 				tracing.RecordError(span, task.Err)
 			}


### PR DESCRIPTION
#Closes MAG-3331
Jira ticket: MAG-3331

## The problem

Two customer captures (`agent_docs/bug-reports/missing-logs/`), two questions the logs could not
answer.

**Solana `getBlock`** — the primary held the request for its full 10s timeout, the hedge ticker fell
over to a backup, and the backup answered 14 MB half a second later:

```
+10002ms DEB direct RPC relay failed      endpoint=onerpc-primary  (10s deadline)
+10549ms DEB direct RPC relay succeeded   endpoint=tatum-backup  latency=547ms   ← the answer
+10699ms INF ProcessingResult RETURNED    has_reply=true  reply_size=14405401
```

Which provider produced those bytes appears **once, at DEBUG**. At INFO the request looks like it
returned 14 MB from nowhere.

**Polygon `eth_sendRawTransaction`** — a single provider timed out after 11s and the request died
with no second attempt and no `[BackupProviders]` line at all. The cause is `relaypolicy.Decide`
returning `Stop("Stateful")`: a possibly-executed write must not run twice. Correct, and invisible —
indistinguishable from the router giving up.

## What this adds

Both answers ride the line that **already fires once per request** on the return path.
`ProcessingResult RETURNED` reported `has_result`/`has_reply`/`reply_size` and nothing about the
outcome. It becomes `relay finished`:

```
INF relay finished  served_by=tatum-backup  status=200  stop_reason=Success   has_reply=true
INF relay finished  served_by=              status=0    stop_reason=Stateful  has_reply=false
```

- **`served_by`** — who produced the returned bytes. Filled **only when something was served**:
  `GetProvider()` still returns a provider on a failed result, and reporting that would make the
  field lie on exactly the requests an operator reads most carefully. The failure is already
  attributed by the per-endpoint line and by `error`.
- **`stop_reason`** — why there was no further attempt. Carried state machine → `Done` instruction →
  processor, mirroring the existing cross-validation fail-fast reason. No interface change.

This deliberately does **not** promote `policy.Decide`'s `Stop` to INFO — that would add a line to
every single-attempt request to say what the terminal line now says once.

Also: the circuit-breaker warning read *"All providers exhausted, stopping retries"* immediately
before the Solana request **succeeded** on an in-flight relay. It stops new attempts, not in-flight
ones, and now says so.

## Local verification

Router run at `--log-level info` against controllable mock upstreams, four shapes:

| case | scenario | result |
|---|---|---|
| A | healthy | `served_by=onerpc-primary  stop_reason=Success` |
| B | **Solana shape** — primary stalls, backup answers | `served_by=tatum-backup  stop_reason=Success` |
| C | **Polygon shape** — stateful write, timeout | `served_by=<empty>  stop_reason=Stateful` |
| D | every upstream 429 | `served_by=<empty>  stop_reason=AllProvidersExhausted` |

**Case D initially returned `stop_reason=` empty.** The `SendStop` arm stops the request without
consulting the policy, so it never set a reason — the circuit breaker and the first-message failure
both exit that way. They now name their own (`AllProvidersExhausted`, `FirstMessageFailed`). That
was found by running it, not by reading it.

```bash
make lint    # go vet ./...            — clean
make test    # go test ./... -count=1  — exit 0, 34 packages, 0 FAIL
```

## Reviewer notes

- **golangci-lint was not run locally** — the local binary is v1.64.8 (go1.24) against this repo's
  Go 1.26 target and refuses to load the config. `go vet` is clean; CI gates the rest.
- **Not included, deliberately:** per-attempt latency, `returned_block`, and a write-executed verdict
  for stateful methods. All defensible; none is needed for the two blind spots these captures show.
  The write-executed one is the most interesting follow-up — a context deadline *after dispatch*
  leaves "did my transaction execute?" genuinely unknown, unlike a 429.
- Independent of #351 (different files); the two can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ES82b8aH1E9jj8zRWerT8h
