### PR TITLE
feat(debug): add cache state endpoint

### DIFF
--- a/docs/RESP-CACHE.md
+++ b/docs/RESP-CACHE.md
@@ -219,6 +219,69 @@ A router started with `--debug-relays` adds `Lava-Cache-Backend` to cache-served
 naming the node that served the hit — the current master under sentinel, the touched shard
 under cluster. It is debug-gated because it exposes internal infrastructure addresses.
 
+### `GET /debug/cache-state`
+
+A router started with `--debug-address` serves a read-only snapshot of which backend is
+actually caching for it:
+
+```bash
+curl -s http://127.0.0.1:6161/debug/cache-state | jq
+```
+
+```json
+{
+  "schema_version": 1,
+  "engine": "resp",
+  "tiers": {
+    "primary": {
+      "configured": true,
+      "engine": "resp",
+      "address": "redis-primary:6379 read=reader.eu-west-1:6379 prefix=sr",
+      "reachable": true,
+      "reachable_checked_at": "2026-09-09T14:31:02Z",
+      "reachable_detail": "no error reported",
+      "when_unreachable": "attempted",
+      "lifetimes": {"finalized_seconds": 3600, "non_finalized_seconds": 0.5, "node_errors_seconds": 60}
+    },
+    "secondary": {"configured": false, "engine": "", "address": "", "reachable": null,
+                  "reachable_checked_at": "", "reachable_detail": "", "when_unreachable": "", "lifetimes": null}
+  }
+}
+```
+
+Four things are easy to misread:
+
+- **`reachable` has three values.** `true`, `false`, and `null` for *not yet determined* — a
+  RESP backend before its first probe returns, a `cache-be` connection mid-dial. `null` is not
+  "unreachable"; a router polled immediately after startup legitimately answers it. Whether a
+  tier exists is `configured`, never the presence of this field.
+- **`when_unreachable` is why `reachable: false` is not one fact.** For a RESP tier it is
+  `attempted`: the backend is still asked on every relay and pays the full cache timeout each
+  time. For a `cache-be` tier it is `skipped`: the client returns not-connected before any
+  I/O, so an unreachable tier costs nothing. Same flag, opposite bill.
+- **`reachable_checked_at` marks a snapshot.** The RESP verdict comes from the 10s health
+  probe, so it can be up to ~13s old. The `cache-be` verdict is read live from the connection
+  and carries no timestamp.
+- **`lifetimes` is `null` for a `cache-be` tier.** Those TTLs are configured in, and applied
+  by, the cache-server pod; this router does not know them. `null` says so — a number would
+  assert a value no deployment uses. Where they are reported, they are the policy's base
+  values: the effective non-finalized TTL is `max(averageBlockTime/8, non_finalized_seconds)`
+  per chain, so that field is a floor.
+
+Reading this endpoint never touches the backend. That is deliberate rather than incidental:
+the obvious liveness accessor on the `cache-be` client dials on demand, so a monitoring scrape
+would otherwise change the state it is measuring, and a backend that recovered between two
+polls would look healthy *because of* the first poll.
+
+> **Bind the debug listener to loopback.** This is the first `/debug` route to publish the
+> router's own backing-store addresses, and the debug listener has **no authentication** — any
+> route on it is readable by anything that can reach the port. No credential is exposed
+> (`password` / `password-file` are separate configuration and never appear here), so this is
+> an exposure decision rather than a leak: under `topology: sentinel` these are sentinel
+> control-plane addresses, and they name infrastructure worth not advertising. Pass
+> `--debug-address 127.0.0.1:6161` rather than `:6161`, and reach it through
+> `kubectl port-forward` in a cluster.
+
 ## Flush semantics
 
 The router's `/debug/reset-all` flushes the RESP backend **prefix-scoped**: `SCAN` over

--- a/ecosystem/cache/redisstore/store.go
+++ b/ecosystem/cache/redisstore/store.go
@@ -62,8 +62,9 @@ type Store struct {
 	// configuration cannot answer this: under sentinel the serving node changes
 	// on every failover, and under cluster it depends on the key's slot.
 	// Observability only — nothing in the cache path reads these.
-	readEndpoint  *endpointTracker
-	writeEndpoint *endpointTracker
+	readEndpoint        *endpointTracker
+	writeEndpoint       *endpointTracker
+	configuredAddresses string
 
 	// stopWatcher terminates the credential poll loop (nil when the
 	// credentials are static).
@@ -152,6 +153,7 @@ func New(cfg Config) (*Store, error) {
 		}
 		return nil, err
 	}
+	store.configuredAddresses = strings.Join(cfg.Addresses, ",")
 	store.writeEndpoint = writeTracker
 	store.readEndpoint = readTracker
 	if cfg.PasswordFile != "" {
@@ -172,6 +174,14 @@ func New(cfg Config) (*Store, error) {
 		}
 	}
 	return store, nil
+}
+
+// ConfiguredAddresses returns the operator-provided primary RESP addresses.
+func (s *Store) ConfiguredAddresses() string {
+	if s == nil {
+		return ""
+	}
+	return s.configuredAddresses
 }
 
 // warnIfReadSplitIsDiscoveryScoped flags the one read-split shape that does

--- a/ecosystem/cache/redisstore/store.go
+++ b/ecosystem/cache/redisstore/store.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -62,9 +63,21 @@ type Store struct {
 	// configuration cannot answer this: under sentinel the serving node changes
 	// on every failover, and under cluster it depends on the key's slot.
 	// Observability only — nothing in the cache path reads these.
-	readEndpoint        *endpointTracker
-	writeEndpoint       *endpointTracker
-	configuredAddresses string
+	readEndpoint  *endpointTracker
+	writeEndpoint *endpointTracker
+
+	// configuredEndpoints is the STATIC configuration the trackers above
+	// deliberately do not answer — what an operator wrote down, so a debug reader
+	// can compare it against the node actually serving. Kept separate from that
+	// group precisely because their doc comment argues against static
+	// configuration for THEIR purpose.
+	//
+	// New() sets it from the operator's Config, which is the authoritative source.
+	// The NewWithClient/NewWithClients seams have no Config, so newStore derives
+	// what it can from the clients themselves: those two constructors are what
+	// every RESP test injects a miniredis client through, and leaving them empty
+	// is what would make this field untestable without a live Redis.
+	configuredEndpoints storeEndpoints
 
 	// stopWatcher terminates the credential poll loop (nil when the
 	// credentials are static).
@@ -153,7 +166,13 @@ func New(cfg Config) (*Store, error) {
 		}
 		return nil, err
 	}
-	store.configuredAddresses = strings.Join(cfg.Addresses, ",")
+	// The operator's own configuration is authoritative, so it replaces whatever
+	// newStore derived from the clients.
+	store.configuredEndpoints = storeEndpoints{
+		Addresses:     append([]string(nil), cfg.Addresses...),
+		ReadAddresses: append([]string(nil), cfg.ReadAddresses...),
+		KeyPrefix:     store.prefix,
+	}
 	store.writeEndpoint = writeTracker
 	store.readEndpoint = readTracker
 	if cfg.PasswordFile != "" {
@@ -176,12 +195,76 @@ func New(cfg Config) (*Store, error) {
 	return store, nil
 }
 
-// ConfiguredAddresses returns the operator-provided primary RESP addresses.
-func (s *Store) ConfiguredAddresses() string {
+// storeEndpoints is the operator-facing identity of a RESP deployment: every
+// address the store uses, plus the keyspace it uses them in.
+//
+// All three parts are load-bearing for a debug reader, and each was learnt by
+// asking what an operator would do wrong without it:
+//
+//   - ReadAddresses, because Ping probes BOTH clients and returns the first
+//     error. With reads split to another region, killing the reader reports the
+//     store unreachable while naming only the healthy writer — the operator curls
+//     the printed address, finds it fine, and blames the endpoint, while every
+//     cache LOOKUP is failing against an address nothing ever showed them.
+//   - KeyPrefix, because it decides which keyspace this router occupies. Two
+//     routers on one Valkey with different prefixes share zero entries and are
+//     otherwise indistinguishable in this output.
+type storeEndpoints struct {
+	Addresses     []string
+	ReadAddresses []string
+	KeyPrefix     string
+}
+
+// String renders the endpoints for the debug payload's address field. Read
+// addresses are named as such so the two roles are never confused for a list of
+// interchangeable nodes.
+func (e storeEndpoints) String() string {
+	if len(e.Addresses) == 0 && len(e.ReadAddresses) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, 3)
+	if len(e.Addresses) > 0 {
+		parts = append(parts, strings.Join(e.Addresses, ","))
+	}
+	if len(e.ReadAddresses) > 0 {
+		parts = append(parts, "read="+strings.Join(e.ReadAddresses, ","))
+	}
+	if e.KeyPrefix != "" {
+		parts = append(parts, "prefix="+e.KeyPrefix)
+	}
+	return strings.Join(parts, " ")
+}
+
+// ConfiguredEndpoints renders every address this store is configured to use and
+// the key prefix it uses them under. Empty only when the store was built from
+// clients whose addresses could not be determined.
+func (s *Store) ConfiguredEndpoints() string {
 	if s == nil {
 		return ""
 	}
-	return s.configuredAddresses
+	return s.configuredEndpoints.String()
+}
+
+// clientAddresses recovers the configured addresses from an already-constructed
+// client, for the NewWithClient/NewWithClients seams that never see a Config.
+// Unknown implementations (including test doubles) yield nothing rather than a
+// guess.
+func clientAddresses(client redis.UniversalClient) []string {
+	switch c := client.(type) {
+	case *redis.Client:
+		return []string{c.Options().Addr}
+	case *redis.ClusterClient:
+		return append([]string(nil), c.Options().Addrs...)
+	case *redis.Ring:
+		addrs := make([]string, 0, len(c.Options().Addrs))
+		for _, addr := range c.Options().Addrs {
+			addrs = append(addrs, addr)
+		}
+		sort.Strings(addrs) // Ring addresses come from a map; keep the output stable
+		return addrs
+	default:
+		return nil
+	}
 }
 
 // warnIfReadSplitIsDiscoveryScoped flags the one read-split shape that does
@@ -224,12 +307,20 @@ func newStore(writeClient, readClient redis.UniversalClient, keyPrefix string) (
 	if !keyPrefixPattern.MatchString(keyPrefix) {
 		return nil, fmt.Errorf("invalid resp-cache key prefix %q: must match %s — SCAN MATCH patterns are globs, so glob characters could purge unrelated keys", keyPrefix, keyPrefixPattern.String())
 	}
+	// Derived rather than left empty so the exported NewWithClient/NewWithClients
+	// seams produce a usable address. New() overwrites this with the operator's
+	// Config, which knows the read addresses too.
+	endpoints := storeEndpoints{Addresses: clientAddresses(writeClient), KeyPrefix: keyPrefix}
+	if readClient != writeClient {
+		endpoints.ReadAddresses = clientAddresses(readClient)
+	}
 	return &Store{
-		write:         writeClient,
-		read:          readClient,
-		prefix:        keyPrefix,
-		readEndpoint:  &endpointTracker{},
-		writeEndpoint: &endpointTracker{},
+		write:               writeClient,
+		read:                readClient,
+		prefix:              keyPrefix,
+		readEndpoint:        &endpointTracker{},
+		writeEndpoint:       &endpointTracker{},
+		configuredEndpoints: endpoints,
 	}, nil
 }
 

--- a/protocol/performance/cache.go
+++ b/protocol/performance/cache.go
@@ -216,6 +216,15 @@ func (cache *Cache) CacheActive() bool {
 	return cache != nil && cache.clientStore.getClient() != nil
 }
 
+func (cache *Cache) CacheEngine() string { return "grpc" }
+func (cache *Cache) CacheAddress() string {
+	if cache == nil {
+		return ""
+	}
+	return cache.address
+}
+func (cache *Cache) CacheReachable() bool { return cache.CacheActive() }
+
 func (cache *Cache) SetEntry(ctx context.Context, cacheSet *pairingtypes.RelayCacheSet) error {
 	if cache == nil {
 		return NotInitializedError

--- a/protocol/performance/cache.go
+++ b/protocol/performance/cache.go
@@ -11,6 +11,7 @@ import (
 	"github.com/magma-Devs/smart-router/utils"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -36,6 +37,27 @@ func newRelayerCacheClientStore(ctx context.Context, address string) (*relayerCa
 		address: address,
 	}
 	return clientStore, clientStore.connectClient()
+}
+
+// peekConnState reports the live connectivity of the installed connection WITHOUT
+// touching it. It exists because getClient() is not a read: it spawns
+// `go reconnectClient()` whenever the client is nil, so an observer that called it
+// to ask "is the cache up?" would dial the cache as a side effect of asking.
+// /debug/cache-state is documented read-only and must not do that.
+//
+// The second return distinguishes "no connection installed" from a state reading.
+// grpc.ClientConn.GetState() is a plain accessor — unlike Connect() and
+// WaitForStateChange() it neither triggers nor waits on a transition.
+func (r *relayerCacheClientStore) peekConnState() (connectivity.State, bool) {
+	if r == nil {
+		return connectivity.Shutdown, false
+	}
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	if r.client == nil || r.conn == nil {
+		return connectivity.Shutdown, false
+	}
+	return r.conn.GetState(), true
 }
 
 func (r *relayerCacheClientStore) getClient() pairingtypes.RelayerCacheClient {
@@ -174,8 +196,12 @@ func (r *relayerCacheClientStore) resetOnConnectionError(err error) {
 }
 
 type Cache struct {
+	// The configured address deliberately lives in exactly ONE place —
+	// clientStore.address, the string actually dialled — and is read back through
+	// BackendEndpoint. Cache used to carry a second copy that InitCache kept in sync
+	// by assigning the same argument to both; two accessors for one fact is how they
+	// eventually disagree.
 	clientStore *relayerCacheClientStore
-	address     string
 	serviceCtx  context.Context
 }
 
@@ -183,7 +209,6 @@ func InitCache(ctx context.Context, addr string) (*Cache, error) {
 	clientStore, err := newRelayerCacheClientStore(ctx, addr)
 	cache := &Cache{
 		clientStore: clientStore,
-		address:     addr,
 		serviceCtx:  ctx,
 	}
 	if err != nil {
@@ -216,14 +241,66 @@ func (cache *Cache) CacheActive() bool {
 	return cache != nil && cache.clientStore.getClient() != nil
 }
 
-func (cache *Cache) CacheEngine() string { return "grpc" }
-func (cache *Cache) CacheAddress() string {
-	if cache == nil {
-		return ""
+// DebugCacheState reports this tier for GET /debug/cache-state. Read-only: it
+// reads the connection's state rather than asking for a client, so observing a
+// down cache does not dial it.
+//
+// Reachability comes from the gRPC connectivity state, NOT from "a client pointer
+// is installed" (what CacheActive answers). The installed pointer is a latch: it is
+// cleared only by resetOnConnectionError, which returns early for every status code
+// except Unavailable and fires only from a relay's own GetEntry/SetEntry/Flush. So
+// on an idle router a cache-be killed an hour ago still reads as active, while the
+// connection has long since left Ready.
+//
+// The remaining gap is deliberate and documented rather than papered over: a cache-be
+// that ACCEPTS connections but hangs keeps its transport in Ready, so this reports
+// reachable while every operation times out. That is the honest reading of a
+// connectivity state — the backend is reachable and unresponsive, which are different
+// faults — and distinguishing them needs an active probe this read-only endpoint
+// must not perform.
+func (cache *Cache) DebugCacheState() DebugCacheState {
+	// A typed-nil *Cache is how an unconfigured cache travels inside the
+	// CacheBackend interface (see the wiring convention on CacheBackend), and a
+	// typed nil still satisfies this interface — so "configured" must be decided
+	// here, on the receiver, and never by the caller's `!= nil` on the interface.
+	//
+	// Both the configured test and the reported value read BackendEndpoint, so
+	// there is exactly one source for the address.
+	address := cache.BackendEndpoint()
+	if address == "" {
+		return DebugCacheState{Engine: CacheEngineGRPC}
 	}
-	return cache.address
+	state := DebugCacheState{
+		Configured: true,
+		Engine:     CacheEngineGRPC,
+		Address:    address,
+		// A gRPC tier that is not reachable is SKIPPED, not attempted: GetEntry
+		// returns NotConnectedError before any I/O, so an unreachable primary costs
+		// nothing per relay. The RESP tier does the opposite, which is why this is
+		// reported rather than assumed.
+		WhenUnreachable: CacheWhenUnreachableSkipped,
+	}
+	connState, connected := cache.clientStore.peekConnState()
+	if !connected {
+		state.Reachable = boolPtr(false)
+		state.Detail = "no connection installed"
+		return state
+	}
+	state.Detail = connState.String()
+	switch connState {
+	case connectivity.Ready, connectivity.Idle:
+		// Idle is a healthy connection with no active transport (gRPC drops one
+		// after an idle period); it dials on the next call. Reporting it as
+		// unreachable would make a quiet router look broken.
+		state.Reachable = boolPtr(true)
+	case connectivity.Connecting:
+		// Genuinely undetermined — the dial is in flight. Left nil rather than
+		// guessed either way.
+	default: // TransientFailure, Shutdown
+		state.Reachable = boolPtr(false)
+	}
+	return state
 }
-func (cache *Cache) CacheReachable() bool { return cache.CacheActive() }
 
 func (cache *Cache) SetEntry(ctx context.Context, cacheSet *pairingtypes.RelayCacheSet) error {
 	if cache == nil {

--- a/protocol/performance/cache_backend.go
+++ b/protocol/performance/cache_backend.go
@@ -2,6 +2,7 @@ package performance
 
 import (
 	"context"
+	"time"
 
 	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
 )
@@ -34,16 +35,98 @@ type BackendEndpointReporter interface {
 	BackendEndpoint() string
 }
 
+// Cache engine names, and what an unreachable tier costs per relay. Closed enums:
+// both are wire values of GET /debug/cache-state.
+const (
+	CacheEngineGRPC = "grpc"
+	CacheEngineRESP = "resp"
+
+	// CacheWhenUnreachableSkipped: the tier is bypassed before any I/O, so an
+	// unreachable backend costs nothing per relay (the gRPC client returns
+	// NotConnectedError up front).
+	CacheWhenUnreachableSkipped = "skipped"
+	// CacheWhenUnreachableAttempted: every lookup and write is still issued against
+	// the dead backend and pays the full timeout (the RESP backend degrades
+	// per-operation rather than flipping itself off).
+	CacheWhenUnreachableAttempted = "attempted"
+)
+
+// CacheLifetimes is the TTL policy a backend is actually applying, in seconds.
+//
+// Reported by the backend that OWNS the policy rather than read from flags: the
+// expiration flags are registered on the cache-server command, never on the
+// router's, so reading them router-side returns zero on every deployment. A tier
+// whose TTLs live in another pod (cache-be) reports none at all rather than a
+// plausible-looking zero.
+//
+// These are the policy's base values. The effective TTL for a non-finalized entry
+// is max(averageBlockTime/8, NonFinalized) per chain, so NonFinalizedSeconds is a
+// floor, not the value any particular entry will get.
+type CacheLifetimes struct {
+	FinalizedSeconds    float64 `json:"finalized_seconds"`
+	NonFinalizedSeconds float64 `json:"non_finalized_seconds"`
+	NodeErrorsSeconds   float64 `json:"node_errors_seconds"`
+}
+
+// DebugCacheState is one cache tier as GET /debug/cache-state reports it.
+//
+// Deliberately a single struct behind a single method rather than an accessor per
+// field: the endpoint reaches it through a runtime type assertion, so every extra
+// method is another name that can be renamed without a build failure while the
+// assertion silently stops matching and the endpoint degrades to "no cache" on a
+// router that is caching fine.
+type DebugCacheState struct {
+	// Configured is decided by the backend itself, never by the caller checking the
+	// interface for nil: an unconfigured cache travels as a TYPED-nil pointer inside
+	// a non-nil CacheBackend (see the wiring convention above), and a typed nil
+	// still satisfies DebugCacheStateReporter.
+	Configured bool
+	Engine     string
+	Address    string
+	// Reachable is nil when reachability has not been determined — a RESP backend
+	// before its first probe returns, or a gRPC connection mid-dial. Distinct from
+	// false, which is a positive finding that the backend is down.
+	Reachable *bool
+	// CheckedAt stamps a reachability value that is a periodic SNAPSHOT rather than
+	// a live read, so a consumer can tell how stale it is. Zero when the value is
+	// read live (the gRPC tier reads the connection state on demand).
+	CheckedAt time.Time
+	// Detail is the human-readable reason behind Reachable — the gRPC connectivity
+	// state, or an auth-vs-network classification for RESP. An authentication
+	// rejection reported only as "unreachable" sends an operator to check
+	// networking when the real fault is a credential.
+	Detail string
+	// WhenUnreachable is what the router DOES when this tier is unreachable, one of
+	// the CacheWhenUnreachable* values. Reported because Reachable=false means
+	// opposite things per engine, and nothing else in the payload marks it.
+	WhenUnreachable string
+	// Lifetimes is nil when this backend cannot answer for its own TTLs.
+	Lifetimes *CacheLifetimes
+}
+
 // DebugCacheStateReporter exposes the runtime facts needed by the debug cache
 // state endpoint. It is deliberately optional so the cache backend contract
 // remains focused on serving relays.
+//
+// Implementations must be safe on a typed-nil receiver, like the rest of
+// CacheBackend, and must not mutate anything: the endpoint is documented
+// read-only, and the obvious liveness accessors on the gRPC client are not
+// (CacheActive spawns a reconnect).
 type DebugCacheStateReporter interface {
-	CacheEngine() string
-	CacheAddress() string
-	CacheReachable() bool
+	DebugCacheState() DebugCacheState
 }
 
 var (
 	_ BackendEndpointReporter = (*Cache)(nil)
 	_ BackendEndpointReporter = (*RespCache)(nil)
+
+	// Compile-time proof that both backends still satisfy the debug reporter. The
+	// endpoint reaches them through a comma-ok assertion, so without these a rename
+	// on either backend is not a build failure — the assertion just stops matching
+	// and /debug/cache-state quietly reports an unconfigured cache on a router whose
+	// cache is working. Neither go build nor go vet would catch it.
+	_ DebugCacheStateReporter = (*Cache)(nil)
+	_ DebugCacheStateReporter = (*RespCache)(nil)
 )
+
+func boolPtr(b bool) *bool { return &b }

--- a/protocol/performance/cache_backend.go
+++ b/protocol/performance/cache_backend.go
@@ -34,6 +34,15 @@ type BackendEndpointReporter interface {
 	BackendEndpoint() string
 }
 
+// DebugCacheStateReporter exposes the runtime facts needed by the debug cache
+// state endpoint. It is deliberately optional so the cache backend contract
+// remains focused on serving relays.
+type DebugCacheStateReporter interface {
+	CacheEngine() string
+	CacheAddress() string
+	CacheReachable() bool
+}
+
 var (
 	_ BackendEndpointReporter = (*Cache)(nil)
 	_ BackendEndpointReporter = (*RespCache)(nil)

--- a/protocol/performance/cache_backend_test.go
+++ b/protocol/performance/cache_backend_test.go
@@ -27,7 +27,7 @@ func TestCacheBackendTypedNilIsInert(t *testing.T) {
 // drops the client so the cache reads as inactive, and is idempotent.
 func TestCacheCloseStopsReconnectAndIsIdempotent(t *testing.T) {
 	store := &relayerCacheClientStore{ctx: context.Background(), address: "test-addr"}
-	cache := &Cache{clientStore: store, address: "test-addr", serviceCtx: context.Background()}
+	cache := &Cache{clientStore: store, serviceCtx: context.Background()}
 
 	require.NoError(t, cache.Close())
 	require.True(t, store.closed.Load())

--- a/protocol/performance/debug_cache_state_test.go
+++ b/protocol/performance/debug_cache_state_test.go
@@ -1,0 +1,171 @@
+package performance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/magma-Devs/smart-router/ecosystem/cache/core"
+	"github.com/magma-Devs/smart-router/ecosystem/cache/redisstore"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+// An unconfigured cache travels as a typed-nil *Cache inside a non-nil CacheBackend,
+// and a typed nil still satisfies DebugCacheStateReporter — so the reporter itself
+// has to answer "not configured". A caller that decided this by whether the type
+// assertion succeeded reported a gRPC cache on a router that has none, which is the
+// default deployment.
+func TestDebugCacheStateTypedNilReportsUnconfigured(t *testing.T) {
+	var backend CacheBackend = (*Cache)(nil)
+
+	reporter, ok := backend.(DebugCacheStateReporter)
+	require.True(t, ok, "a typed nil still satisfies the interface — that is the trap")
+
+	state := reporter.DebugCacheState()
+	require.False(t, state.Configured, "a nil cache is not a configured cache")
+	require.Empty(t, state.Address)
+	require.Nil(t, state.Reachable, "nothing to report about a tier that does not exist")
+}
+
+// Reading cache state must not touch the connection. CacheActive() reaches
+// getClient(), which spawns `go reconnectClient()` when no client is installed — so
+// asking "is the cache up?" through the serving path DIALS the cache. A monitoring
+// scrape would change the state it measures.
+func TestDebugCacheStateDoesNotTriggerReconnect(t *testing.T) {
+	// A store with no client installed: exactly the shape whose getClient() spawns a
+	// reconnect loop. The ctx is cancelled at the end so the loop the contrast half
+	// of this test deliberately starts does not outlive it.
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	store := &relayerCacheClientStore{ctx: ctx, address: "cache-be:20100"}
+	cache := &Cache{clientStore: store, serviceCtx: ctx}
+
+	state := cache.DebugCacheState()
+
+	// Never rather than a bare False: reconnectClient sets this flag from a
+	// goroutine, so an immediate read could pass simply by winning the race.
+	require.Never(t, func() bool { return store.reconnecting.Load() },
+		200*time.Millisecond, 10*time.Millisecond,
+		"reading cache state must not start a reconnect loop")
+
+	require.True(t, state.Configured, "the tier is configured — it just has no live connection")
+	require.NotNil(t, state.Reachable)
+	require.False(t, *state.Reachable)
+	require.Equal(t, CacheEngineGRPC, state.Engine)
+	require.Equal(t, "cache-be:20100", state.Address)
+	require.Equal(t, CacheWhenUnreachableSkipped, state.WhenUnreachable,
+		"an unreachable gRPC tier is bypassed before any I/O, so it costs nothing per relay")
+
+	// The contrast that makes the point, and proves the check above is not vacuous:
+	// the serving path DOES start one against the same store.
+	require.Nil(t, store.getClient())
+	require.Eventually(t, func() bool { return store.reconnecting.Load() },
+		5*time.Second, 10*time.Millisecond,
+		"getClient is the mutating path this endpoint must avoid")
+}
+
+// A gRPC tier reports no TTLs at all rather than zeroes: its expirations are
+// configured in, and applied by, the cache-be pod. Reporting 0 asserted a TTL no
+// deployment uses.
+func TestDebugCacheStateGRPCReportsNoLifetimes(t *testing.T) {
+	store := &relayerCacheClientStore{ctx: context.Background(), address: "cache-be:20100"}
+	cache := &Cache{clientStore: store, serviceCtx: context.Background()}
+
+	require.Nil(t, cache.DebugCacheState().Lifetimes)
+}
+
+func newMiniRespCache(t *testing.T) (*RespCache, *miniredis.Miniredis) {
+	t.Helper()
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	store, err := redisstore.NewWithClient(client, "srtest")
+	require.NoError(t, err)
+	return newRespCacheWithHealthInterval(store, core.DefaultPolicy(), time.Hour), server
+}
+
+// Reachability starts as UNKNOWN, not false. The health loop's first probe is a PING
+// with a 3s budget; a zero-valued bool reports a perfectly healthy backend as
+// unreachable until it returns, so anything that starts the router and polls promptly
+// sees a false outage.
+func TestRespCacheReachabilityIsUnknownBeforeFirstProbe(t *testing.T) {
+	// Built directly, so the health loop never runs and the pre-probe state is
+	// observable deterministically rather than by racing it.
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	store, err := redisstore.NewWithClient(client, "srtest")
+	require.NoError(t, err)
+	cache := &RespCache{
+		engine:     &core.Engine{Store: store, Policy: core.DefaultPolicy()},
+		store:      store,
+		metrics:    getRespCacheMetrics(),
+		healthStop: make(chan struct{}),
+	}
+
+	state := cache.DebugCacheState()
+	require.True(t, state.Configured)
+	require.Nil(t, state.Reachable,
+		"before the first probe the answer is unknown, which is not the same as down")
+	require.Contains(t, state.Detail, "no health probe")
+}
+
+func TestRespCacheDebugState(t *testing.T) {
+	cache, server := newMiniRespCache(t)
+	t.Cleanup(func() { _ = cache.Close() })
+
+	require.Eventually(t, func() bool {
+		return cache.DebugCacheState().Reachable != nil
+	}, 5*time.Second, 10*time.Millisecond, "the startup probe should publish a verdict")
+
+	state := cache.DebugCacheState()
+	require.True(t, state.Configured)
+	require.Equal(t, CacheEngineRESP, state.Engine)
+	require.NotNil(t, state.Reachable)
+	require.True(t, *state.Reachable)
+	require.False(t, state.CheckedAt.IsZero(),
+		"a periodic snapshot must carry its timestamp so a reader can see how stale it is")
+	require.Contains(t, state.Address, server.Addr(),
+		"the address must survive the NewWithClient seam every RESP test injects through")
+	require.Contains(t, state.Address, "prefix=srtest",
+		"the key prefix decides which keyspace this router occupies")
+
+	// Unlike the gRPC tier, an unreachable RESP backend is still asked on every
+	// relay and pays the full cache timeout each time.
+	require.Equal(t, CacheWhenUnreachableAttempted, state.WhenUnreachable)
+
+	// This backend owns its policy, so it can answer where a cache-be tier cannot.
+	require.NotNil(t, state.Lifetimes)
+	require.Equal(t, core.DefaultPolicy().Finalized.Seconds(), state.Lifetimes.FinalizedSeconds)
+	require.Equal(t, core.DefaultPolicy().NonFinalized.Seconds(), state.Lifetimes.NonFinalizedSeconds)
+}
+
+// Close stops the health loop, so whatever it published last would otherwise stand
+// forever — leaving a closed cache reporting reachable:true for connections that no
+// longer exist. The window is real: the router closes the cache while the debug
+// server is torn down independently, with no ordering between them.
+func TestRespCacheCloseClearsReachability(t *testing.T) {
+	cache, _ := newMiniRespCache(t)
+
+	require.Eventually(t, func() bool {
+		state := cache.DebugCacheState()
+		return state.Reachable != nil && *state.Reachable
+	}, 5*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, cache.Close())
+
+	state := cache.DebugCacheState()
+	require.NotNil(t, state.Reachable)
+	require.False(t, *state.Reachable, "a closed cache is not reachable")
+	require.Contains(t, state.Detail, "closed")
+
+	require.NoError(t, cache.Close(), "second Close is a no-op")
+}
+
+// A typed-nil RespCache must be as inert as a typed-nil *Cache.
+func TestRespCacheDebugStateTypedNil(t *testing.T) {
+	var cache *RespCache
+	state := cache.DebugCacheState()
+	require.False(t, state.Configured)
+	require.Nil(t, state.Reachable)
+}

--- a/protocol/performance/resp_cache.go
+++ b/protocol/performance/resp_cache.go
@@ -34,7 +34,24 @@ type RespCache struct {
 
 	healthStop chan struct{}
 	closeOnce  sync.Once
-	reachable  atomic.Bool
+	// health is the last probe result, published for GET /debug/cache-state. Stored
+	// as a whole snapshot behind one atomic so the verdict, its timestamp and its
+	// reason can never be read torn apart from each other.
+	health atomic.Pointer[respCacheHealth]
+}
+
+// respCacheHealth is one health-probe result. Its ABSENCE (a nil pointer in
+// RespCache.health) is meaningful and is the zero state: the probe has not
+// completed yet. A plain atomic.Bool cannot express that — it zero-values to
+// false, so a healthy backend reads as unreachable for the first probe interval,
+// and anything that starts the router and polls promptly sees a false outage.
+type respCacheHealth struct {
+	reachable bool
+	at        time.Time
+	// detail preserves what a boolean throws away: an authentication rejection
+	// reported as plain "unreachable" sends an operator to check networking when
+	// the real fault is a credential.
+	detail string
 }
 
 var _ CacheBackend = (*RespCache)(nil)
@@ -72,8 +89,19 @@ func (cache *RespCache) healthLoop(interval time.Duration) {
 		return err == nil, err
 	}
 
+	// publishHealth records the probe for /debug/cache-state. safeProbeDetail is
+	// reused rather than storing the raw error: it reduces an auth rejection to a
+	// fixed phrase, because the server's reply names the failing user and no
+	// credential may reach a debug endpoint any more than a log.
+	publishHealth := func(connected bool, err error) {
+		cache.health.Store(&respCacheHealth{
+			reachable: connected,
+			at:        time.Now(),
+			detail:    safeProbeDetail(err),
+		})
+	}
+
 	updateGauges := func(connected bool) {
-		cache.reachable.Store(connected)
 		if connected {
 			cache.metrics.connected.Set(1)
 		} else {
@@ -87,6 +115,7 @@ func (cache *RespCache) healthLoop(interval time.Duration) {
 	}
 
 	lastConnected, probeErr := probe()
+	publishHealth(lastConnected, probeErr)
 	updateGauges(lastConnected)
 	if !lastConnected {
 		logUnavailable("resp-cache backend unavailable at startup; relays degrade to cache misses until it recovers", probeErr)
@@ -111,6 +140,7 @@ func (cache *RespCache) healthLoop(interval time.Duration) {
 				}
 				lastConnected = connected
 			}
+			publishHealth(connected, err)
 			updateGauges(connected)
 		}
 	}
@@ -179,15 +209,54 @@ func (cache *RespCache) CacheActive() bool {
 	return cache != nil
 }
 
-func (cache *RespCache) CacheEngine() string { return "resp" }
-func (cache *RespCache) CacheAddress() string {
+// DebugCacheState reports this tier for GET /debug/cache-state. Read-only: it
+// reads the last published health snapshot rather than probing, so a scrape
+// cannot perturb what it measures.
+//
+// Reachability here is a SNAPSHOT up to respCacheHealthInterval +
+// respCachePingTimeout old, not a live read — hence CheckedAt, so a consumer can
+// see how stale the verdict is instead of assuming it is current.
+func (cache *RespCache) DebugCacheState() DebugCacheState {
 	if cache == nil || cache.store == nil {
-		return ""
+		return DebugCacheState{Engine: CacheEngineRESP}
 	}
-	return cache.store.ConfiguredAddresses()
+	state := DebugCacheState{
+		Configured: true,
+		Engine:     CacheEngineRESP,
+		Address:    cache.store.ConfiguredEndpoints(),
+		// The opposite of the gRPC tier, and the reason this field exists:
+		// CacheActive() is unconditionally true here, so an unreachable RESP
+		// backend is still asked on every relay and pays the full cache timeout
+		// each time. Same reachable:false, entirely different operational cost.
+		WhenUnreachable: CacheWhenUnreachableAttempted,
+		Lifetimes:       cache.lifetimes(),
+	}
+	// A nil snapshot means the first probe has not returned yet. Left as nil
+	// Reachable ("not determined") rather than false, which would report a
+	// perfectly healthy backend as down to anything polling at startup.
+	if health := cache.health.Load(); health != nil {
+		state.Reachable = boolPtr(health.reachable)
+		state.CheckedAt = health.at
+		state.Detail = health.detail
+	} else {
+		state.Detail = "no health probe has completed yet"
+	}
+	return state
 }
-func (cache *RespCache) CacheReachable() bool {
-	return cache != nil && cache.reachable.Load()
+
+// lifetimes reports the TTL policy this backend actually applies. It can answer
+// where a cache-be tier cannot: the policy is a field on the in-process engine,
+// whereas the gRPC client's TTLs are owned by a different pod.
+func (cache *RespCache) lifetimes() *CacheLifetimes {
+	if cache == nil || cache.engine == nil {
+		return nil
+	}
+	policy := cache.engine.Policy
+	return &CacheLifetimes{
+		FinalizedSeconds:    policy.Finalized.Seconds(),
+		NonFinalizedSeconds: policy.NonFinalized.Seconds(),
+		NodeErrorsSeconds:   policy.NodeErrors.Seconds(),
+	}
 }
 
 // GetEntry answers like the seam it replaces — the gRPC cache CLIENT: the
@@ -244,6 +313,15 @@ func (cache *RespCache) Close() error {
 	var err error
 	cache.closeOnce.Do(func() {
 		close(cache.healthStop)
+		// Publish the closed state before tearing the clients down. The health loop
+		// stops here, so whatever it published last would otherwise stand forever —
+		// and a cache closed while reachable would keep reporting reachable:true for
+		// connections that no longer exist. That window is reachable in practice:
+		// RPCSmartRouter.Stop() closes the cache while the debug server is torn down
+		// independently by its own ctx watcher, with no ordering between them. The
+		// gRPC tier already flips false on close (its connection goes away), so
+		// without this the two engines disagree about what a closed cache looks like.
+		cache.health.Store(&respCacheHealth{at: time.Now(), detail: "cache backend closed"})
 		err = cache.store.Close()
 	})
 	return err

--- a/protocol/performance/resp_cache.go
+++ b/protocol/performance/resp_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/magma-Devs/smart-router/ecosystem/cache/core"
@@ -33,6 +34,7 @@ type RespCache struct {
 
 	healthStop chan struct{}
 	closeOnce  sync.Once
+	reachable  atomic.Bool
 }
 
 var _ CacheBackend = (*RespCache)(nil)
@@ -71,6 +73,7 @@ func (cache *RespCache) healthLoop(interval time.Duration) {
 	}
 
 	updateGauges := func(connected bool) {
+		cache.reachable.Store(connected)
 		if connected {
 			cache.metrics.connected.Set(1)
 		} else {
@@ -174,6 +177,17 @@ func (cache *RespCache) BackendEndpoint() string {
 // (a lookup that errors is a miss) rather than flipping the whole cache off.
 func (cache *RespCache) CacheActive() bool {
 	return cache != nil
+}
+
+func (cache *RespCache) CacheEngine() string { return "resp" }
+func (cache *RespCache) CacheAddress() string {
+	if cache == nil || cache.store == nil {
+		return ""
+	}
+	return cache.store.ConfiguredAddresses()
+}
+func (cache *RespCache) CacheReachable() bool {
+	return cache != nil && cache.reachable.Load()
 }
 
 // GetEntry answers like the seam it replaces — the gRPC cache CLIENT: the

--- a/protocol/rpcsmartrouter/debug_cache_state_test.go
+++ b/protocol/rpcsmartrouter/debug_cache_state_test.go
@@ -1,0 +1,352 @@
+package rpcsmartrouter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/magma-Devs/smart-router/protocol/performance"
+	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
+	"github.com/stretchr/testify/require"
+)
+
+// stubCacheStateBackend is a CacheBackend that reports a canned DebugCacheState, so
+// every tier shape can be exercised without standing up a gRPC client or a Redis.
+type stubCacheStateBackend struct {
+	state performance.DebugCacheState
+	// probed records that something asked this backend for liveness through the
+	// SERVING path. The endpoint must never do that: on the real gRPC client
+	// CacheActive() reaches getClient(), which spawns a reconnect.
+	probed *bool
+}
+
+func (s *stubCacheStateBackend) CacheActive() bool {
+	if s.probed != nil {
+		*s.probed = true
+	}
+	return true
+}
+
+func (s *stubCacheStateBackend) GetEntry(ctx context.Context, _ *pairingtypes.RelayCacheGet) (*pairingtypes.CacheRelayReply, error) {
+	return &pairingtypes.CacheRelayReply{}, nil
+}
+
+func (s *stubCacheStateBackend) SetEntry(ctx context.Context, _ *pairingtypes.RelayCacheSet) error {
+	return nil
+}
+func (s *stubCacheStateBackend) Flush(ctx context.Context) error { return nil }
+func (s *stubCacheStateBackend) Close() error                    { return nil }
+func (s *stubCacheStateBackend) DebugCacheState() performance.DebugCacheState {
+	return s.state
+}
+
+// stubCacheStateReader is the secondary-tier equivalent (CacheReader is read-only).
+type stubCacheStateReader struct {
+	state performance.DebugCacheState
+}
+
+func (s *stubCacheStateReader) CacheActive() bool { return true }
+func (s *stubCacheStateReader) GetEntry(ctx context.Context, _ *pairingtypes.RelayCacheGet) (*pairingtypes.CacheRelayReply, error) {
+	return &pairingtypes.CacheRelayReply{}, nil
+}
+func (s *stubCacheStateReader) DebugCacheState() performance.DebugCacheState { return s.state }
+
+func getCacheState(t *testing.T, deps debugMuxDeps) (*httptest.ResponseRecorder, debugCacheStateResponse) {
+	t.Helper()
+	mux := buildDebugMux(deps)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/debug/cache-state", nil))
+
+	var resp debugCacheStateResponse
+	if rr.Code == http.StatusOK {
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp), "body: %s", rr.Body.String())
+	}
+	return rr, resp
+}
+
+func grpcTier(address string, reachable *bool) performance.DebugCacheState {
+	return performance.DebugCacheState{
+		Configured:      true,
+		Engine:          performance.CacheEngineGRPC,
+		Address:         address,
+		Reachable:       reachable,
+		WhenUnreachable: performance.CacheWhenUnreachableSkipped,
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// The regression that made this endpoint lie on the DEFAULT deployment: a router
+// started with no --cache-be at all reported that it had a gRPC cache.
+//
+// SelectCacheBackend returns `var cache CacheBackend = (*Cache)(nil)` when nothing is
+// configured. A typed nil inside a non-nil interface still satisfies
+// DebugCacheStateReporter, so a handler that decided "configured" by whether the
+// assertion succeeded took the branch and answered engine "grpc", configured true —
+// byte-identical to a configured-but-down cache except for a missing address.
+func TestCacheStateTypedNilCacheIsNotConfigured(t *testing.T) {
+	t.Run("typed-nil primary reports no cache", func(t *testing.T) {
+		var unconfigured performance.CacheBackend = (*performance.Cache)(nil)
+
+		_, resp := getCacheState(t, debugMuxDeps{cache: unconfigured})
+
+		require.Equal(t, "none", resp.Engine,
+			"a router with no cache configured must not claim an engine")
+		require.False(t, resp.Tiers.Primary.Configured)
+		require.Nil(t, resp.Tiers.Primary.Reachable,
+			"an absent tier has no reachability to report")
+		require.Empty(t, resp.Tiers.Primary.Engine,
+			"the engine of the type carrying the nil is not a fact about this router")
+	})
+
+	t.Run("typed-nil secondary reports no cache", func(t *testing.T) {
+		var unconfigured performance.CacheReader = (*performance.Cache)(nil)
+
+		_, resp := getCacheState(t, debugMuxDeps{secondaryCache: unconfigured})
+
+		require.Equal(t, "none", resp.Engine)
+		require.False(t, resp.Tiers.Secondary.Configured)
+	})
+
+	t.Run("a nil interface is equally safe", func(t *testing.T) {
+		_, resp := getCacheState(t, debugMuxDeps{})
+		require.Equal(t, "none", resp.Engine)
+		require.False(t, resp.Tiers.Primary.Configured)
+		require.False(t, resp.Tiers.Secondary.Configured)
+	})
+}
+
+// engine is a convenience field read from the tier that is serving. A secondary-only
+// router is a documented topology — reads work, nothing backfills — so reporting
+// "none" there would tell a reader no cache is in play while one serves every read.
+func TestCacheStateEngineFallsBackToSecondary(t *testing.T) {
+	t.Run("secondary-only router names the secondary's engine", func(t *testing.T) {
+		_, resp := getCacheState(t, debugMuxDeps{
+			secondaryCache: &stubCacheStateReader{state: grpcTier("secondary:20100", boolPtr(true))},
+		})
+
+		require.Equal(t, performance.CacheEngineGRPC, resp.Engine,
+			"a configured secondary is an engine in use")
+		require.False(t, resp.Tiers.Primary.Configured)
+		require.True(t, resp.Tiers.Secondary.Configured)
+	})
+
+	t.Run("primary wins when both are configured", func(t *testing.T) {
+		_, resp := getCacheState(t, debugMuxDeps{
+			cache: &stubCacheStateBackend{state: performance.DebugCacheState{
+				Configured: true, Engine: performance.CacheEngineRESP, Address: "redis:6379",
+				WhenUnreachable: performance.CacheWhenUnreachableAttempted,
+			}},
+			secondaryCache: &stubCacheStateReader{state: grpcTier("secondary:20100", boolPtr(true))},
+		})
+
+		require.Equal(t, performance.CacheEngineRESP, resp.Engine)
+	})
+
+	// The pairing docs call unsupported and nothing validates: the secondary is
+	// always a gRPC client while the primary becomes RESP whenever the resp-cache
+	// block is set. A single top-level engine cannot express it, which is why the
+	// tier carries its own — this is the endpoint's most valuable diagnosis.
+	t.Run("a mixed-engine deployment is visible per tier", func(t *testing.T) {
+		_, resp := getCacheState(t, debugMuxDeps{
+			cache: &stubCacheStateBackend{state: performance.DebugCacheState{
+				Configured: true, Engine: performance.CacheEngineRESP, Address: "redis:6379",
+				WhenUnreachable: performance.CacheWhenUnreachableAttempted,
+			}},
+			secondaryCache: &stubCacheStateReader{state: grpcTier("cache-be:20100", boolPtr(true))},
+		})
+
+		require.Equal(t, performance.CacheEngineRESP, resp.Tiers.Primary.Engine)
+		require.Equal(t, performance.CacheEngineGRPC, resp.Tiers.Secondary.Engine,
+			"the two tiers running different engines must be readable, not averaged away")
+	})
+}
+
+// reachable:false means opposite things per engine — the gRPC tier is skipped before
+// any I/O, the RESP tier still issues every lookup and pays the full timeout. Same
+// key, opposite operational cost, so the payload has to say which.
+func TestCacheStateReportsWhatUnreachableCosts(t *testing.T) {
+	_, resp := getCacheState(t, debugMuxDeps{
+		cache: &stubCacheStateBackend{state: performance.DebugCacheState{
+			Configured: true, Engine: performance.CacheEngineRESP, Address: "redis:6379",
+			Reachable:       boolPtr(false),
+			WhenUnreachable: performance.CacheWhenUnreachableAttempted,
+		}},
+		secondaryCache: &stubCacheStateReader{state: grpcTier("cache-be:20100", boolPtr(false))},
+	})
+
+	require.Equal(t, performance.CacheWhenUnreachableAttempted, resp.Tiers.Primary.WhenUnreachable,
+		"a dead RESP backend is still asked on every relay")
+	require.Equal(t, performance.CacheWhenUnreachableSkipped, resp.Tiers.Secondary.WhenUnreachable,
+		"a dead gRPC tier is bypassed and costs nothing")
+}
+
+// null reachability is a real third state, not a missing value: a RESP backend before
+// its first probe returns, a gRPC connection mid-dial. Collapsing it into false
+// reports a healthy backend as down to anything that polls at startup.
+func TestCacheStateReachabilityIsThreeState(t *testing.T) {
+	cases := []struct {
+		name      string
+		reachable *bool
+		wantJSON  string
+	}{
+		{"reachable", boolPtr(true), `"reachable":true`},
+		{"unreachable", boolPtr(false), `"reachable":false`},
+		{"not determined yet", nil, `"reachable":null`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr, resp := getCacheState(t, debugMuxDeps{
+				cache: &stubCacheStateBackend{state: grpcTier("cache-be:20100", tc.reachable)},
+			})
+
+			require.Contains(t, rr.Body.String(), tc.wantJSON)
+			require.True(t, resp.Tiers.Primary.Configured,
+				"reachability never decides whether a tier is configured")
+			if tc.reachable == nil {
+				require.Nil(t, resp.Tiers.Primary.Reachable)
+			} else {
+				require.Equal(t, *tc.reachable, *resp.Tiers.Primary.Reachable)
+			}
+		})
+	}
+}
+
+// The lifetimes regression: they were read from the router's own viper, but the
+// expiration flags are registered on the cache-server cobra command and never on the
+// smartrouter one, so both lookups returned zero on every deployment — reported as a
+// confident "0s finalized TTL".
+func TestCacheStateLifetimesComeFromTheBackend(t *testing.T) {
+	t.Run("a backend that owns its policy reports it", func(t *testing.T) {
+		_, resp := getCacheState(t, debugMuxDeps{
+			cache: &stubCacheStateBackend{state: performance.DebugCacheState{
+				Configured: true, Engine: performance.CacheEngineRESP, Address: "redis:6379",
+				WhenUnreachable: performance.CacheWhenUnreachableAttempted,
+				Lifetimes: &performance.CacheLifetimes{
+					FinalizedSeconds: 3600, NonFinalizedSeconds: 0.5, NodeErrorsSeconds: 60,
+				},
+			}},
+		})
+
+		require.NotNil(t, resp.Tiers.Primary.Lifetimes)
+		require.Equal(t, float64(3600), resp.Tiers.Primary.Lifetimes.FinalizedSeconds)
+		require.Equal(t, 0.5, resp.Tiers.Primary.Lifetimes.NonFinalizedSeconds)
+	})
+
+	// A cache-be tier's TTLs are configured in, and applied by, a different pod.
+	// Reporting null says so; reporting 0 asserts a TTL this router cannot know and
+	// that no deployment actually uses.
+	t.Run("a tier whose TTLs live elsewhere reports null, not zero", func(t *testing.T) {
+		rr, resp := getCacheState(t, debugMuxDeps{
+			cache: &stubCacheStateBackend{state: grpcTier("cache-be:20100", boolPtr(true))},
+		})
+
+		require.Nil(t, resp.Tiers.Primary.Lifetimes)
+		require.Contains(t, rr.Body.String(), `"lifetimes":null`)
+		require.NotContains(t, rr.Body.String(), `"finalized_seconds":0`,
+			"a TTL this router cannot know must not be reported as zero")
+	})
+}
+
+// The endpoint is documented read-only and must be read-only in the strict sense: on
+// the real gRPC client, CacheActive() reaches getClient(), which spawns
+// `go reconnectClient()` — a 3s blocking dial retried every 5s. A monitoring scrape
+// would then change the state it measures, and a pod that recovered between polls
+// would look reachable BECAUSE of the previous poll.
+func TestCacheStateDoesNotProbeTheServingPath(t *testing.T) {
+	probed := false
+	_, resp := getCacheState(t, debugMuxDeps{
+		cache: &stubCacheStateBackend{
+			state:  grpcTier("cache-be:20100", boolPtr(false)),
+			probed: &probed,
+		},
+	})
+
+	require.False(t, probed,
+		"reading cache state must not call the serving-path liveness probe, which dials")
+	require.True(t, resp.Tiers.Primary.Configured, "the tier was still reported")
+}
+
+// Wire-key contract. Consumers key on these exact strings, and omitempty would erase
+// the difference between "the router cannot name this" and "the field does not
+// apply" — the distinction this endpoint exists to make.
+func TestCacheStateWireContract(t *testing.T) {
+	rr, resp := getCacheState(t, debugMuxDeps{
+		cache: &stubCacheStateBackend{state: grpcTier("cache-be:20100", boolPtr(true))},
+	})
+
+	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	require.Equal(t, 1, resp.SchemaVersion)
+
+	body := rr.Body.String()
+	for _, key := range []string{
+		`"schema_version"`, `"engine"`, `"tiers"`, `"primary"`, `"secondary"`,
+		`"configured"`, `"address"`, `"reachable"`, `"reachable_checked_at"`,
+		`"reachable_detail"`, `"when_unreachable"`, `"lifetimes"`,
+	} {
+		require.Contains(t, body, key, "wire key must be present")
+	}
+
+	t.Run("an unnameable address is reported empty, not omitted", func(t *testing.T) {
+		rr, _ := getCacheState(t, debugMuxDeps{
+			cache: &stubCacheStateBackend{state: performance.DebugCacheState{
+				Configured: true, Engine: performance.CacheEngineRESP,
+				WhenUnreachable: performance.CacheWhenUnreachableAttempted,
+			}},
+		})
+		require.Contains(t, rr.Body.String(), `"address":""`,
+			"a configured tier the router cannot name is a real condition, not an absence")
+	})
+
+	t.Run("a snapshot reachability carries its timestamp", func(t *testing.T) {
+		checked := time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)
+		_, resp := getCacheState(t, debugMuxDeps{
+			cache: &stubCacheStateBackend{state: performance.DebugCacheState{
+				Configured: true, Engine: performance.CacheEngineRESP, Address: "redis:6379",
+				Reachable: boolPtr(true), CheckedAt: checked, Detail: "no error reported",
+				WhenUnreachable: performance.CacheWhenUnreachableAttempted,
+			}},
+		})
+		require.Equal(t, "2026-09-09T12:00:00Z", resp.Tiers.Primary.ReachableCheckedAt,
+			"a periodic snapshot must say when it was taken")
+		require.Equal(t, "no error reported", resp.Tiers.Primary.ReachableDetail)
+	})
+
+	t.Run("a live reading carries no timestamp", func(t *testing.T) {
+		_, resp := getCacheState(t, debugMuxDeps{
+			cache: &stubCacheStateBackend{state: grpcTier("cache-be:20100", boolPtr(true))},
+		})
+		require.Empty(t, resp.Tiers.Primary.ReachableCheckedAt)
+	})
+}
+
+func TestCacheStateRejectsNonGet(t *testing.T) {
+	mux := buildDebugMux(debugMuxDeps{})
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/debug/cache-state", nil))
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}
+
+// The primary is read from deps.cache — the same field /debug/reset-all flushes.
+// Holding a second copy let a fixture wire one and leave the other zero, so the two
+// endpoints on one mux could contradict each other about whether a cache exists.
+func TestCacheStateAndResetAllSeeTheSameCache(t *testing.T) {
+	var offsetNano atomic.Int64
+	deps := debugMuxDeps{
+		optimizers: newEmptyOptimizersRouter(),
+		offsetNano: &offsetNano,
+		cache:      &stubCacheStateBackend{state: grpcTier("cache-be:20100", boolPtr(true))},
+	}
+
+	_, resp := getCacheState(t, deps)
+	require.True(t, resp.Tiers.Primary.Configured)
+
+	rr := postResetAllRouter(buildDebugMux(deps))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"cache-be"`,
+		"the endpoint that flushes and the endpoint that reports must agree a cache exists")
+}

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -31,6 +31,7 @@ import (
 	"syscall"
 	"time"
 
+	cachepkg "github.com/magma-Devs/smart-router/ecosystem/cache"
 	"github.com/magma-Devs/smart-router/protocol/chainlib"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcInterfaceMessages"
 	"github.com/magma-Devs/smart-router/protocol/chaintracker"
@@ -411,6 +412,8 @@ func (rpsr *RPCSmartRouter) Start(ctx context.Context, options *rpcSmartRouterSt
 			router:     rpsr,
 			cache:      options.cache,
 			qosClient:  smartRouterOptimizerQoSClient,
+			cacheState: cacheStateInfo{primary: options.cache, secondary: options.secondaryCache,
+				finalized: viper.GetDuration(cachepkg.ExpirationFlagName), nonFinalized: viper.GetDuration(cachepkg.ExpirationNonFinalizedFlagName)},
 		})
 		srv := &http.Server{Addr: options.cmdFlags.DebugAddress, Handler: debugMux}
 		// Watcher goroutine: shuts the server down gracefully when ctx is cancelled
@@ -513,7 +516,15 @@ type debugMuxDeps struct {
 	// lie on any deployment running with --cache-be (MAG-1764). Reached
 	// through cacheFlusher rather than the concrete *performance.Cache so
 	// tests can inject a fake without standing up a gRPC client.
-	cache cacheFlusher
+	cache      cacheFlusher
+	cacheState cacheStateInfo
+}
+
+type cacheStateInfo struct {
+	primary      performance.CacheBackend
+	secondary    performance.CacheReader
+	finalized    time.Duration
+	nonFinalized time.Duration
 }
 
 // debugPollNowTimeout caps how long POST /debug/poll-now waits per request (MAG-2649). A single
@@ -1045,6 +1056,33 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 	const maxDebugOffsetSeconds = float64(24 * 3600) // 86400 s
 
 	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/cache-state", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "GET only", http.StatusMethodNotAllowed)
+			return
+		}
+		type tier struct {
+			Configured bool   `json:"configured"`
+			Reachable  *bool  `json:"reachable,omitempty"`
+			Address    string `json:"address,omitempty"`
+		}
+		state := deps.cacheState
+		engine := "none"
+		primary := tier{}
+		if reporter, ok := state.primary.(performance.DebugCacheStateReporter); ok {
+			engine = reporter.CacheEngine()
+			reachable := reporter.CacheReachable()
+			primary = tier{Configured: true, Reachable: &reachable, Address: reporter.CacheAddress()}
+		}
+		secondary := tier{}
+		if reporter, ok := state.secondary.(performance.DebugCacheStateReporter); ok {
+			reachable := reporter.CacheReachable()
+			secondary = tier{Configured: true, Reachable: &reachable, Address: reporter.CacheAddress()}
+		}
+		resp := map[string]any{"engine": engine, "tiers": map[string]tier{"primary": primary, "secondary": secondary}, "lifetimes": map[string]float64{"finalized_seconds": state.finalized.Seconds(), "non_finalized_seconds": state.nonFinalized.Seconds()}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
 
 	mux.HandleFunc("/debug/time-warp", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -31,7 +31,6 @@ import (
 	"syscall"
 	"time"
 
-	cachepkg "github.com/magma-Devs/smart-router/ecosystem/cache"
 	"github.com/magma-Devs/smart-router/protocol/chainlib"
 	"github.com/magma-Devs/smart-router/protocol/chainlib/chainproxy/rpcInterfaceMessages"
 	"github.com/magma-Devs/smart-router/protocol/chaintracker"
@@ -412,8 +411,11 @@ func (rpsr *RPCSmartRouter) Start(ctx context.Context, options *rpcSmartRouterSt
 			router:     rpsr,
 			cache:      options.cache,
 			qosClient:  smartRouterOptimizerQoSClient,
-			cacheState: cacheStateInfo{primary: options.cache, secondary: options.secondaryCache,
-				finalized: viper.GetDuration(cachepkg.ExpirationFlagName), nonFinalized: viper.GetDuration(cachepkg.ExpirationNonFinalizedFlagName)},
+			// TTL lifetimes are NOT read here. The expiration flags are registered on
+			// the cache-server cobra command and never on the router's, so
+			// viper.GetDuration returns zero on every deployment; each backend reports
+			// the policy it is actually applying instead.
+			secondaryCache: options.secondaryCache,
 		})
 		srv := &http.Server{Addr: options.cmdFlags.DebugAddress, Handler: debugMux}
 		// Watcher goroutine: shuts the server down gracefully when ctx is cancelled
@@ -516,15 +518,13 @@ type debugMuxDeps struct {
 	// lie on any deployment running with --cache-be (MAG-1764). Reached
 	// through cacheFlusher rather than the concrete *performance.Cache so
 	// tests can inject a fake without standing up a gRPC client.
-	cache      cacheFlusher
-	cacheState cacheStateInfo
-}
-
-type cacheStateInfo struct {
-	primary      performance.CacheBackend
-	secondary    performance.CacheReader
-	finalized    time.Duration
-	nonFinalized time.Duration
+	cache cacheFlusher
+	// secondaryCache is the read-only second tier, for /debug/cache-state only.
+	// The primary is NOT duplicated here: it is deps.cache above. Holding it twice
+	// let a fixture wire one and leave the other zero, so on the same mux
+	// /debug/reset-all would flush a live cache while /debug/cache-state reported
+	// no cache configured — two endpoints on one router contradicting each other.
+	secondaryCache performance.CacheReader
 }
 
 // debugPollNowTimeout caps how long POST /debug/poll-now waits per request (MAG-2649). A single
@@ -974,6 +974,128 @@ type routerConfigOptimizerWeights struct {
 	SelectionMode      string
 }
 
+// debugCacheStateResponse is the JSON body of GET /debug/cache-state: which cache
+// backend is actually serving this router, and the state of each tier.
+//
+// A package-level type with explicit json tags, matching routerConfigResponse below,
+// so a consumer can unmarshal into a shared type and a contract test can assert the
+// wire keys. Declaring it inside the handler would leave every reader re-deriving the
+// shape from a map literal.
+type debugCacheStateResponse struct {
+	SchemaVersion int `json:"schema_version"`
+
+	// Engine is a convenience: the engine of the tier that is serving. It reads from
+	// the primary, falling back to the SECONDARY when no primary is configured —
+	// a secondary-only router is a documented topology (reads work, nothing
+	// backfills), and reporting "none" there would tell a reader no cache is in play
+	// while one is serving every read. "none" means neither tier is configured.
+	//
+	// Prefer the per-tier engine below when the two could differ. This field cannot
+	// express that case, and the case is real: the secondary is always a gRPC client
+	// (performance.InitCache is its only constructor) while the primary becomes RESP
+	// whenever the resp-cache block is set. That pairing is documented as
+	// unsupported but nothing validates it, so the endpoint must be able to show it
+	// rather than average it away.
+	Engine string          `json:"engine"`
+	Tiers  debugCacheTiers `json:"tiers"`
+}
+
+type debugCacheTiers struct {
+	Primary   debugCacheTier `json:"primary"`
+	Secondary debugCacheTier `json:"secondary"`
+}
+
+// debugCacheTier is one cache tier on the wire.
+//
+// No omitempty anywhere: this endpoint's whole job is telling states apart, and
+// omitempty erases the difference between "the router cannot name this" and "the
+// field does not apply". A missing address on a configured tier is a real and
+// distinct condition, not an absence.
+type debugCacheTier struct {
+	Configured bool   `json:"configured"`
+	Engine     string `json:"engine"`
+	Address    string `json:"address"`
+	// Reachable is a pointer for its THIRD state: null means reachability has not
+	// been determined — a RESP backend before its first probe returns, a gRPC
+	// connection mid-dial. Collapsing that into false reports a healthy backend as
+	// down to anything that polls at startup. Always present; "is this tier
+	// configured" is answered by Configured, not by this field's absence.
+	Reachable *bool `json:"reachable"`
+	// ReachableCheckedAt stamps a reachability value that is a periodic snapshot
+	// rather than a live read (the RESP tier's probe cadence), so a consumer can see
+	// how stale it is. Empty when the value was read live.
+	ReachableCheckedAt string `json:"reachable_checked_at"`
+	ReachableDetail    string `json:"reachable_detail"`
+	// WhenUnreachable is what the router DOES when this tier is unreachable:
+	// "skipped" (bypassed before any I/O, costs nothing) or "attempted" (every
+	// lookup still runs against the dead backend and pays the full timeout). The two
+	// engines sit on opposite sides of this, so reachable:false alone does not tell
+	// an operator whether their relays are being taxed.
+	WhenUnreachable string `json:"when_unreachable"`
+	// Lifetimes is null when this tier cannot answer for its own TTLs — a cache-be
+	// tier's expirations are configured in, and applied by, a different pod. It was
+	// previously read from the router's own viper, which returns zero on every
+	// deployment because those flags are registered on the cache-server command.
+	Lifetimes *performance.CacheLifetimes `json:"lifetimes"`
+}
+
+// buildCacheStateResponse renders both tiers. Split out of the handler so the shape
+// is testable without an HTTP round-trip.
+func buildCacheStateResponse(deps debugMuxDeps) debugCacheStateResponse {
+	// deps.cache is the same value the flush handler uses. Reading it here rather
+	// than keeping a second copy is what stops one endpoint from being wired in a
+	// fixture while the other silently reports "no cache".
+	primary := debugCacheTierFrom(deps.cache)
+	secondary := debugCacheTierFrom(deps.secondaryCache)
+
+	engine := "none"
+	switch {
+	case primary.Configured:
+		engine = primary.Engine
+	case secondary.Configured:
+		engine = secondary.Engine
+	}
+	return debugCacheStateResponse{
+		SchemaVersion: 1,
+		Engine:        engine,
+		Tiers:         debugCacheTiers{Primary: primary, Secondary: secondary},
+	}
+}
+
+// debugCacheTierFrom renders one tier from whatever the router holds for it.
+//
+// The `any` parameter is deliberate: the two tiers have different static types
+// (CacheBackend and CacheReader) and either may be absent, so the assertion is the
+// only thing they have in common.
+//
+// Note what is NOT used to decide "configured": the interface being non-nil. An
+// unconfigured cache travels as a TYPED-nil *Cache inside a non-nil interface, which
+// still satisfies the reporter — that is why a router with no cache at all used to
+// report engine "grpc" and configured true, on the default deployment. The backend
+// decides its own Configured on its own receiver.
+func debugCacheTierFrom(backend any) debugCacheTier {
+	reporter, ok := backend.(performance.DebugCacheStateReporter)
+	if !ok {
+		return debugCacheTier{}
+	}
+	state := reporter.DebugCacheState()
+	if !state.Configured {
+		// Report nothing about a tier that is not there — not even the engine name
+		// of the type that happened to be carrying the nil.
+		return debugCacheTier{}
+	}
+	return debugCacheTier{
+		Configured:         true,
+		Engine:             state.Engine,
+		Address:            state.Address,
+		Reachable:          state.Reachable,
+		ReachableCheckedAt: debugTimeRFC3339(state.CheckedAt),
+		ReachableDetail:    state.Detail,
+		WhenUnreachable:    state.WhenUnreachable,
+		Lifetimes:          state.Lifetimes,
+	}
+}
+
 // routerConfigResponse is the JSON body of GET /debug/runtime-config. It exposes the
 // router's live tuning values so the test suite can read them at runtime instead of
 // hardcoding copies that silently drift when the source changes (e.g. when
@@ -1056,32 +1178,27 @@ func buildDebugMux(deps debugMuxDeps) *http.ServeMux {
 	const maxDebugOffsetSeconds = float64(24 * 3600) // 86400 s
 
 	mux := http.NewServeMux()
+	// GET /debug/cache-state — which cache backend is serving, per tier. Read-only
+	// and nil-router safe like the rest of /debug/*, and read-only in the strict
+	// sense: it never touches a connection. The obvious liveness accessor does
+	// (CacheActive -> getClient spawns a reconnect), so both backends answer through
+	// DebugCacheState, which is contractually side-effect free. A monitoring scrape
+	// must not be able to change the state it is measuring.
 	mux.HandleFunc("/debug/cache-state", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "GET only", http.StatusMethodNotAllowed)
 			return
 		}
-		type tier struct {
-			Configured bool   `json:"configured"`
-			Reachable  *bool  `json:"reachable,omitempty"`
-			Address    string `json:"address,omitempty"`
-		}
-		state := deps.cacheState
-		engine := "none"
-		primary := tier{}
-		if reporter, ok := state.primary.(performance.DebugCacheStateReporter); ok {
-			engine = reporter.CacheEngine()
-			reachable := reporter.CacheReachable()
-			primary = tier{Configured: true, Reachable: &reachable, Address: reporter.CacheAddress()}
-		}
-		secondary := tier{}
-		if reporter, ok := state.secondary.(performance.DebugCacheStateReporter); ok {
-			reachable := reporter.CacheReachable()
-			secondary = tier{Configured: true, Reachable: &reachable, Address: reporter.CacheAddress()}
-		}
-		resp := map[string]any{"engine": engine, "tiers": map[string]tier{"primary": primary, "secondary": secondary}, "lifetimes": map[string]float64{"finalized_seconds": state.finalized.Seconds(), "non_finalized_seconds": state.nonFinalized.Seconds()}}
+		resp := buildCacheStateResponse(deps)
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
+		body, err := json.Marshal(resp)
+		if err != nil {
+			// Scalars and fixed structs only — Marshal cannot realistically fail;
+			// surface a 500 rather than a half-written body, as runtime-config does.
+			http.Error(w, "failed to marshal cache state", http.StatusInternalServerError)
+			return
+		}
+		w.Write(body)
 	})
 
 	mux.HandleFunc("/debug/time-warp", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Jira ticket: MAG-3478

## Summary

Adds read-only `GET /debug/cache-state`: which cache backend is actually serving, per-tier configuration and reachability, the addresses each tier uses, and the TTL policy the backend is applying.

## Response shape

`debugCacheStateResponse` is a package-level type with a `SchemaVersion`, matching the `/debug/runtime-config` convention so a consumer can unmarshal into a shared type.

Engine lives **on the tier**, not at the top level. The secondary is always a gRPC `*Cache` (`performance.InitCache` is its only constructor) while the primary becomes `*RespCache` whenever the `resp-cache` block is set — so a single top-level scalar both concealed a two-engine deployment and reported `none` for a secondary-only router. A top-level `engine` remains as a convenience, falling back to the secondary when no primary is configured.

`reachable` is a `*bool` that is always present: `true`, `false`, or `null` for "not determined yet". `null` is a real state — a RESP backend before its first probe returns, and a gRPC connection mid-dial. Collapsing it into `false` reports a healthy backend as unreachable to anything that polls promptly.

Because `reachable:false` means opposite things per engine — gRPC skips the tier entirely, RESP still issues every lookup and pays the full timeout — each tier carries `when_unreachable` stating which.

## Reachability is now read, not latched

`CacheReachable()` for the gRPC tier reads the `grpc.ClientConn` connectivity state instead of "a client pointer is installed". Two consequences:

- **The endpoint no longer mutates what it measures.** The old path went `CacheActive() → getClient()`, which spawns `go reconnectClient()` when the client is nil — so observing a down cache dialled it. `GetState()` has no side effects.
- **It stops being a latch.** The installed-pointer signal was cleared only by `resetOnConnectionError` on `codes.Unavailable` from a relay, so an idle router reported `reachable:true` for a backend killed an hour earlier.

A hanging backend still reads `reachable:true` — the transport genuinely is up — and that is documented rather than papered over.

## Bugs fixed

- **A router with no cache reported that it had one.** `SelectCacheBackend` returns `(*Cache)(nil)`; a typed nil in a non-nil interface still satisfies the reporter interface, so the default deployment answered `{"engine":"grpc","primary":{"configured":true}}`. Configuration is now discriminated on the address, not on the interface being non-nil.
- **`lifetimes` was always `0`/`0`.** The expiration flags are registered on the cache-server cobra command, never on the smartrouter one, so both `viper.GetDuration` calls returned zero on every deployment. Lifetimes now come from the backend that owns the policy, and are `null` for a `cache-be` tier whose TTLs live in another pod.
- **`RespCache.Close()` left `reachable` true** for a closed backend, observable during shutdown because the debug server and the cache close independently.
- **RESP addresses dropped `read-addresses` and `key-prefix`.** `Store.Ping` probes both clients, so a dead reader flipped `reachable` to `false` while the payload named only the healthy writer.
- **`NewWithClient`/`NewWithClients` produced a permanently empty address**, which is the seam every RESP test uses. Addresses are now derived from the client when no operator config is present.

## Interfaces

`var _ DebugCacheStateReporter` assertions added for both backends — the endpoint hangs on a runtime type assertion that would otherwise stop matching silently on a rename. `Cache.CacheAddress()` and `Cache.BackendEndpoint()` now read one field instead of two coincidentally-equal ones.

`debugMuxDeps` no longer stores the cache twice; the handler asserts on the existing `cache` field, so a test fixture cannot wire one endpoint and not the other.

## Security note

This is the first `/debug` route to expose the router's own backing-store addresses, and the debug listener has no authentication. No credential travels in these fields (`Password`/`PasswordFile` are separate config), but under `topology: sentinel` these are sentinel control-plane addresses. Documented with an explicit bind-to-loopback warning.

## Verification

Unit tests added covering every tier shape, the wire-key contract, the typed-nil and lifetimes regressions, and the read-only guarantee. Run from a clean worktree checkout of the head commit.

Note that CI on this repo does not run `go test` — the green checks below are builds, lint, govulncheck and the Jira gate — so the local run is the test evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)