### PR TITLE
chore(lint): drop the redundant int64 conversion on NOT_APPLICABLE

### DIFF
--- a/protocol/chainlib/chain_fetcher_addon_probe_test.go
+++ b/protocol/chainlib/chain_fetcher_addon_probe_test.go
@@ -95,7 +95,7 @@ func TestFetchLatestBlockNumKeepsBaseCollectionSemantics(t *testing.T) {
 
 	block, err := fetcher.FetchLatestBlockNum(context.Background())
 	require.Error(t, err)
-	require.Equal(t, int64(spectypes.NOT_APPLICABLE), block)
+	require.Equal(t, spectypes.NOT_APPLICABLE, block)
 }
 
 // acalaVerifications is the set GetVerifications returns for a node declaring


### PR DESCRIPTION
#Closes MAG-3391
Jira ticket: MAG-3391

## The problem

`protocol/chainlib/chain_fetcher_addon_probe_test.go:98` converts a value that already has the
target type:

```go
require.Equal(t, int64(spectypes.NOT_APPLICABLE), block)
```

`NOT_APPLICABLE` is declared `int64 = -1` in `types/spec/constants.go`, so `unconvert` flags it.

It sits on `main`, so every branch inherits it and every lint job log carries:

```
##[error]protocol/chainlib/chain_fetcher_addon_probe_test.go:98:24: unnecessary conversion (unconvert)
##[error]issues found
```

The `lint` check still reports **pass**, because the step is `continue-on-error`. That is the part
worth fixing: the check that would tell a contributor their branch introduced a lint problem is
green regardless, and the log that would tell them instead already has a permanent error in it for
theirs to hide behind.

Same class as the fix in #365, which cleared the other instance.

## Verification

```
golangci-lint run protocol/chainlib/...          → 0 issues
go test ./protocol/chainlib/ -run 'TestChainFetcher|AddonProbe'  → ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
