### PR TITLE
ci(pr-gate): skip the pruning verification on PublicNode so the fresh install comes up

### DIFF
--- a/.github/workflows/pr-gate-build-artifact.yml
+++ b/.github/workflows/pr-gate-build-artifact.yml
@@ -909,7 +909,15 @@ jobs:
                 metrics: []
                 behavior: {}
               nodes:
+                # PublicNode's free endpoint answers any request for a block behind
+                # head with "403 Archive requests require a personal token" (seen
+                # 2026-09-10; gate runs 34445468359 and 34446688209 both timed out
+                # here). The ETH1 spec's pruning verification asks for head minus 128
+                # at startup, so without this skip the router never reports ready and
+                # helm --wait expires. chain-id still runs. The chart renders this
+                # node-level key as skip-verifications on the node-url.
                 - name: "PublicNode"
+                  skip_verifications: "pruning"
                   endpoints:
                     - url: "https://ethereum-rpc.publicnode.com/"
                       interface: "jsonrpc"


### PR DESCRIPTION
# Description

Closes: no GitHub issue

The PR gate's "Deploy and validate latest Helm chart with PR image" step has failed for every run since 2026-09-10. PublicNode's free endpoint now answers any request for a block behind head with `403 Archive requests require a personal token`. The ETH1 spec's `pruning` verification asks for head minus 128 at startup, so the router marks its only provider unhealthy, `/readyz` stays 503, and `helm --wait --atomic --timeout 10m` rolls the release back. Gate runs [34445468359](https://github.com/Magma-Devs/smart-router/actions/runs/34445468359) and [34446688209](https://github.com/Magma-Devs/smart-router/actions/runs/34446688209) (both for #378) failed this way; #376's green run the day before used the same chart commit (`49330b2`), workflow and specs. The second run captured the router logs:

```
"provider node error" ... "HTTP 403: Archive requests require a personal token" chain_id=ETH1
"[-] verify failed sending chainMessage"
"invalid Verification on provider startup"
"ATTENTION: no healthy providers" staticConfigured=1 backupConfigured=0
```

This adds `skip_verifications: "pruning"` to the PublicNode node in the gate's generated values (`write_values_file` in `.github/workflows/pr-gate-build-artifact.yml`). The chart renders that node-level key as `skip-verifications: ["pruning"]` on the node-url, which the router honours per node-url (`common.NodeUrl.ShouldSkipVerification`). The `chain-id` verification still runs, and PublicNode answers `eth_chainId`.

Most critical to review: the eight added lines in the `nodes:` block of the values heredoc.

## Verification

- Rendered chart 6.8.0 at the gate's commit with helm 3.16.2 against the values extracted from this workflow. Compared with today's render, the only differences are the skip on the PublicNode node-url, the values echo, and the config checksum annotation.
- The mandatory `test-connectivity` helm test only format-checks the endpoint URL; the gate's post-install smoke uses `eth_chainId`.
- The workflow parses as YAML, the run script passes `bash -n`, and actionlint reports no findings.
- `go test ./protocol/chainlib/ ./protocol/rpcsmartrouter/ -run 'Skip|NeedsLatestBlock|StandaloneAddons' -count=1` passes, including the test that a skipped pruning verification no longer pulls in the head probe.

## Testing before merge

The gate runs this workflow from `main`, so dispatch it from this branch to run the patched gate against #378 (it deploys to dev-sim-prtests and publishes the status on #378's head):

```
gh workflow run pr-gate-build-artifact.yml --ref ci/pr-gate-skip-publicnode-pruning -f pr_number=378
```

## Follow-ups, not in this PR

- Helm's rollback deletes the pod before `print_helm_diagnostics` runs, so router logs are usually lost on failure (the first run above lost them).
- The chart's default values also list PublicNode; other consumers may hit the same rejection.

## Jira ticket

Jira ticket: MAG-3568

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] read the [contribution guide](https://github.com/magma-Devs/smart-router/blob/main/CONTRIBUTING.md)
* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change (not breaking)
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification (the two failing gate runs above)
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests (workflow-only change; verified by rendering the chart, see Verification)
* [x] updated the relevant documentation or specification (rationale comment in the workflow)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6LFGBAyHkeZKbBoUUXWwA
