### PR TITLE
feat(cache): make the tier that served a request readable off the reply (MAG-3540)

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -365,6 +365,17 @@ across `outcome`, where before `_failed_total` was a single series.
 > (`cache_tier="secondary"`) appears only when `secondary-cache-be` is
 > configured; see `docs/SECONDARY-CACHE.md`.
 
+> **Do not use these counters to check a single request.** They are incremented
+> on a detached goroutine **after** the reply is written, and nothing orders the
+> two — so reading one straight after its reply is a race, and polling until it
+> settles makes the result depend on how long you waited rather than on what the
+> router did. Send the `lava-debug-relay` directive instead and read
+> `Lava-Cache-Tier` / `Lava-Cache-Outcome` off the reply, which cannot race
+> because it *is* the reply. The `outcome` values are the same four, plus `off`
+> / `skipped` / `unknown` for a tier that was not consulted (those three never
+> label a metric — there was no lookup to count). See
+> [SECONDARY-CACHE.md](SECONDARY-CACHE.md#reading-the-tier-per-request).
+
 #### RESP cache backend — `smartrouter_resp_cache_*`
 
 Present only when the router runs with a RESP-compatible (Redis/Valkey) cache

--- a/docs/SECONDARY-CACHE.md
+++ b/docs/SECONDARY-CACHE.md
@@ -86,11 +86,11 @@ outside the router — the last column is what you look at to confirm it.
 
 | Situation | What the router does | How you see it |
 | --- | --- | --- |
-| **Primary misses, secondary has it** | Serves the secondary's answer to the caller, then copies it into the primary. No upstream call. | Response header `Lava-Provider-Address: Cached`; `smartrouter_cache_success_total{cache_tier="secondary"}` increments |
-| **Both tiers miss** | Falls through to your upstream nodes exactly as it does today. The only cost is the one extra lookup, bounded by the timeout. | `smartrouter_cache_failed_total{cache_tier="secondary",outcome="miss"}` increments; the response carries a real upstream address |
+| **Primary misses, secondary has it** | Serves the secondary's answer to the caller, then copies it into the primary. No upstream call. | `Lava-Cache-Tier: secondary` on the reply (under `lava-debug-relay`); `smartrouter_cache_success_total{cache_tier="secondary"}` increments |
+| **Both tiers miss** | Falls through to your upstream nodes exactly as it does today. The only cost is the one extra lookup, bounded by the timeout. | `Lava-Cache-Outcome: primary=miss,secondary=miss` on the reply; `smartrouter_cache_failed_total{cache_tier="secondary",outcome="miss"}` increments; the response carries a real upstream address |
 | **Secondary is configured read-only** | Reads it, never writes it — for responses or for admin operations. | No write traffic from this router in the secondary's log. The router has no code path that can write it (see below) |
-| **Secondary is down, slow, or unreachable** | Skips the tier and goes to upstreams. Reconnects in the background. Request serving is unaffected. | `outcome="error"` or `outcome="timeout"` on `smartrouter_cache_failed_total`; latency stays inside `secondary-cache-timeout` |
-| **No secondary configured** (the default) | Identical to previous releases. Nothing is added to the request path. | No `cache_tier="secondary"` series exist at all |
+| **Secondary is down, slow, or unreachable** | Skips the tier and goes to upstreams. Reconnects in the background. Request serving is unaffected. | `Lava-Cache-Outcome: …,secondary=error` (or `timeout`) alongside a real upstream address on the same reply — both halves at once; the matching `smartrouter_cache_failed_total` outcome; latency stays inside `secondary-cache-timeout` |
+| **No secondary configured** (the default) | Identical to previous releases. Nothing is added to the request path. | `Lava-Cache-Outcome: …,secondary=off`; no `cache_tier="secondary"` series exist at all |
 
 Two of these are worth calling out because they are guaranteed rather than
 merely implemented:
@@ -162,6 +162,58 @@ enabled, each lookup is a span carrying `cache.tier` and `cache.outcome`, and
 the request's root span records which tier served it. See
 [METRICS.md](METRICS.md#cache) for the full reference and the dashboard
 migration note.
+
+### Reading the tier per request
+
+The counters answer "which tier is serving my traffic". They cannot answer
+"which tier served *this* request" — they are incremented on a separate thread
+**after** the reply has already been written, so reading one straight after a
+reply is a race, and waiting for it makes the answer a matter of timing rather
+than of what the router did.
+
+Send `lava-debug-relay` and the reply carries the answer itself:
+
+```bash
+curl -si -X POST http://<router>:3360 -H 'Content-Type: application/json' \
+  -H 'lava-debug-relay: true' \
+  -d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x1194567",false],"id":1}' \
+  | grep -i lava-cache
+```
+
+```
+Lava-Cache-Tier: secondary
+Lava-Cache-Outcome: primary=miss,secondary=hit
+```
+
+`Lava-Cache-Tier` is the tier that served — `primary`, `secondary`, or `none`
+when a provider answered. `Lava-Cache-Outcome` always names both tiers, in that
+order, so a caller can match the whole string:
+
+| Outcome value | The tier was |
+| --- | --- |
+| `hit` / `miss` / `error` / `timeout` | consulted; same four values the `outcome` metric label uses |
+| `off` | not consulted — unconfigured, or its client has marked itself disconnected |
+| `skipped` | active but not asked: a bypass rule applied (cross-validation, stateful, `lava-force-cache-refresh`, a non-cacheable block), or the primary hit first and the secondary is only consulted after a primary non-hit |
+| `unknown` | not observed at all — this reply was built on a path that performs no cache lookup |
+
+Both headers are emitted on every reply that carries the directive, including
+`none` and the not-consulted values. An absent header therefore means only
+"router too old, or the directive was not honored" — never "nothing served it".
+
+Two limits worth knowing:
+
+- **They describe the winning attempt.** Retries and hedges each run their own
+  cache lookup; the reply reports the lookups made on the attempt whose response
+  you received.
+- **WebSocket has no per-message response headers**, so a cache hit delivered
+  over a subscription cannot carry them — the same limitation
+  `Lava-Provider-Address` already has there. Use the counters for WebSocket.
+
+Under `--debug-relays` (the operator flag, not this directive) a cache hit also
+carries `Lava-Cache-Backend`, naming the node that served it — the primary's
+cache-be address or the secondary's, chosen by the tier that actually answered.
+That one stays behind the flag because it exposes an internal infrastructure
+address, which no client should be able to ask for.
 
 ## Seeing it work
 
@@ -395,15 +447,29 @@ Serve two blocks neither cache holds:
 
 ```bash
 for b in 0x1030301 0x1030302; do
-  curl -s --max-time 25 -X POST http://127.0.0.1:3360 -H 'Content-Type: application/json' \
-    -d "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getBlockByNumber\",\"params\":[\"$b\",false],\"id\":1}" | head -c 500; echo
+  curl -si --max-time 25 -X POST http://127.0.0.1:3360 -H 'Content-Type: application/json' \
+    -H 'lava-debug-relay: true' \
+    -d "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getBlockByNumber\",\"params\":[\"$b\",false],\"id\":1}" \
+    | grep -iE 'lava-provider-address|lava-cache-outcome'
 done
 sleep 1
 curl -s http://127.0.0.1:7779/metrics | grep '^smartrouter_cache_failed_total' \
   | grep 'cache_tier="secondary"' | grep eth_getBlockByNumber
 ```
 
-Both requests return real block data from upstream, and the metrics show:
+Both requests return real block data from upstream, and the headers show both
+halves of the acceptance criterion on the same reply — a provider served it,
+**and** the secondary failed on the way:
+
+```
+Lava-Provider-Address: 0x…                        ← a real upstream, not "Cached"
+Lava-Cache-Outcome: primary=miss,secondary=error   ← first request
+
+Lava-Provider-Address: 0x…
+Lava-Cache-Outcome: primary=miss,secondary=off     ← second request
+```
+
+The metrics say the same thing in aggregate:
 
 ```
 smartrouter_cache_failed_total{…,cache_tier="secondary",method="eth_getBlockByNumber",outcome="error"} 1
@@ -411,9 +477,11 @@ smartrouter_cache_failed_total{…,cache_tier="secondary",method="eth_getBlockBy
 
 Exactly **one** `error`, then silence — the client detects the dead connection
 once, marks the tier inactive, and subsequent requests skip it entirely rather
-than paying the timeout every time. (Filtering on the method keeps the router's
-own `eth_blockNumber` tip queries, which carry their own series, out of the
-way.)
+than paying the timeout every time. That is why the second reply reads `off`
+rather than `error`: `off` means the tier is not being consulted at all, which
+is precisely the state the single counter increment describes. (Filtering on the
+method keeps the router's own `eth_blockNumber` tip queries, which carry their
+own series, out of the way.)
 
 #### Restart it and watch the router heal
 
@@ -472,25 +540,30 @@ the wrong tier:
 B='{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x1194567",false],"id":1}'
 curl -s -X POST http://127.0.0.1:3361 -H 'Content-Type: application/json' -d "$B" >/dev/null
 sleep 2
-curl -si -X POST http://127.0.0.1:3360 -H 'Content-Type: application/json' -d "$B" \
-  | grep -i lava-provider-address
-sleep 1
-curl -s http://127.0.0.1:7779/metrics | grep '^smartrouter_cache_success_total' \
-  | grep 'cache_tier="secondary"'
+curl -si -X POST http://127.0.0.1:3360 -H 'Content-Type: application/json' \
+  -H 'lava-debug-relay: true' -d "$B" \
+  | grep -iE 'lava-provider-address|lava-cache-tier|lava-cache-outcome'
 ```
 
 ```
 Lava-Provider-Address: Cached
-smartrouter_cache_success_total{…,cache_tier="secondary",method="eth_getBlockByNumber"} 1   ← +1
+Lava-Cache-Tier: secondary
+Lava-Cache-Outcome: primary=miss,secondary=hit
 ```
 
-The header alone cannot close this step: nothing in the response names the tier
-that answered — both carry the same locally minted header set, and the body is
-the same bytes. (The one difference is invisible here and by design: an entry
-that came from the secondary replays only its `Content-Type` /
-`Content-Encoding`, not whatever other upstream headers the writer's node
-happened to send.) The `cache_tier` counter is what tells you which tier
-answered.
+`Lava-Provider-Address` alone cannot close this step — a primary hit and a
+secondary hit both report `Cached`, both carry the same locally minted header
+set, and the body is the same bytes. (The one difference is invisible here and
+by design: an entry that came from the secondary replays only its
+`Content-Type` / `Content-Encoding`, not whatever other upstream headers the
+writer's node happened to send.)
+
+`Lava-Cache-Tier` names the tier that answered, and `Lava-Cache-Outcome` says
+what each tier did on the way. Both are part of the reply, so there is nothing
+to wait for — see [Reading the tier per
+request](#reading-the-tier-per-request) below. The `cache_tier` counter answers
+the same question in aggregate, and is what you want for a dashboard rather
+than for one request.
 
 ### UC-5 — Unconfigured is fully backwards compatible
 
@@ -598,7 +671,7 @@ walkthrough](#manual-demo-walkthrough); this section records where each one is
 | **UC-1** Primary miss with secondary fallback — served without hitting providers, populator decides the backfill | Covered | `TestSecondaryCacheHitServesWithoutPrimary`, `TestSecondaryHitBackfillsPrimaryWithExactKeyAndValidSeenBlock` (backfill goes through a **real** cache server, so a follow-up primary GET provably hits) |
 | **UC-2** Secondary miss — full fall-through, no overhead beyond the lookup | Covered | `TestSecondaryCacheTimeoutAndErrorAreMisses` — one subtest per outcome (`clean not-found`, `timeout`, `error`), each pinning that the miss leaves nothing behind |
 | **UC-3** Secondary configured read-only — never modified by this router | Covered | Structural: `performance.CacheReader` exposes only `CacheActive`/`GetEntry`, so writes are a compile error. `TestSecondaryCacheConfigValidate` pins that any mode but `read-only` aborts startup |
-| **UC-4** Secondary unreachable — skipped, no impact, reconnects | Covered | `TestSecondaryCacheTimeoutAndErrorAreMisses` (bounded by the timeout), `TestSecondaryCacheActiveNilSafety`; reconnection is the primary's own loop, shared unchanged |
+| **UC-4** Secondary unreachable — skipped, no impact, reconnects | Covered | `TestSecondaryCacheTimeoutAndErrorAreMisses` (bounded by the timeout), `TestSecondaryCacheReportsItsOutcomeOnEveryNonHit` (the failure stays reportable on a provider-served reply), `TestSecondaryCacheActiveNilSafety`; reconnection is the primary's own loop, shared unchanged |
 | **UC-5** No secondary configured — fully backwards compatible | Covered | `TestSecondaryCacheActiveNilSafety` (nil interface *and* typed-nil client), `TestSecondaryCacheFlagAndYamlWiring` |
 
 ### Must-have requirements
@@ -619,7 +692,7 @@ walkthrough](#manual-demo-walkthrough); this section records where each one is
 
 | Requirement | Status |
 | --- | --- |
-| Prometheus metric parity with a `cache_tier` label | Built, exactly as the PRD suggested — one label rather than separate metric names, plus an `outcome` label splitting miss/error/timeout |
+| Prometheus metric parity with a `cache_tier` label | Built, exactly as the PRD suggested — one label rather than separate metric names, plus an `outcome` label splitting miss/error/timeout. The same facts are also readable per request off the reply, which the counters cannot do — see [Reading the tier per request](#reading-the-tier-per-request) |
 | Secondary lookups visible in traces | Built — each lookup is a span carrying `cache.tier` and `cache.outcome`; the root span records which tier served |
 | Log the secondary configuration at startup | Built — one line with address, mode, and timeout |
 | Configurable access mode | Built as an explicit setting; only `read-only` is accepted. Read-write is deferred and rejected at startup rather than ignored |

--- a/protocol/common/cache_lookup.go
+++ b/protocol/common/cache_lookup.go
@@ -1,0 +1,113 @@
+package common
+
+import "strings"
+
+// Cache tier and lookup-outcome values. Defined here rather than in protocol/metrics
+// because two consumers now share them — the cache_tier/outcome metric labels and the
+// per-request Lava-Cache-Tier / Lava-Cache-Outcome headers (MAG-3540) — and a metric
+// label that disagreed with the header on the same request would defeat the point of
+// having both. protocol/metrics aliases these; protocol/common must not import it.
+const (
+	CacheTierPrimary   = "primary"
+	CacheTierSecondary = "secondary"
+	// CacheTierNone is header-only: no tier served this response. It is emitted
+	// explicitly rather than by omitting the header, so an absent Lava-Cache-Tier can
+	// only mean "router too old / directive not honored" and never "a provider served
+	// it". Without it a test could pass having measured nothing.
+	CacheTierNone = "none"
+
+	// The four lookup outcomes, shared verbatim with the smartrouter_cache_* metric
+	// labels. A tier reporting one of these was actually consulted on this request.
+	CacheOutcomeHit     = "hit"
+	CacheOutcomeMiss    = "miss"
+	CacheOutcomeError   = "error"
+	CacheOutcomeTimeout = "timeout"
+
+	// The three not-consulted values. Header-only — no lookup happened, so there is
+	// nothing to count and none of these ever labels a metric. They are kept distinct
+	// rather than collapsed into one "n/a" because each sends the reader somewhere
+	// different when a cache assertion fails.
+	//
+	// CacheOutcomeOff: the tier is unconfigured or its client reports itself
+	// disconnected. The overwhelmingly common cause of a surprising secondary-cache
+	// result, and the one an operator can fix.
+	CacheOutcomeOff = "off"
+	// CacheOutcomeSkipped: the tier is active but was not asked on this request —
+	// either a bypass rule applied to both tiers (cross-validation, stateful,
+	// lava-force-cache-refresh, a non-cacheable requested block), or the primary
+	// already hit and the secondary is only consulted after a primary non-hit.
+	CacheOutcomeSkipped = "skipped"
+	// CacheOutcomeUnknown: this response was never built on a path that performs a
+	// cache lookup at all (a fail-fast result, a synthesized error). Reported rather
+	// than guessed "off": the tier may well be live, this response simply carries no
+	// observation of it.
+	CacheOutcomeUnknown = "unknown"
+)
+
+// CacheLookupReport is what the cache tiers did on the attempt that produced a given
+// RelayResult, carried on the result so it can be read at reply time.
+//
+// It exists because the only pre-existing answer to "which tier served request X" was
+// the cache_tier metric label, incremented on a detached goroutine AFTER the reply is
+// written (`go RecordCacheResult(...)`). Nothing orders the two, so a test reading the
+// counter straight after its reply races it and has to poll — which makes correctness a
+// matter of timing rather than of router behaviour (MAG-3540). A response header is
+// immune by construction: it IS the reply, so "read after the reply" and "read the
+// header" are the same instant.
+//
+// Per-ATTEMPT, not per-request. Retries and hedges each run their own cache lookup in
+// their own sendRelayToEndpoint call, and each stamps its own results. The report a
+// caller sees therefore describes the lookups made on the attempt whose response won.
+// That is what makes it race-free without a lock: every field is written before the
+// attempt's relay goroutines start, and read-only thereafter.
+type CacheLookupReport struct {
+	// ServedTier is CacheTierPrimary, CacheTierSecondary, or CacheTierNone when a
+	// provider (or nothing) answered.
+	ServedTier string
+	// PrimaryOutcome and SecondaryOutcome are one of the four lookup outcomes when the
+	// tier was consulted, or one of the three not-consulted values when it was not.
+	PrimaryOutcome   string
+	SecondaryOutcome string
+}
+
+// ServedBy returns a copy naming the tier that answered. A copy rather than a mutation
+// so the caller's running report — which the request keeps using when this tier did not
+// serve — cannot be left claiming a hit it did not produce.
+func (r CacheLookupReport) ServedBy(tier string) CacheLookupReport {
+	r.ServedTier = tier
+	return r
+}
+
+// TierHeaderValue renders the Lava-Cache-Tier value, mapping the zero value onto an
+// explicit "none" so the header is never emitted empty.
+func (r CacheLookupReport) TierHeaderValue() string {
+	if r.ServedTier == "" {
+		return CacheTierNone
+	}
+	return r.ServedTier
+}
+
+// OutcomeHeaderValue renders the Lava-Cache-Outcome value as "primary=<x>,secondary=<y>".
+//
+// Both tiers are always named, always in that order, so a caller can assert the whole
+// string rather than parsing for the field it cares about. An unset field renders as
+// "unknown" — a result built off the cache path carries no observation of either tier,
+// and reporting "off" there would state as fact something this response cannot know.
+func (r CacheLookupReport) OutcomeHeaderValue() string {
+	var b strings.Builder
+	b.WriteString(CacheTierPrimary)
+	b.WriteString("=")
+	b.WriteString(outcomeOrUnknown(r.PrimaryOutcome))
+	b.WriteString(",")
+	b.WriteString(CacheTierSecondary)
+	b.WriteString("=")
+	b.WriteString(outcomeOrUnknown(r.SecondaryOutcome))
+	return b.String()
+}
+
+func outcomeOrUnknown(outcome string) string {
+	if outcome == "" {
+		return CacheOutcomeUnknown
+	}
+	return outcome
+}

--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -40,6 +40,15 @@ const (
 	// internal infrastructure addresses, so it is emitted ONLY under
 	// --debug-relays, never to ordinary clients.
 	CACHE_BACKEND_HEADER_NAME = "Lava-Cache-Backend"
+	// CACHE_TIER_HEADER_NAME names the cache tier that served the response
+	// ("primary" | "secondary" | "none"), and CACHE_OUTCOME_HEADER_NAME gives what
+	// each tier did ("primary=miss,secondary=error"). Both are emitted together
+	// whenever the request carried the lava-debug-relay directive — see
+	// CacheLookupReport for why a header rather than the cache_tier counter, and note
+	// that unlike CACHE_BACKEND_HEADER_NAME above these values name no infrastructure,
+	// which is what makes a client-settable directive an acceptable gate for them.
+	CACHE_TIER_HEADER_NAME    = "Lava-Cache-Tier"
+	CACHE_OUTCOME_HEADER_NAME = "Lava-Cache-Outcome"
 	// these headers need to be lowercase
 	BLOCK_PROVIDERS_ADDRESSES_HEADER_NAME         = "lava-providers-block"
 	RELAY_TIMEOUT_HEADER_NAME                     = "lava-relay-timeout"
@@ -554,6 +563,12 @@ type RelayResult struct {
 	// hold it — but the endpoint is healthy, so the direct-RPC availability gate
 	// excludes it. Orthogonal to both flags above.
 	IsDataScope bool
+	// CacheLookup is what each cache tier did on the attempt that produced this result,
+	// surfaced to the caller as Lava-Cache-Tier / Lava-Cache-Outcome when the request
+	// carried lava-debug-relay. Same shape as the per-request serving facts above that
+	// headers already read (IsNodeError, StatusCode, CrossValidationFailureReason);
+	// see CacheLookupReport for why the cache_tier counter could not answer this.
+	CacheLookup CacheLookupReport
 }
 
 // ApplyNodeErrorClassification stamps every registry-derived policy flag onto a node-error

--- a/protocol/metrics/cache_outcome.go
+++ b/protocol/metrics/cache_outcome.go
@@ -6,20 +6,29 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/magma-Devs/smart-router/protocol/common"
 )
 
 // Cache tier and lookup-outcome label values (docs/METRICS.md#cache).
 // Both are closed enums: cache_tier distinguishes the primary cache from the
 // optional read-only secondary, and outcome splits the former catch-all "failed"
 // classification so operators can tell a clean miss from a broken or slow tier.
+//
+// Aliased from protocol/common, which is where the same values are also rendered into
+// the per-request Lava-Cache-Tier / Lava-Cache-Outcome headers. One definition, so a
+// counter and a header describing the same lookup cannot drift apart. common carries
+// three further not-consulted values (off / skipped / unknown) that are deliberately
+// NOT aliased here: no lookup happened, so there is nothing to count, and admitting
+// them would widen a metric label enum documented as closed.
 const (
-	CacheTierPrimary   = "primary"
-	CacheTierSecondary = "secondary"
+	CacheTierPrimary   = common.CacheTierPrimary
+	CacheTierSecondary = common.CacheTierSecondary
 
-	CacheOutcomeHit     = "hit"
-	CacheOutcomeMiss    = "miss"
-	CacheOutcomeError   = "error"
-	CacheOutcomeTimeout = "timeout"
+	CacheOutcomeHit     = common.CacheOutcomeHit
+	CacheOutcomeMiss    = common.CacheOutcomeMiss
+	CacheOutcomeError   = common.CacheOutcomeError
+	CacheOutcomeTimeout = common.CacheOutcomeTimeout
 )
 
 // ClassifyCacheLookupOutcome maps a cache GetEntry result onto the closed outcome

--- a/protocol/rpcsmartrouter/directive_metadata_roundtrip_test.go
+++ b/protocol/rpcsmartrouter/directive_metadata_roundtrip_test.go
@@ -1,9 +1,16 @@
 package rpcsmartrouter
 
 import (
+	"context"
+	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/magma-Devs/smart-router/protocol/chainlib"
 	"github.com/magma-Devs/smart-router/protocol/common"
+	"github.com/magma-Devs/smart-router/protocol/lavasession"
+	pairingtypes "github.com/magma-Devs/smart-router/types/relay"
+	spectypes "github.com/magma-Devs/smart-router/types/spec"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,5 +36,85 @@ func TestMetadataFromDirectiveHeadersRoundTrip(t *testing.T) {
 	t.Run("empty maps to nil metadata", func(t *testing.T) {
 		require.Nil(t, metadataFromDirectiveHeaders(nil))
 		require.Nil(t, metadataFromDirectiveHeaders(map[string]string{}))
+	})
+}
+
+// TestCacheTierDirectiveDoesNotChangeTheCacheKey guards the trap under the cache-tier
+// headers (MAG-3540). hashCacheRequest marshals the ENTIRE RelayPrivateData, metadata
+// included, into the cache key. A request asking to be told which tier served it must
+// therefore ask with a header that cannot reach that metadata — otherwise the flagged
+// request lands in its own cache lane, never hits, and a test asserting a cache
+// outcome passes having measured nothing. That is the exact failure mode this feature
+// exists to escape, so it is guarded rather than argued.
+//
+// lava-debug-relay qualifies because it is registered in SPECIAL_LAVA_DIRECTIVE_HEADERS
+// and stripped by LavaDirectiveHeaders before ParseMsg, so it is gone before the key is
+// built. A newly minted header fails a second way worth recording: BaseChainParser
+// .HandleHeaders keeps only headers the SPEC declares, so an undeclared name is
+// dropped and the router never sees the request at all — and a name a spec DOES
+// declare pass_send lands in the metadata and moves the key. Registered directive or
+// nothing.
+func TestCacheTierDirectiveDoesNotChangeTheCacheKey(t *testing.T) {
+	ctx := context.Background()
+
+	// The registration is what makes the stripping happen; without it the directive
+	// would be an ordinary header and everything below would change meaning.
+	require.Contains(t, common.SPECIAL_LAVA_DIRECTIVE_HEADERS, common.LAVA_DEBUG_RELAY,
+		"the cache-tier headers are gated on this directive, which must stay a stripped one")
+
+	serverHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	chainParser, _, _, closeServer, _, err := chainlib.CreateChainLibMocks(ctx, "LAVA", spectypes.APIInterfaceRest, serverHandler, nil, "../../", nil)
+	if closeServer != nil {
+		t.Cleanup(closeServer)
+	}
+	require.NoError(t, err)
+
+	rpcss := &RPCSmartRouterServer{
+		chainParser:    chainParser,
+		listenEndpoint: &lavasession.RPCEndpoint{ChainID: "LAVA", ApiInterface: spectypes.APIInterfaceRest},
+	}
+
+	const apiURL = "/cosmos/base/tendermint/v1beta1/blocks/latest"
+	// ParseRelay is the real entry point: it strips the directives, and the metadata
+	// that survives into RelayPrivateData is what the key is built from.
+	parse := func(t *testing.T, url string, metadata []pairingtypes.Metadata) chainlib.ProtocolMessage {
+		t.Helper()
+		protocolMessage, err := rpcss.ParseRelay(ctx, url, "", http.MethodGet, "test-dapp", "127.0.0.1", metadata)
+		require.NoError(t, err)
+		return protocolMessage
+	}
+	hashOf := func(t *testing.T, protocolMessage chainlib.ProtocolMessage) []byte {
+		t.Helper()
+		hashKey, _, err := protocolMessage.HashCacheRequest("LAVA")
+		require.NoError(t, err)
+		return hashKey
+	}
+
+	plain := parse(t, apiURL, nil)
+
+	t.Run("the directive never reaches the metadata the key is built from", func(t *testing.T) {
+		withDirective := parse(t, apiURL, []pairingtypes.Metadata{{Name: common.LAVA_DEBUG_RELAY, Value: "true"}})
+		for _, metadata := range withDirective.RelayPrivateData().Metadata {
+			require.NotEqual(t, common.LAVA_DEBUG_RELAY, strings.ToLower(metadata.Name),
+				"a directive that survived into RelayPrivateData would be hashed into the cache key")
+		}
+		require.Contains(t, withDirective.GetDirectiveHeaders(), common.LAVA_DEBUG_RELAY,
+			"stripped from the request, but still delivered to the router as a directive")
+	})
+
+	t.Run("lava-debug-relay leaves the key untouched", func(t *testing.T) {
+		withDirective := parse(t, apiURL, []pairingtypes.Metadata{{Name: common.LAVA_DEBUG_RELAY, Value: "true"}})
+		require.Equal(t, hashOf(t, plain), hashOf(t, withDirective),
+			"asking for the cache tier must not move the request into its own cache lane")
+	})
+
+	// Sensitivity control, so the equality above cannot pass because the hash is
+	// degenerate. It varies the request rather than a header because this spec
+	// declares no pass_send headers at all — see the note above on why an arbitrary
+	// header is not a usable control here.
+	t.Run("a different request does change the key", func(t *testing.T) {
+		other := parse(t, "/cosmos/base/tendermint/v1beta1/blocks/1", nil)
+		require.NotEqual(t, hashOf(t, plain), hashOf(t, other),
+			"the key must distinguish requests, or the equality assertions above prove nothing")
 	})
 }

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -1651,6 +1651,10 @@ func (rpcss *RPCSmartRouterServer) sendRelayToDirectEndpoints(
 	relayProcessor *relaycore.RelayProcessor,
 	consistencyFallback *consistencyFallbackState,
 	analytics *metrics.RelayMetrics,
+	// cacheReport is what the cache tiers did on this attempt, already complete before
+	// this call: passed by value and only read from here on, so the relay goroutines
+	// below can each copy it onto their own result without synchronization.
+	cacheReport common.CacheLookupReport,
 ) error {
 	chainMessage := protocolMessage
 
@@ -1913,6 +1917,11 @@ func (rpcss *RPCSmartRouterServer) sendRelayToDirectEndpoints(
 			localRelayResult := &common.RelayResult{
 				ProviderInfo: common.ProviderInfo{ProviderAddress: endpointAddress},
 				Finalized:    true, // Direct responses don't need consensus
+				// A provider is answering, so no tier served — but the tiers were still
+				// consulted, and whether the secondary missed, errored or timed out on
+				// the way is exactly what the resilience cases assert alongside "a
+				// provider answered". ServedTier stays "none" here.
+				CacheLookup: cacheReport,
 			}
 
 			var errResponse error
@@ -3689,6 +3698,22 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 	crossValidationEnabled := selection == relaycore.CrossValidation && crossValidationParams != nil
 	primaryCacheActive := rpcss.cache != nil && rpcss.cache.CacheActive()
 	secondaryCacheActive := rpcss.secondaryCacheActive()
+
+	// What the tiers did on THIS attempt, carried onto every result this attempt
+	// produces so the caller can read it off the reply instead of racing the
+	// cache_tier counter, which is incremented after the reply has gone out
+	// (MAG-3540). Seeded to the truth for a request that performs no lookup at all:
+	// an inactive tier reports "off", an active one that is never asked — because a
+	// bypass rule applied below, or because the primary hit first — keeps "skipped".
+	// Each branch that does look up overwrites its own field.
+	cacheReport := common.CacheLookupReport{ServedTier: common.CacheTierNone, PrimaryOutcome: common.CacheOutcomeOff, SecondaryOutcome: common.CacheOutcomeOff}
+	if primaryCacheActive {
+		cacheReport.PrimaryOutcome = common.CacheOutcomeSkipped
+	}
+	if secondaryCacheActive {
+		cacheReport.SecondaryOutcome = common.CacheOutcomeSkipped
+	}
+
 	if primaryCacheActive || secondaryCacheActive {
 		if crossValidationEnabled {
 			// Cross-validation requires fresh endpoint validation - cache would defeat consensus verification
@@ -3771,7 +3796,10 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 							utils.LogAttr("lookupFinalized", lookupFinalized),
 						)
 
-						cacheLatencyMs := func() float64 {
+						// Returns the outcome alongside the latency so the span, the counter and
+						// the response header all describe the same classification of the same
+						// lookup, rather than each re-deriving it from cacheError.
+						cacheLatencyMs, primaryOutcome := func() (float64, string) {
 							_, cacheSpan := tracing.StartInternalSpan(ctx, tracing.SpanCacheLookup)
 							defer cacheSpan.End()
 							cacheStart := time.Now()
@@ -3788,9 +3816,11 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 							cancel()
 							latencyMs := float64(time.Since(cacheStart).Milliseconds())
 							cacheHit := cacheError == nil && cacheReply != nil && cacheReply.GetReply() != nil
-							tracing.RecordCacheResult(ctx, cacheSpan, metrics.CacheTierPrimary, metrics.ClassifyCacheLookupOutcome(cacheError, cacheHit), cacheHit, latencyMs)
-							return latencyMs
+							outcome := metrics.ClassifyCacheLookupOutcome(cacheError, cacheHit)
+							tracing.RecordCacheResult(ctx, cacheSpan, metrics.CacheTierPrimary, outcome, cacheHit, latencyMs)
+							return latencyMs, outcome
 						}()
+						cacheReport.PrimaryOutcome = primaryOutcome
 
 						// Generate the actual cache key that will be used for lookup
 						actualLookupCacheKey := make([]byte, len(hashKey))
@@ -3843,6 +3873,9 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 								// lava-identified-node-error header exactly like a live one.
 								IsNodeError:  isNodeError,
 								ProviderInfo: common.ProviderInfo{ProviderAddress: ""},
+								// The secondary is only consulted after a primary non-hit, so it
+								// keeps whichever not-consulted value it was seeded with.
+								CacheLookup: cacheReport.ServedBy(common.CacheTierPrimary),
 							}
 							// MAG-2160 Finding 1: a cache hit's reply.LatestBlock is the block that was
 							// current when the response was CACHED — it is not a fresh observation of the
@@ -3865,7 +3898,7 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 							go rpcss.smartRouterEndpointMetrics.RecordCacheResult(chainId, apiInterface, protocolMessage.GetApi().GetName(), metrics.CacheTierPrimary, metrics.CacheOutcomeHit, cacheLatencyMs)
 							return nil
 						}
-						go rpcss.smartRouterEndpointMetrics.RecordCacheResult(chainId, apiInterface, protocolMessage.GetApi().GetName(), metrics.CacheTierPrimary, metrics.ClassifyCacheLookupOutcome(cacheError, false), cacheLatencyMs)
+						go rpcss.smartRouterEndpointMetrics.RecordCacheResult(chainId, apiInterface, protocolMessage.GetApi().GetName(), metrics.CacheTierPrimary, primaryOutcome, cacheLatencyMs)
 						// Cache miss - will relay to endpoint
 						latestBlockHashRequested, earliestBlockHashRequested = rpcss.getEarliestBlockHashRequestedFromCacheReply(cacheReply)
 						utils.LavaFormatTrace("[Archive Debug] Reading block hashes from cache", utils.LogAttr("latestBlockHashRequested", latestBlockHashRequested), utils.LogAttr("earliestBlockHashRequested", earliestBlockHashRequested), utils.LogAttr("GUID", ctx))
@@ -3877,7 +3910,7 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 					// left them: those scalars steer local block resolution and archive routing,
 					// and the secondary is a trust boundary, not a second source of chain state.
 					if secondaryCacheActive {
-						if rpcss.trySecondaryCacheLookup(ctx, protocolMessage, localRelayData, relayProcessor, analytics, hashKey, outputFormatter, requestedBlockForCache) {
+						if rpcss.trySecondaryCacheLookup(ctx, protocolMessage, localRelayData, relayProcessor, analytics, hashKey, outputFormatter, requestedBlockForCache, &cacheReport) {
 							return nil
 						}
 					}
@@ -4026,7 +4059,7 @@ func (rpcss *RPCSmartRouterServer) sendRelayToEndpoint(
 		utils.LogAttr("num_sessions", len(sessions)),
 		utils.LogAttr("GUID", ctx),
 	)
-	return rpcss.sendRelayToDirectEndpoints(ctx, sessions, protocolMessage, relayProcessor, consistencyFallback, analytics)
+	return rpcss.sendRelayToDirectEndpoints(ctx, sessions, protocolMessage, relayProcessor, consistencyFallback, analytics, cacheReport)
 }
 
 // relayInnerDirect handles relay requests using direct RPC connections (smart router mode)
@@ -4722,8 +4755,26 @@ func (rpcss *RPCSmartRouterServer) appendHeadersToRelayResult(ctx context.Contex
 		// pod) and must never reach ordinary clients. Under sentinel it is the
 		// current master, so it visibly changes across a failover — which is
 		// what makes a promotion observable from the outside.
-		if providerAddress == "Cached" && rpcss.debugRelays && rpcss.cache != nil {
-			if reporter, ok := rpcss.cache.(performance.BackendEndpointReporter); ok {
+		//
+		// The reporter is chosen by the tier that actually served (MAG-3540). It used
+		// to be the primary unconditionally, but a SECONDARY hit also arrives here with
+		// providerAddress == "Cached" — so an entry the secondary served was reported
+		// with the primary's backend address. The tier was not merely unreported then,
+		// it was misreported. No recorded tier means no header rather than a guess.
+		//
+		// Note the gate: --debug-relays, the operator flag, NOT the client-settable
+		// lava-debug-relay directive the cache-tier headers below use. The tier name is
+		// a fact about routing; this is an infrastructure address, and a client must not
+		// be able to ask for one.
+		if providerAddress == "Cached" && rpcss.debugRelays {
+			var reporter performance.BackendEndpointReporter
+			switch relayResult.CacheLookup.ServedTier {
+			case common.CacheTierPrimary:
+				reporter, _ = rpcss.cache.(performance.BackendEndpointReporter)
+			case common.CacheTierSecondary:
+				reporter, _ = rpcss.secondaryCache.(performance.BackendEndpointReporter)
+			}
+			if reporter != nil {
 				if endpoint := reporter.BackendEndpoint(); endpoint != "" {
 					metadataReply = append(metadataReply, pairingtypes.Metadata{
 						Name:  common.CACHE_BACKEND_HEADER_NAME,
@@ -4935,6 +4986,34 @@ func (rpcss *RPCSmartRouterServer) appendHeadersToRelayResult(ctx context.Contex
 			pairingtypes.Metadata{
 				Name:  common.REQUESTED_BLOCK_HEADER_NAME,
 				Value: strconv.FormatInt(protocolMessage.RelayPrivateData().GetRequestBlock(), 10),
+			})
+
+		// Which tier served this request, and what each tier did on the way (MAG-3540).
+		// Gated on the per-request directive rather than --debug-relays because no
+		// deployed router sets that flag, so a flag-gated header would be silently
+		// absent on exactly the runners that need it; the directive is owned by the
+		// caller and needs no deploy change. It is safe to gate on a client-settable
+		// header precisely because these two values name nothing internal.
+		//
+		// lava-debug-relay is also the only directive that can carry this without
+		// breaking it: hashCacheRequest marshals the whole RelayPrivateData, metadata
+		// included, into the cache key, so a newly minted request header would put the
+		// flagged request in its own cache lane — it would never hit, and a test would
+		// assert against a miss having measured nothing. lava-debug-relay is registered
+		// in common.SPECIAL_LAVA_DIRECTIVE_HEADERS and stripped by LavaDirectiveHeaders
+		// before ParseMsg, so it never reaches the key.
+		//
+		// Both are emitted unconditionally under the directive, including "none" and
+		// the not-consulted outcomes: an absent header must be able to mean only
+		// "router too old / directive not honored", never "nothing served it".
+		metadataReply = append(metadataReply,
+			pairingtypes.Metadata{
+				Name:  common.CACHE_TIER_HEADER_NAME,
+				Value: relayResult.CacheLookup.TierHeaderValue(),
+			},
+			pairingtypes.Metadata{
+				Name:  common.CACHE_OUTCOME_HEADER_NAME,
+				Value: relayResult.CacheLookup.OutcomeHeaderValue(),
 			})
 
 		routerKey := lavasession.NewRouterKeyFromExtensions(protocolMessage.GetExtensions())

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -1921,6 +1921,9 @@ type MockProtocolMessage struct {
 	api            *spectypes.Api
 	requestedBlock int64 // configurable requested block, defaults to 0
 	userData       common.UserData
+	// directiveHeaders drives the per-request debug gate in appendHeadersToRelayResult
+	// (lava-debug-relay). Nil means an ordinary client request.
+	directiveHeaders map[string]string
 }
 
 func (m *MockProtocolMessage) GetApi() *spectypes.Api {
@@ -1952,7 +1955,7 @@ func (m *MockProtocolMessage) GetExtensions() []*spectypes.Extension {
 }
 
 func (m *MockProtocolMessage) GetDirectiveHeaders() map[string]string {
-	return nil
+	return m.directiveHeaders
 }
 
 func (m *MockProtocolMessage) GetCrossValidationParameters() (common.CrossValidationParams, bool, error) {
@@ -3250,7 +3253,7 @@ func TestSendRelayToDirectEndpoints_CrossValidationGuardReleasesAllSessions(t *t
 	defer cancel()
 
 	start := time.Now()
-	sendErr := rpcss.sendRelayToDirectEndpoints(callCtx, sessionsMap, protocolMsg, relayProcessor, nil, nil)
+	sendErr := rpcss.sendRelayToDirectEndpoints(callCtx, sessionsMap, protocolMsg, relayProcessor, nil, nil, common.CacheLookupReport{})
 	elapsed := time.Since(start)
 
 	require.Less(t, elapsed, time.Second,
@@ -3450,6 +3453,7 @@ func (s *stubCacheBackend) CacheActive() bool { return true }
 func (s *stubCacheBackend) GetEntry(ctx context.Context, _ *pairingtypes.RelayCacheGet) (*pairingtypes.CacheRelayReply, error) {
 	return &pairingtypes.CacheRelayReply{}, nil
 }
+
 func (s *stubCacheBackend) SetEntry(ctx context.Context, _ *pairingtypes.RelayCacheSet) error {
 	return nil
 }
@@ -3457,31 +3461,53 @@ func (s *stubCacheBackend) Flush(ctx context.Context) error { return nil }
 func (s *stubCacheBackend) Close() error                    { return nil }
 func (s *stubCacheBackend) BackendEndpoint() string         { return s.endpoint }
 
-// The Lava-Cache-Backend header names the node that served a hit. It exposes an
-// internal infrastructure address, so it must appear ONLY under --debug-relays.
-func TestCacheBackendHeaderIsDebugGated(t *testing.T) {
-	ctx := context.Background()
+// stubSecondaryCache is a CacheReader that also reports a backend endpoint, so the
+// backend header can be shown to name the SECONDARY's node on a secondary hit.
+type stubSecondaryCache struct{ endpoint string }
 
-	findHeader := func(metadata []pairingtypes.Metadata, name string) *pairingtypes.Metadata {
-		for i := range metadata {
-			if metadata[i].Name == name {
-				return &metadata[i]
-			}
+func (s *stubSecondaryCache) CacheActive() bool { return true }
+func (s *stubSecondaryCache) GetEntry(ctx context.Context, _ *pairingtypes.RelayCacheGet) (*pairingtypes.CacheRelayReply, error) {
+	return &pairingtypes.CacheRelayReply{}, nil
+}
+func (s *stubSecondaryCache) BackendEndpoint() string { return s.endpoint }
+
+// findMetadataHeader returns the named header from a reply's metadata, or nil.
+func findMetadataHeader(metadata []pairingtypes.Metadata, name string) *pairingtypes.Metadata {
+	for i := range metadata {
+		if metadata[i].Name == name {
+			return &metadata[i]
 		}
-		return nil
 	}
+	return nil
+}
 
-	// A cache-resolved relay: no provider address, so the header logic reports
-	// "Cached" and considers naming the backend.
+// appendHeadersForCacheHit runs the header pass over a cache-resolved relay: no
+// provider address, so the header logic reports "Cached" and considers naming the
+// backend. The report is what the two cache hit sites stamp on their result.
+func appendHeadersForCacheHit(t *testing.T, server *RPCSmartRouterServer, report common.CacheLookupReport, directives map[string]string) []pairingtypes.Metadata {
+	t.Helper()
+	relayResult := &common.RelayResult{
+		ProviderInfo: common.ProviderInfo{ProviderAddress: ""},
+		Reply:        &pairingtypes.RelayReply{Metadata: []pairingtypes.Metadata{}},
+		CacheLookup:  report,
+	}
+	server.appendHeadersToRelayResult(context.Background(), relayResult, 0, &MockRelayProcessorForHeaders{
+		successResults: []common.RelayResult{{ProviderInfo: common.ProviderInfo{ProviderAddress: ""}}},
+	}, &MockProtocolMessage{api: &spectypes.Api{Name: "eth_blockNumber"}, directiveHeaders: directives}, "eth_blockNumber", nil, true)
+	return relayResult.Reply.Metadata
+}
+
+// The Lava-Cache-Backend header names the node that served a hit. It exposes an
+// internal infrastructure address, so it must appear ONLY under --debug-relays — and
+// it must name the backend of the tier that ACTUALLY served (MAG-3540). It used to
+// report the primary's address unconditionally, so an entry the secondary served was
+// labelled with the primary's node.
+func TestCacheBackendHeaderIsDebugGated(t *testing.T) {
+	servedByPrimary := common.CacheLookupReport{ServedTier: common.CacheTierPrimary, PrimaryOutcome: common.CacheOutcomeHit, SecondaryOutcome: common.CacheOutcomeSkipped}
+	servedBySecondary := common.CacheLookupReport{ServedTier: common.CacheTierSecondary, PrimaryOutcome: common.CacheOutcomeMiss, SecondaryOutcome: common.CacheOutcomeHit}
+
 	appendFor := func(server *RPCSmartRouterServer) []pairingtypes.Metadata {
-		relayResult := &common.RelayResult{
-			ProviderInfo: common.ProviderInfo{ProviderAddress: ""},
-			Reply:        &pairingtypes.RelayReply{Metadata: []pairingtypes.Metadata{}},
-		}
-		server.appendHeadersToRelayResult(ctx, relayResult, 0, &MockRelayProcessorForHeaders{
-			successResults: []common.RelayResult{{ProviderInfo: common.ProviderInfo{ProviderAddress: ""}}},
-		}, &MockProtocolMessage{api: &spectypes.Api{Name: "eth_blockNumber"}}, "eth_blockNumber", nil, true)
-		return relayResult.Reply.Metadata
+		return appendHeadersForCacheHit(t, server, servedByPrimary, nil)
 	}
 
 	t.Run("debug on - names the serving backend", func(t *testing.T) {
@@ -3489,7 +3515,7 @@ func TestCacheBackendHeaderIsDebugGated(t *testing.T) {
 			debugRelays: true,
 			cache:       &stubCacheBackend{endpoint: "10.0.0.11:63812"},
 		})
-		header := findHeader(metadata, common.CACHE_BACKEND_HEADER_NAME)
+		header := findMetadataHeader(metadata, common.CACHE_BACKEND_HEADER_NAME)
 		require.NotNil(t, header)
 		require.Equal(t, "10.0.0.11:63812", header.Value)
 	})
@@ -3499,9 +3525,9 @@ func TestCacheBackendHeaderIsDebugGated(t *testing.T) {
 			debugRelays: false,
 			cache:       &stubCacheBackend{endpoint: "10.0.0.11:63812"},
 		})
-		require.Nil(t, findHeader(metadata, common.CACHE_BACKEND_HEADER_NAME),
+		require.Nil(t, findMetadataHeader(metadata, common.CACHE_BACKEND_HEADER_NAME),
 			"the header leaks internal infrastructure addresses and must stay behind --debug-relays")
-		require.NotNil(t, findHeader(metadata, common.PROVIDER_ADDRESS_HEADER_NAME),
+		require.NotNil(t, findMetadataHeader(metadata, common.PROVIDER_ADDRESS_HEADER_NAME),
 			"the ordinary provider header is unaffected")
 	})
 
@@ -3510,11 +3536,155 @@ func TestCacheBackendHeaderIsDebugGated(t *testing.T) {
 			debugRelays: true,
 			cache:       &stubCacheBackend{endpoint: ""},
 		})
-		require.Nil(t, findHeader(metadata, common.CACHE_BACKEND_HEADER_NAME))
+		require.Nil(t, findMetadataHeader(metadata, common.CACHE_BACKEND_HEADER_NAME))
 	})
 
 	t.Run("no cache backend - nil interface is safe", func(t *testing.T) {
 		metadata := appendFor(&RPCSmartRouterServer{debugRelays: true})
-		require.Nil(t, findHeader(metadata, common.CACHE_BACKEND_HEADER_NAME))
+		require.Nil(t, findMetadataHeader(metadata, common.CACHE_BACKEND_HEADER_NAME))
+	})
+
+	// The mislabel regression: both tiers are live and reachable, and the SECONDARY
+	// served. Before MAG-3540 this reported the primary's address.
+	t.Run("secondary served - names the secondary's backend, not the primary's", func(t *testing.T) {
+		metadata := appendHeadersForCacheHit(t, &RPCSmartRouterServer{
+			debugRelays:    true,
+			cache:          &stubCacheBackend{endpoint: "10.0.0.11:63812"},
+			secondaryCache: &stubSecondaryCache{endpoint: "10.9.9.9:6379"},
+		}, servedBySecondary, nil)
+		header := findMetadataHeader(metadata, common.CACHE_BACKEND_HEADER_NAME)
+		require.NotNil(t, header)
+		require.Equal(t, "10.9.9.9:6379", header.Value,
+			"a secondary hit must not be attributed to the primary's backend")
+	})
+
+	t.Run("secondary served but only the primary can report - header omitted rather than wrong", func(t *testing.T) {
+		metadata := appendHeadersForCacheHit(t, &RPCSmartRouterServer{
+			debugRelays: true,
+			cache:       &stubCacheBackend{endpoint: "10.0.0.11:63812"},
+		}, servedBySecondary, nil)
+		require.Nil(t, findMetadataHeader(metadata, common.CACHE_BACKEND_HEADER_NAME),
+			"with no reporter for the serving tier the router must say nothing, not name another tier's node")
+	})
+
+	t.Run("no tier recorded - no backend is guessed", func(t *testing.T) {
+		metadata := appendHeadersForCacheHit(t, &RPCSmartRouterServer{
+			debugRelays: true,
+			cache:       &stubCacheBackend{endpoint: "10.0.0.11:63812"},
+		}, common.CacheLookupReport{}, nil)
+		require.Nil(t, findMetadataHeader(metadata, common.CACHE_BACKEND_HEADER_NAME))
+	})
+}
+
+// MAG-3540. Which tier served a request was previously readable only from the
+// cache_tier counter, which is incremented on a detached goroutine AFTER the reply is
+// written — so a test reading it straight after its reply races it. These two headers
+// are part of the reply, so there is nothing to wait for.
+func TestCacheTierHeaders(t *testing.T) {
+	withDirective := map[string]string{common.LAVA_DEBUG_RELAY: "true"}
+
+	tierOf := func(metadata []pairingtypes.Metadata) *pairingtypes.Metadata {
+		return findMetadataHeader(metadata, common.CACHE_TIER_HEADER_NAME)
+	}
+	outcomeOf := func(metadata []pairingtypes.Metadata) *pairingtypes.Metadata {
+		return findMetadataHeader(metadata, common.CACHE_OUTCOME_HEADER_NAME)
+	}
+
+	t.Run("no directive - neither header is emitted", func(t *testing.T) {
+		metadata := appendHeadersForCacheHit(t, &RPCSmartRouterServer{},
+			common.CacheLookupReport{ServedTier: common.CacheTierPrimary, PrimaryOutcome: common.CacheOutcomeHit}, nil)
+		require.Nil(t, tierOf(metadata))
+		require.Nil(t, outcomeOf(metadata))
+	})
+
+	// Every case an MAG-2659 test asserts, hit and resilience alike.
+	for _, tc := range []struct {
+		name    string
+		report  common.CacheLookupReport
+		tier    string
+		outcome string
+	}{
+		{
+			name:    "primary hit - the secondary is never asked",
+			report:  common.CacheLookupReport{ServedTier: common.CacheTierPrimary, PrimaryOutcome: common.CacheOutcomeHit, SecondaryOutcome: common.CacheOutcomeSkipped},
+			tier:    "primary",
+			outcome: "primary=hit,secondary=skipped",
+		},
+		{
+			name:    "secondary hit after a primary miss - the cross-zone rescue",
+			report:  common.CacheLookupReport{ServedTier: common.CacheTierSecondary, PrimaryOutcome: common.CacheOutcomeMiss, SecondaryOutcome: common.CacheOutcomeHit},
+			tier:    "secondary",
+			outcome: "primary=miss,secondary=hit",
+		},
+		{
+			// P1.2: a provider answered, and the point of the case is that BOTH
+			// tiers missed on the way.
+			name:    "both tiers miss - a provider served",
+			report:  common.CacheLookupReport{ServedTier: common.CacheTierNone, PrimaryOutcome: common.CacheOutcomeMiss, SecondaryOutcome: common.CacheOutcomeMiss},
+			tier:    "none",
+			outcome: "primary=miss,secondary=miss",
+		},
+		{
+			// P3.1 / P3.2: the resilience acceptance criterion. Both halves have to
+			// be provable at once — the request succeeded, AND the secondary failed.
+			name:    "secondary errored - a provider served anyway",
+			report:  common.CacheLookupReport{ServedTier: common.CacheTierNone, PrimaryOutcome: common.CacheOutcomeMiss, SecondaryOutcome: common.CacheOutcomeError},
+			tier:    "none",
+			outcome: "primary=miss,secondary=error",
+		},
+		{
+			// P3.4: just over the timeout boundary.
+			name:    "secondary timed out - a provider served anyway",
+			report:  common.CacheLookupReport{ServedTier: common.CacheTierNone, PrimaryOutcome: common.CacheOutcomeMiss, SecondaryOutcome: common.CacheOutcomeTimeout},
+			tier:    "none",
+			outcome: "primary=miss,secondary=timeout",
+		},
+		{
+			name:    "no secondary configured - reported off, not miss",
+			report:  common.CacheLookupReport{ServedTier: common.CacheTierNone, PrimaryOutcome: common.CacheOutcomeMiss, SecondaryOutcome: common.CacheOutcomeOff},
+			tier:    "none",
+			outcome: "primary=miss,secondary=off",
+		},
+		{
+			// A bypass rule (cross-validation, stateful, force-refresh) means no
+			// lookup ran. Reported distinctly so a test cannot assert a cache
+			// outcome on a request that never consulted the cache and pass having
+			// measured nothing.
+			name:    "cache bypassed - both tiers skipped",
+			report:  common.CacheLookupReport{ServedTier: common.CacheTierNone, PrimaryOutcome: common.CacheOutcomeSkipped, SecondaryOutcome: common.CacheOutcomeSkipped},
+			tier:    "none",
+			outcome: "primary=skipped,secondary=skipped",
+		},
+		{
+			// A result built off the cache path entirely (a fail-fast, a synthesized
+			// error). It carries no observation of either tier, and says so rather
+			// than reporting "off" for tiers that may well be live.
+			name:    "no record at all - unknown, and the tier is still explicit",
+			report:  common.CacheLookupReport{},
+			tier:    "none",
+			outcome: "primary=unknown,secondary=unknown",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			metadata := appendHeadersForCacheHit(t, &RPCSmartRouterServer{}, tc.report, withDirective)
+
+			tier := tierOf(metadata)
+			require.NotNil(t, tier, "the tier header must always be present under the directive")
+			require.Equal(t, tc.tier, tier.Value)
+
+			outcome := outcomeOf(metadata)
+			require.NotNil(t, outcome, "the outcome header must always be present under the directive")
+			require.Equal(t, tc.outcome, outcome.Value)
+		})
+	}
+
+	// The load-bearing property: absence can only mean "router too old / directive not
+	// honored". It must never be how "no tier served" is expressed, or a test could
+	// pass having measured nothing.
+	t.Run("no tier served - says none rather than going silent", func(t *testing.T) {
+		metadata := appendHeadersForCacheHit(t, &RPCSmartRouterServer{},
+			common.CacheLookupReport{ServedTier: common.CacheTierNone, PrimaryOutcome: common.CacheOutcomeMiss, SecondaryOutcome: common.CacheOutcomeMiss}, withDirective)
+		require.NotNil(t, tierOf(metadata))
+		require.Equal(t, common.CacheTierNone, tierOf(metadata).Value)
 	})
 }

--- a/protocol/rpcsmartrouter/secondary_cache.go
+++ b/protocol/rpcsmartrouter/secondary_cache.go
@@ -54,8 +54,10 @@ func (rpcss *RPCSmartRouterServer) secondaryCacheActive() bool {
 //   - The lookup runs under the operator-configured secondary-cache-timeout rather
 //     than the primary's fixed budget.
 //   - Every attempted lookup is recorded with cache_tier=secondary and its outcome
-//     (hit|miss|error|timeout) in the smartrouter_cache_* series and on its own
-//     smartrouter.CacheLookup span. Router request counters
+//     (hit|miss|error|timeout) in the smartrouter_cache_* series, on its own
+//     smartrouter.CacheLookup span, and on cacheReport — the last of which is the only
+//     one of the three the caller of a single request can read without racing the
+//     reply. Router request counters
 //     (RecordCacheHitRequest, provider_address="Cached") fire for a hit on either
 //     tier, unchanged in shape.
 func (rpcss *RPCSmartRouterServer) trySecondaryCacheLookup(
@@ -67,6 +69,7 @@ func (rpcss *RPCSmartRouterServer) trySecondaryCacheLookup(
 	hashKey []byte,
 	outputFormatter func([]byte) []byte,
 	requestedBlockForCache int64,
+	cacheReport *common.CacheLookupReport,
 ) (served bool) {
 	chainId, apiInterface := rpcss.GetChainIdAndApiInterface()
 
@@ -121,6 +124,13 @@ func (rpcss *RPCSmartRouterServer) trySecondaryCacheLookup(
 	}
 	tracing.RecordCacheResult(ctx, cacheSpan, metrics.CacheTierSecondary, outcome, hit, latencyMs)
 	cacheSpan.End()
+	// Recorded for every outcome, not just a hit: the four resilience cases in
+	// MAG-2659 assert that a provider served the request AND that the secondary
+	// failed on the way (miss / error / timeout). Their whole point is the second
+	// half, which no header on a winning cache result could carry — on those
+	// requests no tier wins. The caller carries this report on to the provider
+	// result, so the pair survives to the reply either way.
+	cacheReport.SecondaryOutcome = outcome
 	go rpcss.smartRouterEndpointMetrics.RecordCacheResult(chainId, apiInterface, protocolMessage.GetApi().GetName(), metrics.CacheTierSecondary, outcome, latencyMs)
 	if !hit {
 		// miss, error, and timeout all degrade to a miss; nothing from the reply is
@@ -177,6 +187,11 @@ func (rpcss *RPCSmartRouterServer) trySecondaryCacheLookup(
 		// populator's node-error check is what rejects its backfill.
 		IsNodeError:  isNodeError,
 		ProviderInfo: common.ProviderInfo{ProviderAddress: ""}, // rendered as "Cached", same as a primary hit
+		// What distinguishes this reply from a primary hit for the caller: both carry
+		// the same locally minted header set and the same bytes, so before MAG-3540
+		// nothing in the response named the tier. It also picks which backend the
+		// debug-gated Lava-Cache-Backend header reports.
+		CacheLookup: cacheReport.ServedBy(common.CacheTierSecondary),
 	}
 
 	// Backfill: the populator owns ALL eligibility — node-error, status-code,

--- a/protocol/rpcsmartrouter/secondary_cache_test.go
+++ b/protocol/rpcsmartrouter/secondary_cache_test.go
@@ -137,6 +137,15 @@ func newSecondaryTestServer(chainParser chainlib.ChainParser, primary *performan
 // processed result when one was served.
 func runSecondaryLookup(t *testing.T, rpcss *RPCSmartRouterServer, protocolMessage chainlib.ProtocolMessage, requestedBlockForCache int64) (bool, *common.RelayResult) {
 	t.Helper()
+	served, result, _ := runSecondaryLookupWithReport(t, rpcss, protocolMessage, requestedBlockForCache)
+	return served, result
+}
+
+// runSecondaryLookupWithReport is runSecondaryLookup plus the cache report the lookup
+// wrote. The report is the only way to see what the secondary did when it did NOT
+// serve, which is what the resilience cases assert.
+func runSecondaryLookupWithReport(t *testing.T, rpcss *RPCSmartRouterServer, protocolMessage chainlib.ProtocolMessage, requestedBlockForCache int64) (bool, *common.RelayResult, common.CacheLookupReport) {
+	t.Helper()
 	ctx := context.Background()
 	hashKey, outputFormatter, err := protocolMessage.HashCacheRequest("LAVA")
 	require.NoError(t, err)
@@ -151,17 +160,24 @@ func runSecondaryLookup(t *testing.T, rpcss *RPCSmartRouterServer, protocolMessa
 	waitDone := make(chan struct{})
 	go func() { _ = relayProcessor.WaitForResults(waitCtx); close(waitDone) }()
 
-	served := rpcss.trySecondaryCacheLookup(ctx, protocolMessage, protocolMessage.RelayPrivateData(), relayProcessor, nil, hashKey, outputFormatter, requestedBlockForCache)
+	// Seeded the way sendRelayToEndpoint seeds it for an active secondary consulted
+	// after a primary that produced no hit.
+	cacheReport := common.CacheLookupReport{
+		ServedTier:       common.CacheTierNone,
+		PrimaryOutcome:   common.CacheOutcomeMiss,
+		SecondaryOutcome: common.CacheOutcomeSkipped,
+	}
+	served := rpcss.trySecondaryCacheLookup(ctx, protocolMessage, protocolMessage.RelayPrivateData(), relayProcessor, nil, hashKey, outputFormatter, requestedBlockForCache, &cacheReport)
 	if !served {
 		waitCancel()
 		<-waitDone
-		return false, nil
+		return false, nil, cacheReport
 	}
 	<-waitDone
 	result, processingErr := relayProcessor.ProcessingResult()
 	require.NoError(t, processingErr)
 	require.NotNil(t, result)
-	return true, result
+	return true, result, cacheReport
 }
 
 func directGet(rcs *ecocache.RelayerCacheServer, hashKey []byte, block, seenBlock int64) *pairingtypes.CacheRelayReply {
@@ -231,7 +247,7 @@ func TestSecondaryCacheTimeoutAndErrorAreMisses(t *testing.T) {
 		hashKey, outputFormatter, err := protocolMessage.HashCacheRequest("LAVA")
 		require.NoError(t, err)
 		served := rpcss.trySecondaryCacheLookup(context.Background(), protocolMessage,
-			protocolMessage.RelayPrivateData(), nil, nil, hashKey, outputFormatter, 100)
+			protocolMessage.RelayPrivateData(), nil, nil, hashKey, outputFormatter, 100, &common.CacheLookupReport{})
 		require.False(t, served, "a not-found must fall through to providers")
 
 		gets := fake.recorded()
@@ -254,6 +270,54 @@ func TestSecondaryCacheTimeoutAndErrorAreMisses(t *testing.T) {
 		rpcss := newSecondaryTestServer(chainParser, nil, fake, 100*time.Millisecond)
 		served, _ := runSecondaryLookup(t, rpcss, protocolMessage, 100)
 		require.False(t, served)
+	})
+}
+
+// A non-hit degrades to a miss for SERVING, but it must not degrade to a miss for
+// REPORTING: the four resilience cases in MAG-2659 assert that a provider answered
+// AND what the secondary did on the way, and "the secondary was consulted and it
+// errored" is exactly what a miss would hide (MAG-3540). This drives the real lookup
+// rather than a hand-built report, so it fails if the report is never written.
+func TestSecondaryCacheReportsItsOutcomeOnEveryNonHit(t *testing.T) {
+	chainParser, protocolMessage := buildRestProtocolMessage(t, context.Background(), 100)
+
+	t.Run("clean miss", func(t *testing.T) {
+		fake := &fakeCacheReader{active: true, reply: &pairingtypes.CacheRelayReply{Reply: nil}}
+		rpcss := newSecondaryTestServer(chainParser, nil, fake, 100*time.Millisecond)
+		served, _, report := runSecondaryLookupWithReport(t, rpcss, protocolMessage, 100)
+		require.False(t, served)
+		require.Equal(t, common.CacheOutcomeMiss, report.SecondaryOutcome)
+		require.Equal(t, common.CacheTierNone, report.ServedTier, "a non-hit must not claim to have served")
+	})
+
+	t.Run("transport error", func(t *testing.T) {
+		fake := &fakeCacheReader{active: true, err: errors.New("connection reset")}
+		rpcss := newSecondaryTestServer(chainParser, nil, fake, 100*time.Millisecond)
+		served, _, report := runSecondaryLookupWithReport(t, rpcss, protocolMessage, 100)
+		require.False(t, served)
+		require.Equal(t, common.CacheOutcomeError, report.SecondaryOutcome,
+			"a dead secondary must be distinguishable from one that simply did not hold the entry")
+		require.Equal(t, common.CacheTierNone, report.ServedTier)
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		fake := &fakeCacheReader{active: true, delay: 500 * time.Millisecond, reply: &pairingtypes.CacheRelayReply{Reply: &pairingtypes.RelayReply{Data: []byte("late")}}}
+		rpcss := newSecondaryTestServer(chainParser, nil, fake, 30*time.Millisecond)
+		served, _, report := runSecondaryLookupWithReport(t, rpcss, protocolMessage, 100)
+		require.False(t, served)
+		require.Equal(t, common.CacheOutcomeTimeout, report.SecondaryOutcome)
+		require.Equal(t, common.CacheTierNone, report.ServedTier)
+	})
+
+	t.Run("hit names the secondary on the served result", func(t *testing.T) {
+		fake := &fakeCacheReader{active: true, reply: &pairingtypes.CacheRelayReply{Reply: &pairingtypes.RelayReply{Data: []byte(`{"ok":true}`)}}}
+		rpcss := newSecondaryTestServer(chainParser, nil, fake, 100*time.Millisecond)
+		served, result, report := runSecondaryLookupWithReport(t, rpcss, protocolMessage, 100)
+		require.True(t, served)
+		require.Equal(t, common.CacheOutcomeHit, report.SecondaryOutcome)
+		// The result is what carries the answer out to the reply, so assert there too.
+		require.Equal(t, common.CacheTierSecondary, result.CacheLookup.ServedTier)
+		require.Equal(t, common.CacheOutcomeHit, result.CacheLookup.SecondaryOutcome)
 	})
 }
 
@@ -607,7 +671,7 @@ func TestSecondaryLookupNeverRequestsForeignBlockHashHeights(t *testing.T) {
 	hashKey, outputFormatter, err := protocolMessage.HashCacheRequest("ETH1")
 	require.NoError(t, err)
 	served := rpcss.trySecondaryCacheLookup(context.Background(), protocolMessage,
-		protocolMessage.RelayPrivateData(), nil, nil, hashKey, outputFormatter, 100)
+		protocolMessage.RelayPrivateData(), nil, nil, hashKey, outputFormatter, 100, &common.CacheLookupReport{})
 	require.False(t, served, "reply-less entry is a miss")
 
 	gets := fake.recorded()


### PR DESCRIPTION
Jira ticket: MAG-3540

Which cache tier answered a request could only be learnt from the `cache_tier` label on the Prometheus counters — and that counter is incremented on a detached goroutine **after** the reply is written (`go RecordCacheResult(...)`). Nothing orders the two, so a test reading it straight after its own reply races it and has to poll until the numbers settle. That makes correctness a matter of how long you waited rather than of what the router did.

## What this adds

Two headers, emitted on every reply carrying the existing `lava-debug-relay` directive:

```
Lava-Cache-Tier: primary | secondary | none
Lava-Cache-Outcome: primary=<outcome>,secondary=<outcome>
```

A response header is immune to the ordering problem by construction — it *is* the reply, so "read after the reply" and "read the header" are the same instant.

`Lava-Cache-Outcome` always names both tiers, always in that order, so a caller can assert the whole string rather than parsing for one field:

| Value | The tier was |
| --- | --- |
| `hit` / `miss` / `error` / `timeout` | consulted — the same four values the `outcome` metric label uses |
| `off` | not consulted: unconfigured, or its client has marked itself disconnected |
| `skipped` | active but not asked: a bypass rule applied (cross-validation, stateful, `lava-force-cache-refresh`, non-cacheable block), or the primary hit first |
| `unknown` | not observed at all — this reply was built on a path that performs no cache lookup |

`off` / `skipped` / `unknown` are header-only and never label a metric: there was no lookup to count. They exist so a test cannot assert a cache outcome on a request that never consulted the cache and pass having measured nothing.

Both headers are always emitted under the directive, including `none`. An absent header can therefore mean only "router too old / directive not honored", never "nothing served it".

## Why it needs no lock

The report is per-**attempt**. Both cache lookups are locals in a single `sendRelayToEndpoint` call and are complete before that attempt's relay goroutines start, so stamping them onto the results that attempt produces is race-free by construction. The provider path has exactly one `RelayResult` construction site, so carrying it there cost one parameter. Retries and hedges each run their own lookup; the reply describes the attempt whose response won.

This is what made a per-request debug ring unnecessary — the per-attempt structure I originally read as the obstacle turned out to be the answer.

## Why this gate

- **The directive, not `--debug-relays`.** No deployed router sets that flag (verified on both clusters), so a flag-gated header would be silently absent on exactly the runners that need it. It is safe to gate on a client-settable header precisely because these two values name nothing internal.
- **It has to be a *registered* directive.** `hashCacheRequest` marshals `RelayPrivateData` (metadata included) into the cache key. `lava-debug-relay` is in `SPECIAL_LAVA_DIRECTIVE_HEADERS` and stripped by `LavaDirectiveHeaders` before the key is built, so it cannot move the request into its own cache lane. Guarded by a test rather than left as an argument.

## Bug fixed along the way

`Lava-Cache-Backend` was gated on `rpcss.cache` unconditionally — but a **secondary** hit also reaches the header pass with `providerAddress == "Cached"`, so an entry the secondary served was reported with the *primary's* backend address. It now picks its reporter by the tier that actually served, and names nothing when no tier is recorded.

It deliberately **keeps** its `--debug-relays` flag gate rather than moving to the directive: it exposes an internal infrastructure address, and a client must not be able to ask for one. The tier headers carry no such value, which is what makes the directive acceptable for them.

## Note for whoever writes the resilience assertions

When a secondary dies mid-run the client marks the tier inactive after **one** failure, so the first post-death reply reads `secondary=error` and every later one reads `secondary=off`. That mirrors the counter's "one `error` increment, then silence". An assertion that polls for `error` on an arbitrary later request will not find it — assert on the first post-death request, or accept `error|off`.

## Testing

- Every value of both headers, including the four secondary-cache resilience shapes, plus the gate (no directive → neither header).
- The secondary's outcome is recorded on **every** non-hit, driven through the real lookup rather than a hand-built record, so it fails if the report is never written.
- The `Lava-Cache-Backend` mislabel: both tiers live, secondary serves, header must name the secondary's node.
- The cache key is byte-identical with and without the directive, the directive never reaches `RelayPrivateData.Metadata`, and the key is not degenerate.

Each guard was confirmed to fail against a mutated implementation. Verified from a clean `git worktree` checkout of the head commit — not the working directory: `go build ./...`, `go vet ./protocol/...`, and `go test` on `rpcsmartrouter`, `common` and `metrics` all pass. Worth stating explicitly, since CI on this repo does not run `go test`: the green checks below say nothing about these tests.

## Docs

`SECONDARY-CACHE.md` gains a "Reading the tier per request" section; UC-3 and UC-4 now read the tier off the reply, and UC-4 shows both halves of the resilience criterion on a single response. The claim that nothing in the response names the tier is gone. `METRICS.md` says plainly not to use these counters to check a single request, and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)