### PR TITLE
feat(resp-cache): configurable cache lookup budget (--cache-timeout) + remote lab test lanes

### DIFF
--- a/docs/RESP-CACHE.md
+++ b/docs/RESP-CACHE.md
@@ -82,6 +82,17 @@ router never starts half-configured.
 TTLs are the cache engine's own (finalized ~1h, non-finalized scaled to the chain's block
 time, short-lived node errors) — the same table the default cache uses.
 
+One budget lives on the **router**, not in this block: every cache **lookup** runs inside
+the per-relay `--cache-timeout` flag (default `50ms`, sized for a same-zone backend; writes
+are asynchronous under a separate 5s budget). A warm-connection read costs one network
+round trip, so a backend further away than the budget times out on **every** lookup —
+`smartrouter_resp_cache_failed_total{kind="timeout",op="get"}` climbs while writes keep
+landing, and no relay is ever served as `Cached`. For a cross-region backend raise the flag
+above the round-trip time (e.g. `--cache-timeout 400ms`), and prefer co-locating the router
+with the backend: a hit always costs ~1 RTT, and a miss waits out the budget before falling
+through to the upstream. (`--secondary-cache-timeout` is the same knob for the secondary
+tier.)
+
 Config values are **not** environment-expanded: a `${VAR}` written here is read literally as
 the value.
 

--- a/protocol/common/cobra_common.go
+++ b/protocol/common/cobra_common.go
@@ -127,6 +127,7 @@ const (
 	MaxSessionsPerProviderFlagName   = "max-sessions-per-provider"  // Max number of sessions allowed per provider
 	DefaultProcessingTimeoutFlagName = "default-processing-timeout" // default timeout for relay processing
 	MinRelayTimeoutFlagName          = "min-relay-timeout"          // minimum relay timeout floor (default 1s)
+	CacheTimeoutFlagName             = "cache-timeout"              // per-relay cache lookup budget (default 50ms)
 
 	// ResponseCompressionFlag controls the encoding used by the fiber compress
 	// middleware on client-facing responses. Accepted values: "gzip", "brotli", "off".

--- a/protocol/common/timeout.go
+++ b/protocol/common/timeout.go
@@ -13,7 +13,7 @@ const (
 	CacheWriteTimeout     = 5 * time.Second
 	AverageWorldLatency   = 300 * time.Millisecond
 	DefaultTimeoutSeconds = 30 // default timeout in seconds, can be overridden by flag
-	CacheTimeout          = 50 * time.Millisecond
+	DefaultCacheTimeout   = 50 * time.Millisecond
 	// On subscriptions we must use context.Background(),
 	// we cant have a context.WithTimeout() context, meaning we can hang for ever.
 	// to avoid that we introduced a first reply timeout using a routine.
@@ -24,6 +24,18 @@ const (
 // DefaultTimeout is the configurable default timeout for relay processing.
 // It can be overridden via the --default-processing-timeout flag on consumer and smart router commands.
 var DefaultTimeout = time.Duration(DefaultTimeoutSeconds) * time.Second
+
+// CacheTimeout is the per-relay cache LOOKUP budget (reads only; writes are
+// asynchronous under CacheWriteTimeout). The default is sized for a same-zone
+// backend; it can be overridden via the --cache-timeout flag on the smart
+// router command for backends a network away — a RESP backend such as
+// ElastiCache in another region needs at least one round trip per lookup, so
+// a budget below the RTT turns every read into a timeout while writes still
+// land. Raising it trades added miss latency (a miss now waits up to this
+// budget before falling through to the upstream) for the ability to hit at
+// all; the secondary tier's --secondary-cache-timeout exists for the same
+// reason.
+var CacheTimeout = DefaultCacheTimeout
 
 // MinimumTimePerRelayDelay is the minimum relay timeout floor used by GetTimePerCu.
 // It can be overridden via the --min-relay-timeout flag on consumer and smart router commands.
@@ -69,6 +81,17 @@ func ValidateAndCapMinRelayTimeout() {
 			utils.LogAttr("invalid_value", MinimumTimePerRelayDelay),
 		)
 		MinimumTimePerRelayDelay = time.Second
+	}
+
+	// Guard CacheTimeout <= 0: the lookup context would be born expired and
+	// every cache read would fail immediately — a silently disabled cache.
+	if CacheTimeout <= 0 {
+		utils.LavaFormatWarning("cache-timeout is zero or negative, resetting to default",
+			nil,
+			utils.LogAttr("invalid_value", CacheTimeout),
+			utils.LogAttr("reset_to", DefaultCacheTimeout),
+		)
+		CacheTimeout = DefaultCacheTimeout
 	}
 }
 

--- a/protocol/common/timeout_test.go
+++ b/protocol/common/timeout_test.go
@@ -115,6 +115,33 @@ func TestValidateAndCapMinRelayTimeout(t *testing.T) {
 	}
 }
 
+// --- ValidateAndCapMinRelayTimeout: the CacheTimeout guard ---
+
+func TestValidateAndCapCacheTimeout(t *testing.T) {
+	tests := []struct {
+		name  string
+		input time.Duration
+		want  time.Duration
+	}{
+		{name: "positive value kept (WAN-sized budget)", input: 400 * time.Millisecond, want: 400 * time.Millisecond},
+		{name: "default kept", input: DefaultCacheTimeout, want: DefaultCacheTimeout},
+		{name: "zero resets to default", input: 0, want: DefaultCacheTimeout},
+		{name: "negative resets to default", input: -time.Second, want: DefaultCacheTimeout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := CacheTimeout
+			t.Cleanup(func() { CacheTimeout = orig })
+			CacheTimeout = tt.input
+
+			ValidateAndCapMinRelayTimeout()
+
+			require.Equal(t, tt.want, CacheTimeout)
+		})
+	}
+}
+
 // --- GetTimePerCu respects MinimumTimePerRelayDelay ---
 
 func TestGetTimePerCu_DefaultFloor(t *testing.T) {

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -3511,6 +3511,7 @@ rpcsmartrouter smartrouter_examples/smartrouter_eth.yml --cache-be "127.0.0.1:77
 
 	cmdRPCSmartRouter.Flags().DurationVar(&common.DefaultTimeout, common.DefaultProcessingTimeoutFlagName, common.DefaultTimeout, "default timeout for relay processing (e.g., 30s, 1m)")
 	cmdRPCSmartRouter.Flags().DurationVar(&common.MinimumTimePerRelayDelay, common.MinRelayTimeoutFlagName, common.MinimumTimePerRelayDelay, "minimum relay timeout floor applied to all methods when CU-based timeout is lower (e.g., 1s, 5s)")
+	cmdRPCSmartRouter.Flags().DurationVar(&common.CacheTimeout, common.CacheTimeoutFlagName, common.CacheTimeout, "per-relay cache lookup budget; must exceed the network round trip to the cache backend, so raise it for a remote (e.g. cross-region RESP) backend (e.g., 400ms)")
 	cmdRPCSmartRouter.Flags().IntVar(&lavasession.MaxSessionsAllowedPerProvider, common.MaxSessionsPerProviderFlagName, lavasession.MaxSessionsAllowedPerProvider, "max number of sessions allowed per provider")
 
 	// batch request size limit

--- a/scripts/pre_setups/init_smartrouter_eth_redis_cluster_remote.sh
+++ b/scripts/pre_setups/init_smartrouter_eth_redis_cluster_remote.sh
@@ -1,0 +1,607 @@
+#!/bin/bash
+# Smart Router -> REMOTE Redis OSS 7.4 CLUSTER, 3 masters (the cache-test lab) — AUTH
+#
+# Redis OSS sibling of init_smartrouter_eth_valkey_cluster_remote.sh — same
+# lane shape, fourth lab backend. It points a locally built router at the
+# shared Redis OSS CLUSTER, so the resp-cache cluster topology is exercised
+# against the classic engine: the client uses the configured addresses only as
+# DISCOVERY SEEDS, learns the slot map, and talks to whichever master owns
+# each key's hash slot.
+#
+#   redis cluster    <seed host>:7001-7003   (a remote Redis OSS 7.4, 3 masters,
+#                    slots 0-5460 / 5461-10922 / 10923-16383; plain TCP + AUTH,
+#                    no TLS. The nodes ANNOUNCE their public addresses — a bare
+#                    GET without -c really answers "MOVED 14438
+#                    <node>:7003" — which is what makes an internet
+#                    client possible: discovery and redirects hand back
+#                    addresses the router must be able to dial.)
+#   smartrouter      0.0.0.0:${ROUTER_PORT}   (metrics :${METRICS_PORT})
+#
+# EVERYTHING talks straight to the remote cluster: the router dials it for
+# caching, and the script's own checks (pre-flight, per-node key scans,
+# --flush) use a local redis-cli/valkey-cli when one is installed or speak
+# inline RESP over bash's /dev/tcp otherwise — no docker, no local backend.
+# (For a TLS cluster, borrow the openssl s_client transport from the
+# standalone lanes; this lab is deliberately plain TCP.)
+#
+# The password surface has NO flag form (flags carry only addresses and
+# topology), so the lane GENERATES a config with a full resp-cache: block under
+# git-ignored debugging/ — the credential never lands in the repo tree.
+#
+# CLUSTER SPECIFICS WORTH KNOWING
+#   - Keys spray across the three masters by hash slot, so "did writes land"
+#     is a PER-NODE question: the smoke scans every master and shows the
+#     split. A handful of smoke keys may well land on only one or two masters
+#     — that is hashing, not a failure; the assertion is total > 0.
+#   - Lava-Cache-Backend names the node the client LAST dialed, so on a hit
+#     expect ONE OF the three masters, not always :7001.
+#   - SCAN is per-node, and multi-key DEL would CROSSSLOT — --flush therefore
+#     scans each master and deletes its keys one by one on that same node.
+#
+# THE READ BUDGET AND THE WAN (why this lane passes --cache-timeout)
+#   Cache READS run inside the per-relay --cache-timeout budget (default 50ms,
+#   sized for a same-zone backend); a warm GET costs one round trip to the
+#   owning master, so a budget below the RTT times out on EVERY lookup while
+#   the asynchronous writes (5s budget) still land. The lane measures the RTT
+#   and passes a budget sized to it (2*RTT + 150ms; CACHE_TIMEOUT overrides).
+#   A hit still costs ~1 RTT — co-locate router and cluster in production and
+#   keep the 50ms default.
+#
+# USAGE
+#   scripts/pre_setups/init_smartrouter_eth_redis_cluster_remote.sh            # bring up + smoke
+#   scripts/pre_setups/init_smartrouter_eth_redis_cluster_remote.sh --status   # cluster + router state
+#   scripts/pre_setups/init_smartrouter_eth_redis_cluster_remote.sh --flush    # delete ONLY this lane's keys
+#   scripts/pre_setups/init_smartrouter_eth_redis_cluster_remote.sh --stop     # stop the router
+#
+# ENVIRONMENT
+#   REDIS_CLUSTER_SEEDS     comma-separated discovery seeds
+#                           (host:7001,host:7002,host:7003)
+#   REDIS_CLUSTER_PASSWORD  REQUIRED — the cache-test lab credential (never
+#                           baked into the script; export it before running)
+#   REDIS_CLUSTER_USERNAME  ACL user (default: none -> AUTH default user)
+#   REDIS_CLUSTER_DIAL_TIMEOUT (1s) resp-cache dial-timeout (WAN-sized)
+#   CACHE_TIMEOUT       per-relay cache lookup budget passed to the router as
+#                       --cache-timeout (default: computed from measured RTT)
+#   ROUTER_PORT (3378)  METRICS_PORT (7798)   <- clear of the sibling lanes
+#                       (3377/7797 valkey-cluster, 3375-6/7795-6 the remote
+#                       standalones, 3360/7779 resp, 3370/7790 sentinel,
+#                       3380-1/7801-2 multiregion)
+#   KEY_PREFIX (sr-$USER) per-user prefix so testers on the SHARED backend
+#                       never scan or flush each other's entries
+#   ETH_RPC_URL_1/2, ETH_WS_URL_1/2   upstreams     HEALTH_INTERVAL (15s)
+#   SKIP_SMOKE=1        bring up only
+#
+# OWNERSHIP SAFETY: never `killall`. Reclaims only the router it recorded
+# starting (pid + start-time fingerprint, or a command line naming this lane's
+# generated config) and refuses to run if its ports are held by anything else.
+# The lab cluster is shared infrastructure: this lane only ever touches keys
+# under its own prefix, and only on --flush.
+
+__dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+PROJECT_ROOT=$(cd "${__dir}"/../.. && pwd)
+
+LOGS_DIR="${PROJECT_ROOT}/debugging/logs"
+mkdir -p "$LOGS_DIR"
+
+REDIS_CLUSTER_SEEDS="${REDIS_CLUSTER_SEEDS:-}"
+REDIS_CLUSTER_PASSWORD="${REDIS_CLUSTER_PASSWORD:-}"
+REDIS_CLUSTER_USERNAME="${REDIS_CLUSTER_USERNAME:-}"
+REDIS_CLUSTER_DIAL_TIMEOUT="${REDIS_CLUSTER_DIAL_TIMEOUT:-1s}"
+CACHE_TIMEOUT="${CACHE_TIMEOUT:-}"   # empty -> sized from the measured RTT below
+ROUTER_PORT="${ROUTER_PORT:-3378}"
+METRICS_PORT="${METRICS_PORT:-7798}"
+HEALTH_INTERVAL="${HEALTH_INTERVAL:-15s}"
+
+IFS=',' read -r -a NODES <<< "$REDIS_CLUSTER_SEEDS"
+SEED0="${NODES[0]}"
+
+# Per-user prefix, restricted to the router's allowed charset [A-Za-z0-9._-].
+KEY_PREFIX="${KEY_PREFIX:-sr-$(id -un 2>/dev/null)}"
+KEY_PREFIX=$(printf '%s' "$KEY_PREFIX" | tr -cd 'A-Za-z0-9._-')
+[[ -n "$KEY_PREFIX" ]] || KEY_PREFIX="sr-lab"
+
+ROUTER_SCREEN="sr-redis-cluster-remote"
+CONFIG_REL="debugging/smartrouter_eth_redis_cluster_remote.yml"
+CONFIG_FILE="${PROJECT_ROOT}/${CONFIG_REL}"
+PIDFILE="${PROJECT_ROOT}/debugging/.redis-cluster-remote-router.pid"
+ROUTER_LOG="${LOGS_DIR}/SMARTROUTER_REDIS_CLUSTER_REMOTE.log"
+
+# --- backend probe: a local CLI when installed, raw RESP over /dev/tcp else --
+# Every probe goes STRAIGHT to a cluster node — no docker, no sidecars. Auth
+# for a local CLI travels via environment, not -a, so the password never shows
+# in ps; both names are exported because the two CLIs each read their own.
+export REDISCLI_AUTH="$REDIS_CLUSTER_PASSWORD" VALKEYCLI_AUTH="$REDIS_CLUSTER_PASSWORD"
+CLI_BIN=""
+for c in redis-cli valkey-cli; do
+    command -v "$c" >/dev/null 2>&1 && { CLI_BIN="$c"; break; }
+done
+CLI_USER_ARGS=()
+[[ -n "$REDIS_CLUSTER_USERNAME" ]] && CLI_USER_ARGS=(--user "$REDIS_CLUSTER_USERNAME")
+AUTH_CRED="${REDIS_CLUSTER_USERNAME:+${REDIS_CLUSTER_USERNAME} }${REDIS_CLUSTER_PASSWORD}"
+
+resp_cmd() { # $1 = node host:port, $2 = ONE inline RESP command; raw reply stream
+    local host="${1%%:*}" port="${1##*:}"
+    if [[ -n "$CLI_BIN" ]]; then
+        # shellcheck disable=SC2086 — the inline command is intentionally split
+        "$CLI_BIN" -h "$host" -p "$port" "${CLI_USER_ARGS[@]}" $2
+        return
+    fi
+    # This script is bash (shebang), so /dev/tcp is available even though the
+    # surrounding interactive shell may be zsh. QUIT makes the node close the
+    # connection, ending cat; a watchdog bounds a black-holed node.
+    local pid wd
+    ( exec 3<>"/dev/tcp/${host}/${port}" 2>/dev/null || exit 1
+      printf 'AUTH %s\r\n%s\r\nQUIT\r\n' "$AUTH_CRED" "$2" >&3
+      cat <&3 ) 2>/dev/null &
+    pid=$!
+    ( sleep 10; kill "$pid" 2>/dev/null ) >/dev/null 2>&1 &
+    wd=$!
+    wait "$pid" 2>/dev/null; local rc=$?
+    kill "$wd" 2>/dev/null; wait "$wd" 2>/dev/null
+    return $rc
+}
+
+node_keys() { # $1 = host:port -> this lane's keys living on THAT node (SCAN is per-node)
+    if [[ -n "$CLI_BIN" ]]; then
+        "$CLI_BIN" -h "${1%%:*}" -p "${1##*:}" "${CLI_USER_ARGS[@]}" --scan --pattern "${KEY_PREFIX}:*" 2>/dev/null
+    else
+        # One SCAN pass; COUNT 1000 covers the small lab keyspace, and every
+        # caller polls, so a rare partial batch self-heals on the next try.
+        resp_cmd "$1" "SCAN 0 MATCH ${KEY_PREFIX}:* COUNT 1000" | tr -d '\r' | grep "^${KEY_PREFIX}:"
+    fi
+}
+backend_keys() { local n; for n in "${NODES[@]}"; do node_keys "$n"; done; }
+
+# --- ownership helpers (house pattern: pid + start-time fingerprint) ---------
+proc_fingerprint() { ps -p "$1" -o lstart= 2>/dev/null | tr -s ' '; }
+
+reclaim_owned() {
+    [[ -f "$PIDFILE" ]] || return 0
+    local rec_pid rec_fp cur_fp
+    rec_pid=$(cut -d'|' -f1 "$PIDFILE" 2>/dev/null)
+    rec_fp=$(cut -d'|' -f2- "$PIDFILE" 2>/dev/null)
+    [[ -n "$rec_pid" ]] || { rm -f "$PIDFILE"; return 0; }
+    cur_fp=$(proc_fingerprint "$rec_pid")
+    if [[ -z "$cur_fp" ]]; then rm -f "$PIDFILE"; return 0; fi
+    if [[ "$cur_fp" != "$rec_fp" ]]; then
+        echo "  stale pid file (pid $rec_pid is now another process) — leaving it alone"
+        rm -f "$PIDFILE"; return 0
+    fi
+    echo "  stopping this lane's previous router (pid $rec_pid)"
+    kill "$rec_pid" 2>/dev/null || true
+    for _ in $(seq 1 20); do [[ -z "$(proc_fingerprint "$rec_pid")" ]] && break; sleep 0.25; done
+    rm -f "$PIDFILE"
+}
+
+# Fallback when the pid file is missing (crash between spawn and record): the
+# port holder's command line names a file only this lane generates — identity,
+# not a name match.
+reclaim_by_identity() {
+    local pid
+    pid=$(lsof -nP -iTCP:${ROUTER_PORT} -sTCP:LISTEN -t 2>/dev/null | head -1)
+    [[ -n "$pid" ]] || return 0
+    ps -p "$pid" -o command= 2>/dev/null | grep -qF -- "$CONFIG_REL" || return 0
+    echo "  stopping this lane's router by identity (pid $pid, no pid file)"
+    kill "$pid" 2>/dev/null || true
+    for _ in $(seq 1 20); do
+        lsof -nP -iTCP:${ROUTER_PORT} -sTCP:LISTEN -t >/dev/null 2>&1 || break
+        sleep 0.25
+    done
+}
+
+# One TCP connect = one network round trip; three samples against the first
+# seed, keep the smallest positive. This decides the --cache-timeout below.
+sample_rtt_ms() {
+    local best="" t ms
+    for _ in 1 2 3; do
+        t=$(curl -s -o /dev/null -w '%{time_connect}' --connect-timeout 5 -m 2 \
+              "telnet://${SEED0}" </dev/null 2>/dev/null)
+        ms=$(awk -v t="${t:-0}" 'BEGIN{printf "%d", t*1000}')
+        [[ "$ms" -gt 0 ]] && { [[ -z "$best" || "$ms" -lt "$best" ]] && best="$ms"; }
+    done
+    echo "$best"
+}
+
+backend_version() { # prints "redis 7.4.11 (cluster)" style, empty on failure
+    # Judged by OUTPUT, not exit code (transport helpers exit non-zero on
+    # peer-close races).
+    local info v m
+    info=$(resp_cmd "$SEED0" "INFO server" 2>/dev/null)
+    [[ -n "$info" ]] || return 0
+    v=$(echo "$info" | awk -F: '/^valkey_version/{print $2}' | tr -d '\r')
+    [[ -n "$v" ]] && v="valkey $v" || v="redis $(echo "$info" | awk -F: '/^redis_version/{print $2}' | tr -d '\r')"
+    # Valkey with extended-redis-compatibility off renames redis_mode to
+    # server_mode — accept either (this lane GATES on the mode).
+    m=$(echo "$info" | awk -F: '/^(redis|server)_mode/{print $2; exit}' | tr -d '\r')
+    echo "${v}${m:+ (${m})}"
+}
+
+cluster_state() { resp_cmd "$SEED0" "CLUSTER INFO" 2>/dev/null | tr -d '\r' | awk -F: '/^cluster_state/{print $2}'; }
+
+show_masters() { # indented "host:port slots" lines from the live topology
+    resp_cmd "$SEED0" "CLUSTER NODES" 2>/dev/null | tr -d '\r' \
+        | awk '/master/ {sub(/@.*/, "", $2); print "    " $2, $9}'
+}
+
+teardown() {
+    echo "[Teardown] stopping this lane's router (nothing else is signalled)"
+    reclaim_owned
+    reclaim_by_identity
+    screen -S "$ROUTER_SCREEN" -X quit 2>/dev/null || true
+    echo "[Teardown] done. The lab cluster is untouched; this lane's keys expire"
+    echo "           by TTL, or delete them now: $0 --flush"
+    echo "           The generated config keeps the credential: rm -f ${CONFIG_REL}"
+}
+
+status() {
+    echo "backend  ${REDIS_CLUSTER_SEEDS}"
+    echo "         $(backend_version)  cluster_state:$(cluster_state)  ping: $(resp_cmd "$SEED0" PING | tr -d '\r' | grep -m1 -E '^\+?PONG$' || echo FAILED)"
+    local n split=""
+    for n in "${NODES[@]}"; do split+=":${n##*:}=$(node_keys "$n" | wc -l | tr -d ' ') "; done
+    echo "keys     ${split}under '${KEY_PREFIX}:' (per master — SCAN is per-node)"
+    local rtt; rtt=$(sample_rtt_ms)
+    echo "rtt      ${rtt:-<unmeasurable>} ms  (the lane sizes --cache-timeout to this; production default 50ms)"
+    if [[ -f "$PIDFILE" ]]; then
+        local pid; pid=$(cut -d'|' -f1 "$PIDFILE")
+        [[ -n "$(proc_fingerprint "$pid")" ]] && echo "router   UP (pid $pid) http://127.0.0.1:${ROUTER_PORT}" \
+                                              || echo "router   recorded pid $pid is gone (crashed?) — re-run the lane"
+    else
+        echo "router   not recorded as running"
+    fi
+    curl -s -m 5 "http://127.0.0.1:${METRICS_PORT}/metrics" 2>/dev/null \
+        | grep -E '^smartrouter_resp_cache_(connected|connection_errors_total|failed_total)' | sed 's/^/metric   /'
+}
+
+flush() {
+    # SCAN is per-node and multi-key DEL would CROSSSLOT, so: scan each master
+    # and delete ITS keys one by one on that same node — a single-key DEL on
+    # the node that returned it can neither CROSSSLOT nor MOVED.
+    local n k total=0
+    for n in "${NODES[@]}"; do
+        while IFS= read -r k; do
+            [[ -n "$k" ]] || continue
+            resp_cmd "$n" "DEL $k" >/dev/null
+            total=$((total + 1))
+        done < <(node_keys "$n")
+    done
+    [[ "$total" -gt 0 ]] && echo "deleted $total key(s) under '${KEY_PREFIX}:' across the masters (only this lane's prefix)" \
+                         || echo "no keys under '${KEY_PREFIX}:' — nothing to delete"
+}
+
+# The remote seeds and credential are required and never hard-coded (secret
+# scanners; shared infra). Every verb except --stop needs them to reach it.
+if [[ "$1" != "--stop" && "$1" != "stop" ]] && { [[ -z "$REDIS_CLUSTER_SEEDS" || -z "$REDIS_CLUSTER_PASSWORD" ]]; }; then
+    echo "ERROR: set REDIS_CLUSTER_SEEDS and REDIS_CLUSTER_PASSWORD (remote cluster seeds + credential), e.g.:"
+    echo "  REDIS_CLUSTER_SEEDS=<host>:7001,<host>:7002,<host>:7003 REDIS_CLUSTER_PASSWORD='...' $0 ${1:-}"
+    exit 1
+fi
+
+case "$1" in
+    --stop|stop)     teardown; exit 0 ;;
+    --status|status) status;   exit 0 ;;
+    --flush|flush)   flush;    exit $? ;;
+esac
+
+command -v screen >/dev/null || { echo "ERROR: this lane needs screen"; exit 1; }
+command -v curl   >/dev/null || { echo "ERROR: this lane needs curl"; exit 1; }
+
+ETH_RPC_URL_1="${ETH_RPC_URL_1:-https://ethereum-rpc.publicnode.com}"
+ETH_WS_URL_1="${ETH_WS_URL_1:-wss://ethereum-rpc.publicnode.com}"
+ETH_RPC_URL_2="${ETH_RPC_URL_2:-https://eth.drpc.org}"
+ETH_WS_URL_2="${ETH_WS_URL_2:-wss://eth.drpc.org}"
+
+echo "============================================"
+echo "Smart Router -> REMOTE Redis OSS CLUSTER, 3 masters (AUTH)"
+echo "============================================"
+echo "Seeds:    ${REDIS_CLUSTER_SEEDS}"
+echo "Prefix:   ${KEY_PREFIX}:   (per-user isolation on the shared lab backend)"
+echo ""
+
+# --- pre-flight: prove the CLUSTER before spending a build on it -------------
+# The router does NOT dial at construction and degrades per-operation, so a bad
+# seed/password would still log "resp-cache backend configured" and the lane
+# would look green while silently missing forever. Three hard gates: an
+# authenticated PING, mode=cluster (someone pointing this lane at a standalone
+# gets one clear line, not a baffling cluster-client failure), and
+# cluster_state:ok (full slot coverage — a partial cluster serves errors).
+echo "[Setup] pre-flight: authenticated ping + topology via ${CLI_BIN:-/dev/tcp}"
+PROBE_OUT=$(resp_cmd "$SEED0" PING 2>&1 | tr -d '\r')
+if ! echo "$PROBE_OUT" | grep -qE '^\+?PONG$'; then
+    echo "ERROR: ${SEED0} did not answer an authenticated PING:"
+    echo "       $(echo "${PROBE_OUT:-<no reply>}" | head -2 | tr '\n' ' ')"
+    echo "       Check network/VPN, REDIS_CLUSTER_PASSWORD, or REDIS_CLUSTER_SEEDS."
+    exit 1
+fi
+BACKEND_DESC=$(backend_version)
+if [[ "$BACKEND_DESC" != *"(cluster)"* ]]; then
+    echo "ERROR: ${SEED0} reports '${BACKEND_DESC:-<unknown>}' — not a cluster node."
+    echo "       For a standalone backend use init_smartrouter_eth_redis_oss_remote.sh."
+    exit 1
+fi
+STATE=$(cluster_state)
+if [[ "$STATE" != "ok" ]]; then
+    echo "ERROR: cluster_state is '${STATE:-<none>}' (want ok) — the cluster is not serving all slots."
+    exit 1
+fi
+echo "  backend: ${BACKEND_DESC} — PONG, cluster_state:ok"
+echo "  masters (discovered live; the config below carries only SEEDS):"
+show_masters
+
+RTT_MS=$(sample_rtt_ms)
+if [[ -z "$CACHE_TIMEOUT" ]]; then
+    # The lookup budget must exceed the backend RTT or every read times out —
+    # writes would still land and the lane would look "up" while never serving
+    # a single hit (the failure mode this lane exists to catch).
+    if [[ -n "$RTT_MS" ]]; then CACHE_TIMEOUT="$(( 2 * RTT_MS + 150 ))ms"; else CACHE_TIMEOUT="750ms"; fi
+fi
+echo "  rtt: ~${RTT_MS:-?}ms -> --cache-timeout ${CACHE_TIMEOUT}"
+echo "       (the production default, 50ms, suits a same-zone backend; a hit here"
+echo "       still costs ~1 RTT — co-locate router and cluster in production)"
+echo ""
+
+echo "[Setup] reclaiming this lane's previous run (if any)"
+reclaim_owned
+reclaim_by_identity
+screen -S "$ROUTER_SCREEN" -X quit 2>/dev/null || true
+sleep 1
+
+# Anything still on this lane's ports is NOT ours: refuse, never evict.
+BLOCKED=0
+for port in "$ROUTER_PORT" "$METRICS_PORT"; do
+    if lsof -nP -iTCP:$port -sTCP:LISTEN >/dev/null 2>&1; then
+        [[ "$BLOCKED" == "0" ]] && { echo "ERROR: this lane's port(s) are held by process(es) it does not own."; echo "       Refusing to run. Nothing was signalled."; }
+        echo "  port $port:"; lsof -nP -iTCP:$port -sTCP:LISTEN | sed 's/^/    /'
+        BLOCKED=1
+    fi
+done
+[[ "$BLOCKED" == "1" ]] && { echo ""; echo "Free them, or move this lane: ROUTER_PORT=3379 METRICS_PORT=7799 $0"; exit 1; }
+
+echo "[Setup] installing binaries"
+# env -u GOFLAGS: when the calling shell exports GOFLAGS (any value), make
+# auto-re-exports its own GOFLAGS := ... -ldflags '...' to the child go
+# install, and go's $GOFLAGS env parser cannot read the quoted ldflags —
+# "go: parsing $GOFLAGS: unknown flag -w". Scrubbing it keeps the Makefile's
+# flags on argv only, where the quoting is legal.
+env -u GOFLAGS make -C "$PROJECT_ROOT" install || { echo "ERROR: make install failed"; exit 1; }
+
+# --- router config -----------------------------------------------------------
+# Generated (not checked in) because it embeds the credential; debugging/ is
+# git-ignored and the file is created 0600.
+echo "[Setup] generating ${CONFIG_REL}"
+umask 077
+USERNAME_LINE=""
+[[ -n "$REDIS_CLUSTER_USERNAME" ]] && USERNAME_LINE="  username: \"${REDIS_CLUSTER_USERNAME}\"
+"
+SEED_ADDRS=""
+for n in "${NODES[@]}"; do
+    [[ -n "$SEED_ADDRS" ]] && SEED_ADDRS+=", "
+    SEED_ADDRS+="\"${n}\""
+done
+
+cat > "$CONFIG_FILE" <<EOF
+# GENERATED by scripts/pre_setups/init_smartrouter_eth_redis_cluster_remote.sh.
+# Contains a credential (the shared cache-test lab password) — this file lives
+# in git-ignored debugging/ and must never be committed.
+
+metrics-listen-address: "0.0.0.0:${METRICS_PORT}"
+
+resp-cache:
+  topology: cluster
+  # DISCOVERY SEEDS, not the node list: the client asks these for the slot
+  # map and then dials whatever the nodes ANNOUNCE. This lab announces its
+  # public addresses (a bare GET really answers MOVED <slot> <public-addr>),
+  # which is why an internet client works; a cluster that announces private
+  # IPs is unreachable from outside no matter what is written here.
+  # (db: is rejected under cluster — one logical database.)
+  addresses: [${SEED_ADDRS}]
+${USERNAME_LINE}  password: "${REDIS_CLUSTER_PASSWORD}"
+  key-prefix: "${KEY_PREFIX}"
+  # The repo default (500ms) is LAN-sized; a WAN dial pays 2-3 round trips,
+  # and a too-small value makes the connected gauge flap.
+  dial-timeout: "${REDIS_CLUSTER_DIAL_TIMEOUT}"
+  # No tls: block — this lab speaks plain TCP + AUTH (see the header).
+
+endpoints:
+  - listen-address: "0.0.0.0:${ROUTER_PORT}"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    network-address: "0.0.0.0:${ROUTER_PORT}"
+
+direct-rpc:
+  - name: "eth-rpc-1"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "${ETH_RPC_URL_1}"
+        skip-verifications:
+          - chain-id
+          - pruning
+      - url: "${ETH_WS_URL_1}"
+
+  - name: "eth-rpc-2"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "${ETH_RPC_URL_2}"
+        skip-verifications:
+          - chain-id
+          - pruning
+      - url: "${ETH_WS_URL_2}"
+EOF
+
+# --- router ------------------------------------------------------------------
+# If the router logs its backend line but the first cache op then fails oddly,
+# suspect the go-redis streaming-credentials init for this client type before
+# anything else — the failover client historically accepted the provider but
+# never initialized its re-auth manager (see redisstore/config.go). Standalone
+# and the Valkey cluster use the same provider and are proven by the sibling
+# lanes.
+echo "[Setup] starting the smart router (:${ROUTER_PORT}) against the cluster"
+screen -d -m -S "$ROUTER_SCREEN" bash -c "cd $PROJECT_ROOT && source ~/.bashrc; smartrouter \
+$CONFIG_REL \
+--log-level debug \
+--use-static-spec $PROJECT_ROOT/specs/ethereum.json \
+--debug-relays \
+--cache-timeout ${CACHE_TIMEOUT} \
+--relays-health-interval ${HEALTH_INTERVAL} 2>&1 | tee $ROUTER_LOG"
+sleep 0.5
+
+ROUTER_OK=0
+for _ in $(seq 1 45); do
+    grep -q "resp-cache backend configured" "$ROUTER_LOG" 2>/dev/null && { ROUTER_OK=1; break; }
+    grep -q "^Error:" "$ROUTER_LOG" 2>/dev/null && break
+    sleep 1
+done
+if [[ "$ROUTER_OK" != "1" ]]; then
+    echo "ERROR: the router never reported its RESP backend — last log lines:"
+    tail -8 "$ROUTER_LOG" 2>/dev/null | sed 's/^/  /'
+    exit 1
+fi
+
+ROUTER_PID=""
+for _ in $(seq 1 60); do
+    ROUTER_PID=$(lsof -nP -iTCP:${ROUTER_PORT} -sTCP:LISTEN -t 2>/dev/null | head -1)
+    [[ -n "$ROUTER_PID" ]] && break
+    sleep 1
+done
+[[ -n "$ROUTER_PID" ]] || { echo "ERROR: the router never bound :${ROUTER_PORT}"; tail -8 "$ROUTER_LOG" | sed 's/^/  /'; exit 1; }
+printf '%s|%s\n' "$ROUTER_PID" "$(proc_fingerprint "$ROUTER_PID")" > "$PIDFILE"
+echo "  router: UP (pid ${ROUTER_PID}) with the remote cluster backend"
+
+# --- smoke -------------------------------------------------------------------
+if [[ "$SKIP_SMOKE" != "1" ]]; then
+    echo ""
+    echo "[Smoke] router health -> relay -> writes across the masters -> cache hit"
+    note() { printf '  %-34s %s\n' "$1" "$2"; }
+    SMOKE_FAIL=0
+    # LATEST-shaped relay to drive traffic; a fixed long-finalized block for a
+    # deterministic key (same one on every run and every router).
+    RELAY_TIP='{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+    RELAY_FIXED='{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x112a880",false],"id":1}'
+    relay() { curl -sf -m 20 -X POST "http://127.0.0.1:${ROUTER_PORT}" -H 'Content-Type: application/json' -d "$1"; }
+    hits() { curl -sf "http://127.0.0.1:${METRICS_PORT}/metrics" | awk '/^smartrouter_cache_success_total/ {sum += $NF} END {printf "%d", sum}'; }
+
+    HEALTH=""
+    for _ in $(seq 1 30); do
+        HEALTH=$(curl -s -o /dev/null -w '%{http_code}' -m 10 "http://127.0.0.1:${ROUTER_PORT}/lava/health")
+        [[ "$HEALTH" == "200" ]] && break
+        sleep 1
+    done
+    [[ "$HEALTH" == "200" ]] && note "router /lava/health" "200" || { note "router /lava/health" "$HEALTH (want 200)"; SMOKE_FAIL=1; }
+
+    # The gauge is driven by a periodic probe (3s budget — WAN-tolerant); give
+    # it a couple of cycles rather than sampling once.
+    CONNECTED=""
+    for _ in $(seq 1 30); do
+        CONNECTED=$(curl -sf "http://127.0.0.1:${METRICS_PORT}/metrics" | awk '/^smartrouter_resp_cache_connected/ {print $NF; exit}')
+        [[ "$CONNECTED" == "1" ]] && break
+        sleep 1
+    done
+    [[ "$CONNECTED" == "1" ]] && note "resp_cache_connected" "1" || { note "resp_cache_connected" "${CONNECTED:-<none>} (want 1)"; SMOKE_FAIL=1; }
+
+    BODY=$(relay "$RELAY_FIXED" || true)
+    [[ "$BODY" == *'"result"'* ]] && note "relay eth_getBlockByNumber" "ok" \
+        || { note "relay" "unexpected: ${BODY:0:60}"; SMOKE_FAIL=1; }
+
+    # Writes are asynchronous and spray across the masters by hash slot —
+    # poll the TOTAL while driving more traffic, then show the split. A small
+    # sample may land on one or two masters only; that is hashing, not a bug.
+    KEYS=0
+    for _ in $(seq 1 20); do
+        relay "$RELAY_TIP" >/dev/null 2>&1 || true
+        KEYS=$(backend_keys | wc -l | tr -d ' ')
+        [[ "$KEYS" -gt 0 ]] && break
+        sleep 1
+    done
+    if [[ "$KEYS" -gt 0 ]]; then
+        SPLIT=""
+        for n in "${NODES[@]}"; do SPLIT+=":${n##*:}=$(node_keys "$n" | wc -l | tr -d ' ') "; done
+        note "keys across the masters" "$KEYS total (${SPLIT%% })"
+    else
+        note "keys across the masters" "none (writes should land from anywhere)"; SMOKE_FAIL=1
+    fi
+
+    HIT_OK=0
+    for _ in $(seq 1 20); do
+        relay "$RELAY_FIXED" >/dev/null 2>&1 || true
+        sleep 0.5
+        [[ "$(hits)" -gt 0 ]] && { HIT_OK=1; break; }
+    done
+    if [[ "$HIT_OK" == "1" ]]; then
+        note "cache_success_total" "$(hits) (>0)"
+        HDR=$(curl -s -D - -o /dev/null -m 20 -X POST "http://127.0.0.1:${ROUTER_PORT}" -H 'Content-Type: application/json' -d "$RELAY_FIXED" | grep -i '^Lava-Cache-Backend' | tr -d '\r')
+        [[ -n "$HDR" ]] && note "hit served by" "${HDR#*: } (one of the masters — last dialed)"
+    else
+        # connected=1 + keys present + zero hits means lookups still time out:
+        # compare --cache-timeout against the RTT and watch the get-timeout
+        # counter (smartrouter_resp_cache_failed_total) before suspecting auth.
+        note "cache_success_total" "0 (expected >0 with --cache-timeout ${CACHE_TIMEOUT} at ~${RTT_MS:-?}ms RTT)"
+        SMOKE_FAIL=1
+    fi
+
+    echo ""
+    [[ "$SMOKE_FAIL" == "0" ]] && echo "  SMOKE PASS — the router is spraying entries across the remote Redis cluster." \
+        || { echo "  SMOKE FAIL — see $ROUTER_LOG"; exit 1; }
+fi
+
+# The 'rc' helper the samples below rely on — a FUNCTION taking a node
+# host:port first (SCAN/TTL are per-node in a cluster), then the command.
+# Named 'rc' so it coexists with the sibling lanes' vk/rd/vc in one shell.
+# The raw variant wraps /dev/tcp in `bash -c` so it also works when pasted
+# into zsh (macOS default), where /dev/tcp does not exist.
+if [[ -n "$CLI_BIN" ]]; then
+    RC_SETUP="export REDISCLI_AUTH='${REDIS_CLUSTER_PASSWORD}' VALKEYCLI_AUTH=\"\$REDISCLI_AUTH\"
+  rc() { local hp=\"\$1\"; shift; ${CLI_BIN} -h \"\${hp%%:*}\" -p \"\${hp##*:}\"${REDIS_CLUSTER_USERNAME:+ --user ${REDIS_CLUSTER_USERNAME}} \"\$@\"; }"
+else
+    RC_SETUP="rc() { local hp=\"\$1\"; shift; bash -c 'exec 3<>\"/dev/tcp/\$0/\$1\"; printf \"AUTH ${AUTH_CRED}\\r\\n%s\\r\\nQUIT\\r\\n\" \"\$2\" >&3; cat <&3' \"\${hp%%:*}\" \"\${hp##*:}\" \"\$*\" 2>/dev/null; }"
+fi
+
+cat <<EOF
+
+============================================
+REMOTE REDIS OSS CLUSTER LANE — CHEAT SHEET
+============================================
+Router    http://127.0.0.1:${ROUTER_PORT}    metrics http://127.0.0.1:${METRICS_PORT}/metrics
+Cluster   ${REDIS_CLUSTER_SEEDS}  (AUTH, plain TCP)
+Config    ${CONFIG_REL}   (holds the credential — git-ignored)
+Log       tail -f ${ROUTER_LOG}
+
+One-time in your shell (paste as-is), then use 'rc <node> <COMMAND>':
+  ${RC_SETUP}
+
+--- PROVE THE CLUSTER CACHE IS WORKING -----
+
+1. See the topology the router discovers (masters + slot ranges):
+     rc ${SEED0} CLUSTER NODES | awk '/master/ {print \$2, \$9}'
+
+2. Warm the cache — relay a fixed, long-finalized block (deterministic key):
+     curl -s -X POST http://127.0.0.1:${ROUTER_PORT} -H 'Content-Type: application/json' \\
+       -d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x112a880",false],"id":1}' | head -c 120; echo
+
+3. Find where entries landed — SCAN is PER NODE, so ask each master; the
+   split across them is the cluster working:
+     for n in ${NODES[*]##*:}; do echo ":\$n"; rc ${SEED0%%:*}:\$n SCAN 0 MATCH '${KEY_PREFIX}:*' COUNT 1000; done
+     rc <node-that-has-it> TTL '<paste a key>'
+
+4. Repeat the SAME relay and look at the headers — a hit is served as
+   "Cached"; Lava-Cache-Backend names the LAST-DIALED node, so expect ONE OF
+   the masters (not always :${SEED0##*:}):
+     curl -s -D - -o /dev/null -X POST http://127.0.0.1:${ROUTER_PORT} -H 'Content-Type: application/json' \\
+       -d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x112a880",false],"id":1}' \\
+       | grep -iE 'lava-(provider-address|cache-backend)'
+     # (hits work even far from the cluster — the lane raised the lookup
+     #  budget with --cache-timeout ${CACHE_TIMEOUT}; the production default is 50ms)
+
+5. The counters move — success/requests per tier, plus backend health:
+     curl -s http://127.0.0.1:${METRICS_PORT}/metrics | grep -E '^smartrouter_cache_(success|requests)_total'
+     curl -s http://127.0.0.1:${METRICS_PORT}/metrics | grep '^smartrouter_resp_cache'
+
+6. Watch the router decide, live:
+     tail -f ${ROUTER_LOG} | grep -iE 'cache (lookup|hit|miss)|resp-cache'
+
+--------------------------------------------
+Status (cluster state, per-master keys, RTT):      $0 --status
+Clean up this lane's keys (never anyone else's):   $0 --flush
+Stop the router:                                   $0 --stop
+============================================
+EOF

--- a/scripts/pre_setups/init_smartrouter_eth_redis_oss_remote.sh
+++ b/scripts/pre_setups/init_smartrouter_eth_redis_oss_remote.sh
@@ -1,0 +1,577 @@
+#!/bin/bash
+# Smart Router -> REMOTE Redis OSS 7.1 STANDALONE (the cache-test lab) — TLS + AUTH
+#
+# Redis OSS sibling of init_smartrouter_eth_valkey_remote.sh: same lane, second
+# lab engine. It points a locally built router at the shared Redis OSS backend,
+# so the resp-cache path is exercised against a real remote standalone Redis
+# with the production-shaped surface: TLS on the wire, password AUTH, DNS
+# endpoint. Distinct ports/identity from the Valkey lane, so BOTH remote lanes
+# can run at once for an engine-by-engine comparison.
+#
+#   redis        $REDIS_HOST:$REDIS_PORT   (a remote Redis OSS 7.1
+#                standalone — ElastiCache-style TLS endpoint behind an AWS NLB
+#                in us-east-1; the cert does not verify against public roots
+#                -> verification is skipped, same as redis-cli --insecure)
+#   smartrouter  0.0.0.0:${ROUTER_PORT}   (metrics :${METRICS_PORT})
+#
+# EVERYTHING talks straight to that remote endpoint: the router dials it for
+# caching, and the script's own checks (pre-flight ping, key scans, --flush)
+# use a local redis-cli/valkey-cli when one is installed or plain openssl
+# s_client speaking RESP otherwise. No docker, no local backend, no sidecars.
+#
+# The password + TLS surface has NO flag form (flags carry only addresses and
+# topology), so the lane GENERATES a config with a full resp-cache: block under
+# git-ignored debugging/ — the credential never lands in the repo tree.
+#
+# THE READ BUDGET AND THE WAN (why this lane passes --cache-timeout)
+#   - Cache WRITES are asynchronous with a 5s budget (common.CacheWriteTimeout):
+#     they land from anywhere. The smoke proves them by scanning the lane's
+#     key prefix on the lab backend.
+#   - Cache READS run inside the per-relay --cache-timeout budget (default
+#     50ms, sized for a same-zone backend). A warm-connection GET costs one
+#     network round trip, so a budget below the backend RTT turns EVERY lookup
+#     into a timeout — smartrouter_resp_cache_failed_total{kind="timeout",
+#     op="get"} climbs while writes still land, and relays are answered by the
+#     upstream (Lava-Provider-Address: eth-rpc-N, never Cached).
+#   - The lane therefore measures the RTT and passes a --cache-timeout sized
+#     to it (2*RTT + 150ms headroom; CACHE_TIMEOUT overrides), so cache HITS
+#     work from anywhere. The trade is honest: a hit saves the upstream call
+#     but still costs ~1 RTT, and a miss now waits up to the budget before
+#     falling through. Production should co-locate router and backend and
+#     keep the 50ms default.
+#
+# USAGE
+#   scripts/pre_setups/init_smartrouter_eth_redis_oss_remote.sh            # bring up + smoke
+#   scripts/pre_setups/init_smartrouter_eth_redis_oss_remote.sh --status   # backend + router state
+#   scripts/pre_setups/init_smartrouter_eth_redis_oss_remote.sh --flush    # delete ONLY this lane's keys
+#   scripts/pre_setups/init_smartrouter_eth_redis_oss_remote.sh --stop     # stop the router
+#
+# ENVIRONMENT
+#   REDIS_HOST          REQUIRED — the remote Redis host   REDIS_PORT (6380)
+#   REDIS_PASSWORD      REQUIRED — the cache-test lab credential (never baked
+#                       into the script; export it before running)
+#   REDIS_USERNAME      ACL user (default: none -> AUTH default user)
+#   REDIS_CA_FILE       PEM to VERIFY the server against; unset -> skip
+#                       verification (the lab cert does not verify)
+#   REDIS_DIAL_TIMEOUT  (1s) resp-cache dial-timeout. The repo default (500ms)
+#                       is LAN-sized; a WAN dial pays TCP + TLS = 2-3 RTTs.
+#   CACHE_TIMEOUT       per-relay cache lookup budget passed to the router as
+#                       --cache-timeout (default: computed from measured RTT)
+#   ROUTER_PORT (3376)  METRICS_PORT (7796)   <- clear of the sibling lanes
+#                       (3375/7795 valkey-remote, 3360/7779 resp, 3370/7790
+#                       sentinel, 3380-1/7801-2 multiregion)
+#   KEY_PREFIX (sr-$USER) per-user prefix so testers on the SHARED backend
+#                       never scan or flush each other's entries
+#   ETH_RPC_URL_1/2, ETH_WS_URL_1/2   upstreams     HEALTH_INTERVAL (15s)
+#   SKIP_SMOKE=1        bring up only
+#
+# OWNERSHIP SAFETY: never `killall`. Reclaims only the router it recorded
+# starting (pid + start-time fingerprint, or a command line naming this lane's
+# generated config) and refuses to run if its ports are held by anything else.
+# The lab backend is shared infrastructure: this lane only ever touches keys
+# under its own prefix, and only on --flush.
+
+__dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+PROJECT_ROOT=$(cd "${__dir}"/../.. && pwd)
+
+LOGS_DIR="${PROJECT_ROOT}/debugging/logs"
+mkdir -p "$LOGS_DIR"
+
+REDIS_HOST="${REDIS_HOST:-}"
+REDIS_PORT="${REDIS_PORT:-6380}"
+REDIS_PASSWORD="${REDIS_PASSWORD:-}"
+REDIS_USERNAME="${REDIS_USERNAME:-}"
+REDIS_CA_FILE="${REDIS_CA_FILE:-}"
+REDIS_DIAL_TIMEOUT="${REDIS_DIAL_TIMEOUT:-1s}"
+CACHE_TIMEOUT="${CACHE_TIMEOUT:-}"   # empty -> sized from the measured RTT below
+ROUTER_PORT="${ROUTER_PORT:-3376}"
+METRICS_PORT="${METRICS_PORT:-7796}"
+HEALTH_INTERVAL="${HEALTH_INTERVAL:-15s}"
+
+# Per-user prefix, restricted to the router's allowed charset [A-Za-z0-9._-].
+KEY_PREFIX="${KEY_PREFIX:-sr-$(id -un 2>/dev/null)}"
+KEY_PREFIX=$(printf '%s' "$KEY_PREFIX" | tr -cd 'A-Za-z0-9._-')
+[[ -n "$KEY_PREFIX" ]] || KEY_PREFIX="sr-lab"
+
+ROUTER_SCREEN="sr-redis-oss-remote"
+CONFIG_REL="debugging/smartrouter_eth_redis_oss_remote.yml"
+CONFIG_FILE="${PROJECT_ROOT}/${CONFIG_REL}"
+PIDFILE="${PROJECT_ROOT}/debugging/.redis-oss-remote-router.pid"
+ROUTER_LOG="${LOGS_DIR}/SMARTROUTER_REDIS_OSS_REMOTE.log"
+
+# --- backend probe: a local CLI when installed, raw RESP-over-TLS otherwise --
+# Every probe goes STRAIGHT to the remote endpoint — no docker, no sidecars.
+# Auth for a local redis-cli/valkey-cli travels via environment, not -a, so
+# the password never shows in ps; both names are exported because the two CLIs
+# each read their own variable.
+export REDISCLI_AUTH="$REDIS_PASSWORD" VALKEYCLI_AUTH="$REDIS_PASSWORD"
+CLI_BIN=""
+for c in redis-cli valkey-cli; do
+    command -v "$c" >/dev/null 2>&1 || continue
+    "$c" --help 2>&1 | grep -q -- '--tls' && { CLI_BIN="$c"; break; }
+done
+CLI_ARGS=(--tls -h "$REDIS_HOST" -p "$REDIS_PORT")
+if [[ -n "$REDIS_CA_FILE" ]]; then CLI_ARGS+=(--cacert "$REDIS_CA_FILE"); else CLI_ARGS+=(--insecure); fi
+[[ -n "$REDIS_USERNAME" ]] && CLI_ARGS+=(--user "$REDIS_USERNAME")
+rcli() { "$CLI_BIN" "${CLI_ARGS[@]}" "$@"; }
+
+# Without a CLI the script speaks inline RESP over TLS itself through openssl
+# s_client (present on macOS and Linux). -servername: ElastiCache-style
+# endpoints route on SNI. QUIT makes the server close the stream, which ends
+# s_client; a watchdog bounds a black-holed connection.
+OPENSSL_TRUST=()
+[[ -n "$REDIS_CA_FILE" ]] && OPENSSL_TRUST=(-CAfile "$REDIS_CA_FILE" -verify_return_error)
+resp_cmd() { # $1 = ONE inline RESP command; prints the raw reply stream
+    if [[ -n "$CLI_BIN" ]]; then
+        # shellcheck disable=SC2086 — the inline command is intentionally split
+        rcli $1
+        return
+    fi
+    local pid wd
+    printf 'AUTH %s\r\n%s\r\nQUIT\r\n' \
+        "${REDIS_USERNAME:+${REDIS_USERNAME} }${REDIS_PASSWORD}" "$1" \
+        | openssl s_client -connect "${REDIS_HOST}:${REDIS_PORT}" \
+              -servername "$REDIS_HOST" "${OPENSSL_TRUST[@]}" -quiet -ign_eof 2>/dev/null &
+    pid=$!
+    ( sleep 10; kill "$pid" 2>/dev/null ) >/dev/null 2>&1 &
+    wd=$!
+    wait "$pid" 2>/dev/null; local rc=$?
+    kill "$wd" 2>/dev/null; wait "$wd" 2>/dev/null
+    return $rc
+}
+backend_keys() { # this lane's keys on the backend, one per line
+    if [[ -n "$CLI_BIN" ]]; then
+        rcli --scan --pattern "${KEY_PREFIX}:*" 2>/dev/null
+    else
+        # One SCAN pass; COUNT 1000 covers the small lab keyspace, and every
+        # caller polls, so a rare partial batch self-heals on the next try.
+        resp_cmd "SCAN 0 MATCH ${KEY_PREFIX}:* COUNT 1000" | tr -d '\r' | grep "^${KEY_PREFIX}:"
+    fi
+}
+HAVE_PROBE=""
+{ [[ -n "$CLI_BIN" ]] || command -v openssl >/dev/null 2>&1; } && HAVE_PROBE=1
+
+# --- ownership helpers (house pattern: pid + start-time fingerprint) ---------
+proc_fingerprint() { ps -p "$1" -o lstart= 2>/dev/null | tr -s ' '; }
+
+reclaim_owned() {
+    [[ -f "$PIDFILE" ]] || return 0
+    local rec_pid rec_fp cur_fp
+    rec_pid=$(cut -d'|' -f1 "$PIDFILE" 2>/dev/null)
+    rec_fp=$(cut -d'|' -f2- "$PIDFILE" 2>/dev/null)
+    [[ -n "$rec_pid" ]] || { rm -f "$PIDFILE"; return 0; }
+    cur_fp=$(proc_fingerprint "$rec_pid")
+    if [[ -z "$cur_fp" ]]; then rm -f "$PIDFILE"; return 0; fi
+    if [[ "$cur_fp" != "$rec_fp" ]]; then
+        echo "  stale pid file (pid $rec_pid is now another process) — leaving it alone"
+        rm -f "$PIDFILE"; return 0
+    fi
+    echo "  stopping this lane's previous router (pid $rec_pid)"
+    kill "$rec_pid" 2>/dev/null || true
+    for _ in $(seq 1 20); do [[ -z "$(proc_fingerprint "$rec_pid")" ]] && break; sleep 0.25; done
+    rm -f "$PIDFILE"
+}
+
+# Fallback when the pid file is missing (crash between spawn and record): the
+# port holder's command line names a file only this lane generates — identity,
+# not a name match.
+reclaim_by_identity() {
+    local pid
+    pid=$(lsof -nP -iTCP:${ROUTER_PORT} -sTCP:LISTEN -t 2>/dev/null | head -1)
+    [[ -n "$pid" ]] || return 0
+    ps -p "$pid" -o command= 2>/dev/null | grep -qF -- "$CONFIG_REL" || return 0
+    echo "  stopping this lane's router by identity (pid $pid, no pid file)"
+    kill "$pid" 2>/dev/null || true
+    for _ in $(seq 1 20); do
+        lsof -nP -iTCP:${ROUTER_PORT} -sTCP:LISTEN -t >/dev/null 2>&1 || break
+        sleep 0.25
+    done
+}
+
+# One TCP connect = one network round trip; three samples, keep the smallest
+# positive. This is what decides whether cache HITS are physically possible
+# inside the router's 50ms read budget.
+sample_rtt_ms() {
+    local best="" t ms
+    for _ in 1 2 3; do
+        t=$(curl -s -o /dev/null -w '%{time_connect}' --connect-timeout 5 -m 2 \
+              "telnet://${REDIS_HOST}:${REDIS_PORT}" </dev/null 2>/dev/null)
+        ms=$(awk -v t="${t:-0}" 'BEGIN{printf "%d", t*1000}')
+        [[ "$ms" -gt 0 ]] && { [[ -z "$best" || "$ms" -lt "$best" ]] && best="$ms"; }
+    done
+    echo "$best"
+}
+
+backend_version() { # prints "redis 7.1.0 (standalone)" style, empty on failure
+    # Judged by OUTPUT, not exit code: s_client exits non-zero when the peer
+    # TCP-closes without a TLS close_notify, as NLB-fronted endpoints do.
+    local info v m
+    info=$(resp_cmd "INFO server" 2>/dev/null)
+    [[ -n "$info" ]] || return 0
+    v=$(echo "$info" | awk -F: '/^valkey_version/{print $2}' | tr -d '\r')
+    [[ -n "$v" ]] && v="valkey $v" || v="redis $(echo "$info" | awk -F: '/^redis_version/{print $2}' | tr -d '\r')"
+    # Valkey with extended-redis-compatibility off renames redis_mode to
+    # server_mode — accept either.
+    m=$(echo "$info" | awk -F: '/^(redis|server)_mode/{print $2; exit}' | tr -d '\r')
+    echo "${v}${m:+ (${m})}"
+}
+
+teardown() {
+    echo "[Teardown] stopping this lane's router (nothing else is signalled)"
+    reclaim_owned
+    reclaim_by_identity
+    screen -S "$ROUTER_SCREEN" -X quit 2>/dev/null || true
+    echo "[Teardown] done. The lab backend is untouched; this lane's keys expire"
+    echo "           by TTL, or delete them now: $0 --flush"
+    echo "           The generated config keeps the credential: rm -f ${CONFIG_REL}"
+}
+
+status() {
+    if [[ -n "$HAVE_PROBE" ]]; then
+        echo "backend  ${REDIS_HOST}:${REDIS_PORT}  $(backend_version)  ping: $(resp_cmd PING | tr -d '\r' | grep -m1 -E '^\+?PONG$' || echo FAILED)"
+        echo "keys     $(backend_keys | wc -l | tr -d ' ') under '${KEY_PREFIX}:'"
+    else
+        echo "backend  ${REDIS_HOST}:${REDIS_PORT}  (no redis-cli/valkey-cli and no openssl — cannot probe)"
+    fi
+    local rtt; rtt=$(sample_rtt_ms)
+    echo "rtt      ${rtt:-<unmeasurable>} ms  (the lane sizes --cache-timeout to this; production default 50ms)"
+    if [[ -f "$PIDFILE" ]]; then
+        local pid; pid=$(cut -d'|' -f1 "$PIDFILE")
+        [[ -n "$(proc_fingerprint "$pid")" ]] && echo "router   UP (pid $pid) http://127.0.0.1:${ROUTER_PORT}" \
+                                              || echo "router   recorded pid $pid is gone (crashed?) — re-run the lane"
+    else
+        echo "router   not recorded as running"
+    fi
+    curl -s -m 5 "http://127.0.0.1:${METRICS_PORT}/metrics" 2>/dev/null \
+        | grep -E '^smartrouter_resp_cache_(connected|connection_errors_total|failed_total)' | sed 's/^/metric   /'
+}
+
+flush() {
+    [[ -n "$HAVE_PROBE" ]] || { echo "ERROR: --flush needs redis-cli/valkey-cli or openssl"; exit 1; }
+    local keys n
+    keys=$(backend_keys)
+    n=$(printf '%s' "$keys" | grep -c .)
+    [[ "$n" -gt 0 ]] || { echo "no keys under '${KEY_PREFIX}:' — nothing to delete"; return 0; }
+    echo "deleting $n key(s) under '${KEY_PREFIX}:' on ${REDIS_HOST} (only this lane's prefix)"
+    # One inline DEL carries them all — key names never contain spaces.
+    resp_cmd "DEL $(echo "$keys" | tr '\n' ' ')" >/dev/null
+    echo "done"
+}
+
+# The remote endpoint and credential are required and never hard-coded (secret
+# scanners; shared infra). Every verb except --stop needs them to reach it.
+if [[ "$1" != "--stop" && "$1" != "stop" ]] && { [[ -z "$REDIS_HOST" || -z "$REDIS_PASSWORD" ]]; }; then
+    echo "ERROR: set REDIS_HOST and REDIS_PASSWORD (the remote Redis endpoint + credential), e.g.:"
+    echo "  REDIS_HOST=<host> REDIS_PASSWORD='...' $0 ${1:-}"
+    exit 1
+fi
+
+case "$1" in
+    --stop|stop)     teardown; exit 0 ;;
+    --status|status) status;   exit 0 ;;
+    --flush|flush)   flush;    exit $? ;;
+esac
+
+command -v screen >/dev/null || { echo "ERROR: this lane needs screen"; exit 1; }
+command -v curl   >/dev/null || { echo "ERROR: this lane needs curl"; exit 1; }
+
+ETH_RPC_URL_1="${ETH_RPC_URL_1:-https://ethereum-rpc.publicnode.com}"
+ETH_WS_URL_1="${ETH_WS_URL_1:-wss://ethereum-rpc.publicnode.com}"
+ETH_RPC_URL_2="${ETH_RPC_URL_2:-https://eth.drpc.org}"
+ETH_WS_URL_2="${ETH_WS_URL_2:-wss://eth.drpc.org}"
+
+echo "============================================"
+echo "Smart Router -> REMOTE Redis OSS standalone (TLS + AUTH)"
+echo "============================================"
+echo "Backend:  ${REDIS_HOST}:${REDIS_PORT}"
+echo "Prefix:   ${KEY_PREFIX}:   (per-user isolation on the shared lab backend)"
+echo ""
+
+# --- pre-flight: prove the backend before spending a build on it -------------
+# The router does NOT dial at construction and degrades per-operation, so a bad
+# host/password would still log "resp-cache backend configured" and the lane
+# would look green while silently missing forever. When a TLS-capable CLI is
+# available, an explicit authenticated PING is therefore a HARD gate.
+if [[ -n "$HAVE_PROBE" ]]; then
+    echo "[Setup] pre-flight: authenticated TLS ping straight to the endpoint (via ${CLI_BIN:-openssl})"
+    PROBE_OUT=$(resp_cmd PING 2>&1 | tr -d '\r')
+    if ! echo "$PROBE_OUT" | grep -qE '^\+?PONG$'; then
+        echo "ERROR: ${REDIS_HOST}:${REDIS_PORT} did not answer an authenticated PING:"
+        echo "       $(echo "${PROBE_OUT:-<no reply>}" | head -2 | tr '\n' ' ')"
+        echo "       Check network/VPN, REDIS_PASSWORD, or point the lane elsewhere (REDIS_HOST=...)."
+        exit 1
+    fi
+    echo "  backend: $(backend_version) — PONG"
+else
+    echo "  WARNING: no redis-cli/valkey-cli and no openssl on PATH — skipping the"
+    echo "           backend pre-flight and key-scan checks. The router's own gauge"
+    echo "           (smartrouter_resp_cache_connected) becomes the only connectivity signal."
+fi
+
+RTT_MS=$(sample_rtt_ms)
+if [[ -z "$CACHE_TIMEOUT" ]]; then
+    # The lookup budget must exceed the backend RTT or every read times out —
+    # writes would still land and the lane would look "up" while never serving
+    # a single hit (the failure mode this lane exists to catch).
+    if [[ -n "$RTT_MS" ]]; then CACHE_TIMEOUT="$(( 2 * RTT_MS + 150 ))ms"; else CACHE_TIMEOUT="750ms"; fi
+fi
+echo "  rtt: ~${RTT_MS:-?}ms -> --cache-timeout ${CACHE_TIMEOUT}"
+echo "       (the production default, 50ms, suits a same-zone backend; a hit here"
+echo "       still costs ~1 RTT — co-locate router and backend in production)"
+echo ""
+
+echo "[Setup] reclaiming this lane's previous run (if any)"
+reclaim_owned
+reclaim_by_identity
+screen -S "$ROUTER_SCREEN" -X quit 2>/dev/null || true
+sleep 1
+
+# Anything still on this lane's ports is NOT ours: refuse, never evict.
+BLOCKED=0
+for port in "$ROUTER_PORT" "$METRICS_PORT"; do
+    if lsof -nP -iTCP:$port -sTCP:LISTEN >/dev/null 2>&1; then
+        [[ "$BLOCKED" == "0" ]] && { echo "ERROR: this lane's port(s) are held by process(es) it does not own."; echo "       Refusing to run. Nothing was signalled."; }
+        echo "  port $port:"; lsof -nP -iTCP:$port -sTCP:LISTEN | sed 's/^/    /'
+        BLOCKED=1
+    fi
+done
+[[ "$BLOCKED" == "1" ]] && { echo ""; echo "Free them, or move this lane: ROUTER_PORT=3377 METRICS_PORT=7797 $0"; exit 1; }
+
+echo "[Setup] installing binaries"
+# env -u GOFLAGS: when the calling shell exports GOFLAGS (any value), make
+# auto-re-exports its own GOFLAGS := ... -ldflags '...' to the child go
+# install, and go's $GOFLAGS env parser cannot read the quoted ldflags —
+# "go: parsing $GOFLAGS: unknown flag -w". Scrubbing it keeps the Makefile's
+# flags on argv only, where the quoting is legal.
+env -u GOFLAGS make -C "$PROJECT_ROOT" install || { echo "ERROR: make install failed"; exit 1; }
+
+# --- router config -----------------------------------------------------------
+# Generated (not checked in) because it embeds the credential; debugging/ is
+# git-ignored and the file is created 0600.
+echo "[Setup] generating ${CONFIG_REL}"
+umask 077
+USERNAME_LINE=""
+[[ -n "$REDIS_USERNAME" ]] && USERNAME_LINE="  username: \"${REDIS_USERNAME}\"
+"
+if [[ -n "$REDIS_CA_FILE" ]]; then
+    TLS_TRUST_LINES="    # Verify the server against the operator-supplied bundle.
+    ca-file: \"${REDIS_CA_FILE}\""
+else
+    TLS_TRUST_LINES="    # The lab endpoint's certificate does not verify against public roots
+    # (redis-cli needs --insecure for the same reason). Supply REDIS_CA_FILE
+    # to verify instead. server-name / cert-file / key-file (mTLS) are also
+    # available — docs/RESP-CACHE.md.
+    insecure-skip-verify: true"
+fi
+
+cat > "$CONFIG_FILE" <<EOF
+# GENERATED by scripts/pre_setups/init_smartrouter_eth_redis_oss_remote.sh.
+# Contains a credential (the shared cache-test lab password) — this file lives
+# in git-ignored debugging/ and must never be committed.
+
+metrics-listen-address: "0.0.0.0:${METRICS_PORT}"
+
+resp-cache:
+  topology: standalone
+  addresses: ["${REDIS_HOST}:${REDIS_PORT}"]
+${USERNAME_LINE}  password: "${REDIS_PASSWORD}"
+  key-prefix: "${KEY_PREFIX}"
+  # The repo default (500ms) is LAN-sized; a WAN dial pays TCP + TLS handshake,
+  # 2-3 round trips, and a too-small value makes the connected gauge flap.
+  dial-timeout: "${REDIS_DIAL_TIMEOUT}"
+  tls:
+    enabled: true
+${TLS_TRUST_LINES}
+
+endpoints:
+  - listen-address: "0.0.0.0:${ROUTER_PORT}"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    network-address: "0.0.0.0:${ROUTER_PORT}"
+
+direct-rpc:
+  - name: "eth-rpc-1"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "${ETH_RPC_URL_1}"
+        skip-verifications:
+          - chain-id
+          - pruning
+      - url: "${ETH_WS_URL_1}"
+
+  - name: "eth-rpc-2"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "${ETH_RPC_URL_2}"
+        skip-verifications:
+          - chain-id
+          - pruning
+      - url: "${ETH_WS_URL_2}"
+EOF
+
+# --- router ------------------------------------------------------------------
+echo "[Setup] starting the smart router (:${ROUTER_PORT}) against ${REDIS_HOST}"
+screen -d -m -S "$ROUTER_SCREEN" bash -c "cd $PROJECT_ROOT && source ~/.bashrc; smartrouter \
+$CONFIG_REL \
+--log-level debug \
+--use-static-spec $PROJECT_ROOT/specs/ethereum.json \
+--debug-relays \
+--cache-timeout ${CACHE_TIMEOUT} \
+--relays-health-interval ${HEALTH_INTERVAL} 2>&1 | tee $ROUTER_LOG"
+sleep 0.5
+
+ROUTER_OK=0
+for _ in $(seq 1 45); do
+    grep -q "resp-cache backend configured" "$ROUTER_LOG" 2>/dev/null && { ROUTER_OK=1; break; }
+    grep -q "^Error:" "$ROUTER_LOG" 2>/dev/null && break
+    sleep 1
+done
+if [[ "$ROUTER_OK" != "1" ]]; then
+    echo "ERROR: the router never reported its RESP backend — last log lines:"
+    tail -8 "$ROUTER_LOG" 2>/dev/null | sed 's/^/  /'
+    exit 1
+fi
+
+ROUTER_PID=""
+for _ in $(seq 1 60); do
+    ROUTER_PID=$(lsof -nP -iTCP:${ROUTER_PORT} -sTCP:LISTEN -t 2>/dev/null | head -1)
+    [[ -n "$ROUTER_PID" ]] && break
+    sleep 1
+done
+[[ -n "$ROUTER_PID" ]] || { echo "ERROR: the router never bound :${ROUTER_PORT}"; tail -8 "$ROUTER_LOG" | sed 's/^/  /'; exit 1; }
+printf '%s|%s\n' "$ROUTER_PID" "$(proc_fingerprint "$ROUTER_PID")" > "$PIDFILE"
+echo "  router: UP (pid ${ROUTER_PID}) with the remote RESP backend"
+
+# --- smoke -------------------------------------------------------------------
+if [[ "$SKIP_SMOKE" != "1" ]]; then
+    echo ""
+    echo "[Smoke] router health -> relay -> writes on the lab backend -> cache hit"
+    note() { printf '  %-34s %s\n' "$1" "$2"; }
+    SMOKE_FAIL=0
+    # LATEST-shaped relay to drive traffic; a fixed long-finalized block for a
+    # deterministic key (same one on every run and every router).
+    RELAY_TIP='{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+    RELAY_FIXED='{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x112a880",false],"id":1}'
+    relay() { curl -sf -m 20 -X POST "http://127.0.0.1:${ROUTER_PORT}" -H 'Content-Type: application/json' -d "$1"; }
+    hits() { curl -sf "http://127.0.0.1:${METRICS_PORT}/metrics" | awk '/^smartrouter_cache_success_total/ {sum += $NF} END {printf "%d", sum}'; }
+
+    HEALTH=""
+    for _ in $(seq 1 30); do
+        HEALTH=$(curl -s -o /dev/null -w '%{http_code}' -m 10 "http://127.0.0.1:${ROUTER_PORT}/lava/health")
+        [[ "$HEALTH" == "200" ]] && break
+        sleep 1
+    done
+    [[ "$HEALTH" == "200" ]] && note "router /lava/health" "200" || { note "router /lava/health" "$HEALTH (want 200)"; SMOKE_FAIL=1; }
+
+    # The gauge is driven by a periodic probe (3s budget — WAN-tolerant); give
+    # it a couple of cycles rather than sampling once.
+    CONNECTED=""
+    for _ in $(seq 1 30); do
+        CONNECTED=$(curl -sf "http://127.0.0.1:${METRICS_PORT}/metrics" | awk '/^smartrouter_resp_cache_connected/ {print $NF; exit}')
+        [[ "$CONNECTED" == "1" ]] && break
+        sleep 1
+    done
+    [[ "$CONNECTED" == "1" ]] && note "resp_cache_connected" "1" || { note "resp_cache_connected" "${CONNECTED:-<none>} (want 1)"; SMOKE_FAIL=1; }
+
+    BODY=$(relay "$RELAY_FIXED" || true)
+    [[ "$BODY" == *'"result"'* ]] && note "relay eth_getBlockByNumber" "ok" \
+        || { note "relay" "unexpected: ${BODY:0:60}"; SMOKE_FAIL=1; }
+
+    # Writes are asynchronous — poll while driving more traffic.
+    if [[ -n "$HAVE_PROBE" ]]; then
+        KEYS=0
+        for _ in $(seq 1 20); do
+            relay "$RELAY_TIP" >/dev/null 2>&1 || true
+            KEYS=$(backend_keys | wc -l | tr -d ' ')
+            [[ "$KEYS" -gt 0 ]] && break
+            sleep 1
+        done
+        [[ "$KEYS" -gt 0 ]] && note "keys on the lab backend" "$KEYS under '${KEY_PREFIX}:'" \
+            || { note "keys on the lab backend" "none (writes should land from anywhere)"; SMOKE_FAIL=1; }
+    else
+        note "keys on the lab backend" "skipped (no CLI and no openssl)"
+    fi
+
+    HIT_OK=0
+    for _ in $(seq 1 20); do
+        relay "$RELAY_FIXED" >/dev/null 2>&1 || true
+        sleep 0.5
+        [[ "$(hits)" -gt 0 ]] && { HIT_OK=1; break; }
+    done
+    if [[ "$HIT_OK" == "1" ]]; then
+        note "cache_success_total" "$(hits) (>0)"
+        HDR=$(curl -s -D - -o /dev/null -m 20 -X POST "http://127.0.0.1:${ROUTER_PORT}" -H 'Content-Type: application/json' -d "$RELAY_FIXED" | grep -i '^Lava-Cache-Backend' | tr -d '\r')
+        [[ -n "$HDR" ]] && note "hit served by" "${HDR#*: }"
+    else
+        # connected=1 + keys present + zero hits means lookups still time out:
+        # compare --cache-timeout against the RTT and watch the get-timeout
+        # counter (smartrouter_resp_cache_failed_total) before suspecting auth.
+        note "cache_success_total" "0 (expected >0 with --cache-timeout ${CACHE_TIMEOUT} at ~${RTT_MS:-?}ms RTT)"
+        SMOKE_FAIL=1
+    fi
+
+    echo ""
+    [[ "$SMOKE_FAIL" == "0" ]] && echo "  SMOKE PASS — the router is talking TLS+AUTH to the remote Redis OSS." \
+        || { echo "  SMOKE FAIL — see $ROUTER_LOG"; exit 1; }
+fi
+
+# The 'rd' helper the samples below rely on: an alias when a local CLI exists,
+# otherwise a tiny function speaking RESP over TLS via openssl — either way it
+# talks straight to the remote endpoint. Named 'rd' (not the Valkey lane's
+# 'vk') so both lanes' helpers can coexist in one shell.
+if [[ -n "$CLI_BIN" ]]; then
+    RD_SETUP="export REDISCLI_AUTH='${REDIS_PASSWORD}' VALKEYCLI_AUTH=\"\$REDISCLI_AUTH\"
+  alias rd='${CLI_BIN} ${CLI_ARGS[*]}'"
+else
+    RD_SETUP="rd() { printf 'AUTH ${REDIS_PASSWORD}\\r\\n%s\\r\\nQUIT\\r\\n' \"\$*\" | openssl s_client -connect ${REDIS_HOST}:${REDIS_PORT} -servername ${REDIS_HOST} -quiet -ign_eof 2>/dev/null; }"
+fi
+
+cat <<EOF
+
+============================================
+REMOTE REDIS OSS LANE — CHEAT SHEET
+============================================
+Router    http://127.0.0.1:${ROUTER_PORT}    metrics http://127.0.0.1:${METRICS_PORT}/metrics
+Backend   ${REDIS_HOST}:${REDIS_PORT}  (TLS + AUTH, standalone)
+Config    ${CONFIG_REL}   (holds the credential — git-ignored)
+Log       tail -f ${ROUTER_LOG}
+
+One-time in your shell (paste as-is), then use 'rd <COMMAND>':
+  ${RD_SETUP}
+
+--- PROVE THE CACHE IS WORKING -------------
+
+1. Warm it — relay a fixed, long-finalized block (deterministic cache key,
+   same key on every run):
+     curl -s -X POST http://127.0.0.1:${ROUTER_PORT} -H 'Content-Type: application/json' \\
+       -d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x112a880",false],"id":1}' | head -c 120; echo
+
+2. The entry lands on the lab backend (write is async — give it a second),
+   with a real TTL from the router's policy:
+     rd SCAN 0 MATCH '${KEY_PREFIX}:*' COUNT 1000
+     rd TTL '<paste one key from the scan>'
+
+3. Repeat the SAME relay and look at the headers — a cache hit is served as
+   "Cached" and Lava-Cache-Backend names the node that served it:
+     curl -s -D - -o /dev/null -X POST http://127.0.0.1:${ROUTER_PORT} -H 'Content-Type: application/json' \\
+       -d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x112a880",false],"id":1}' \\
+       | grep -iE 'lava-(provider-address|cache-backend)'
+     # expect:  Lava-Provider-Address: Cached  +  Lava-Cache-Backend: ${REDIS_HOST}:${REDIS_PORT}
+     # (works even far from the backend — the lane raised the router's lookup
+     #  budget with --cache-timeout ${CACHE_TIMEOUT}; the production default is 50ms)
+
+4. The counters move — success/requests per tier, plus backend health:
+     curl -s http://127.0.0.1:${METRICS_PORT}/metrics | grep -E '^smartrouter_cache_(success|requests)_total'
+     curl -s http://127.0.0.1:${METRICS_PORT}/metrics | grep '^smartrouter_resp_cache'
+
+5. Watch the router decide, live:
+     tail -f ${ROUTER_LOG} | grep -iE 'cache (lookup|hit|miss)|resp-cache'
+
+--------------------------------------------
+Status (backend ping, RTT, keys, gauges):          $0 --status
+Clean up this lane's keys (never anyone else's):   $0 --flush
+Stop the router:                                   $0 --stop
+============================================
+EOF

--- a/scripts/pre_setups/init_smartrouter_eth_valkey_cluster_remote.sh
+++ b/scripts/pre_setups/init_smartrouter_eth_valkey_cluster_remote.sh
@@ -1,0 +1,603 @@
+#!/bin/bash
+# Smart Router -> REMOTE Valkey 8.1 CLUSTER, 3 masters (the cache-test lab) — AUTH
+#
+# Cluster sibling of init_smartrouter_eth_valkey_remote.sh (standalone) and
+# init_smartrouter_eth_redis_oss_remote.sh: same lane shape, third lab backend.
+# It points a locally built router at the shared Valkey CLUSTER, so the
+# resp-cache cluster topology is exercised for real: the client uses the
+# configured addresses only as DISCOVERY SEEDS, learns the slot map, and talks
+# to whichever master owns each key's hash slot.
+#
+#   valkey cluster   <seed host>:7001-7003   (a remote Valkey 8.1, 3 masters,
+#                    slots 0-5460 / 5461-10922 / 10923-16383; plain TCP + AUTH,
+#                    no TLS — unlike the standalone labs. The nodes ANNOUNCE
+#                    their public addresses, which is what makes an internet
+#                    client possible at all: discovery and MOVED redirects hand
+#                    back addresses the router must be able to dial.)
+#   smartrouter      0.0.0.0:${ROUTER_PORT}   (metrics :${METRICS_PORT})
+#
+# EVERYTHING talks straight to the remote cluster: the router dials it for
+# caching, and the script's own checks (pre-flight, per-node key scans,
+# --flush) use a local valkey-cli/redis-cli when one is installed or speak
+# inline RESP over bash's /dev/tcp otherwise — no docker, no local backend.
+# (For a TLS cluster, borrow the openssl s_client transport from the
+# standalone lanes; this lab is deliberately plain TCP.)
+#
+# The password surface has NO flag form (flags carry only addresses and
+# topology), so the lane GENERATES a config with a full resp-cache: block under
+# git-ignored debugging/ — the credential never lands in the repo tree.
+#
+# CLUSTER SPECIFICS WORTH KNOWING
+#   - Keys spray across the three masters by hash slot, so "did writes land"
+#     is a PER-NODE question: the smoke scans every master and shows the
+#     split. A handful of smoke keys may well land on only one or two masters
+#     — that is hashing, not a failure; the assertion is total > 0.
+#   - Lava-Cache-Backend names the node the client LAST dialed, so on a hit
+#     expect ONE OF the three masters, not always :7001.
+#   - SCAN is per-node, and multi-key DEL would CROSSSLOT — --flush therefore
+#     scans each master and deletes its keys one by one on that same node.
+#
+# THE READ BUDGET AND THE WAN (why this lane passes --cache-timeout)
+#   Cache READS run inside the per-relay --cache-timeout budget (default 50ms,
+#   sized for a same-zone backend); a warm GET costs one round trip to the
+#   owning master, so a budget below the RTT times out on EVERY lookup while
+#   the asynchronous writes (5s budget) still land. The lane measures the RTT
+#   and passes a budget sized to it (2*RTT + 150ms; CACHE_TIMEOUT overrides).
+#   A hit still costs ~1 RTT — co-locate router and cluster in production and
+#   keep the 50ms default.
+#
+# USAGE
+#   scripts/pre_setups/init_smartrouter_eth_valkey_cluster_remote.sh            # bring up + smoke
+#   scripts/pre_setups/init_smartrouter_eth_valkey_cluster_remote.sh --status   # cluster + router state
+#   scripts/pre_setups/init_smartrouter_eth_valkey_cluster_remote.sh --flush    # delete ONLY this lane's keys
+#   scripts/pre_setups/init_smartrouter_eth_valkey_cluster_remote.sh --stop     # stop the router
+#
+# ENVIRONMENT
+#   VALKEY_CLUSTER_SEEDS     comma-separated discovery seeds
+#                            (host:7001,host:7002,host:7003)
+#   VALKEY_CLUSTER_PASSWORD  REQUIRED — the cache-test lab credential (never
+#                            baked into the script; export it before running)
+#   VALKEY_CLUSTER_USERNAME  ACL user (default: none -> AUTH default user)
+#   VALKEY_CLUSTER_DIAL_TIMEOUT (1s) resp-cache dial-timeout (WAN-sized)
+#   CACHE_TIMEOUT       per-relay cache lookup budget passed to the router as
+#                       --cache-timeout (default: computed from measured RTT)
+#   ROUTER_PORT (3377)  METRICS_PORT (7797)   <- clear of the sibling lanes
+#                       (3375/7795 valkey, 3376/7796 redis-oss, 3360/7779 resp,
+#                       3370/7790 sentinel, 3380-1/7801-2 multiregion)
+#   KEY_PREFIX (sr-$USER) per-user prefix so testers on the SHARED backend
+#                       never scan or flush each other's entries
+#   ETH_RPC_URL_1/2, ETH_WS_URL_1/2   upstreams     HEALTH_INTERVAL (15s)
+#   SKIP_SMOKE=1        bring up only
+#
+# OWNERSHIP SAFETY: never `killall`. Reclaims only the router it recorded
+# starting (pid + start-time fingerprint, or a command line naming this lane's
+# generated config) and refuses to run if its ports are held by anything else.
+# The lab cluster is shared infrastructure: this lane only ever touches keys
+# under its own prefix, and only on --flush.
+
+__dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+PROJECT_ROOT=$(cd "${__dir}"/../.. && pwd)
+
+LOGS_DIR="${PROJECT_ROOT}/debugging/logs"
+mkdir -p "$LOGS_DIR"
+
+VALKEY_CLUSTER_SEEDS="${VALKEY_CLUSTER_SEEDS:-}"
+VALKEY_CLUSTER_PASSWORD="${VALKEY_CLUSTER_PASSWORD:-}"
+VALKEY_CLUSTER_USERNAME="${VALKEY_CLUSTER_USERNAME:-}"
+VALKEY_CLUSTER_DIAL_TIMEOUT="${VALKEY_CLUSTER_DIAL_TIMEOUT:-1s}"
+CACHE_TIMEOUT="${CACHE_TIMEOUT:-}"   # empty -> sized from the measured RTT below
+ROUTER_PORT="${ROUTER_PORT:-3377}"
+METRICS_PORT="${METRICS_PORT:-7797}"
+HEALTH_INTERVAL="${HEALTH_INTERVAL:-15s}"
+
+IFS=',' read -r -a NODES <<< "$VALKEY_CLUSTER_SEEDS"
+SEED0="${NODES[0]}"
+
+# Per-user prefix, restricted to the router's allowed charset [A-Za-z0-9._-].
+KEY_PREFIX="${KEY_PREFIX:-sr-$(id -un 2>/dev/null)}"
+KEY_PREFIX=$(printf '%s' "$KEY_PREFIX" | tr -cd 'A-Za-z0-9._-')
+[[ -n "$KEY_PREFIX" ]] || KEY_PREFIX="sr-lab"
+
+ROUTER_SCREEN="sr-valkey-cluster-remote"
+CONFIG_REL="debugging/smartrouter_eth_valkey_cluster_remote.yml"
+CONFIG_FILE="${PROJECT_ROOT}/${CONFIG_REL}"
+PIDFILE="${PROJECT_ROOT}/debugging/.valkey-cluster-remote-router.pid"
+ROUTER_LOG="${LOGS_DIR}/SMARTROUTER_VALKEY_CLUSTER_REMOTE.log"
+
+# --- backend probe: a local CLI when installed, raw RESP over /dev/tcp else --
+# Every probe goes STRAIGHT to a cluster node — no docker, no sidecars. Auth
+# for a local CLI travels via environment, not -a, so the password never shows
+# in ps; both names are exported because the two CLIs each read their own.
+export REDISCLI_AUTH="$VALKEY_CLUSTER_PASSWORD" VALKEYCLI_AUTH="$VALKEY_CLUSTER_PASSWORD"
+CLI_BIN=""
+for c in valkey-cli redis-cli; do
+    command -v "$c" >/dev/null 2>&1 && { CLI_BIN="$c"; break; }
+done
+CLI_USER_ARGS=()
+[[ -n "$VALKEY_CLUSTER_USERNAME" ]] && CLI_USER_ARGS=(--user "$VALKEY_CLUSTER_USERNAME")
+AUTH_CRED="${VALKEY_CLUSTER_USERNAME:+${VALKEY_CLUSTER_USERNAME} }${VALKEY_CLUSTER_PASSWORD}"
+
+resp_cmd() { # $1 = node host:port, $2 = ONE inline RESP command; raw reply stream
+    local host="${1%%:*}" port="${1##*:}"
+    if [[ -n "$CLI_BIN" ]]; then
+        # shellcheck disable=SC2086 — the inline command is intentionally split
+        "$CLI_BIN" -h "$host" -p "$port" "${CLI_USER_ARGS[@]}" $2
+        return
+    fi
+    # This script is bash (shebang), so /dev/tcp is available even though the
+    # surrounding interactive shell may be zsh. QUIT makes the node close the
+    # connection, ending cat; a watchdog bounds a black-holed node.
+    local pid wd
+    ( exec 3<>"/dev/tcp/${host}/${port}" 2>/dev/null || exit 1
+      printf 'AUTH %s\r\n%s\r\nQUIT\r\n' "$AUTH_CRED" "$2" >&3
+      cat <&3 ) 2>/dev/null &
+    pid=$!
+    ( sleep 10; kill "$pid" 2>/dev/null ) >/dev/null 2>&1 &
+    wd=$!
+    wait "$pid" 2>/dev/null; local rc=$?
+    kill "$wd" 2>/dev/null; wait "$wd" 2>/dev/null
+    return $rc
+}
+
+node_keys() { # $1 = host:port -> this lane's keys living on THAT node (SCAN is per-node)
+    if [[ -n "$CLI_BIN" ]]; then
+        "$CLI_BIN" -h "${1%%:*}" -p "${1##*:}" "${CLI_USER_ARGS[@]}" --scan --pattern "${KEY_PREFIX}:*" 2>/dev/null
+    else
+        # One SCAN pass; COUNT 1000 covers the small lab keyspace, and every
+        # caller polls, so a rare partial batch self-heals on the next try.
+        resp_cmd "$1" "SCAN 0 MATCH ${KEY_PREFIX}:* COUNT 1000" | tr -d '\r' | grep "^${KEY_PREFIX}:"
+    fi
+}
+backend_keys() { local n; for n in "${NODES[@]}"; do node_keys "$n"; done; }
+
+# --- ownership helpers (house pattern: pid + start-time fingerprint) ---------
+proc_fingerprint() { ps -p "$1" -o lstart= 2>/dev/null | tr -s ' '; }
+
+reclaim_owned() {
+    [[ -f "$PIDFILE" ]] || return 0
+    local rec_pid rec_fp cur_fp
+    rec_pid=$(cut -d'|' -f1 "$PIDFILE" 2>/dev/null)
+    rec_fp=$(cut -d'|' -f2- "$PIDFILE" 2>/dev/null)
+    [[ -n "$rec_pid" ]] || { rm -f "$PIDFILE"; return 0; }
+    cur_fp=$(proc_fingerprint "$rec_pid")
+    if [[ -z "$cur_fp" ]]; then rm -f "$PIDFILE"; return 0; fi
+    if [[ "$cur_fp" != "$rec_fp" ]]; then
+        echo "  stale pid file (pid $rec_pid is now another process) — leaving it alone"
+        rm -f "$PIDFILE"; return 0
+    fi
+    echo "  stopping this lane's previous router (pid $rec_pid)"
+    kill "$rec_pid" 2>/dev/null || true
+    for _ in $(seq 1 20); do [[ -z "$(proc_fingerprint "$rec_pid")" ]] && break; sleep 0.25; done
+    rm -f "$PIDFILE"
+}
+
+# Fallback when the pid file is missing (crash between spawn and record): the
+# port holder's command line names a file only this lane generates — identity,
+# not a name match.
+reclaim_by_identity() {
+    local pid
+    pid=$(lsof -nP -iTCP:${ROUTER_PORT} -sTCP:LISTEN -t 2>/dev/null | head -1)
+    [[ -n "$pid" ]] || return 0
+    ps -p "$pid" -o command= 2>/dev/null | grep -qF -- "$CONFIG_REL" || return 0
+    echo "  stopping this lane's router by identity (pid $pid, no pid file)"
+    kill "$pid" 2>/dev/null || true
+    for _ in $(seq 1 20); do
+        lsof -nP -iTCP:${ROUTER_PORT} -sTCP:LISTEN -t >/dev/null 2>&1 || break
+        sleep 0.25
+    done
+}
+
+# One TCP connect = one network round trip; three samples against the first
+# seed, keep the smallest positive. This decides the --cache-timeout below.
+sample_rtt_ms() {
+    local best="" t ms
+    for _ in 1 2 3; do
+        t=$(curl -s -o /dev/null -w '%{time_connect}' --connect-timeout 5 -m 2 \
+              "telnet://${SEED0}" </dev/null 2>/dev/null)
+        ms=$(awk -v t="${t:-0}" 'BEGIN{printf "%d", t*1000}')
+        [[ "$ms" -gt 0 ]] && { [[ -z "$best" || "$ms" -lt "$best" ]] && best="$ms"; }
+    done
+    echo "$best"
+}
+
+backend_version() { # prints "valkey 8.1.10 (cluster)" style, empty on failure
+    # Judged by OUTPUT, not exit code (transport helpers exit non-zero on
+    # peer-close races).
+    local info v m
+    info=$(resp_cmd "$SEED0" "INFO server" 2>/dev/null)
+    [[ -n "$info" ]] || return 0
+    v=$(echo "$info" | awk -F: '/^valkey_version/{print $2}' | tr -d '\r')
+    [[ -n "$v" ]] && v="valkey $v" || v="redis $(echo "$info" | awk -F: '/^redis_version/{print $2}' | tr -d '\r')"
+    # Valkey with extended-redis-compatibility off renames redis_mode to
+    # server_mode — accept either (this lane GATES on the mode).
+    m=$(echo "$info" | awk -F: '/^(redis|server)_mode/{print $2; exit}' | tr -d '\r')
+    echo "${v}${m:+ (${m})}"
+}
+
+cluster_state() { resp_cmd "$SEED0" "CLUSTER INFO" 2>/dev/null | tr -d '\r' | awk -F: '/^cluster_state/{print $2}'; }
+
+show_masters() { # indented "host:port slots" lines from the live topology
+    resp_cmd "$SEED0" "CLUSTER NODES" 2>/dev/null | tr -d '\r' \
+        | awk '/master/ {sub(/@.*/, "", $2); print "    " $2, $9}'
+}
+
+teardown() {
+    echo "[Teardown] stopping this lane's router (nothing else is signalled)"
+    reclaim_owned
+    reclaim_by_identity
+    screen -S "$ROUTER_SCREEN" -X quit 2>/dev/null || true
+    echo "[Teardown] done. The lab cluster is untouched; this lane's keys expire"
+    echo "           by TTL, or delete them now: $0 --flush"
+    echo "           The generated config keeps the credential: rm -f ${CONFIG_REL}"
+}
+
+status() {
+    echo "backend  ${VALKEY_CLUSTER_SEEDS}"
+    echo "         $(backend_version)  cluster_state:$(cluster_state)  ping: $(resp_cmd "$SEED0" PING | tr -d '\r' | grep -m1 -E '^\+?PONG$' || echo FAILED)"
+    local n split=""
+    for n in "${NODES[@]}"; do split+=":${n##*:}=$(node_keys "$n" | wc -l | tr -d ' ') "; done
+    echo "keys     ${split}under '${KEY_PREFIX}:' (per master — SCAN is per-node)"
+    local rtt; rtt=$(sample_rtt_ms)
+    echo "rtt      ${rtt:-<unmeasurable>} ms  (the lane sizes --cache-timeout to this; production default 50ms)"
+    if [[ -f "$PIDFILE" ]]; then
+        local pid; pid=$(cut -d'|' -f1 "$PIDFILE")
+        [[ -n "$(proc_fingerprint "$pid")" ]] && echo "router   UP (pid $pid) http://127.0.0.1:${ROUTER_PORT}" \
+                                              || echo "router   recorded pid $pid is gone (crashed?) — re-run the lane"
+    else
+        echo "router   not recorded as running"
+    fi
+    curl -s -m 5 "http://127.0.0.1:${METRICS_PORT}/metrics" 2>/dev/null \
+        | grep -E '^smartrouter_resp_cache_(connected|connection_errors_total|failed_total)' | sed 's/^/metric   /'
+}
+
+flush() {
+    # SCAN is per-node and multi-key DEL would CROSSSLOT, so: scan each master
+    # and delete ITS keys one by one on that same node — a single-key DEL on
+    # the node that returned it can neither CROSSSLOT nor MOVED.
+    local n k total=0
+    for n in "${NODES[@]}"; do
+        while IFS= read -r k; do
+            [[ -n "$k" ]] || continue
+            resp_cmd "$n" "DEL $k" >/dev/null
+            total=$((total + 1))
+        done < <(node_keys "$n")
+    done
+    [[ "$total" -gt 0 ]] && echo "deleted $total key(s) under '${KEY_PREFIX}:' across the masters (only this lane's prefix)" \
+                         || echo "no keys under '${KEY_PREFIX}:' — nothing to delete"
+}
+
+# The remote seeds and credential are required and never hard-coded (secret
+# scanners; shared infra). Every verb except --stop needs them to reach it.
+if [[ "$1" != "--stop" && "$1" != "stop" ]] && { [[ -z "$VALKEY_CLUSTER_SEEDS" || -z "$VALKEY_CLUSTER_PASSWORD" ]]; }; then
+    echo "ERROR: set VALKEY_CLUSTER_SEEDS and VALKEY_CLUSTER_PASSWORD (remote cluster seeds + credential), e.g.:"
+    echo "  VALKEY_CLUSTER_SEEDS=<host>:7001,<host>:7002,<host>:7003 VALKEY_CLUSTER_PASSWORD='...' $0 ${1:-}"
+    exit 1
+fi
+
+case "$1" in
+    --stop|stop)     teardown; exit 0 ;;
+    --status|status) status;   exit 0 ;;
+    --flush|flush)   flush;    exit $? ;;
+esac
+
+command -v screen >/dev/null || { echo "ERROR: this lane needs screen"; exit 1; }
+command -v curl   >/dev/null || { echo "ERROR: this lane needs curl"; exit 1; }
+
+ETH_RPC_URL_1="${ETH_RPC_URL_1:-https://ethereum-rpc.publicnode.com}"
+ETH_WS_URL_1="${ETH_WS_URL_1:-wss://ethereum-rpc.publicnode.com}"
+ETH_RPC_URL_2="${ETH_RPC_URL_2:-https://eth.drpc.org}"
+ETH_WS_URL_2="${ETH_WS_URL_2:-wss://eth.drpc.org}"
+
+echo "============================================"
+echo "Smart Router -> REMOTE Valkey CLUSTER, 3 masters (AUTH)"
+echo "============================================"
+echo "Seeds:    ${VALKEY_CLUSTER_SEEDS}"
+echo "Prefix:   ${KEY_PREFIX}:   (per-user isolation on the shared lab backend)"
+echo ""
+
+# --- pre-flight: prove the CLUSTER before spending a build on it -------------
+# The router does NOT dial at construction and degrades per-operation, so a bad
+# seed/password would still log "resp-cache backend configured" and the lane
+# would look green while silently missing forever. Three hard gates: an
+# authenticated PING, redis_mode=cluster (someone pointing this lane at a
+# standalone gets one clear line, not a baffling cluster-client failure), and
+# cluster_state:ok (full slot coverage — a partial cluster serves errors).
+echo "[Setup] pre-flight: authenticated ping + topology via ${CLI_BIN:-/dev/tcp}"
+PROBE_OUT=$(resp_cmd "$SEED0" PING 2>&1 | tr -d '\r')
+if ! echo "$PROBE_OUT" | grep -qE '^\+?PONG$'; then
+    echo "ERROR: ${SEED0} did not answer an authenticated PING:"
+    echo "       $(echo "${PROBE_OUT:-<no reply>}" | head -2 | tr '\n' ' ')"
+    echo "       Check network/VPN, VALKEY_CLUSTER_PASSWORD, or VALKEY_CLUSTER_SEEDS."
+    exit 1
+fi
+BACKEND_DESC=$(backend_version)
+if [[ "$BACKEND_DESC" != *"(cluster)"* ]]; then
+    echo "ERROR: ${SEED0} reports '${BACKEND_DESC:-<unknown>}' — not a cluster node."
+    echo "       For a standalone backend use init_smartrouter_eth_valkey_remote.sh."
+    exit 1
+fi
+STATE=$(cluster_state)
+if [[ "$STATE" != "ok" ]]; then
+    echo "ERROR: cluster_state is '${STATE:-<none>}' (want ok) — the cluster is not serving all slots."
+    exit 1
+fi
+echo "  backend: ${BACKEND_DESC} — PONG, cluster_state:ok"
+echo "  masters (discovered live; the config below carries only SEEDS):"
+show_masters
+
+RTT_MS=$(sample_rtt_ms)
+if [[ -z "$CACHE_TIMEOUT" ]]; then
+    # The lookup budget must exceed the backend RTT or every read times out —
+    # writes would still land and the lane would look "up" while never serving
+    # a single hit (the failure mode this lane exists to catch).
+    if [[ -n "$RTT_MS" ]]; then CACHE_TIMEOUT="$(( 2 * RTT_MS + 150 ))ms"; else CACHE_TIMEOUT="750ms"; fi
+fi
+echo "  rtt: ~${RTT_MS:-?}ms -> --cache-timeout ${CACHE_TIMEOUT}"
+echo "       (the production default, 50ms, suits a same-zone backend; a hit here"
+echo "       still costs ~1 RTT — co-locate router and cluster in production)"
+echo ""
+
+echo "[Setup] reclaiming this lane's previous run (if any)"
+reclaim_owned
+reclaim_by_identity
+screen -S "$ROUTER_SCREEN" -X quit 2>/dev/null || true
+sleep 1
+
+# Anything still on this lane's ports is NOT ours: refuse, never evict.
+BLOCKED=0
+for port in "$ROUTER_PORT" "$METRICS_PORT"; do
+    if lsof -nP -iTCP:$port -sTCP:LISTEN >/dev/null 2>&1; then
+        [[ "$BLOCKED" == "0" ]] && { echo "ERROR: this lane's port(s) are held by process(es) it does not own."; echo "       Refusing to run. Nothing was signalled."; }
+        echo "  port $port:"; lsof -nP -iTCP:$port -sTCP:LISTEN | sed 's/^/    /'
+        BLOCKED=1
+    fi
+done
+[[ "$BLOCKED" == "1" ]] && { echo ""; echo "Free them, or move this lane: ROUTER_PORT=3378 METRICS_PORT=7798 $0"; exit 1; }
+
+echo "[Setup] installing binaries"
+# env -u GOFLAGS: when the calling shell exports GOFLAGS (any value), make
+# auto-re-exports its own GOFLAGS := ... -ldflags '...' to the child go
+# install, and go's $GOFLAGS env parser cannot read the quoted ldflags —
+# "go: parsing $GOFLAGS: unknown flag -w". Scrubbing it keeps the Makefile's
+# flags on argv only, where the quoting is legal.
+env -u GOFLAGS make -C "$PROJECT_ROOT" install || { echo "ERROR: make install failed"; exit 1; }
+
+# --- router config -----------------------------------------------------------
+# Generated (not checked in) because it embeds the credential; debugging/ is
+# git-ignored and the file is created 0600.
+echo "[Setup] generating ${CONFIG_REL}"
+umask 077
+USERNAME_LINE=""
+[[ -n "$VALKEY_CLUSTER_USERNAME" ]] && USERNAME_LINE="  username: \"${VALKEY_CLUSTER_USERNAME}\"
+"
+SEED_ADDRS=""
+for n in "${NODES[@]}"; do
+    [[ -n "$SEED_ADDRS" ]] && SEED_ADDRS+=", "
+    SEED_ADDRS+="\"${n}\""
+done
+
+cat > "$CONFIG_FILE" <<EOF
+# GENERATED by scripts/pre_setups/init_smartrouter_eth_valkey_cluster_remote.sh.
+# Contains a credential (the shared cache-test lab password) — this file lives
+# in git-ignored debugging/ and must never be committed.
+
+metrics-listen-address: "0.0.0.0:${METRICS_PORT}"
+
+resp-cache:
+  topology: cluster
+  # DISCOVERY SEEDS, not the node list: the client asks these for the slot
+  # map and then dials whatever the nodes ANNOUNCE. This lab announces its
+  # public addresses, which is why an internet client works; a cluster that
+  # announces private IPs is unreachable from outside no matter what is
+  # written here. (db: is rejected under cluster — one logical database.)
+  addresses: [${SEED_ADDRS}]
+${USERNAME_LINE}  password: "${VALKEY_CLUSTER_PASSWORD}"
+  key-prefix: "${KEY_PREFIX}"
+  # The repo default (500ms) is LAN-sized; a WAN dial pays 2-3 round trips,
+  # and a too-small value makes the connected gauge flap.
+  dial-timeout: "${VALKEY_CLUSTER_DIAL_TIMEOUT}"
+  # No tls: block — this lab speaks plain TCP + AUTH (see the header).
+
+endpoints:
+  - listen-address: "0.0.0.0:${ROUTER_PORT}"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    network-address: "0.0.0.0:${ROUTER_PORT}"
+
+direct-rpc:
+  - name: "eth-rpc-1"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "${ETH_RPC_URL_1}"
+        skip-verifications:
+          - chain-id
+          - pruning
+      - url: "${ETH_WS_URL_1}"
+
+  - name: "eth-rpc-2"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "${ETH_RPC_URL_2}"
+        skip-verifications:
+          - chain-id
+          - pruning
+      - url: "${ETH_WS_URL_2}"
+EOF
+
+# --- router ------------------------------------------------------------------
+# If the router logs its backend line but the first cache op then fails oddly,
+# suspect the go-redis streaming-credentials init for this client type before
+# anything else — the failover client historically accepted the provider but
+# never initialized its re-auth manager (see redisstore/config.go). Standalone
+# uses the same provider and is proven by the sibling lanes.
+echo "[Setup] starting the smart router (:${ROUTER_PORT}) against the cluster"
+screen -d -m -S "$ROUTER_SCREEN" bash -c "cd $PROJECT_ROOT && source ~/.bashrc; smartrouter \
+$CONFIG_REL \
+--log-level debug \
+--use-static-spec $PROJECT_ROOT/specs/ethereum.json \
+--debug-relays \
+--cache-timeout ${CACHE_TIMEOUT} \
+--relays-health-interval ${HEALTH_INTERVAL} 2>&1 | tee $ROUTER_LOG"
+sleep 0.5
+
+ROUTER_OK=0
+for _ in $(seq 1 45); do
+    grep -q "resp-cache backend configured" "$ROUTER_LOG" 2>/dev/null && { ROUTER_OK=1; break; }
+    grep -q "^Error:" "$ROUTER_LOG" 2>/dev/null && break
+    sleep 1
+done
+if [[ "$ROUTER_OK" != "1" ]]; then
+    echo "ERROR: the router never reported its RESP backend — last log lines:"
+    tail -8 "$ROUTER_LOG" 2>/dev/null | sed 's/^/  /'
+    exit 1
+fi
+
+ROUTER_PID=""
+for _ in $(seq 1 60); do
+    ROUTER_PID=$(lsof -nP -iTCP:${ROUTER_PORT} -sTCP:LISTEN -t 2>/dev/null | head -1)
+    [[ -n "$ROUTER_PID" ]] && break
+    sleep 1
+done
+[[ -n "$ROUTER_PID" ]] || { echo "ERROR: the router never bound :${ROUTER_PORT}"; tail -8 "$ROUTER_LOG" | sed 's/^/  /'; exit 1; }
+printf '%s|%s\n' "$ROUTER_PID" "$(proc_fingerprint "$ROUTER_PID")" > "$PIDFILE"
+echo "  router: UP (pid ${ROUTER_PID}) with the remote cluster backend"
+
+# --- smoke -------------------------------------------------------------------
+if [[ "$SKIP_SMOKE" != "1" ]]; then
+    echo ""
+    echo "[Smoke] router health -> relay -> writes across the masters -> cache hit"
+    note() { printf '  %-34s %s\n' "$1" "$2"; }
+    SMOKE_FAIL=0
+    # LATEST-shaped relay to drive traffic; a fixed long-finalized block for a
+    # deterministic key (same one on every run and every router).
+    RELAY_TIP='{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+    RELAY_FIXED='{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x112a880",false],"id":1}'
+    relay() { curl -sf -m 20 -X POST "http://127.0.0.1:${ROUTER_PORT}" -H 'Content-Type: application/json' -d "$1"; }
+    hits() { curl -sf "http://127.0.0.1:${METRICS_PORT}/metrics" | awk '/^smartrouter_cache_success_total/ {sum += $NF} END {printf "%d", sum}'; }
+
+    HEALTH=""
+    for _ in $(seq 1 30); do
+        HEALTH=$(curl -s -o /dev/null -w '%{http_code}' -m 10 "http://127.0.0.1:${ROUTER_PORT}/lava/health")
+        [[ "$HEALTH" == "200" ]] && break
+        sleep 1
+    done
+    [[ "$HEALTH" == "200" ]] && note "router /lava/health" "200" || { note "router /lava/health" "$HEALTH (want 200)"; SMOKE_FAIL=1; }
+
+    # The gauge is driven by a periodic probe (3s budget — WAN-tolerant); give
+    # it a couple of cycles rather than sampling once.
+    CONNECTED=""
+    for _ in $(seq 1 30); do
+        CONNECTED=$(curl -sf "http://127.0.0.1:${METRICS_PORT}/metrics" | awk '/^smartrouter_resp_cache_connected/ {print $NF; exit}')
+        [[ "$CONNECTED" == "1" ]] && break
+        sleep 1
+    done
+    [[ "$CONNECTED" == "1" ]] && note "resp_cache_connected" "1" || { note "resp_cache_connected" "${CONNECTED:-<none>} (want 1)"; SMOKE_FAIL=1; }
+
+    BODY=$(relay "$RELAY_FIXED" || true)
+    [[ "$BODY" == *'"result"'* ]] && note "relay eth_getBlockByNumber" "ok" \
+        || { note "relay" "unexpected: ${BODY:0:60}"; SMOKE_FAIL=1; }
+
+    # Writes are asynchronous and spray across the masters by hash slot —
+    # poll the TOTAL while driving more traffic, then show the split. A small
+    # sample may land on one or two masters only; that is hashing, not a bug.
+    KEYS=0
+    for _ in $(seq 1 20); do
+        relay "$RELAY_TIP" >/dev/null 2>&1 || true
+        KEYS=$(backend_keys | wc -l | tr -d ' ')
+        [[ "$KEYS" -gt 0 ]] && break
+        sleep 1
+    done
+    if [[ "$KEYS" -gt 0 ]]; then
+        SPLIT=""
+        for n in "${NODES[@]}"; do SPLIT+=":${n##*:}=$(node_keys "$n" | wc -l | tr -d ' ') "; done
+        note "keys across the masters" "$KEYS total (${SPLIT%% })"
+    else
+        note "keys across the masters" "none (writes should land from anywhere)"; SMOKE_FAIL=1
+    fi
+
+    HIT_OK=0
+    for _ in $(seq 1 20); do
+        relay "$RELAY_FIXED" >/dev/null 2>&1 || true
+        sleep 0.5
+        [[ "$(hits)" -gt 0 ]] && { HIT_OK=1; break; }
+    done
+    if [[ "$HIT_OK" == "1" ]]; then
+        note "cache_success_total" "$(hits) (>0)"
+        HDR=$(curl -s -D - -o /dev/null -m 20 -X POST "http://127.0.0.1:${ROUTER_PORT}" -H 'Content-Type: application/json' -d "$RELAY_FIXED" | grep -i '^Lava-Cache-Backend' | tr -d '\r')
+        [[ -n "$HDR" ]] && note "hit served by" "${HDR#*: } (one of the masters — last dialed)"
+    else
+        # connected=1 + keys present + zero hits means lookups still time out:
+        # compare --cache-timeout against the RTT and watch the get-timeout
+        # counter (smartrouter_resp_cache_failed_total) before suspecting auth.
+        note "cache_success_total" "0 (expected >0 with --cache-timeout ${CACHE_TIMEOUT} at ~${RTT_MS:-?}ms RTT)"
+        SMOKE_FAIL=1
+    fi
+
+    echo ""
+    [[ "$SMOKE_FAIL" == "0" ]] && echo "  SMOKE PASS — the router is spraying entries across the remote Valkey cluster." \
+        || { echo "  SMOKE FAIL — see $ROUTER_LOG"; exit 1; }
+fi
+
+# The 'vc' helper the samples below rely on — a FUNCTION taking a node
+# host:port first (SCAN/TTL are per-node in a cluster), then the command.
+# Named 'vc' so it coexists with the standalone lanes' vk/rd in one shell.
+# The raw variant wraps /dev/tcp in `bash -c` so it also works when pasted
+# into zsh (macOS default), where /dev/tcp does not exist.
+if [[ -n "$CLI_BIN" ]]; then
+    VC_SETUP="export REDISCLI_AUTH='${VALKEY_CLUSTER_PASSWORD}' VALKEYCLI_AUTH=\"\$REDISCLI_AUTH\"
+  vc() { local hp=\"\$1\"; shift; ${CLI_BIN} -h \"\${hp%%:*}\" -p \"\${hp##*:}\"${VALKEY_CLUSTER_USERNAME:+ --user ${VALKEY_CLUSTER_USERNAME}} \"\$@\"; }"
+else
+    VC_SETUP="vc() { local hp=\"\$1\"; shift; bash -c 'exec 3<>\"/dev/tcp/\$0/\$1\"; printf \"AUTH ${AUTH_CRED}\\r\\n%s\\r\\nQUIT\\r\\n\" \"\$2\" >&3; cat <&3' \"\${hp%%:*}\" \"\${hp##*:}\" \"\$*\" 2>/dev/null; }"
+fi
+
+cat <<EOF
+
+============================================
+REMOTE VALKEY CLUSTER LANE — CHEAT SHEET
+============================================
+Router    http://127.0.0.1:${ROUTER_PORT}    metrics http://127.0.0.1:${METRICS_PORT}/metrics
+Cluster   ${VALKEY_CLUSTER_SEEDS}  (AUTH, plain TCP)
+Config    ${CONFIG_REL}   (holds the credential — git-ignored)
+Log       tail -f ${ROUTER_LOG}
+
+One-time in your shell (paste as-is), then use 'vc <node> <COMMAND>':
+  ${VC_SETUP}
+
+--- PROVE THE CLUSTER CACHE IS WORKING -----
+
+1. See the topology the router discovers (masters + slot ranges):
+     vc ${SEED0} CLUSTER NODES | awk '/master/ {print \$2, \$9}'
+
+2. Warm the cache — relay a fixed, long-finalized block (deterministic key):
+     curl -s -X POST http://127.0.0.1:${ROUTER_PORT} -H 'Content-Type: application/json' \\
+       -d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x112a880",false],"id":1}' | head -c 120; echo
+
+3. Find where entries landed — SCAN is PER NODE, so ask each master; the
+   split across them is the cluster working:
+     for n in ${NODES[*]##*:}; do echo ":\$n"; vc ${SEED0%%:*}:\$n SCAN 0 MATCH '${KEY_PREFIX}:*' COUNT 1000; done
+     vc <node-that-has-it> TTL '<paste a key>'
+
+4. Repeat the SAME relay and look at the headers — a hit is served as
+   "Cached"; Lava-Cache-Backend names the LAST-DIALED node, so expect ONE OF
+   the masters (not always :${SEED0##*:}):
+     curl -s -D - -o /dev/null -X POST http://127.0.0.1:${ROUTER_PORT} -H 'Content-Type: application/json' \\
+       -d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x112a880",false],"id":1}' \\
+       | grep -iE 'lava-(provider-address|cache-backend)'
+     # (hits work even far from the cluster — the lane raised the lookup
+     #  budget with --cache-timeout ${CACHE_TIMEOUT}; the production default is 50ms)
+
+5. The counters move — success/requests per tier, plus backend health:
+     curl -s http://127.0.0.1:${METRICS_PORT}/metrics | grep -E '^smartrouter_cache_(success|requests)_total'
+     curl -s http://127.0.0.1:${METRICS_PORT}/metrics | grep '^smartrouter_resp_cache'
+
+6. Watch the router decide, live:
+     tail -f ${ROUTER_LOG} | grep -iE 'cache (lookup|hit|miss)|resp-cache'
+
+--------------------------------------------
+Status (cluster state, per-master keys, RTT):      $0 --status
+Clean up this lane's keys (never anyone else's):   $0 --flush
+Stop the router:                                   $0 --stop
+============================================
+EOF

--- a/scripts/pre_setups/init_smartrouter_eth_valkey_remote.sh
+++ b/scripts/pre_setups/init_smartrouter_eth_valkey_remote.sh
@@ -1,0 +1,573 @@
+#!/bin/bash
+# Smart Router -> REMOTE Valkey 8.1 STANDALONE (the cache-test lab) — TLS + AUTH
+#
+# Companion to init_smartrouter_eth_resp_cache.sh (local docker valkey). This
+# lane points a locally built router at the shared LAB backend instead, so the
+# resp-cache path is exercised against a real remote standalone Valkey with the
+# production-shaped surface: TLS on the wire, password AUTH, DNS endpoint.
+#
+#   valkey       $VALKEY_HOST:$VALKEY_PORT   (a remote Valkey 8.1
+#                standalone — ElastiCache-style TLS endpoint behind an AWS NLB
+#                in us-east-1; the cert does not verify against public roots
+#                -> verification is skipped, same as redis-cli --insecure)
+#   smartrouter  0.0.0.0:${ROUTER_PORT}   (metrics :${METRICS_PORT})
+#
+# EVERYTHING talks straight to that remote endpoint: the router dials it for
+# caching, and the script's own checks (pre-flight ping, key scans, --flush)
+# use a local valkey-cli/redis-cli when one is installed or plain openssl
+# s_client speaking RESP otherwise. No docker, no local backend, no sidecars.
+#
+# The password + TLS surface has NO flag form (flags carry only addresses and
+# topology), so the lane GENERATES a config with a full resp-cache: block under
+# git-ignored debugging/ — the credential never lands in the repo tree.
+#
+# THE READ BUDGET AND THE WAN (why this lane passes --cache-timeout)
+#   - Cache WRITES are asynchronous with a 5s budget (common.CacheWriteTimeout):
+#     they land from anywhere. The smoke proves them by scanning the lane's
+#     key prefix on the lab backend.
+#   - Cache READS run inside the per-relay --cache-timeout budget (default
+#     50ms, sized for a same-zone backend). A warm-connection GET costs one
+#     network round trip, so a budget below the backend RTT turns EVERY lookup
+#     into a timeout — smartrouter_resp_cache_failed_total{kind="timeout",
+#     op="get"} climbs while writes still land, and relays are answered by the
+#     upstream (Lava-Provider-Address: eth-rpc-N, never Cached).
+#   - The lane therefore measures the RTT and passes a --cache-timeout sized
+#     to it (2*RTT + 150ms headroom; CACHE_TIMEOUT overrides), so cache HITS
+#     work from anywhere. The trade is honest: a hit saves the upstream call
+#     but still costs ~1 RTT, and a miss now waits up to the budget before
+#     falling through. Production should co-locate router and backend and
+#     keep the 50ms default.
+#
+# USAGE
+#   scripts/pre_setups/init_smartrouter_eth_valkey_remote.sh            # bring up + smoke
+#   scripts/pre_setups/init_smartrouter_eth_valkey_remote.sh --status   # backend + router state
+#   scripts/pre_setups/init_smartrouter_eth_valkey_remote.sh --flush    # delete ONLY this lane's keys
+#   scripts/pre_setups/init_smartrouter_eth_valkey_remote.sh --stop     # stop the router
+#
+# ENVIRONMENT
+#   VALKEY_HOST         REQUIRED — the remote Valkey host   VALKEY_PORT (6379)
+#   VALKEY_PASSWORD     REQUIRED — the cache-test lab credential (never baked
+#                       into the script; export it before running)
+#   VALKEY_USERNAME     ACL user (default: none -> AUTH default user)
+#   VALKEY_CA_FILE      PEM to VERIFY the server against; unset -> skip
+#                       verification (the lab cert does not verify)
+#   VALKEY_DIAL_TIMEOUT (1s) resp-cache dial-timeout. The repo default (500ms)
+#                       is LAN-sized; a WAN dial pays TCP + TLS = 2-3 RTTs.
+#   CACHE_TIMEOUT       per-relay cache lookup budget passed to the router as
+#                       --cache-timeout (default: computed from measured RTT)
+#   ROUTER_PORT (3375)  METRICS_PORT (7795)   <- clear of the sibling lanes
+#                       (3360/7779 resp, 3370/7790 sentinel, 3380-1/7801-2 multiregion)
+#   KEY_PREFIX (sr-$USER) per-user prefix so testers on the SHARED backend
+#                       never scan or flush each other's entries
+#   ETH_RPC_URL_1/2, ETH_WS_URL_1/2   upstreams     HEALTH_INTERVAL (15s)
+#   SKIP_SMOKE=1        bring up only
+#
+# OWNERSHIP SAFETY: never `killall`. Reclaims only the router it recorded
+# starting (pid + start-time fingerprint, or a command line naming this lane's
+# generated config) and refuses to run if its ports are held by anything else.
+# The lab backend is shared infrastructure: this lane only ever touches keys
+# under its own prefix, and only on --flush.
+
+__dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+PROJECT_ROOT=$(cd "${__dir}"/../.. && pwd)
+
+LOGS_DIR="${PROJECT_ROOT}/debugging/logs"
+mkdir -p "$LOGS_DIR"
+
+VALKEY_HOST="${VALKEY_HOST:-}"
+VALKEY_PORT="${VALKEY_PORT:-6379}"
+VALKEY_PASSWORD="${VALKEY_PASSWORD:-}"
+VALKEY_USERNAME="${VALKEY_USERNAME:-}"
+VALKEY_CA_FILE="${VALKEY_CA_FILE:-}"
+VALKEY_DIAL_TIMEOUT="${VALKEY_DIAL_TIMEOUT:-1s}"
+CACHE_TIMEOUT="${CACHE_TIMEOUT:-}"   # empty -> sized from the measured RTT below
+ROUTER_PORT="${ROUTER_PORT:-3375}"
+METRICS_PORT="${METRICS_PORT:-7795}"
+HEALTH_INTERVAL="${HEALTH_INTERVAL:-15s}"
+
+# Per-user prefix, restricted to the router's allowed charset [A-Za-z0-9._-].
+KEY_PREFIX="${KEY_PREFIX:-sr-$(id -un 2>/dev/null)}"
+KEY_PREFIX=$(printf '%s' "$KEY_PREFIX" | tr -cd 'A-Za-z0-9._-')
+[[ -n "$KEY_PREFIX" ]] || KEY_PREFIX="sr-lab"
+
+ROUTER_SCREEN="sr-valkey-remote"
+CONFIG_REL="debugging/smartrouter_eth_valkey_remote.yml"
+CONFIG_FILE="${PROJECT_ROOT}/${CONFIG_REL}"
+PIDFILE="${PROJECT_ROOT}/debugging/.valkey-remote-router.pid"
+ROUTER_LOG="${LOGS_DIR}/SMARTROUTER_VALKEY_REMOTE.log"
+
+# --- backend probe: a local CLI when installed, raw RESP-over-TLS otherwise --
+# Every probe goes STRAIGHT to the remote endpoint — no docker, no sidecars.
+# Auth for a local valkey-cli/redis-cli travels via environment, not -a, so
+# the password never shows in ps; both names are exported because the two CLIs
+# each read their own variable.
+export REDISCLI_AUTH="$VALKEY_PASSWORD" VALKEYCLI_AUTH="$VALKEY_PASSWORD"
+CLI_BIN=""
+for c in valkey-cli redis-cli; do
+    command -v "$c" >/dev/null 2>&1 || continue
+    "$c" --help 2>&1 | grep -q -- '--tls' && { CLI_BIN="$c"; break; }
+done
+CLI_ARGS=(--tls -h "$VALKEY_HOST" -p "$VALKEY_PORT")
+if [[ -n "$VALKEY_CA_FILE" ]]; then CLI_ARGS+=(--cacert "$VALKEY_CA_FILE"); else CLI_ARGS+=(--insecure); fi
+[[ -n "$VALKEY_USERNAME" ]] && CLI_ARGS+=(--user "$VALKEY_USERNAME")
+rcli() { "$CLI_BIN" "${CLI_ARGS[@]}" "$@"; }
+
+# Without a CLI the script speaks inline RESP over TLS itself through openssl
+# s_client (present on macOS and Linux). -servername: ElastiCache-style
+# endpoints route on SNI. QUIT makes the server close the stream, which ends
+# s_client; a watchdog bounds a black-holed connection.
+OPENSSL_TRUST=()
+[[ -n "$VALKEY_CA_FILE" ]] && OPENSSL_TRUST=(-CAfile "$VALKEY_CA_FILE" -verify_return_error)
+resp_cmd() { # $1 = ONE inline RESP command; prints the raw reply stream
+    if [[ -n "$CLI_BIN" ]]; then
+        # shellcheck disable=SC2086 — the inline command is intentionally split
+        rcli $1
+        return
+    fi
+    local pid wd
+    printf 'AUTH %s\r\n%s\r\nQUIT\r\n' \
+        "${VALKEY_USERNAME:+${VALKEY_USERNAME} }${VALKEY_PASSWORD}" "$1" \
+        | openssl s_client -connect "${VALKEY_HOST}:${VALKEY_PORT}" \
+              -servername "$VALKEY_HOST" "${OPENSSL_TRUST[@]}" -quiet -ign_eof 2>/dev/null &
+    pid=$!
+    ( sleep 10; kill "$pid" 2>/dev/null ) >/dev/null 2>&1 &
+    wd=$!
+    wait "$pid" 2>/dev/null; local rc=$?
+    kill "$wd" 2>/dev/null; wait "$wd" 2>/dev/null
+    return $rc
+}
+backend_keys() { # this lane's keys on the backend, one per line
+    if [[ -n "$CLI_BIN" ]]; then
+        rcli --scan --pattern "${KEY_PREFIX}:*" 2>/dev/null
+    else
+        # One SCAN pass; COUNT 1000 covers the small lab keyspace, and every
+        # caller polls, so a rare partial batch self-heals on the next try.
+        resp_cmd "SCAN 0 MATCH ${KEY_PREFIX}:* COUNT 1000" | tr -d '\r' | grep "^${KEY_PREFIX}:"
+    fi
+}
+HAVE_PROBE=""
+{ [[ -n "$CLI_BIN" ]] || command -v openssl >/dev/null 2>&1; } && HAVE_PROBE=1
+
+# --- ownership helpers (house pattern: pid + start-time fingerprint) ---------
+proc_fingerprint() { ps -p "$1" -o lstart= 2>/dev/null | tr -s ' '; }
+
+reclaim_owned() {
+    [[ -f "$PIDFILE" ]] || return 0
+    local rec_pid rec_fp cur_fp
+    rec_pid=$(cut -d'|' -f1 "$PIDFILE" 2>/dev/null)
+    rec_fp=$(cut -d'|' -f2- "$PIDFILE" 2>/dev/null)
+    [[ -n "$rec_pid" ]] || { rm -f "$PIDFILE"; return 0; }
+    cur_fp=$(proc_fingerprint "$rec_pid")
+    if [[ -z "$cur_fp" ]]; then rm -f "$PIDFILE"; return 0; fi
+    if [[ "$cur_fp" != "$rec_fp" ]]; then
+        echo "  stale pid file (pid $rec_pid is now another process) — leaving it alone"
+        rm -f "$PIDFILE"; return 0
+    fi
+    echo "  stopping this lane's previous router (pid $rec_pid)"
+    kill "$rec_pid" 2>/dev/null || true
+    for _ in $(seq 1 20); do [[ -z "$(proc_fingerprint "$rec_pid")" ]] && break; sleep 0.25; done
+    rm -f "$PIDFILE"
+}
+
+# Fallback when the pid file is missing (crash between spawn and record): the
+# port holder's command line names a file only this lane generates — identity,
+# not a name match.
+reclaim_by_identity() {
+    local pid
+    pid=$(lsof -nP -iTCP:${ROUTER_PORT} -sTCP:LISTEN -t 2>/dev/null | head -1)
+    [[ -n "$pid" ]] || return 0
+    ps -p "$pid" -o command= 2>/dev/null | grep -qF -- "$CONFIG_REL" || return 0
+    echo "  stopping this lane's router by identity (pid $pid, no pid file)"
+    kill "$pid" 2>/dev/null || true
+    for _ in $(seq 1 20); do
+        lsof -nP -iTCP:${ROUTER_PORT} -sTCP:LISTEN -t >/dev/null 2>&1 || break
+        sleep 0.25
+    done
+}
+
+# One TCP connect = one network round trip; three samples, keep the smallest
+# positive. This is what decides whether cache HITS are physically possible
+# inside the router's 50ms read budget.
+sample_rtt_ms() {
+    local best="" t ms
+    for _ in 1 2 3; do
+        t=$(curl -s -o /dev/null -w '%{time_connect}' --connect-timeout 5 -m 2 \
+              "telnet://${VALKEY_HOST}:${VALKEY_PORT}" </dev/null 2>/dev/null)
+        ms=$(awk -v t="${t:-0}" 'BEGIN{printf "%d", t*1000}')
+        [[ "$ms" -gt 0 ]] && { [[ -z "$best" || "$ms" -lt "$best" ]] && best="$ms"; }
+    done
+    echo "$best"
+}
+
+backend_version() { # prints "valkey 8.1.0 (standalone)" style, empty on failure
+    # Judged by OUTPUT, not exit code: s_client exits non-zero when the peer
+    # TCP-closes without a TLS close_notify, as NLB-fronted endpoints do.
+    local info v m
+    info=$(resp_cmd "INFO server" 2>/dev/null)
+    [[ -n "$info" ]] || return 0
+    v=$(echo "$info" | awk -F: '/^valkey_version/{print $2}' | tr -d '\r')
+    [[ -n "$v" ]] && v="valkey $v" || v="redis $(echo "$info" | awk -F: '/^redis_version/{print $2}' | tr -d '\r')"
+    # Valkey with extended-redis-compatibility off renames redis_mode to
+    # server_mode — accept either.
+    m=$(echo "$info" | awk -F: '/^(redis|server)_mode/{print $2; exit}' | tr -d '\r')
+    echo "${v}${m:+ (${m})}"
+}
+
+teardown() {
+    echo "[Teardown] stopping this lane's router (nothing else is signalled)"
+    reclaim_owned
+    reclaim_by_identity
+    screen -S "$ROUTER_SCREEN" -X quit 2>/dev/null || true
+    echo "[Teardown] done. The lab backend is untouched; this lane's keys expire"
+    echo "           by TTL, or delete them now: $0 --flush"
+    echo "           The generated config keeps the credential: rm -f ${CONFIG_REL}"
+}
+
+status() {
+    if [[ -n "$HAVE_PROBE" ]]; then
+        echo "backend  ${VALKEY_HOST}:${VALKEY_PORT}  $(backend_version)  ping: $(resp_cmd PING | tr -d '\r' | grep -m1 -E '^\+?PONG$' || echo FAILED)"
+        echo "keys     $(backend_keys | wc -l | tr -d ' ') under '${KEY_PREFIX}:'"
+    else
+        echo "backend  ${VALKEY_HOST}:${VALKEY_PORT}  (no valkey-cli/redis-cli and no openssl — cannot probe)"
+    fi
+    local rtt; rtt=$(sample_rtt_ms)
+    echo "rtt      ${rtt:-<unmeasurable>} ms  (the lane sizes --cache-timeout to this; production default 50ms)"
+    if [[ -f "$PIDFILE" ]]; then
+        local pid; pid=$(cut -d'|' -f1 "$PIDFILE")
+        [[ -n "$(proc_fingerprint "$pid")" ]] && echo "router   UP (pid $pid) http://127.0.0.1:${ROUTER_PORT}" \
+                                              || echo "router   recorded pid $pid is gone (crashed?) — re-run the lane"
+    else
+        echo "router   not recorded as running"
+    fi
+    curl -s -m 5 "http://127.0.0.1:${METRICS_PORT}/metrics" 2>/dev/null \
+        | grep -E '^smartrouter_resp_cache_(connected|connection_errors_total|failed_total)' | sed 's/^/metric   /'
+}
+
+flush() {
+    [[ -n "$HAVE_PROBE" ]] || { echo "ERROR: --flush needs valkey-cli/redis-cli or openssl"; exit 1; }
+    local keys n
+    keys=$(backend_keys)
+    n=$(printf '%s' "$keys" | grep -c .)
+    [[ "$n" -gt 0 ]] || { echo "no keys under '${KEY_PREFIX}:' — nothing to delete"; return 0; }
+    echo "deleting $n key(s) under '${KEY_PREFIX}:' on ${VALKEY_HOST} (only this lane's prefix)"
+    # One inline DEL carries them all — key names never contain spaces.
+    resp_cmd "DEL $(echo "$keys" | tr '\n' ' ')" >/dev/null
+    echo "done"
+}
+
+# The remote endpoint and credential are required and never hard-coded (secret
+# scanners; shared infra). Every verb except --stop needs them to reach it.
+if [[ "$1" != "--stop" && "$1" != "stop" ]] && { [[ -z "$VALKEY_HOST" || -z "$VALKEY_PASSWORD" ]]; }; then
+    echo "ERROR: set VALKEY_HOST and VALKEY_PASSWORD (the remote Valkey endpoint + credential), e.g.:"
+    echo "  VALKEY_HOST=<host> VALKEY_PASSWORD='...' $0 ${1:-}"
+    exit 1
+fi
+
+case "$1" in
+    --stop|stop)     teardown; exit 0 ;;
+    --status|status) status;   exit 0 ;;
+    --flush|flush)   flush;    exit $? ;;
+esac
+
+command -v screen >/dev/null || { echo "ERROR: this lane needs screen"; exit 1; }
+command -v curl   >/dev/null || { echo "ERROR: this lane needs curl"; exit 1; }
+
+ETH_RPC_URL_1="${ETH_RPC_URL_1:-https://ethereum-rpc.publicnode.com}"
+ETH_WS_URL_1="${ETH_WS_URL_1:-wss://ethereum-rpc.publicnode.com}"
+ETH_RPC_URL_2="${ETH_RPC_URL_2:-https://eth.drpc.org}"
+ETH_WS_URL_2="${ETH_WS_URL_2:-wss://eth.drpc.org}"
+
+echo "============================================"
+echo "Smart Router -> REMOTE Valkey standalone (TLS + AUTH)"
+echo "============================================"
+echo "Backend:  ${VALKEY_HOST}:${VALKEY_PORT}"
+echo "Prefix:   ${KEY_PREFIX}:   (per-user isolation on the shared lab backend)"
+echo ""
+
+# --- pre-flight: prove the backend before spending a build on it -------------
+# The router does NOT dial at construction and degrades per-operation, so a bad
+# host/password would still log "resp-cache backend configured" and the lane
+# would look green while silently missing forever. When a TLS-capable CLI is
+# available, an explicit authenticated PING is therefore a HARD gate.
+if [[ -n "$HAVE_PROBE" ]]; then
+    echo "[Setup] pre-flight: authenticated TLS ping straight to the endpoint (via ${CLI_BIN:-openssl})"
+    PROBE_OUT=$(resp_cmd PING 2>&1 | tr -d '\r')
+    if ! echo "$PROBE_OUT" | grep -qE '^\+?PONG$'; then
+        echo "ERROR: ${VALKEY_HOST}:${VALKEY_PORT} did not answer an authenticated PING:"
+        echo "       $(echo "${PROBE_OUT:-<no reply>}" | head -2 | tr '\n' ' ')"
+        echo "       Check network/VPN, VALKEY_PASSWORD, or point the lane elsewhere (VALKEY_HOST=...)."
+        exit 1
+    fi
+    echo "  backend: $(backend_version) — PONG"
+else
+    echo "  WARNING: no valkey-cli/redis-cli and no openssl on PATH — skipping the"
+    echo "           backend pre-flight and key-scan checks. The router's own gauge"
+    echo "           (smartrouter_resp_cache_connected) becomes the only connectivity signal."
+fi
+
+RTT_MS=$(sample_rtt_ms)
+if [[ -z "$CACHE_TIMEOUT" ]]; then
+    # The lookup budget must exceed the backend RTT or every read times out —
+    # writes would still land and the lane would look "up" while never serving
+    # a single hit (the failure mode this lane exists to catch).
+    if [[ -n "$RTT_MS" ]]; then CACHE_TIMEOUT="$(( 2 * RTT_MS + 150 ))ms"; else CACHE_TIMEOUT="750ms"; fi
+fi
+echo "  rtt: ~${RTT_MS:-?}ms -> --cache-timeout ${CACHE_TIMEOUT}"
+echo "       (the production default, 50ms, suits a same-zone backend; a hit here"
+echo "       still costs ~1 RTT — co-locate router and backend in production)"
+echo ""
+
+echo "[Setup] reclaiming this lane's previous run (if any)"
+reclaim_owned
+reclaim_by_identity
+screen -S "$ROUTER_SCREEN" -X quit 2>/dev/null || true
+sleep 1
+
+# Anything still on this lane's ports is NOT ours: refuse, never evict.
+BLOCKED=0
+for port in "$ROUTER_PORT" "$METRICS_PORT"; do
+    if lsof -nP -iTCP:$port -sTCP:LISTEN >/dev/null 2>&1; then
+        [[ "$BLOCKED" == "0" ]] && { echo "ERROR: this lane's port(s) are held by process(es) it does not own."; echo "       Refusing to run. Nothing was signalled."; }
+        echo "  port $port:"; lsof -nP -iTCP:$port -sTCP:LISTEN | sed 's/^/    /'
+        BLOCKED=1
+    fi
+done
+[[ "$BLOCKED" == "1" ]] && { echo ""; echo "Free them, or move this lane: ROUTER_PORT=3376 METRICS_PORT=7796 $0"; exit 1; }
+
+echo "[Setup] installing binaries"
+# env -u GOFLAGS: when the calling shell exports GOFLAGS (any value), make
+# auto-re-exports its own GOFLAGS := ... -ldflags '...' to the child go
+# install, and go's $GOFLAGS env parser cannot read the quoted ldflags —
+# "go: parsing $GOFLAGS: unknown flag -w". Scrubbing it keeps the Makefile's
+# flags on argv only, where the quoting is legal.
+env -u GOFLAGS make -C "$PROJECT_ROOT" install || { echo "ERROR: make install failed"; exit 1; }
+
+# --- router config -----------------------------------------------------------
+# Generated (not checked in) because it embeds the credential; debugging/ is
+# git-ignored and the file is created 0600.
+echo "[Setup] generating ${CONFIG_REL}"
+umask 077
+USERNAME_LINE=""
+[[ -n "$VALKEY_USERNAME" ]] && USERNAME_LINE="  username: \"${VALKEY_USERNAME}\"
+"
+if [[ -n "$VALKEY_CA_FILE" ]]; then
+    TLS_TRUST_LINES="    # Verify the server against the operator-supplied bundle.
+    ca-file: \"${VALKEY_CA_FILE}\""
+else
+    TLS_TRUST_LINES="    # The lab endpoint's certificate does not verify against public roots
+    # (redis-cli needs --insecure for the same reason). Supply VALKEY_CA_FILE
+    # to verify instead. server-name / cert-file / key-file (mTLS) are also
+    # available — docs/RESP-CACHE.md.
+    insecure-skip-verify: true"
+fi
+
+cat > "$CONFIG_FILE" <<EOF
+# GENERATED by scripts/pre_setups/init_smartrouter_eth_valkey_remote.sh.
+# Contains a credential (the shared cache-test lab password) — this file lives
+# in git-ignored debugging/ and must never be committed.
+
+metrics-listen-address: "0.0.0.0:${METRICS_PORT}"
+
+resp-cache:
+  topology: standalone
+  addresses: ["${VALKEY_HOST}:${VALKEY_PORT}"]
+${USERNAME_LINE}  password: "${VALKEY_PASSWORD}"
+  key-prefix: "${KEY_PREFIX}"
+  # The repo default (500ms) is LAN-sized; a WAN dial pays TCP + TLS handshake,
+  # 2-3 round trips, and a too-small value makes the connected gauge flap.
+  dial-timeout: "${VALKEY_DIAL_TIMEOUT}"
+  tls:
+    enabled: true
+${TLS_TRUST_LINES}
+
+endpoints:
+  - listen-address: "0.0.0.0:${ROUTER_PORT}"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    network-address: "0.0.0.0:${ROUTER_PORT}"
+
+direct-rpc:
+  - name: "eth-rpc-1"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "${ETH_RPC_URL_1}"
+        skip-verifications:
+          - chain-id
+          - pruning
+      - url: "${ETH_WS_URL_1}"
+
+  - name: "eth-rpc-2"
+    chain-id: "ETH1"
+    api-interface: "jsonrpc"
+    node-urls:
+      - url: "${ETH_RPC_URL_2}"
+        skip-verifications:
+          - chain-id
+          - pruning
+      - url: "${ETH_WS_URL_2}"
+EOF
+
+# --- router ------------------------------------------------------------------
+echo "[Setup] starting the smart router (:${ROUTER_PORT}) against ${VALKEY_HOST}"
+screen -d -m -S "$ROUTER_SCREEN" bash -c "cd $PROJECT_ROOT && source ~/.bashrc; smartrouter \
+$CONFIG_REL \
+--log-level debug \
+--use-static-spec $PROJECT_ROOT/specs/ethereum.json \
+--debug-relays \
+--cache-timeout ${CACHE_TIMEOUT} \
+--relays-health-interval ${HEALTH_INTERVAL} 2>&1 | tee $ROUTER_LOG"
+sleep 0.5
+
+ROUTER_OK=0
+for _ in $(seq 1 45); do
+    grep -q "resp-cache backend configured" "$ROUTER_LOG" 2>/dev/null && { ROUTER_OK=1; break; }
+    grep -q "^Error:" "$ROUTER_LOG" 2>/dev/null && break
+    sleep 1
+done
+if [[ "$ROUTER_OK" != "1" ]]; then
+    echo "ERROR: the router never reported its RESP backend — last log lines:"
+    tail -8 "$ROUTER_LOG" 2>/dev/null | sed 's/^/  /'
+    exit 1
+fi
+
+ROUTER_PID=""
+for _ in $(seq 1 60); do
+    ROUTER_PID=$(lsof -nP -iTCP:${ROUTER_PORT} -sTCP:LISTEN -t 2>/dev/null | head -1)
+    [[ -n "$ROUTER_PID" ]] && break
+    sleep 1
+done
+[[ -n "$ROUTER_PID" ]] || { echo "ERROR: the router never bound :${ROUTER_PORT}"; tail -8 "$ROUTER_LOG" | sed 's/^/  /'; exit 1; }
+printf '%s|%s\n' "$ROUTER_PID" "$(proc_fingerprint "$ROUTER_PID")" > "$PIDFILE"
+echo "  router: UP (pid ${ROUTER_PID}) with the remote RESP backend"
+
+# --- smoke -------------------------------------------------------------------
+if [[ "$SKIP_SMOKE" != "1" ]]; then
+    echo ""
+    echo "[Smoke] router health -> relay -> writes on the lab backend -> cache hit"
+    note() { printf '  %-34s %s\n' "$1" "$2"; }
+    SMOKE_FAIL=0
+    # LATEST-shaped relay to drive traffic; a fixed long-finalized block for a
+    # deterministic key (same one on every run and every router).
+    RELAY_TIP='{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+    RELAY_FIXED='{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x112a880",false],"id":1}'
+    relay() { curl -sf -m 20 -X POST "http://127.0.0.1:${ROUTER_PORT}" -H 'Content-Type: application/json' -d "$1"; }
+    hits() { curl -sf "http://127.0.0.1:${METRICS_PORT}/metrics" | awk '/^smartrouter_cache_success_total/ {sum += $NF} END {printf "%d", sum}'; }
+
+    HEALTH=""
+    for _ in $(seq 1 30); do
+        HEALTH=$(curl -s -o /dev/null -w '%{http_code}' -m 10 "http://127.0.0.1:${ROUTER_PORT}/lava/health")
+        [[ "$HEALTH" == "200" ]] && break
+        sleep 1
+    done
+    [[ "$HEALTH" == "200" ]] && note "router /lava/health" "200" || { note "router /lava/health" "$HEALTH (want 200)"; SMOKE_FAIL=1; }
+
+    # The gauge is driven by a periodic probe (3s budget — WAN-tolerant); give
+    # it a couple of cycles rather than sampling once.
+    CONNECTED=""
+    for _ in $(seq 1 30); do
+        CONNECTED=$(curl -sf "http://127.0.0.1:${METRICS_PORT}/metrics" | awk '/^smartrouter_resp_cache_connected/ {print $NF; exit}')
+        [[ "$CONNECTED" == "1" ]] && break
+        sleep 1
+    done
+    [[ "$CONNECTED" == "1" ]] && note "resp_cache_connected" "1" || { note "resp_cache_connected" "${CONNECTED:-<none>} (want 1)"; SMOKE_FAIL=1; }
+
+    BODY=$(relay "$RELAY_FIXED" || true)
+    [[ "$BODY" == *'"result"'* ]] && note "relay eth_getBlockByNumber" "ok" \
+        || { note "relay" "unexpected: ${BODY:0:60}"; SMOKE_FAIL=1; }
+
+    # Writes are asynchronous — poll while driving more traffic.
+    if [[ -n "$HAVE_PROBE" ]]; then
+        KEYS=0
+        for _ in $(seq 1 20); do
+            relay "$RELAY_TIP" >/dev/null 2>&1 || true
+            KEYS=$(backend_keys | wc -l | tr -d ' ')
+            [[ "$KEYS" -gt 0 ]] && break
+            sleep 1
+        done
+        [[ "$KEYS" -gt 0 ]] && note "keys on the lab backend" "$KEYS under '${KEY_PREFIX}:'" \
+            || { note "keys on the lab backend" "none (writes should land from anywhere)"; SMOKE_FAIL=1; }
+    else
+        note "keys on the lab backend" "skipped (no CLI and no openssl)"
+    fi
+
+    HIT_OK=0
+    for _ in $(seq 1 20); do
+        relay "$RELAY_FIXED" >/dev/null 2>&1 || true
+        sleep 0.5
+        [[ "$(hits)" -gt 0 ]] && { HIT_OK=1; break; }
+    done
+    if [[ "$HIT_OK" == "1" ]]; then
+        note "cache_success_total" "$(hits) (>0)"
+        HDR=$(curl -s -D - -o /dev/null -m 20 -X POST "http://127.0.0.1:${ROUTER_PORT}" -H 'Content-Type: application/json' -d "$RELAY_FIXED" | grep -i '^Lava-Cache-Backend' | tr -d '\r')
+        [[ -n "$HDR" ]] && note "hit served by" "${HDR#*: }"
+    else
+        # connected=1 + keys present + zero hits means lookups still time out:
+        # compare --cache-timeout against the RTT and watch the get-timeout
+        # counter (smartrouter_resp_cache_failed_total) before suspecting auth.
+        note "cache_success_total" "0 (expected >0 with --cache-timeout ${CACHE_TIMEOUT} at ~${RTT_MS:-?}ms RTT)"
+        SMOKE_FAIL=1
+    fi
+
+    echo ""
+    [[ "$SMOKE_FAIL" == "0" ]] && echo "  SMOKE PASS — the router is talking TLS+AUTH to the remote Valkey." \
+        || { echo "  SMOKE FAIL — see $ROUTER_LOG"; exit 1; }
+fi
+
+# The 'vk' helper the samples below rely on: an alias when a local CLI exists,
+# otherwise a tiny function speaking RESP over TLS via openssl — either way it
+# talks straight to the remote endpoint.
+if [[ -n "$CLI_BIN" ]]; then
+    VK_SETUP="export REDISCLI_AUTH='${VALKEY_PASSWORD}' VALKEYCLI_AUTH=\"\$REDISCLI_AUTH\"
+  alias vk='${CLI_BIN} ${CLI_ARGS[*]}'"
+else
+    VK_SETUP="vk() { printf 'AUTH ${VALKEY_PASSWORD}\\r\\n%s\\r\\nQUIT\\r\\n' \"\$*\" | openssl s_client -connect ${VALKEY_HOST}:${VALKEY_PORT} -servername ${VALKEY_HOST} -quiet -ign_eof 2>/dev/null; }"
+fi
+
+cat <<EOF
+
+============================================
+REMOTE VALKEY LANE — CHEAT SHEET
+============================================
+Router    http://127.0.0.1:${ROUTER_PORT}    metrics http://127.0.0.1:${METRICS_PORT}/metrics
+Backend   ${VALKEY_HOST}:${VALKEY_PORT}  (TLS + AUTH, standalone)
+Config    ${CONFIG_REL}   (holds the credential — git-ignored)
+Log       tail -f ${ROUTER_LOG}
+
+One-time in your shell (paste as-is), then use 'vk <COMMAND>':
+  ${VK_SETUP}
+
+--- PROVE THE CACHE IS WORKING -------------
+
+1. Warm it — relay a fixed, long-finalized block (deterministic cache key,
+   same key on every run):
+     curl -s -X POST http://127.0.0.1:${ROUTER_PORT} -H 'Content-Type: application/json' \\
+       -d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x112a880",false],"id":1}' | head -c 120; echo
+
+2. The entry lands on the lab backend (write is async — give it a second),
+   with a real TTL from the router's policy:
+     vk SCAN 0 MATCH '${KEY_PREFIX}:*' COUNT 1000
+     vk TTL '<paste one key from the scan>'
+
+3. Repeat the SAME relay and look at the headers — a cache hit is served as
+   "Cached" and Lava-Cache-Backend names the node that served it:
+     curl -s -D - -o /dev/null -X POST http://127.0.0.1:${ROUTER_PORT} -H 'Content-Type: application/json' \\
+       -d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x112a880",false],"id":1}' \\
+       | grep -iE 'lava-(provider-address|cache-backend)'
+     # expect:  Lava-Provider-Address: Cached  +  Lava-Cache-Backend: ${VALKEY_HOST}:${VALKEY_PORT}
+     # (works even far from the backend — the lane raised the router's lookup
+     #  budget with --cache-timeout ${CACHE_TIMEOUT}; the production default is 50ms)
+
+4. The counters move — success/requests per tier, plus backend health:
+     curl -s http://127.0.0.1:${METRICS_PORT}/metrics | grep -E '^smartrouter_cache_(success|requests)_total'
+     curl -s http://127.0.0.1:${METRICS_PORT}/metrics | grep '^smartrouter_resp_cache'
+
+5. Watch the router decide, live:
+     tail -f ${ROUTER_LOG} | grep -iE 'cache (lookup|hit|miss)|resp-cache'
+
+--------------------------------------------
+Status (backend ping, RTT, keys, gauges):          $0 --status
+Clean up this lane's keys (never anyone else's):   $0 --flush
+Stop the router:                                   $0 --stop
+============================================
+EOF


### PR DESCRIPTION
Jira ticket: MAG-2647

## What

Two additive changes on top of the merged RESP cache backend (#261):

**1. `--cache-timeout` — the per-relay cache lookup budget is now a flag** (default `50ms`, unchanged).

`common.CacheTimeout` was a compile-time constant sized for a same-zone backend. A remote RESP backend (e.g. ElastiCache in another region) needs at least one network round trip per lookup, so any deployment whose RTT exceeds the constant times out on **every** read — `smartrouter_resp_cache_failed_total{kind="timeout",op="get"}` climbs while the asynchronous writes keep landing: the cache fills but never serves a hit, and nothing fails loudly.

The constant becomes a var behind `--cache-timeout`, registered exactly like the existing `--default-processing-timeout` (`DurationVar` into the package var), with a startup guard resetting non-positive values to the 50ms default. The secondary tier already has `--secondary-cache-timeout` for the same cross-zone reason; this is the primary-tier analog. **Default behavior is byte-for-byte unchanged; the flag is opt-in.**

**2. Four remote integration lanes** under `scripts/pre_setups/`, exercising the resp-cache path against real remote ElastiCache-style backends (not the local docker sidecar):

| Lane | Backend | Transport |
|---|---|---|
| `init_smartrouter_eth_valkey_remote.sh` | Valkey 8.1 standalone | TLS + AUTH |
| `init_smartrouter_eth_redis_oss_remote.sh` | Redis OSS 7.1 standalone | TLS + AUTH |
| `init_smartrouter_eth_valkey_cluster_remote.sh` | Valkey 8.1 cluster (3 masters) | plain TCP + AUTH |
| `init_smartrouter_eth_redis_cluster_remote.sh` | Redis OSS 7.4 cluster (3 masters) | plain TCP + AUTH |

Each lane points a locally built router at the remote backend, runs a fail-fast authenticated pre-flight (the router degrades per-operation and would otherwise look green while silently missing), measures RTT and sizes `--cache-timeout` to it, then asserts genuine cache hits: keys land under a per-user prefix and repeat relays return `Lava-Provider-Address: Cached`. `--status` / `--flush` / `--stop` verbs included; ownership-safe (fingerprinted pids, refuses foreign ports, touches only its own key prefix on a shared backend). No docker — checks use a local `redis-cli`/`valkey-cli` when present, else raw RESP over openssl (TLS labs) or `/dev/tcp` (cluster labs). The cluster lanes exercise `topology: cluster` for real: seeds-only discovery, per-node key scans, CROSSSLOT-safe flush.

**Credentials are required via env var** (`VALKEY_PASSWORD` / `REDIS_PASSWORD` / `*_CLUSTER_PASSWORD`), never baked into the scripts — each lane fails fast with a clear message if unset.

## Why it matters

The flag closes a silent-failure hole for any WAN/cross-region RESP backend. The lanes give that path real coverage against the four ElastiCache shapes operators actually deploy.

## Test plan

- `go test ./protocol/common/` — new `TestValidateAndCapCacheTimeout` passes; existing timeout tests unaffected.
- All four lanes verified end-to-end from a laptop (~150ms to us-east-1): pre-flight PONG + version/topology, writes landing (cluster: sprayed across all three masters), and `Cached` responses with `Lava-Cache-Backend` naming the serving node.
- Additive only; `--cache-timeout` defaults to the prior 50ms constant, so unchanged deployments behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
