### PR TITLE
ci: stop PR test routers between validation runs

### DIFF
--- a/.github/workflows/pr-gate-build-artifact.yml
+++ b/.github/workflows/pr-gate-build-artifact.yml
@@ -294,6 +294,39 @@ jobs:
           preflight_result="passed"
           echo "dev-sim-prtests preflight passed"
 
+      - name: Checkout smart-router-automation
+        uses: actions/checkout@v7
+        with:
+          repository: Magma-Devs/smart-router-automation
+          token: ${{ secrets.SMART_ROUTER_AUTOMATION_READ_TOKEN }}
+          path: smart-router-automation
+          persist-credentials: false
+
+      - name: Wake dev-sim-prtests routers for validation
+        id: wake_routers
+        timeout-minutes: 4
+        env:
+          SSH_HOST: ${{ secrets.DEV_SIM_PRTESTS_SSH_HOST }}
+          SSH_KEY: ${{ secrets.DEV_SIM_PRTESTS_SSH_KEY }}
+          NAMESPACE: smart-router
+        run: |
+          set -euo pipefail
+          key_file="$(mktemp)"
+          trap 'rm -f "$key_file"' EXIT
+          printf '%s\n' "$SSH_KEY" > "$key_file"
+          chmod 600 "$key_file"
+          export SSH_OPTS="-i $key_file -o StrictHostKeyChecking=accept-new -o RemoteCommand=none -o RequestTTY=no -o ServerAliveInterval=5 -o ServerAliveCountMax=3"
+          server="${SSH_HOST##*@}"
+          ssh_user="${SSH_HOST%@*}"
+          if [ "$ssh_user" = "$SSH_HOST" ]; then
+            ssh_user="$(id -un)"
+          fi
+          echo "::add-mask::${server}"
+          # Includes eth-sim-router and every deployed chain; the real-node
+          # sleep/wake scripts have a fixed list that omits simulator routers.
+          # The following rollout validates readiness using the new PR image.
+          bash smart-router-automation/scripts/router_power.sh on "$server" "$ssh_user" --replicas 1
+
       - name: Deploy and validate dev-sim-prtests Kubernetes rollout
         env:
           SSH_HOST: ${{ secrets.DEV_SIM_PRTESTS_SSH_HOST }}
@@ -1286,14 +1319,6 @@ jobs:
 
           append_summary "passed"
 
-      - name: Checkout smart-router-automation
-        uses: actions/checkout@v7
-        with:
-          repository: Magma-Devs/smart-router-automation
-          token: ${{ secrets.SMART_ROUTER_AUTOMATION_READ_TOKEN }}
-          path: smart-router-automation
-          persist-credentials: false
-
       - name: Set up Python for automation tests
         uses: actions/setup-python@v7
         with:
@@ -1351,6 +1376,72 @@ jobs:
             echo "- Result: \`failed\`"
           } >> "$GITHUB_STEP_SUMMARY"
           exit 1
+
+      # Keep shutdown in this job, inside the shared workflow concurrency
+      # group, so it finishes before the next PR can wake the same server.
+      - name: Sleep dev-sim-prtests routers after validation
+        if: ${{ always() && steps.wake_routers.outcome != 'skipped' }}
+        timeout-minutes: 4
+        env:
+          SSH_HOST: ${{ secrets.DEV_SIM_PRTESTS_SSH_HOST }}
+          SSH_KEY: ${{ secrets.DEV_SIM_PRTESTS_SSH_KEY }}
+          NAMESPACE: smart-router
+        run: |
+          set -euo pipefail
+          key_file="$(mktemp)"
+          trap 'rm -f "$key_file"' EXIT
+          printf '%s\n' "$SSH_KEY" > "$key_file"
+          chmod 600 "$key_file"
+          export SSH_OPTS="-i $key_file -o StrictHostKeyChecking=accept-new -o RemoteCommand=none -o RequestTTY=no -o ServerAliveInterval=5 -o ServerAliveCountMax=3"
+          server="${SSH_HOST##*@}"
+          ssh_user="${SSH_HOST%@*}"
+          if [ "$ssh_user" = "$SSH_HOST" ]; then
+            ssh_user="$(id -un)"
+          fi
+          echo "::add-mask::${server}"
+          # Retry transient SSH/scale failures. A failed shutdown must fail
+          # the gate instead of reporting success while routers keep polling.
+          stopped=false
+          for attempt in 1 2 3; do
+            if bash smart-router-automation/scripts/router_power.sh off "$server" "$ssh_user"; then
+              stopped=true
+              break
+            fi
+            echo "::warning::Router shutdown attempt ${attempt} failed"
+            sleep 5
+          done
+          if [ "$stopped" != true ]; then
+            echo "::error::Could not stop dev-sim-prtests routers"
+            exit 1
+          fi
+          # router_power.sh scales deployments; also check the resulting
+          # state so a failed deployment listing cannot look like success.
+          ssh -i "$key_file" -o StrictHostKeyChecking=accept-new \
+            -o BatchMode=yes -o ConnectTimeout=20 -o RemoteCommand=none \
+            -o RequestTTY=no -o ServerAliveInterval=5 -o ServerAliveCountMax=3 \
+            "$SSH_HOST" 'bash -se' <<'REMOTE_SLEEP'
+          set -euo pipefail
+          for attempt in $(seq 1 60); do
+            if kubectl -n smart-router get deployments -o json | jq -e '
+              [.items[] | select(.metadata.name | endswith("-router"))]
+              | length > 0 and all(.[];
+                  .spec.replicas == 0 and
+                  (.status.replicas // 0) == 0 and
+                  (.status.terminatingReplicas // 0) == 0)
+            ' >/dev/null; then
+              echo "All dev-sim-prtests chain routers are asleep"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "ERROR: dev-sim-prtests routers did not reach zero replicas" >&2
+          exit 1
+          REMOTE_SLEEP
+          {
+            echo "### dev-sim-prtests router lifecycle"
+            echo ""
+            echo "- Result: all chain routers scaled to 0 after validation"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   preflight-status:
     name: Publish PR Validation Status


### PR DESCRIPTION
# Description

The PR gate leaves the chain routers on `dev-sim-prtests` running after validation, so they continue polling providers between PR runs. Check out `smart-router-automation` before deployment and use its existing `scripts/router_power.sh` to wake all chain routers before validation and scale them to zero after the public readiness smoke.

The shutdown step uses `always()` once wake-up has been attempted, including partial wake failures and cancellation. It retries failed shutdowns and verifies zero desired/running replicas; a failed shutdown fails the gate. Cleanup remains inside the existing shared concurrency group so the next PR cannot start while the previous run is shutting down. Cache and dashboard deployments retain their existing replica counts.

## Jira ticket

Jira ticket: MAG-3439

## Validation

- `actionlint .github/workflows/pr-gate-build-artifact.yml` and `git diff --check` passed.
- 11 local checks passed using the workflow's actual shell steps and the existing automation power script against mocked SSH/Kubernetes: repeated runs, partial wake failure, test failure, transient/persistent shutdown failure, failed listing, unavailable API, empty fleet, running/terminating replicas, and workflow ordering/cleanup conditions. Mock tests verify SSH key permissions/removal and preserve cache/dashboard replicas.
- [Full live workflow](https://github.com/Magma-Devs/smart-router/actions/runs/34027195084) passed: woke all 22 chain-router deployments from zero, passed Kubernetes rollout and Helm compatibility validation, passed all 31 public readiness tests, then scaled all 22 deployments to zero and verified they were asleep.
- [Intentional cancellation test](https://github.com/Magma-Devs/smart-router/actions/runs/34025899013): canceled during Kubernetes rollout after wake-up. The `always()` shutdown step still passed and verified all 22 chain-router deployments at zero. The subsequent full run above proved the next run can wake the fleet again.
- Required `dev-sim-prtests / preflight` check passes. Tracking issue: [MAG-3439](https://magmadevs.atlassian.net/browse/MAG-3439).

Merged into `main` as `d3cec959f5809094a7512c7837729719532896b0`. The [main-branch workflow](https://github.com/Magma-Devs/smart-router/actions/runs/34027662131) also passed all 31 public readiness tests, then scaled all 22 chain-router deployments to zero and verified they were asleep.

## Author Checklist

- [x] Read the contribution guide and used a conventional PR title.
- [x] Targeted `main`; reviewed the workflow diff.
- [x] Added comments explaining lifecycle ordering, script selection, retries, and verification.
- [x] Ran the relevant local validation; no application/Go code changed.
- [x] Attach the required Jira ticket: MAG-3439.
- [x] Confirm live workflow validation and the required `dev-sim-prtests / preflight` check.
- [x] Confirm the required `jira-ticket/validated` check for MAG-3439.


[MAG-3439]: https://magmadevs.atlassian.net/browse/MAG-3439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ