### PR TITLE
fix(chainlib): bound gRPC reflection with the configured reflection-timeout

### DIFF
--- a/protocol/chainlib/grpc.go
+++ b/protocol/chainlib/grpc.go
@@ -179,7 +179,10 @@ func (apip *GrpcChainParser) setupForProvider(reflectionConnection *grpc.ClientC
 			utils.LogAttr("resolution", "block parsing resolves through one registry per chain, so every gRPC node-url on a chain must declare the same descriptor-source and descriptor-set-path"))
 	}
 
-	var remote dyncodec.ProtoFileRegistry = dyncodec.NewGRPCReflectionProtoFileRegistryFromConn(reflectionConnection)
+	// grpc-config is what bounds reflection here. Without it a node that accepts
+	// the reflection stream and never answers blocks until BootValidateTimeout
+	// tears the connector down, and the failure reads as a closed pool (MAG-3371).
+	var remote dyncodec.ProtoFileRegistry = dyncodec.NewGRPCReflectionProtoFileRegistryFromConn(reflectionConnection, grpcConfig.GetReflectionTimeout())
 	remote, err := dyncodec.ProtoFileRegistryForGrpcConfig(grpcConfig, remote)
 	if err != nil {
 		return err

--- a/protocol/chainlib/grpcproxy/dyncodec/remote_grpc_reflection.go
+++ b/protocol/chainlib/grpcproxy/dyncodec/remote_grpc_reflection.go
@@ -3,6 +3,7 @@ package dyncodec
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/magma-Devs/smart-router/utils"
 	"google.golang.org/grpc"
@@ -12,9 +13,24 @@ import (
 	"google.golang.org/protobuf/types/descriptorpb"
 )
 
-func NewGRPCReflectionProtoFileRegistryFromConn(conn *grpc.ClientConn) *GRPCReflectionProtoFileRegistry {
+// defaultReflectionTimeout mirrors common.GrpcConfig.GetReflectionTimeout's
+// default. It is duplicated rather than imported to keep dyncodec free of the
+// config package, and exists so a zero timeout cannot reintroduce the unbounded
+// behaviour this file used to have.
+const defaultReflectionTimeout = 5 * time.Second
+
+// NewGRPCReflectionProtoFileRegistryFromConn builds a reflection-backed registry.
+//
+// reflectionTimeout bounds each reflection exchange; zero or negative takes the
+// default above, so a caller that has no configured value still gets a bound
+// rather than none.
+func NewGRPCReflectionProtoFileRegistryFromConn(conn *grpc.ClientConn, reflectionTimeout time.Duration) *GRPCReflectionProtoFileRegistry {
+	if reflectionTimeout <= 0 {
+		reflectionTimeout = defaultReflectionTimeout
+	}
 	return &GRPCReflectionProtoFileRegistry{
-		rpb: grpc_reflection_v1alpha.NewServerReflectionClient(conn),
+		rpb:     grpc_reflection_v1alpha.NewServerReflectionClient(conn),
+		timeout: reflectionTimeout,
 	}
 }
 
@@ -22,6 +38,23 @@ func NewGRPCReflectionProtoFileRegistryFromConn(conn *grpc.ClientConn) *GRPCRefl
 // which uses grpc reflection to resolve files.
 type GRPCReflectionProtoFileRegistry struct {
 	rpb grpc_reflection_v1alpha.ServerReflectionClient
+
+	// timeout bounds one reflection exchange. Both methods below open a stream,
+	// send a single request and read a single reply before returning, so a
+	// call-scoped deadline is the whole operation's deadline.
+	//
+	// It is load-bearing because a server can accept the stream and then never
+	// answer: gRPC applies no deadline of its own, so an unbounded call blocks
+	// until something else tears the connection down. On the startup-verification
+	// path that is BootValidateTimeout, and the failure then surfaces as a closed
+	// connection pool rather than as reflection never answering (MAG-3371).
+	timeout time.Duration
+}
+
+// reflectionCtx returns the deadline-bounded context for one exchange. The
+// caller must call cancel once it has finished with the stream.
+func (g *GRPCReflectionProtoFileRegistry) reflectionCtx() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), g.timeout)
 }
 
 func (g *GRPCReflectionProtoFileRegistry) ProtoFileByPath(path string) (_ *descriptorpb.FileDescriptorProto, err error) {
@@ -31,7 +64,10 @@ func (g *GRPCReflectionProtoFileRegistry) ProtoFileByPath(path string) (_ *descr
 		}
 	}()
 
-	stream, err := g.rpb.ServerReflectionInfo(context.Background())
+	ctx, cancel := g.reflectionCtx()
+	defer cancel()
+
+	stream, err := g.rpb.ServerReflectionInfo(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +94,10 @@ func (g *GRPCReflectionProtoFileRegistry) ProtoFileContainingSymbol(name protore
 			err = fmt.Errorf("proto file containing symbol: %w", err)
 		}
 	}()
-	stream, err := g.rpb.ServerReflectionInfo(context.Background())
+	ctx, cancel := g.reflectionCtx()
+	defer cancel()
+
+	stream, err := g.rpb.ServerReflectionInfo(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/chainlib/grpcproxy/dyncodec/remote_grpc_reflection_timeout_test.go
+++ b/protocol/chainlib/grpcproxy/dyncodec/remote_grpc_reflection_timeout_test.go
@@ -1,0 +1,97 @@
+package dyncodec
+
+import (
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/chainlib/grpcproxy/testproto"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
+)
+
+// hangingReflectionServer accepts the reflection stream and then never answers.
+//
+// That is the shape of the upstream this guards against: a gateway that serves
+// gRPC methods normally but does not implement reflection behind it does NOT
+// refuse the stream — it accepts it and stays silent, so the client waits on a
+// reply that never comes.
+type hangingReflectionServer struct {
+	grpc_reflection_v1alpha.UnimplementedServerReflectionServer
+}
+
+func (s *hangingReflectionServer) ServerReflectionInfo(stream grpc_reflection_v1alpha.ServerReflection_ServerReflectionInfoServer) error {
+	<-stream.Context().Done()
+	return stream.Context().Err()
+}
+
+func hangingReflectionConn(t *testing.T) *grpc.ClientConn {
+	t.Helper()
+	grpcSrv := grpc.NewServer()
+	grpc_reflection_v1alpha.RegisterServerReflectionServer(grpcSrv, &hangingReflectionServer{})
+	return testproto.InMemoryClientConn(t, grpcSrv)
+}
+
+// TestReflectionFailsAtItsDeadlineRatherThanHanging is the regression for
+// MAG-3371: both reflection calls used context.Background(), so a silent server
+// blocked until some outer context tore the connection down. On the startup
+// verification path that was BootValidateTimeout, and the failure then surfaced
+// as a closed connection pool instead of as reflection never answering.
+//
+// The elapsed-time bound is the assertion that matters — an unbounded call fails
+// it by never returning.
+func TestReflectionFailsAtItsDeadlineRatherThanHanging(t *testing.T) {
+	const timeout = 150 * time.Millisecond
+
+	for _, tc := range []struct {
+		name string
+		call func(r *GRPCReflectionProtoFileRegistry) error
+	}{
+		{
+			name: "ProtoFileByPath",
+			call: func(r *GRPCReflectionProtoFileRegistry) error {
+				_, err := r.ProtoFileByPath("google/protobuf/descriptor.proto")
+				return err
+			},
+		},
+		{
+			name: "ProtoFileContainingSymbol",
+			call: func(r *GRPCReflectionProtoFileRegistry) error {
+				_, err := r.ProtoFileContainingSymbol("google.protobuf.DescriptorProto")
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			remote := NewGRPCReflectionProtoFileRegistryFromConn(hangingReflectionConn(t), timeout)
+			defer remote.Close()
+
+			start := time.Now()
+			err := tc.call(remote)
+			elapsed := time.Since(start)
+
+			require.Error(t, err, "a server that never answers must produce an error")
+			require.GreaterOrEqual(t, elapsed, timeout,
+				"must wait for its own deadline rather than failing early")
+			require.Less(t, elapsed, 5*time.Second,
+				"must fail at the reflection deadline, not hang until an outer context cancels it")
+		})
+	}
+}
+
+// TestZeroReflectionTimeoutTakesTheDefault pins the invariant that an unset
+// timeout means the default, never "no deadline" — the state this file was in
+// before MAG-3371. Asserted on the field because exercising it for real would
+// cost the full default in test time.
+func TestZeroReflectionTimeoutTakesTheDefault(t *testing.T) {
+	conn := hangingReflectionConn(t)
+
+	for _, given := range []time.Duration{0, -1 * time.Second} {
+		remote := NewGRPCReflectionProtoFileRegistryFromConn(conn, given)
+		require.Equal(t, defaultReflectionTimeout, remote.timeout,
+			"a non-positive timeout must fall back to the default, not disable the deadline")
+	}
+
+	remote := NewGRPCReflectionProtoFileRegistryFromConn(conn, 2*time.Second)
+	require.Equal(t, 2*time.Second, remote.timeout, "a configured timeout must be honoured")
+}

--- a/protocol/chainlib/grpcproxy/dyncodec/remotes_test.go
+++ b/protocol/chainlib/grpcproxy/dyncodec/remotes_test.go
@@ -71,7 +71,7 @@ func TestRemotes(t *testing.T) {
 	}
 
 	t.Run("test grpc remote", func(t *testing.T) {
-		remote := NewGRPCReflectionProtoFileRegistryFromConn(conn)
+		remote := NewGRPCReflectionProtoFileRegistryFromConn(conn, 0)
 		testRemote(remote)
 	})
 


### PR DESCRIPTION
#Closes MAG-3371

Jira ticket: MAG-3371

A gRPC upstream that accepts a reflection stream and never answers hung the router indefinitely, and the failure was then reported as a connection-pool error.

## The bug

Both reflection calls in `remote_grpc_reflection.go` opened their stream with `context.Background()` — `ProtoFileByPath` and `ProtoFileContainingSymbol`. gRPC applies no deadline of its own, so a silent server blocked until something else tore the connection down.

`GrpcConfig.ReflectionTimeout` exists for exactly this, defaults to 5s, and is documented as *"Only used when DescriptorSource is reflection or hybrid"* — but `GetReflectionTimeout()` was read **only** from `direct_rpc_connection.go`. Setting `reflection-timeout` had no effect on the chainlib proxy path.

## It also surfaced in the wrong layer

During startup verification `validateProvider` passes `attemptCtx` as the connector's *lifetime* context. When the reflection call burned the whole `BootValidateTimeout`, that context expired, the connector was closed, and the in-flight relay returned `ErrGRPCConnectorClosed`:

```
grpc get connection failed  ErrMsg: grpc connector is closed
failed to fetch latest block number
retry: provider verification still failing
```

So an upstream that simply does not serve reflection read as a connector/pool defect. Found in production against an upstream that answers `GetNodeInfo` with `grpc-status: 0` in 0.45s while hanging indefinitely on reflection.

## The change

- each reflection exchange gets a deadline from `GetReflectionTimeout()`; both methods open a stream, send one request and read one reply before returning, so a call-scoped deadline bounds the whole operation
- a **non-positive timeout takes the 5s default** rather than disabling the deadline, so an unset value cannot reintroduce the unbounded behaviour
- the constructor now takes the timeout explicitly, so every call site has to decide

## Test plan

- [x] `go build ./...`, `go vet ./protocol/chainlib/...` clean
- [x] `go test ./protocol/chainlib/...` and `./protocol/chainlib/grpcproxy/...` pass
- [x] **the regression test was verified against the old behaviour**: with the deadline reverted it hangs until the Go test timeout (`panic: test timed out after 20s`); with the fix it passes in 0.3s
- [x] both reflection methods covered, plus the non-positive-timeout fallback

## Related

- **MAG-3370** — the production incident this came from
- **MAG-3372** — the chart cannot express `grpc-config`, so `reflection-timeout` and `descriptor-source` are unreachable through it today
