### PR TITLE
fix(ci): complete chart 6 PR gate migration

### DIFF
--- a/.github/workflows/pr-gate-build-artifact.yml
+++ b/.github/workflows/pr-gate-build-artifact.yml
@@ -283,9 +283,9 @@ jobs:
             "$SSH_HOST" \
             'set -euo pipefail
              hostname
-             kubectl get ns lava-infra
-             kubectl get deploy -n lava-infra
-             kubectl get pods -n lava-infra' >"$ssh_stdout" 2>"$ssh_stderr"; then
+             kubectl get ns smart-router
+             kubectl get deploy -n smart-router
+             kubectl get pods -n smart-router' >"$ssh_stdout" 2>"$ssh_stderr"; then
             echo "::error::dev-sim-prtests preflight failed while connecting or running read-only checks"
             print_sanitized_remote_output
             exit 1
@@ -324,24 +324,24 @@ jobs:
 
           ssh_opts=(-i "$key_file" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o RemoteCommand=none -o RequestTTY=no -o ServerAliveInterval=30 -o ServerAliveCountMax=20)
 
-          previous_image="$(ssh "${ssh_opts[@]}" "$SSH_HOST" "kubectl -n lava-infra get deployment eth-sim-router -o jsonpath='{range .spec.template.spec.containers[?(@.name==\"router\")]}{.image}{end}'")"
+          previous_image="$(ssh "${ssh_opts[@]}" "$SSH_HOST" "kubectl -n smart-router get deployment eth-sim-router -o jsonpath='{range .spec.template.spec.containers[?(@.name==\"router\")]}{.image}{end}'")"
           if [ -z "$previous_image" ]; then
-            echo "::error::Could not capture current image for lava-infra/deployment/eth-sim-router container router"
+            echo "::error::Could not capture current image for smart-router/deployment/eth-sim-router container router"
             exit 1
           fi
-          previous_args_b64="$(ssh "${ssh_opts[@]}" "$SSH_HOST" "kubectl -n lava-infra get deployment eth-sim-router -o json | jq -c '.spec.template.spec.containers[] | select(.name==\"router\").args // []' | base64 | tr -d '\n'")"
+          previous_args_b64="$(ssh "${ssh_opts[@]}" "$SSH_HOST" "kubectl -n smart-router get deployment eth-sim-router -o json | jq -c '.spec.template.spec.containers[] | select(.name==\"router\").args // []' | base64 | tr -d '\n'")"
           if [ -z "$previous_args_b64" ]; then
-            echo "::error::Could not capture current args for lava-infra/deployment/eth-sim-router container router"
+            echo "::error::Could not capture current args for smart-router/deployment/eth-sim-router container router"
             exit 1
           fi
 
           rollback_remote() {
-            echo "Attempting rollback for lava-infra/deployment/eth-sim-router container router"
+            echo "Attempting rollback for smart-router/deployment/eth-sim-router container router"
             # shellcheck disable=SC2029
             ssh "${ssh_opts[@]}" "$SSH_HOST" "PREVIOUS_IMAGE='${previous_image}' PREVIOUS_ARGS_B64='${previous_args_b64}' bash -s" <<'REMOTE_ROLLBACK'
           set -euo pipefail
 
-          NAMESPACE="lava-infra"
+          NAMESPACE="smart-router"
           DEPLOYMENT="eth-sim-router"
           CONTAINER="router"
 
@@ -389,11 +389,11 @@ jobs:
           if ! ssh "${ssh_opts[@]}" "$SSH_HOST" "PR_IMAGE='${PR_IMAGE}' PREVIOUS_IMAGE='${previous_image}' PREVIOUS_ARGS_B64='${previous_args_b64}' bash -s" 2>&1 <<'REMOTE_ROLLOUT' | tee "$rollout_output"
           set -euo pipefail
 
-          NAMESPACE="lava-infra"
+          NAMESPACE="smart-router"
           DEPLOYMENT="eth-sim-router"
           SERVICE="eth-sim-router"
           CONTAINER="router"
-          SELECTOR="app.lavanet.io/router=eth-sim"
+          SELECTOR="app.smart-router-id=eth-sim"
           SERVICE_PORT="3000"
           HEALTH_PATH="/lava/health"
           previous_image="${PREVIOUS_IMAGE:-}"
@@ -615,13 +615,13 @@ jobs:
           {
             echo "### dev-sim-prtests Kubernetes rollout validation"
             echo ""
-            echo "- Namespace: \`lava-infra\`"
+            echo "- Namespace: \`smart-router\`"
             echo "- Deployment: \`eth-sim-router\`"
             echo "- Container: \`router\`"
             echo "- Service: \`eth-sim-router\`"
             echo "- PR image: \`${PR_IMAGE}\`"
-            echo "- Rollout command: \`kubectl -n lava-infra set image deployment/eth-sim-router router=${PR_IMAGE}\`"
-            echo "- Readiness command: \`kubectl -n lava-infra rollout status deployment/eth-sim-router --timeout=600s\`"
+            echo "- Rollout command: \`kubectl -n smart-router set image deployment/eth-sim-router router=${PR_IMAGE}\`"
+            echo "- Readiness command: \`kubectl -n smart-router rollout status deployment/eth-sim-router --timeout=600s\`"
             echo "- Smoke endpoint: \`${smoke_endpoint}\`"
             echo "- Validation result: \`passed\`"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -752,7 +752,7 @@ jobs:
           CHART_REPO_DIR="${REMOTE_TMP}/smart-router-helm-chart"
           VALUES_FILE="${REMOTE_TMP}/dev-pr-gate-values.yaml"
           PULL_SECRET_NAME="ghcr-secret"
-          PULL_SECRET_SOURCE_NAMESPACE="lava-infra"
+          PULL_SECRET_SOURCE_NAMESPACE="smart-router"
           ROUTER_ID="eth"
           ROUTER_SERVICE="${ROUTER_ID}-router"
           SERVICE_PORT="3000"
@@ -790,7 +790,7 @@ jobs:
             echo "Recent namespace events:"
             kubectl -n "$NAMESPACE" get events --sort-by=.lastTimestamp | tail -50 || true
             echo "Router logs:"
-            kubectl -n "$NAMESPACE" logs -l "app.lavanet.io/router=${ROUTER_ID}" -c router --all-containers=false --tail=120 2>&1 | redact_sensitive_output || true
+            kubectl -n "$NAMESPACE" logs -l "app.smart-router-id=${ROUTER_ID}" -c router --all-containers=false --tail=120 2>&1 | redact_sensitive_output || true
             echo "Cache logs:"
             kubectl -n "$NAMESPACE" logs deployment/router-cache -c cache --tail=120 2>&1 | redact_sensitive_output || true
             echo "Helm test pod logs:"
@@ -839,8 +839,8 @@ jobs:
 
           copy_pull_secret() {
             kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
-            kubectl -n lava-infra get secret ghcr-secret -o yaml \
-              | sed "s/namespace: lava-infra/namespace: ${NAMESPACE}/" \
+            kubectl -n "$PULL_SECRET_SOURCE_NAMESPACE" get secret "$PULL_SECRET_NAME" -o yaml \
+              | sed "s/namespace: ${PULL_SECRET_SOURCE_NAMESPACE}/namespace: ${NAMESPACE}/" \
               | kubectl apply -f -
             kubectl -n "$NAMESPACE" get secret "$PULL_SECRET_NAME" >/dev/null
             echo "Copied image pull secret ${PULL_SECRET_NAME} into ${NAMESPACE}"
@@ -1339,7 +1339,7 @@ jobs:
             exit 0
           fi
 
-          echo "::warning::smart-router-automation public readiness smoke failed but is non-blocking (build_defaults=${build_defaults_status}, build_deployment=${build_deployment_status}, pytest=${pytest_status})"
+          echo "::error::smart-router-automation public readiness smoke failed (build_defaults=${build_defaults_status}, build_deployment=${build_deployment_status}, pytest=${pytest_status})"
           {
             echo "### smart-router-automation public readiness"
             echo ""
@@ -1348,11 +1348,9 @@ jobs:
             echo "- Target URL: \`https://eth-sim-jsonrpc.${CLUSTER_HOST}\`"
             echo "- Pytest command: \`python -m pytest tests/ -m cluster_readiness_smoke_public -v --no-cov\`"
             echo "- Command exit codes: build_defaults=\`${build_defaults_status}\`, build_deployment=\`${build_deployment_status}\`, pytest=\`${pytest_status}\`"
-            echo "- Result: \`warning-only / failed but non-blocking\`"
-            echo ""
-            echo "This smoke covers broad prtests public readiness and is not the blocking Smart Router PR artifact gate."
+            echo "- Result: \`failed\`"
           } >> "$GITHUB_STEP_SUMMARY"
-          exit 0
+          exit 1
 
   preflight-status:
     name: Publish PR Validation Status


### PR DESCRIPTION
Jira ticket: MAG-3351

#Closes MAG-3351

## Why

The canonical `prtests` simulator moved to Helm chart 6 and the `smart-router` namespace, while the PR gate was temporarily rolled back to the retired `lava-infra` layout. The public automation smoke also returned exit 0 after real pytest failures, allowing a misleading green gate.

## What

- Point preflight, rollout, rollback, pull-secret copy, and diagnostics at `smart-router`.
- Use chart 6's `app.smart-router-id` selector everywhere.
- Make smart-router-automation readiness failures blocking so the published required status reflects the actual result.
- Keep `dev-sim-prtests / preflight` as the status consumed by the active main ruleset.

## Validation

- Workflow parses as YAML.
- `actionlint .github/workflows/pr-gate-build-artifact.yml`
- `git diff --check`
- No `lava-infra`, `app.lavanet.io`, or non-blocking failure path remains in the workflow.
- Full live workflow dispatch passed: https://github.com/Magma-Devs/smart-router/actions/runs/33614410740

Supersedes #357; the box-dependent steps remain enabled because the underlying `prtests` environment now runs chart 6.