### PR TITLE
fix(ws): tell the node to stop pushing when a client disconnects

### DIFF
--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
@@ -2052,7 +2052,7 @@ func rewriteSubscriptionID(msg *rpcclient.JsonrpcMessage, routerID string, numer
 		response := map[string]any{
 			"jsonrpc": "2.0",
 			"method":  msg.Method,
-			"params":  json.RawMessage(rewritten),
+			"params":  rewritten,
 		}
 		return json.Marshal(response)
 	}

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
@@ -1656,16 +1656,71 @@ func (dwsm *DirectWSSubscriptionManager) handleClientDisconnect(
 		upstreamConn := activeSub.upstreamConnection
 		upstreamPool := activeSub.upstreamPool
 		go func() {
+			// Tell the NODE first, while the connection is still pooled and live:
+			// NotifySubscriptionRemoved below may scale it down, and Unsubscribe
+			// sends nothing on the wire. Ordering is the whole fix.
+			dwsm.teardownUpstreamSubscription(activeSub)
 			activeSub.upstreamSubscription.Unsubscribe()
 			activeSub.cancel()
 			close(activeSub.closeSubChan)
+			// Moved inside the goroutine so it runs AFTER the teardown above.
+			if upstreamConn != nil {
+				upstreamPool.NotifySubscriptionRemoved(upstreamConn)
+			}
 		}()
 		delete(dwsm.activeSubscriptions, hashedParams)
 		dwsm.totalSubscriptions.Add(-1) // Decrement global counter
-		// Notify pool to potentially scale down
-		if upstreamConn != nil {
-			upstreamPool.NotifySubscriptionRemoved(upstreamConn)
-		}
+	}
+}
+
+// upstreamUnsubscribeTimeout bounds the teardown call below. Some gateways never
+// answer an unsubscribe; without a bound the disconnect path would block on one.
+const upstreamUnsubscribeTimeout = 10 * time.Second
+
+// teardownUpstreamSubscription tells the NODE to stop pushing.
+//
+// This is the half a client disconnect skipped. ClientSubscription.Unsubscribe
+// only signals this process's forwarding goroutine — unlike upstream go-ethereum
+// it sends nothing on the wire — so the explicit call below is the only thing
+// that reaches the node. Without it the node keeps publishing a subscription
+// nobody reads, and because the connection is POOLED the next subscription to
+// the same query inherits those pushes: every client that closed its socket
+// without an explicit unsubscribe adds one more copy of every event, to every
+// future subscriber, until the process restarts.
+//
+// Measured on a Tendermint tenant before the fix: copies per block climbed
+// 7 -> 8 -> 9 -> 10 over four sequential subscribe/disconnect cycles, with one
+// client connected each time (MAG-3366). The explicit-unsubscribe path always
+// did this correctly, which is why it went unnoticed — a well-behaved client
+// sends unsubscribe, and a real one just closes the socket.
+//
+// Best-effort by design: it also runs where the connection may already be gone
+// (upstream disconnect, shutdown), so a failure is traced rather than warned.
+// Must be called WITHOUT dwsm.lock held — it makes a network call.
+func (dwsm *DirectWSSubscriptionManager) teardownUpstreamSubscription(activeSub *directActiveSubscription) {
+	if activeSub == nil || activeSub.upstreamConnection == nil {
+		return
+	}
+	client := activeSub.upstreamConnection.GetClient()
+	if client == nil {
+		return
+	}
+
+	var params interface{}
+	if dwsm.apiInterface == "tendermintrpc" {
+		params = map[string]interface{}{"query": activeSub.upstreamID}
+	} else {
+		params = []interface{}{activeSub.upstreamID}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), upstreamUnsubscribeTimeout)
+	defer cancel()
+	if _, err := client.CallContext(ctx, json.RawMessage("1"),
+		getUnsubscribeMethod(activeSub.subscribeMethod), params, true, false); err != nil {
+		utils.LavaFormatTrace("DirectWS: upstream unsubscribe on disconnect failed",
+			utils.LogAttr("error", err),
+			utils.LogAttr("upstreamID", activeSub.upstreamID),
+		)
 	}
 }
 
@@ -1698,10 +1753,17 @@ func (dwsm *DirectWSSubscriptionManager) cleanupSubscription(hashedParams string
 	delete(dwsm.activeSubscriptions, hashedParams)
 	dwsm.totalSubscriptions.Add(-1) // Decrement global counter
 
-	// Notify pool to potentially scale down
-	if activeSub.upstreamConnection != nil {
-		activeSub.upstreamPool.NotifySubscriptionRemoved(activeSub.upstreamConnection)
-	}
+	// Same omission as the disconnect path: without this the node keeps pushing.
+	// Async because this runs under dwsm.lock and makes a network call, and the
+	// pool notify goes after it so the connection is still live when it is used.
+	upstreamConn := activeSub.upstreamConnection
+	upstreamPool := activeSub.upstreamPool
+	go func() {
+		dwsm.teardownUpstreamSubscription(activeSub)
+		if upstreamConn != nil {
+			upstreamPool.NotifySubscriptionRemoved(upstreamConn)
+		}
+	}()
 
 	utils.LavaFormatTrace("DirectWS: subscription cleaned up",
 		utils.LogAttr("hashedParams", utils.ToHexString(hashedParams)),

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
@@ -3376,3 +3376,77 @@ func TestGenerateNumericRouterID(t *testing.T) {
 		seen[id] = struct{}{}
 	}
 }
+
+// TestClientDisconnect_TearsDownUpstreamSubscription is MAG-3366's regression.
+//
+// A client that closes its socket without sending an explicit unsubscribe used
+// to leave the node publishing: ClientSubscription.Unsubscribe only signals this
+// process's forwarding goroutine, and nothing was sent on the wire. Because the
+// upstream connection is POOLED, the next subscription to the same query
+// inherited those pushes, so every such disconnect added one more copy of every
+// event for every future subscriber, permanently.
+//
+// Measured on a Tendermint tenant before the fix: 7 -> 8 -> 9 -> 10 copies per
+// block over four sequential subscribe/disconnect cycles, one client each time.
+//
+// The explicit-unsubscribe path always did this correctly, which is why it went
+// unnoticed — well-behaved clients unsubscribe, real ones close the socket. So
+// this test does NOT unsubscribe: it cancels the client context, which is what
+// a closed websocket does.
+func TestClientDisconnect_TearsDownUpstreamSubscription(t *testing.T) {
+	mockSrv := newMockSubscriptionServer()
+	mockSrv.messageInterval = 20 * time.Millisecond
+	defer mockSrv.Close()
+
+	nodeUrl := &common.NodeUrl{Url: mockSrv.URL()}
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc", "ETH", "jsonrpc",
+		[]*common.NodeUrl{nodeUrl},
+		nil, nil, nil,
+	)
+
+	// The CLIENT's context — cancelling it is the disconnect.
+	clientCtx, disconnect := context.WithCancel(context.Background())
+
+	subscribeBody, err := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  "eth_subscribe",
+		"params":  []interface{}{"newHeads"},
+		"id":      1,
+	})
+	require.NoError(t, err)
+
+	subscribeMsg := &mockWSProtocolMessageWithRawData{
+		mockWSProtocolMessage: mockWSProtocolMessage{
+			method: "eth_subscribe",
+			params: []interface{}{"newHeads"},
+		},
+		rawData: subscribeBody,
+	}
+
+	reply, repliesChan, err := manager.StartSubscription(
+		clientCtx, subscribeMsg, "dapp-disc", "10.0.0.1", "ws-disc", nil)
+	require.NoError(t, err, "subscribe must succeed")
+	require.NotNil(t, reply)
+	require.NotNil(t, repliesChan)
+
+	require.Contains(t, mockSrv.ObservedMethods(), "eth_subscribe",
+		"precondition: the upstream must have been subscribed")
+	require.NotContains(t, mockSrv.ObservedMethods(), "eth_unsubscribe",
+		"precondition: nothing should have been torn down yet")
+
+	// The client goes away WITHOUT sending eth_unsubscribe.
+	disconnect()
+
+	require.Eventually(t, func() bool {
+		for _, m := range mockSrv.ObservedMethods() {
+			if m == "eth_unsubscribe" {
+				return true
+			}
+		}
+		return false
+	}, 15*time.Second, 50*time.Millisecond,
+		"a client disconnect must tell the NODE to stop pushing; without it the "+
+			"pooled connection keeps delivering and every later subscriber gets an extra copy")
+}


### PR DESCRIPTION
#Closes MAG-3366

Jira ticket: MAG-3366

**Not merging this — leaving it for review.**

The ledger recorded this as *"`NewBlock` subscribers get a success ack and then silence"*. That symptom is gone: `NewBlock` delivers 18 contiguous blocks, `cosmoshub-4`, ~180–220KB frames. What it does instead is deliver **every event many times over, growing without bound**.

## Measured on a live Tendermint tenant

One client per run — subscribe, then close the socket:

```
run 1: events=42 unique=6 copies_per_block=7.0
run 2: events=48 unique=6 copies_per_block=8.0
run 3: events=54 unique=6 copies_per_block=9.0
later: events=70 unique=7 copies_per_block=10.0
```

**+1 copy per subscribe/disconnect cycle, permanently, for every future subscriber.** The pod was 17 minutes old at 10 copies. Ethereum `newHeads` through the same fleet is clean, so it is not the edge.

## Root cause

`handleClientDisconnect`'s last-client branch:

```go
go func() {
    activeSub.upstreamSubscription.Unsubscribe()
    activeSub.cancel()
    close(activeSub.closeSubChan)
}()
```

`ClientSubscription.Unsubscribe()` **in this tree only signals the local forwarding goroutine** — unlike upstream go-ethereum it sends nothing on the wire. So the node is never told. `cleanupSubscription` has the same omission.

The **client-initiated** `Unsubscribe` path is correct — it makes an explicit `client.CallContext(...)`. That is why this went unnoticed: a well-behaved client sends unsubscribe, a real one closes the socket.

And because the upstream connection is **pooled**, the node keeps publishing that query on a connection later reused, so each new subscription inherits every leaked one's pushes.

## The change

- teardown extracted into `teardownUpstreamSubscription`, called from **both** disconnect paths
- `NotifySubscriptionRemoved` moves **inside** the goroutine so it runs *after* the teardown — it can scale the connection down, and the call needs it live. Ordering is the fix.
- best-effort and traced rather than warned: it also runs where the connection is already gone (upstream disconnect, shutdown)
- no network call under `dwsm.lock`

## Test plan

- [x] `TestClientDisconnect_TearsDownUpstreamSubscription` cancels the client context **without unsubscribing** — what a closed socket does — and asserts the upstream observed `eth_unsubscribe`
- [x] **fails against the previous code**: `Condition never satisfied`, FAIL at 15s. Passes in 0.09s with the fix
- [x] full `protocol/rpcsmartrouter` package green (88.9s)
- [x] `-race` green across the subscription tests
- [x] `go vet`, `gofmt` clean

## Worth a separate look

`WebSocketConfig.MaxMessageSize` (1 MB, documented under "Message limits") is **read nowhere in the tree**. Dead config, unrelated to this fix.
